### PR TITLE
Add TEST-NET skip condition to demo-housekeeping T3 description

### DIFF
--- a/plugins/f5xc-sales-engineer/agents/demo-housekeeping.md
+++ b/plugins/f5xc-sales-engineer/agents/demo-housekeeping.md
@@ -89,6 +89,10 @@ tiers T0 through T5 with numbered checks.
 - **T2: Platform Prerequisites** — Product enablement, DNS, platform
   state. FAIL blocks execution.
 - **T3: Origin / Service Health** — Origin reachability. WARN only.
+  If `F5XC_ORIGIN_IP` is an RFC 5737 TEST-NET address
+  (`192.0.2.0/24`, `198.51.100.0/24`, or `203.0.113.0/24`), skip T3
+  entirely — these IPs are documentation placeholders and are not
+  routable.
 - **T4: Environment Clean** — Check for leftover demo objects. If
   found, auto-teardown by reading and executing commands from
   `docs/api-automation/phase-4-teardown.mdx`, then re-check.


### PR DESCRIPTION
## Summary

- Update demo-housekeeping agent T3 tier summary to mention RFC 5737 TEST-NET skip condition
- When `F5XC_ORIGIN_IP` is in `192.0.2.0/24`, `198.51.100.0/24`, or `203.0.113.0/24`, T3 is skipped entirely

## Test plan

- [ ] Verify agent definition renders correctly
- [ ] Run Prepare stage with TEST-NET origin IP — confirm T3 reports SKIP

Related to f5xc-salesdemos/csd#343

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)