### PR TITLE
fix: complete f5xc-sales-engineer documentation coverage

### DIFF
--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Contributing a Plugin
 sidebar:
-  order: 5
+  order: 6
 ---
 
 import { Steps, Aside, FileTree } from '@astrojs/starlight/components';

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -41,23 +41,26 @@ marketplace to Claude Code and installing your first plugin.
 
 3. **Install a plugin**
 
-   Install the docs tools plugin:
+   Install the plugin you need:
 
    ```
    /plugin install f5xc-docs-tools@f5xc-salesdemos-marketplace
+   /plugin install f5xc-sales-engineer@f5xc-salesdemos-marketplace
    ```
 
 4. **Use the plugin**
 
-   Navigate to any f5xc-salesdemos content repository and
-   run the MDX review command:
+   Navigate to any f5xc-salesdemos content repository.
+
+   For **docs tools**, run the MDX review command:
 
    ```
    /f5xc-docs-tools:review-mdx
    ```
 
-   Claude reviews all MDX files in `docs/` and reports
-   errors, warnings, and suggestions.
+   For **sales engineer**, use trigger phrases like
+   "prepare the demo", "run the demo", or "walk through
+   the demo" — the plugin activates automatically.
 
 </Steps>
 
@@ -67,6 +70,7 @@ To update an installed plugin to the latest version:
 
 ```
 /plugin update f5xc-docs-tools@f5xc-salesdemos-marketplace
+/plugin update f5xc-sales-engineer@f5xc-salesdemos-marketplace
 ```
 
 ## Uninstalling
@@ -75,6 +79,7 @@ Remove a plugin:
 
 ```
 /plugin uninstall f5xc-docs-tools@f5xc-salesdemos-marketplace
+/plugin uninstall f5xc-sales-engineer@f5xc-salesdemos-marketplace
 ```
 
 Remove the marketplace entirely:
@@ -94,7 +99,8 @@ to your project's `.claude/settings.json`:
     "f5xc-salesdemos/marketplace"
   ],
   "enabledPlugins": [
-    "f5xc-docs-tools@f5xc-salesdemos-marketplace"
+    "f5xc-docs-tools@f5xc-salesdemos-marketplace",
+    "f5xc-sales-engineer@f5xc-salesdemos-marketplace"
   ]
 }
 ```

--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -5,14 +5,15 @@ sidebar:
 ---
 
 The f5xc-salesdemos marketplace provides the following plugins.
-Each plugin adds skills and commands to Claude Code that help
-with documentation workflows.
+Each plugin adds skills, commands, and agents to Claude Code
+that help with documentation and demo workflows.
 
 ## Plugin Catalog
 
 | Plugin | Version | Category | Description |
 |--------|---------|----------|-------------|
 | [f5xc-docs-tools](/marketplace/plugins/f5xc-docs-tools/) | 1.0.0 | Productivity | MDX content validation and review tools |
+| [f5xc-sales-engineer](/marketplace/plugins/f5xc-sales-engineer/) | 1.0.0 | Productivity | Sales Engineer persona framework — demo execution, presentation, Q&A, environment management |
 
 ## What's in a Plugin?
 
@@ -28,6 +29,7 @@ Each plugin can include:
 
 ```
 /plugin install f5xc-docs-tools@f5xc-salesdemos-marketplace
+/plugin install f5xc-sales-engineer@f5xc-salesdemos-marketplace
 ```
 
 See [Getting Started](/marketplace/getting-started/) for the

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Reference
 sidebar:
-  order: 6
+  order: 7
 ---
 
 import { Aside } from '@astrojs/starlight/components';


### PR DESCRIPTION
## Summary
- Adds f5xc-sales-engineer to plugin catalog table in `docs/plugins/index.mdx`
- Updates `docs/getting-started.mdx` to reference both plugins in install/update/uninstall examples
- Fixes sidebar order conflict (contributing: 5→6, reference: 6→7)

## Test plan
- [ ] Plugin catalog page lists both f5xc-docs-tools and f5xc-sales-engineer
- [ ] Getting Started guide shows both plugin install commands
- [ ] Sidebar renders in correct order (index 3, docs-tools 4, sales-engineer 5, contributing 6, reference 7)
- [ ] Docs site deploys and all pages are accessible

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)