### PR TITLE
docs: add docs site with landing page and overview

### DIFF
--- a/docs/images/hero.svg
+++ b/docs/images/hero.svg
@@ -1,0 +1,49 @@
+<svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<style>
+  :root {
+    --color-N600: #0f1e57;
+    --color-brand: #e4002b;
+    --color-blue-light: #e5eaff;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --color-N600: #e5eaff;
+      --color-blue-light: #0e41aa;
+    }
+  }
+</style>
+<!-- Storefront awning -->
+<path d="M6 12h28v2H6z" fill="var(--color-brand, #e4002b)"/>
+<path d="M6 14c0 2.2 1.8 4 4 4s4-1.8 4-4" fill="var(--color-brand, #e4002b)" opacity="0.8"/>
+<path d="M14 14c0 2.2 1.8 4 4 4s4-1.8 4-4" fill="var(--color-brand, #e4002b)"/>
+<path d="M22 14c0 2.2 1.8 4 4 4s4-1.8 4-4" fill="var(--color-brand, #e4002b)" opacity="0.8"/>
+<path d="M30 14c0 2.2 1.8 4 4 4V14z" fill="var(--color-brand, #e4002b)"/>
+<path d="M6 14c0 2.2-1.8 4-4 4V14z" fill="var(--color-brand, #e4002b)"/>
+<!-- Store body -->
+<rect x="6" y="18" width="28" height="16" rx="1" fill="var(--color-blue-light, #e5eaff)"/>
+<!-- Door -->
+<rect x="16" y="24" width="8" height="10" rx="0.5" fill="var(--color-N600, #0f1e57)" opacity="0.15"/>
+<rect x="18" y="26" width="1.5" height="6" rx="0.5" fill="var(--color-N600, #0f1e57)" opacity="0.3"/>
+<rect x="20.5" y="26" width="1.5" height="6" rx="0.5" fill="var(--color-N600, #0f1e57)" opacity="0.3"/>
+<!-- Window left -->
+<rect x="8" y="20" width="6" height="5" rx="0.5" fill="var(--color-N600, #0f1e57)" opacity="0.15"/>
+<!-- Grid items in left window -->
+<rect x="8.8" y="20.8" width="2" height="1.5" rx="0.3" fill="var(--color-brand, #e4002b)" opacity="0.6"/>
+<rect x="11.2" y="20.8" width="2" height="1.5" rx="0.3" fill="var(--color-N600, #0f1e57)" opacity="0.3"/>
+<rect x="8.8" y="22.8" width="2" height="1.5" rx="0.3" fill="var(--color-N600, #0f1e57)" opacity="0.3"/>
+<rect x="11.2" y="22.8" width="2" height="1.5" rx="0.3" fill="var(--color-brand, #e4002b)" opacity="0.6"/>
+<!-- Window right -->
+<rect x="26" y="20" width="6" height="5" rx="0.5" fill="var(--color-N600, #0f1e57)" opacity="0.15"/>
+<!-- Grid items in right window -->
+<rect x="26.8" y="20.8" width="2" height="1.5" rx="0.3" fill="var(--color-N600, #0f1e57)" opacity="0.3"/>
+<rect x="29.2" y="20.8" width="2" height="1.5" rx="0.3" fill="var(--color-brand, #e4002b)" opacity="0.6"/>
+<rect x="26.8" y="22.8" width="2" height="1.5" rx="0.3" fill="var(--color-brand, #e4002b)" opacity="0.6"/>
+<rect x="29.2" y="22.8" width="2" height="1.5" rx="0.3" fill="var(--color-N600, #0f1e57)" opacity="0.3"/>
+<!-- Sign -->
+<rect x="14" y="6" width="12" height="6" rx="1" fill="var(--color-N600, #0f1e57)"/>
+<circle cx="17" cy="9" r="1.2" fill="var(--color-brand, #e4002b)"/>
+<circle cx="20" cy="9" r="1.2" fill="var(--color-blue-light, #e5eaff)"/>
+<circle cx="23" cy="9" r="1.2" fill="var(--color-brand, #e4002b)"/>
+<!-- Sign post -->
+<rect x="19" y="4" width="2" height="2" fill="var(--color-N600, #0f1e57)"/>
+</svg>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,11 +1,10 @@
 ---
 title: Marketplace
-description: Plugins, skills, and tools for the F5 Distributed Cloud documentation platform
-sidebar:
-  order: 1
-  hidden: true
 hero:
-  tagline: Plugins, skills, and tools for the F5 Distributed Cloud documentation platform
+  tagline: Plugins, skills, and tools for the F5 Distributed Cloud documentation platform.
   image:
     html: '<img src="/marketplace/images/hero.svg" alt="F5 XC Marketplace" />'
+sidebar:
+  hidden: true
+  order: 0
 ---

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -1,0 +1,31 @@
+---
+title: Overview
+sidebar:
+  order: 1
+---
+
+The **f5xc-salesdemos Marketplace** is a Claude Code plugin
+marketplace for the
+[f5xc-salesdemos](https://github.com/f5xc-salesdemos)
+organization. It provides plugins, skills, and tools that
+extend Claude Code for documentation workflows.
+
+## Available Plugins
+
+| Plugin | Description |
+|--------|-------------|
+| [f5xc-docs-tools](https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-docs-tools) | MDX content validation and review tools for documentation repositories |
+
+## Installation
+
+Add this marketplace to Claude Code:
+
+```
+/plugin marketplace add f5xc-salesdemos/marketplace
+```
+
+Install a plugin:
+
+```
+/plugin install f5xc-docs-tools@f5xc-salesdemos-marketplace
+```


### PR DESCRIPTION
## Summary

- Updated `docs/index.mdx` with hero frontmatter (order 0, hidden sidebar)
- Added `docs/images/hero.svg` — marketplace-themed storefront icon with dark mode support
- Added `docs/overview.mdx` documenting available plugins and installation commands

Closes #11

## Test plan

- [ ] CI checks pass (super-linter, GitHub Pages deploy)
- [ ] Docs site accessible at `https://f5xc-salesdemos.github.io/marketplace/`
- [ ] Hero SVG renders correctly in both light and dark mode
- [ ] Overview page shows plugin table and install commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)