### PR TITLE
feat: add plugin request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-request.md
+++ b/.github/ISSUE_TEMPLATE/plugin-request.md
@@ -1,0 +1,43 @@
+---
+name: Plugin Request
+about: Propose a new plugin for the marketplace
+title: "feat: [plugin-name] plugin"
+labels: enhancement
+---
+
+## Plugin Name
+
+<!-- The identifier for this plugin (kebab-case, e.g., my-plugin) -->
+
+## Problem Statement
+
+<!-- What problem does this plugin solve? Who benefits from it? -->
+
+## Proposed Skills
+
+<!-- List the skills this plugin would provide -->
+
+- **skill-name** — description of what this skill does
+
+## Proposed Commands
+
+<!-- List any slash commands (optional) -->
+
+- `/command-name` — description of what this command does
+
+## Target Repositories
+
+<!-- Which f5xc-salesdemos repositories would use this plugin? -->
+
+- repo-name
+
+## Convention Files
+
+<!-- If this plugin is product-agnostic (like f5xc-sales-engineer),
+     list the convention files each repository would need to provide.
+     Leave blank if not applicable. -->
+
+## Additional Context
+
+<!-- Any other information, references, or examples that help explain
+     the proposed plugin. -->


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/plugin-request.md` for structured plugin proposals
- Template includes: plugin name, problem statement, proposed skills/commands, target repos, convention files
- Does NOT modify the managed `config.yml` — GitHub auto-discovers additional templates

## Test plan

- [ ] Template appears when creating a new issue
- [ ] All sections render correctly
- [ ] Managed config.yml is untouched

Closes #43