### PR TITLE
feat: complete marketplace metadata and expand documentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "f5xc-salesdemos-marketplace",
-  "description": "Claude Code plugins for f5xc-salesdemos documentation repositories",
+  "metadata": {
+    "description": "Claude Code plugins for f5xc-salesdemos documentation repositories"
+  },
   "owner": {
     "name": "f5xc-salesdemos"
   },
@@ -15,7 +17,11 @@
       },
       "source": "./plugins/f5xc-docs-tools",
       "category": "productivity",
-      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-docs-tools"
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-docs-tools",
+      "license": "Apache-2.0",
+      "keywords": ["mdx", "documentation", "validation", "starlight", "astro"],
+      "tags": ["docs", "linting", "content-review", "f5xc"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
     }
   ]
 }

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,0 +1,163 @@
+---
+title: Contributing a Plugin
+sidebar:
+  order: 5
+---
+
+import { Steps, Aside, FileTree } from '@astrojs/starlight/components';
+
+This guide explains how to create a new plugin and add it to
+the f5xc-salesdemos marketplace.
+
+## Plugin Structure
+
+Every plugin lives in its own directory under `plugins/` and
+follows this structure:
+
+<FileTree>
+- plugins/
+  - my-plugin/
+    - .claude-plugin/
+      - plugin.json
+    - skills/
+      - my-skill/
+        - SKILL.md
+        - references/
+          - reference-data.md
+    - commands/
+      - my-command.md
+    - agents/
+      - my-agent.md
+    - README.md
+</FileTree>
+
+## Creating a Plugin
+
+<Steps>
+
+1. **Create the plugin directory**
+
+   ```bash
+   mkdir -p plugins/my-plugin/.claude-plugin
+   mkdir -p plugins/my-plugin/skills
+   mkdir -p plugins/my-plugin/commands
+   ```
+
+2. **Write `plugin.json`**
+
+   Create `plugins/my-plugin/.claude-plugin/plugin.json`:
+
+   ```json
+   {
+     "name": "my-plugin",
+     "description": "What this plugin does",
+     "version": "1.0.0",
+     "author": {
+       "name": "f5xc-salesdemos"
+     },
+     "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/my-plugin",
+     "keywords": ["relevant", "keywords"],
+     "license": "Apache-2.0",
+     "repository": "https://github.com/f5xc-salesdemos/marketplace"
+   }
+   ```
+
+3. **Add skills**
+
+   Create `plugins/my-plugin/skills/my-skill/SKILL.md` with
+   frontmatter:
+
+   ```markdown
+   ---
+   name: my-skill
+   description: One-line description of what this skill does
+   ---
+
+   Detailed instructions for Claude when this skill activates.
+   ```
+
+   Place any reference data in a `references/` subdirectory
+   alongside `SKILL.md`.
+
+4. **Add commands**
+
+   Create `plugins/my-plugin/commands/my-command.md`:
+
+   ```markdown
+   ---
+   description: What this command does
+   argument_hint: "[optional-args]"
+   allowed_tools:
+     - Read
+     - Glob
+     - Grep
+   ---
+
+   Instructions for Claude when the user invokes this command.
+   ```
+
+5. **Add the plugin to marketplace.json**
+
+   Add an entry to the `plugins` array in
+   `.claude-plugin/marketplace.json`:
+
+   ```json
+   {
+     "name": "my-plugin",
+     "description": "What this plugin does",
+     "version": "1.0.0",
+     "author": { "name": "f5xc-salesdemos" },
+     "source": "./plugins/my-plugin",
+     "category": "productivity",
+     "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/my-plugin",
+     "license": "Apache-2.0",
+     "keywords": ["relevant", "keywords"],
+     "tags": ["searchable", "tags"],
+     "repository": "https://github.com/f5xc-salesdemos/marketplace"
+   }
+   ```
+
+6. **Test locally**
+
+   Test your plugin without publishing by pointing Claude Code
+   at the local directory:
+
+   ```bash
+   claude --plugin-dir ./plugins/my-plugin
+   ```
+
+   Verify that skills activate in the right context and
+   commands produce expected output.
+
+</Steps>
+
+## Submitting Your Plugin
+
+<Aside type="tip" title="Repository workflow">
+  This repository enforces a strict governance workflow.
+  See [CONTRIBUTING.md](https://github.com/f5xc-salesdemos/marketplace/blob/main/CONTRIBUTING.md)
+  for the full process.
+</Aside>
+
+<Steps>
+
+1. Create a GitHub issue describing the new plugin
+2. Create a feature branch from `main`
+3. Add your plugin directory and update `marketplace.json`
+4. Add a documentation page at `docs/plugins/my-plugin.mdx`
+5. Open a PR linking to the issue with `Closes #N`
+6. Fix any CI failures and merge after checks pass
+
+</Steps>
+
+## Best Practices
+
+- **Keep skills focused** — one skill should do one thing well
+- **Use reference files** — put large datasets, schemas, and
+  lookup tables in `references/` rather than inline in SKILL.md
+- **Scope intelligently** — check for uncommitted changes to
+  narrow the working set when possible
+- **Group output by severity** — use ERROR, WARNING, and INFO
+  levels so users can prioritize fixes
+- **Write a README** — include usage examples and a description
+  of what each skill and command does

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,0 +1,109 @@
+---
+title: Getting Started
+sidebar:
+  order: 2
+---
+
+import { Steps, Aside, Code } from '@astrojs/starlight/components';
+
+This guide walks you through adding the f5xc-salesdemos
+marketplace to Claude Code and installing your first plugin.
+
+## Prerequisites
+
+- Claude Code **v1.0.33** or later (plugin marketplace support)
+- A GitHub account with access to the
+  [f5xc-salesdemos](https://github.com/f5xc-salesdemos)
+  organization
+
+## Installation
+
+<Steps>
+
+1. **Add the marketplace**
+
+   In any Claude Code session, run:
+
+   ```
+   /plugin marketplace add f5xc-salesdemos/marketplace
+   ```
+
+   This registers the marketplace as a plugin source. You only
+   need to do this once.
+
+2. **Browse available plugins**
+
+   List what the marketplace offers:
+
+   ```
+   /plugin marketplace list f5xc-salesdemos-marketplace
+   ```
+
+3. **Install a plugin**
+
+   Install the docs tools plugin:
+
+   ```
+   /plugin install f5xc-docs-tools@f5xc-salesdemos-marketplace
+   ```
+
+4. **Use the plugin**
+
+   Navigate to any f5xc-salesdemos content repository and
+   run the MDX review command:
+
+   ```
+   /f5xc-docs-tools:review-mdx
+   ```
+
+   Claude reviews all MDX files in `docs/` and reports
+   errors, warnings, and suggestions.
+
+</Steps>
+
+## Updating Plugins
+
+To update an installed plugin to the latest version:
+
+```
+/plugin update f5xc-docs-tools@f5xc-salesdemos-marketplace
+```
+
+## Uninstalling
+
+Remove a plugin:
+
+```
+/plugin uninstall f5xc-docs-tools@f5xc-salesdemos-marketplace
+```
+
+Remove the marketplace entirely:
+
+```
+/plugin marketplace remove f5xc-salesdemos-marketplace
+```
+
+## Team Configuration
+
+To pre-configure the marketplace for your entire team, add it
+to your project's `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": [
+    "f5xc-salesdemos/marketplace"
+  ],
+  "enabledPlugins": [
+    "f5xc-docs-tools@f5xc-salesdemos-marketplace"
+  ]
+}
+```
+
+<Aside type="tip" title="Shared settings">
+  Committing `.claude/settings.json` to your repository means
+  every team member gets the marketplace and plugins
+  automatically — no manual setup required.
+</Aside>
+
+This ensures every contributor has the same tooling available
+from their first Claude Code session in the repository.

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -4,28 +4,40 @@ sidebar:
   order: 1
 ---
 
-The **f5xc-salesdemos Marketplace** is a Claude Code plugin
-marketplace for the
-[f5xc-salesdemos](https://github.com/f5xc-salesdemos)
-organization. It provides plugins, skills, and tools that
-extend Claude Code for documentation workflows.
+A **Claude Code plugin marketplace** is a curated collection of
+plugins that extend Claude Code with new skills, commands, and
+agents. Marketplaces let teams share tooling so every developer
+gets the same capabilities without manual setup.
+
+The **f5xc-salesdemos Marketplace** provides plugins built for
+the [f5xc-salesdemos](https://github.com/f5xc-salesdemos)
+documentation platform — an ecosystem of 20+ repositories that
+publish Astro/Starlight sites to GitHub Pages using a shared
+build pipeline.
+
+## How It Works
+
+1. **Add the marketplace** to Claude Code — this registers it
+   as a plugin source
+2. **Install plugins** from the marketplace — each plugin adds
+   skills and commands to your Claude Code session
+3. **Use the tools** — plugins activate automatically based on
+   context, or you invoke their commands directly
 
 ## Available Plugins
 
-| Plugin | Description |
-|--------|-------------|
-| [f5xc-docs-tools](https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-docs-tools) | MDX content validation and review tools for documentation repositories |
+| Plugin | Category | Description |
+|--------|----------|-------------|
+| [f5xc-docs-tools](/marketplace/plugins/f5xc-docs-tools/) | Productivity | MDX content validation and review tools for documentation repositories |
 
-## Installation
+## Quick Start
 
-Add this marketplace to Claude Code:
+Add the marketplace and install the docs tools plugin:
 
 ```
 /plugin marketplace add f5xc-salesdemos/marketplace
-```
-
-Install a plugin:
-
-```
 /plugin install f5xc-docs-tools@f5xc-salesdemos-marketplace
 ```
+
+See [Getting Started](/marketplace/getting-started/) for a
+full walkthrough.

--- a/docs/plugins/f5xc-docs-tools.mdx
+++ b/docs/plugins/f5xc-docs-tools.mdx
@@ -1,0 +1,156 @@
+---
+title: f5xc-docs-tools
+sidebar:
+  order: 4
+---
+
+import { Aside, Badge, Card, CardGrid, Steps } from '@astrojs/starlight/components';
+
+The **f5xc-docs-tools** plugin validates MDX content files for
+the f5xc-salesdemos documentation pipeline. It catches common
+build-breaking issues before they reach CI, including bare JSX
+characters, invalid imports, broken image references, and
+incomplete frontmatter.
+
+<Badge text="v1.0.0" variant="note" /> <Badge text="Productivity" variant="tip" />
+
+## Installation
+
+```
+/plugin install f5xc-docs-tools@f5xc-salesdemos-marketplace
+```
+
+## Skills
+
+### mdx-content-reviewer
+
+This skill activates automatically when Claude detects you are
+working with MDX files in an f5xc-salesdemos content
+repository. It performs seven validation checks:
+
+<CardGrid>
+  <Card title="Frontmatter validation">
+    Checks required fields like `title` and `sidebar.order`.
+    Splash pages must include `hero` fields and
+    `template: splash`.
+  </Card>
+  <Card title="MDX syntax pitfalls">
+    Detects bare `&lt;` characters and unescaped `\{` `\}`
+    braces that break MDX parsing.
+  </Card>
+  <Card title="Import validation">
+    Validates imports against an allowlist of Starlight
+    built-in and f5xc-salesdemos theme components.
+  </Card>
+  <Card title="Component attributes">
+    Checks required props for components like Screenshot,
+    Aside, Code, LinkCard, Card, and Badge.
+  </Card>
+  <Card title="Image references">
+    Verifies that referenced images exist in the `docs/images/`
+    directory.
+  </Card>
+  <Card title="Structure checks">
+    Ensures `docs/index.mdx` exists and image directories
+    contain no stray MDX files.
+  </Card>
+  <Card title="Export and code blocks">
+    Verifies that variables used in `Code` component `code`
+    props have matching exports.
+  </Card>
+</CardGrid>
+
+#### Scoping behavior
+
+The skill intelligently scopes its review:
+
+- If there are uncommitted or staged changes to `docs/**/*.mdx`
+  files, only those files are reviewed
+- Otherwise, all `docs/**/*.mdx` files are reviewed
+
+#### Output format
+
+Findings are grouped by severity:
+
+- **ERROR** — will break the build; must fix before merging
+- **WARNING** — likely problems that should be addressed
+- **INFO** — suggestions and best practices
+
+Each finding includes the file path, line number, and a
+description of the issue.
+
+## Commands
+
+### /review-mdx
+
+```
+/f5xc-docs-tools:review-mdx [path-or-glob]
+```
+
+Runs the `mdx-content-reviewer` skill on demand.
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `path-or-glob` | No | File path or glob pattern to scope the review. Defaults to all `docs/**/*.mdx` files. |
+
+**Examples:**
+
+```
+# Review all MDX files in docs/
+/f5xc-docs-tools:review-mdx
+
+# Review a specific file
+/f5xc-docs-tools:review-mdx docs/getting-started.mdx
+
+# Review files matching a glob
+/f5xc-docs-tools:review-mdx docs/guides/*.mdx
+```
+
+**Output:** A summary line at the end reports total files
+reviewed and finding counts by severity.
+
+## Allowed Imports
+
+The plugin validates imports against these sources:
+
+**Starlight built-in components** (`@astrojs/starlight/components`):
+
+`Aside` `Badge` `Card` `CardGrid` `Code` `FileTree` `Icon`
+`LinkCard` `Steps` `TabItem` `Tabs`
+
+**f5xc-salesdemos theme components** (`@f5xc-salesdemos/docs-theme/components/`):
+
+`Banner` `Icon` `LinkCard` `Screenshot`
+
+<Aside type="caution">
+  Theme components use default imports from individual `.astro`
+  files. Direct `node_modules` imports, relative paths, and
+  `require()` calls are flagged as warnings.
+</Aside>
+
+## Component Quick Reference
+
+| Component | Required Props | Optional Props |
+|-----------|---------------|----------------|
+| Screenshot | `alt` + at least one of `light` or `dark` | — |
+| Aside | `type` | `title` |
+| Code | `code`, `lang` | `title`, `frame`, `mark`, `ins`, `del` |
+| LinkCard (theme) | `title`, `href` | `description`, `icon` |
+| Card | `title` | `icon` |
+| Badge | `text` | `variant` |
+| Steps | — | — |
+| Tabs / TabItem | TabItem: `label` | — |
+| CardGrid | — | — |
+| FileTree | — | — |
+
+## MDX Pitfalls
+
+Common issues the plugin catches:
+
+| Pitfall | Problem | Fix |
+|---------|---------|-----|
+| Bare `&lt;` | MDX interprets as JSX tag | Use `&amp;lt;`, inline code, or rephrase |
+| Unescaped `\{` `\}` | MDX treats as JSX expression | Use inline code, escape with `\`, or use code block |
+| Braces in filenames | Astro cannot process the file | Never use `\{` or `\}` in `.mdx` filenames |

--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -1,0 +1,34 @@
+---
+title: Plugins
+sidebar:
+  order: 3
+---
+
+The f5xc-salesdemos marketplace provides the following plugins.
+Each plugin adds skills and commands to Claude Code that help
+with documentation workflows.
+
+## Plugin Catalog
+
+| Plugin | Version | Category | Description |
+|--------|---------|----------|-------------|
+| [f5xc-docs-tools](/marketplace/plugins/f5xc-docs-tools/) | 1.0.0 | Productivity | MDX content validation and review tools |
+
+## What's in a Plugin?
+
+Each plugin can include:
+
+- **Skills** — contextual knowledge that Claude activates
+  automatically when relevant (e.g., reviewing MDX files)
+- **Commands** — slash commands you invoke directly
+  (e.g., `/f5xc-docs-tools:review-mdx`)
+- **Agents** — specialized sub-agents for complex tasks
+
+## Installing a Plugin
+
+```
+/plugin install f5xc-docs-tools@f5xc-salesdemos-marketplace
+```
+
+See [Getting Started](/marketplace/getting-started/) for the
+full setup walkthrough.

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -1,0 +1,182 @@
+---
+title: Reference
+sidebar:
+  order: 6
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## marketplace.json Schema
+
+The marketplace manifest lives at
+`.claude-plugin/marketplace.json` in the repository root.
+
+### Top-level fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `$schema` | No | JSON Schema URL for validation |
+| `name` | Yes | Unique marketplace identifier |
+| `metadata.description` | Yes | Human-readable marketplace description |
+| `owner.name` | Yes | Organization or user that owns the marketplace |
+| `owner.email` | No | Contact email |
+| `plugins` | Yes | Array of plugin entries |
+
+### Plugin entry fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Plugin identifier (must match `plugin.json`) |
+| `description` | Yes | Short description of the plugin |
+| `version` | Yes | Semantic version string |
+| `author.name` | Yes | Plugin author |
+| `source` | Yes | Path or URL to the plugin (see Source Types) |
+| `category` | Yes | Plugin category (e.g., `productivity`) |
+| `homepage` | No | URL to plugin documentation or homepage |
+| `license` | No | SPDX license identifier |
+| `keywords` | No | Array of search keywords |
+| `tags` | No | Array of tags for filtering |
+| `repository` | No | Repository URL |
+
+## Plugin Source Types
+
+The `source` field in marketplace.json supports multiple
+formats:
+
+| Type | Example | Description |
+|------|---------|-------------|
+| Relative path | `./plugins/my-plugin` | Plugin in same repository |
+| GitHub shorthand | `owner/repo` | Plugin at repository root |
+| GitHub with path | `owner/repo/path/to/plugin` | Plugin in subdirectory |
+| Git URL | `https://github.com/owner/repo.git` | Git repository |
+| npm package | `npm:@scope/package` | Published npm package |
+
+## plugin.json Schema
+
+Each plugin has a manifest at
+`.claude-plugin/plugin.json` inside its directory.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Plugin identifier |
+| `description` | Yes | What the plugin does |
+| `version` | Yes | Semantic version |
+| `author.name` | Yes | Plugin author |
+| `homepage` | No | Documentation URL |
+| `keywords` | No | Search keywords |
+| `license` | No | SPDX license identifier |
+| `repository` | No | Repository URL |
+
+## Plugin Directory Layout
+
+```
+plugins/my-plugin/
+  .claude-plugin/
+    plugin.json          # Plugin manifest (required)
+  skills/
+    skill-name/
+      SKILL.md           # Skill definition (required per skill)
+      references/        # Reference data files (optional)
+  commands/
+    command-name.md      # Command definition (one per command)
+  agents/
+    agent-name.md        # Agent definition (one per agent)
+  README.md              # Plugin documentation (recommended)
+```
+
+## Environment Variables
+
+Plugins can use these variables in their skill and command
+files:
+
+| Variable | Description |
+|----------|-------------|
+| `$\{CLAUDE_PLUGIN_ROOT\}` | Absolute path to the plugin's root directory |
+
+## Validation
+
+Validate your marketplace and plugin manifests locally:
+
+```bash
+claude plugin validate .
+```
+
+This checks:
+
+- `marketplace.json` schema compliance
+- All referenced plugin directories exist
+- Each plugin has a valid `plugin.json`
+- Skills have properly formatted `SKILL.md` frontmatter
+- Commands have required frontmatter fields
+
+## Team Configuration
+
+### Pre-configuring marketplaces
+
+Add to `.claude/settings.json` in any repository:
+
+```json
+{
+  "extraKnownMarketplaces": [
+    "f5xc-salesdemos/marketplace"
+  ]
+}
+```
+
+### Pre-enabling plugins
+
+```json
+{
+  "enabledPlugins": [
+    "f5xc-docs-tools@f5xc-salesdemos-marketplace"
+  ]
+}
+```
+
+<Aside type="tip">
+  Committing these settings to your repository ensures every
+  team member gets the same marketplace and plugin
+  configuration automatically.
+</Aside>
+
+## Troubleshooting
+
+### Marketplace not found
+
+Verify the marketplace was added:
+
+```
+/plugin marketplace list
+```
+
+If missing, re-add it:
+
+```
+/plugin marketplace add f5xc-salesdemos/marketplace
+```
+
+### Plugin not activating
+
+- Confirm the plugin is installed:
+  `/plugin list`
+- Check that your Claude Code version supports plugins
+  (v1.0.33+)
+- Verify the skill's trigger conditions match your current
+  context
+
+### Skills not triggering automatically
+
+Skills activate based on their `description` field in
+SKILL.md frontmatter. If a skill is not activating when
+expected:
+
+- Check that the description accurately describes the
+  trigger context
+- Use the command directly (e.g., `/f5xc-docs-tools:review-mdx`)
+  as a workaround
+
+### Build errors after review
+
+The plugin reports issues but does not auto-fix them. Apply
+the suggested fixes manually, then re-run the review to
+confirm resolution.

--- a/plugins/f5xc-docs-tools/.claude-plugin/plugin.json
+++ b/plugins/f5xc-docs-tools/.claude-plugin/plugin.json
@@ -6,5 +6,7 @@
     "name": "f5xc-salesdemos"
   },
   "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-docs-tools",
-  "keywords": ["mdx", "documentation", "validation", "starlight", "astro"]
+  "keywords": ["mdx", "documentation", "validation", "starlight", "astro"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
 }


### PR DESCRIPTION
## Summary

- Add missing metadata fields to `marketplace.json` and `plugin.json` (license, keywords, tags, repository, metadata.description)
- Expand docs site from 2 pages to 7 comprehensive pages covering installation, plugin details, contributing, and reference

## Changes

### Marketplace Metadata
- `marketplace.json`: moved `description` into `metadata.description`, added `license`, `keywords`, `tags`, `repository` to plugin entry
- `plugin.json`: added `license` and `repository` fields

### Documentation (5 new pages, 1 rewrite)
- **overview.mdx** — rewritten with expanded marketplace explanation and quick start
- **getting-started.mdx** — step-by-step installation walkthrough with team config
- **plugins/index.mdx** — plugin catalog with descriptions
- **plugins/f5xc-docs-tools.mdx** — detailed plugin docs (7 validation checks, commands, component reference)
- **contributing.mdx** — guide for adding new plugins to the marketplace
- **reference.mdx** — marketplace.json schema, plugin.json schema, troubleshooting

## Test plan

- [ ] Docs site builds without errors (CI `github-pages-deploy` workflow)
- [ ] All 7 pages render with correct sidebar order (0-6)
- [ ] JSON manifests are valid
- [ ] Internal links resolve correctly
- [ ] Super linter passes on all new MDX files

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)