### PR TITLE
feat: add f5xc-repo-governance and f5xc-docs-pipeline plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,6 +39,36 @@
       "keywords": ["sales-engineer", "demo", "persona", "presentation", "f5xc"],
       "tags": ["demo", "sales", "persona", "f5xc"],
       "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "f5xc-repo-governance",
+      "description": "Repository governance workflow — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/f5xc-repo-governance",
+      "category": "productivity",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-repo-governance",
+      "license": "Apache-2.0",
+      "keywords": ["governance", "workflow", "pr", "ci", "rate-limit", "github"],
+      "tags": ["governance", "workflow", "ci", "f5xc"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "f5xc-docs-pipeline",
+      "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/f5xc-docs-pipeline",
+      "category": "productivity",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-docs-pipeline",
+      "license": "Apache-2.0",
+      "keywords": ["docs", "pipeline", "astro", "starlight", "content", "authoring"],
+      "tags": ["docs", "pipeline", "content", "f5xc"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
     }
   ]
 }

--- a/plugins/f5xc-docs-pipeline/.claude-plugin/plugin.json
+++ b/plugins/f5xc-docs-pipeline/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "f5xc-docs-pipeline",
+  "description": "Documentation pipeline architecture for f5xc-salesdemos — config ownership, release dispatch chain, content authoring, managed files, local preview",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos",
+    "url": "https://github.com/f5xc-salesdemos"
+  },
+  "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-docs-pipeline",
+  "keywords": ["docs", "pipeline", "astro", "starlight", "content", "authoring"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/f5xc-docs-pipeline/README.md
+++ b/plugins/f5xc-docs-pipeline/README.md
@@ -1,0 +1,46 @@
+# f5xc-docs-pipeline
+
+Documentation pipeline plugin for `f5xc-salesdemos` —
+guides navigation of the multi-repo build architecture,
+config ownership, and content authoring.
+
+## Skills
+
+### pipeline-navigator
+
+Where to make changes across docs-theme, docs-builder,
+docs-control, and docs-icons. Includes config ownership
+rules, release dispatch chain, and managed files list.
+
+**Activates when:** Deciding which repo to modify,
+understanding config ownership, debugging the release
+dispatch chain, or checking managed files.
+
+**Reference files:**
+
+- `config-ownership.md` — Single-source-of-truth rules
+  for astro.config.mjs, content.config.ts, etc.
+- `release-dispatch-chain.md` — 5-step automated chain
+  from theme/icon merge to content site rebuild
+- `managed-files.md` — Full list of centrally managed
+  files synced by docs-control
+
+### content-author
+
+Content structure, MDX syntax rules, and local Docker
+preview for documentation authors.
+
+**Activates when:** Creating or editing docs content,
+working with MDX files, or setting up local preview.
+
+## Commands
+
+### /preview-docs
+
+Starts a local Docker dev server for docs preview.
+
+## Installation
+
+```bash
+claude /install f5xc-docs-pipeline@f5xc-salesdemos-marketplace
+```

--- a/plugins/f5xc-docs-pipeline/commands/preview-docs.md
+++ b/plugins/f5xc-docs-pipeline/commands/preview-docs.md
@@ -1,0 +1,22 @@
+---
+description: Start a local Docker dev server to preview docs
+allowed_tools:
+  - Bash
+---
+
+Start the local docs preview server using the shared
+Docker build image.
+
+Run this command:
+
+```bash
+docker run --rm -it \
+  -v "$(pwd)/docs:/content/docs" \
+  -p 4321:4321 \
+  -e MODE=dev \
+  ghcr.io/f5xc-salesdemos/docs-builder:latest
+```
+
+Then tell the user to open `http://localhost:4321`.
+Note that file changes on the host require restarting
+the container.

--- a/plugins/f5xc-docs-pipeline/skills/content-author/SKILL.md
+++ b/plugins/f5xc-docs-pipeline/skills/content-author/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: content-author
+description: >-
+  Content authoring guide for f5xc-salesdemos docs repos — file structure,
+  MDX syntax rules, frontmatter requirements, image references, and local
+  Docker preview. Use when creating or editing docs/ content, working with
+  MDX files, setting up local preview, or when the user asks about content
+  structure, MDX syntax, or how to preview docs locally.
+user-invocable: false
+---
+
+# Content Authoring
+
+## Structure
+
+- Place `.md` or `.mdx` files in the `docs/` directory
+- `docs/index.mdx` is required — include YAML frontmatter
+  with at least a `title:` field
+- Static assets (images, diagrams) go in subdirectories
+  like `docs/images/` — folders with no `.md`/`.mdx`
+  files are auto-mounted as public assets
+- Reference assets with root-relative paths:
+  `![alt](/images/diagram.png)`
+
+## MDX Rules
+
+- Bare `<` is treated as a JSX tag — use `&lt;` or wrap
+  in backtick inline code
+- `{` and `}` are JSX expressions — use `\{` and `\}`
+  or wrap in backtick inline code
+- Never use curly braces in `.mdx` filenames
+
+## Local Preview
+
+Run the live dev server (restart to pick up changes):
+
+```bash
+docker run --rm -it \
+  -v "$(pwd)/docs:/content/docs" \
+  -p 4321:4321 \
+  -e MODE=dev \
+  ghcr.io/f5xc-salesdemos/docs-builder:latest
+```
+
+Open `http://localhost:4321`. File changes on the host
+require restarting the container.
+
+For a full production build:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/docs:/content/docs:ro" \
+  -v "$(pwd)/output:/output" \
+  -e GITHUB_REPOSITORY="<owner>/<repo>" \
+  ghcr.io/f5xc-salesdemos/docs-builder:latest
+```
+
+Serve with `npx serve output/ -l 8080` and open
+`http://localhost:8080/<repo>/`.
+
+Full content authoring guide:
+<https://f5xc-salesdemos.github.io/docs-builder/content-authors/>

--- a/plugins/f5xc-docs-pipeline/skills/pipeline-navigator/SKILL.md
+++ b/plugins/f5xc-docs-pipeline/skills/pipeline-navigator/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: pipeline-navigator
+description: >-
+  Documentation pipeline architecture for f5xc-salesdemos — where to make
+  changes across docs-theme, docs-builder, docs-control, and docs-icons.
+  Use when deciding which repository to modify, understanding config ownership
+  (astro.config.mjs, content.config.ts), debugging the release dispatch chain,
+  checking managed files, or when a theme/icon change is not appearing on live
+  sites. Also use when the user asks "where should I make this change" or
+  mentions docs-theme, docs-builder, or the build pipeline.
+user-invocable: false
+---
+
+# Documentation Pipeline Navigator
+
+All `f5xc-salesdemos` repositories publish docs to
+GitHub Pages using a shared pipeline.
+
+## Repository Roles
+
+| Repository | Role | Owns |
+| ---- | ---- | ---- |
+| `docs-theme` | npm package — Starlight plugin, Astro config, CSS, fonts, logos, layout components | `astro.config.mjs`, `config.ts`, `content.config.ts`, all Starlight plugins and Astro integrations |
+| `docs-builder` | Docker image — build orchestration, npm deps, Puppeteer PDF generation, interactive components | `Dockerfile`, `entrypoint.sh`, `package.json` (npm dependency set only) |
+| `docs-control` | Source-of-truth — reusable CI workflows, governance templates, repository settings enforcement | CI workflows, `CLAUDE.md`, PR/issue templates, repository settings |
+| `docs-icons` | npm packages — Iconify JSON icon sets, Astro icon components | Icon packaging, npm publishing, dispatch to docs-builder on release |
+
+Content repositories only need a `docs/` directory — the
+build container and workflow handle everything else.
+CI builds trigger when files in `docs/` change on `main`.
+
+## Where to Make Changes
+
+- **Site appearance, navigation, or Astro config** —
+  change `docs-theme` (owns `astro.config.mjs`,
+  `content.config.ts`, CSS, fonts, logos, and layout
+  components)
+- **Build process, Docker image, or npm deps** —
+  change `docs-builder` (owns the Dockerfile,
+  entrypoint, and dependency set)
+- **Interactive components** (placeholder forms, API
+  viewers, Mermaid rendering) — change `docs-builder`
+- **Icon packages** (Iconify JSON sets, Astro icon
+  components) — change `docs-icons` (publishes npm
+  packages consumed by `docs-builder`)
+- **CI workflow or governance files** —
+  change `docs-control` (syncs managed files and
+  repository settings to downstream repositories)
+- **Page content and images** — change the `docs/`
+  directory in the content repository itself
+- **Never** add `astro.config.mjs`, `package.json`, or
+  build config to a content repository — the pipeline
+  provides these
+- **Never** create `astro.config.mjs`, `uno.config.ts`,
+  or Astro integration config in `docs-builder` — these
+  are owned exclusively by `docs-theme`
+
+## Configuration Ownership
+
+Read `references/config-ownership.md` for the full
+ownership rules including the single-source-of-truth
+mechanism and the pattern for adding new capabilities.
+
+## Release Dispatch Chain
+
+Read `references/release-dispatch-chain.md` for the
+5-step automated chain from theme/icon merge through
+content site rebuild.
+
+If a theme or icon change does not appear on live sites,
+check each step in that chain for failures — do not
+manually trigger `github-pages-deploy.yml` as a
+workaround.
+
+## Managed Files
+
+Read `references/managed-files.md` for the full list of
+files centrally managed by `docs-control` and
+automatically synced to all repos. **Do not modify
+managed files in downstream repos** — local changes will
+be overwritten on the next enforcement run.
+
+To change any managed file, open a PR in
+`f5xc-salesdemos/docs-control` instead.
+
+## Other Infrastructure Repos
+
+The organization also contains repos with their own CI
+pipelines that are not part of the docs theme/build
+dispatch chain but do receive managed files:
+
+| Repo | Role |
+| ---- | ---- |
+| `terraform-provider-f5xc` | Go Terraform provider for F5 Distributed Cloud |
+| `terraform-provider-mcp` | MCP server exposing Terraform provider schemas |
+| `api-mcp` | MCP server for the F5 XC API |

--- a/plugins/f5xc-docs-pipeline/skills/pipeline-navigator/references/config-ownership.md
+++ b/plugins/f5xc-docs-pipeline/skills/pipeline-navigator/references/config-ownership.md
@@ -1,0 +1,42 @@
+# Configuration Ownership Rules
+
+The build image (`docs-builder`) copies configuration
+files from the theme package at image build time. This is
+the mechanism that enforces single-source-of-truth.
+
+## File Ownership
+
+- `astro.config.mjs` — copied from `docs-theme` into the
+  image. **Never** create or override this file in
+  `docs-builder` or any content repository.
+- `content.config.ts` — copied from `docs-theme` into the
+  image. Same rule applies.
+- Astro integrations and Starlight plugins — defined in
+  `docs-theme/config.ts`. To add a new integration, add
+  it to docs-theme, not docs-builder.
+- npm packages (icon packs, runtime libraries) — added to
+  `docs-builder/package.json`. These are build-time
+  dependencies that integrations in docs-theme consume.
+- `uno.config.ts`, `tsconfig.json`, and other tooling
+  configs — owned by `docs-theme` if they affect the Astro
+  build. `docs-builder` must not create competing configs.
+
+## Pattern for Adding New Capabilities
+
+For example, adding icon packs:
+
+1. Add the npm data packages to
+   `docs-builder/package.json`
+2. Add the Astro integration/plugin to
+   `docs-theme/config.ts`
+3. The Dockerfile copies the updated config from
+   docs-theme at build time — no manual config in
+   docs-builder needed
+
+## Icon Package Pipeline
+
+`docs-icons` owns all icon packaging — Iconify JSON sets
+and Astro components. On npm publish, `docs-icons`
+dispatches to `docs-builder` to rebuild the Docker image
+with updated icon packages. Content repositories never
+install icon packages directly.

--- a/plugins/f5xc-docs-pipeline/skills/pipeline-navigator/references/managed-files.md
+++ b/plugins/f5xc-docs-pipeline/skills/pipeline-navigator/references/managed-files.md
@@ -1,0 +1,41 @@
+# Managed Files
+
+The following files are centrally managed by the
+[docs-control](https://github.com/f5xc-salesdemos/docs-control)
+repository and automatically synced to all repos in the
+`f5xc-salesdemos` organization. **Do not modify these
+files in downstream repos** — local changes will be
+overwritten on the next enforcement run.
+
+To change any of these files, open a PR in
+`f5xc-salesdemos/docs-control` instead.
+
+## File List
+
+- `.github/workflows/github-pages-deploy.yml`
+- `.github/workflows/enforce-repo-settings.yml`
+- `.github/workflows/require-linked-issue.yml`
+- `.github/workflows/dependabot-auto-merge.yml`
+- `.github/workflows/super-linter.yml`
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/ISSUE_TEMPLATE/bug_report.md`
+- `.github/ISSUE_TEMPLATE/feature_request.md`
+- `.github/ISSUE_TEMPLATE/documentation.md`
+- `.github/ISSUE_TEMPLATE/config.yml`
+- `CONTRIBUTING.md`
+- `CLAUDE.md`
+- `.editorconfig`
+- `.gitignore`
+- `LICENSE`
+- `.pre-commit-config.yaml`
+- `.yamllint.yaml`
+- `.markdownlint.json`
+- `biome.json`
+- `.jscpd.json`
+- `.textlintrc`
+- `.editorconfig-checker.json`
+- `.checkov.yaml`
+- `zizmor.yaml`
+- `.shellcheckrc`
+- `.codespellrc`
+- `.claude/CLAUDE.md`

--- a/plugins/f5xc-docs-pipeline/skills/pipeline-navigator/references/release-dispatch-chain.md
+++ b/plugins/f5xc-docs-pipeline/skills/pipeline-navigator/references/release-dispatch-chain.md
@@ -1,0 +1,39 @@
+# Release Dispatch Chain
+
+When an infrastructure package (`docs-theme` or
+`docs-icons`) merges to `main`, the following automated
+chain runs end-to-end — no manual triggering should be
+needed:
+
+1. **Semantic Release** publishes a new npm version and
+   creates a GitHub release
+2. **Dispatch to `docs-builder`** — the release event
+   triggers `dispatch-downstream.yml`, which sends a
+   `rebuild-image` repository dispatch
+3. **Docker image rebuild** — `docs-builder` rebuilds the
+   container with the updated package
+4. **Dispatch to content repositories** — `docs-builder`
+   reads `docs-sites.json` from `docs-control` and
+   dispatches `github-pages-deploy.yml` to every content
+   repository
+5. **GitHub Pages rebuild** — each content repository
+   rebuilds its site using the new image
+
+## Debugging
+
+If a theme or icon change does not appear on live sites,
+check each step in this chain for failures:
+
+1. Was a new npm version published? Check the GitHub
+   release in `docs-theme` or `docs-icons`.
+2. Was `docs-builder` dispatched? Check
+   `dispatch-downstream.yml` runs.
+3. Did the Docker image rebuild? Check
+   `docs-builder` workflow runs.
+4. Were content repos dispatched? Check
+   `github-pages-deploy.yml` runs in content repos.
+5. Did content sites rebuild? Check GitHub Pages
+   deployments.
+
+Do not manually trigger `github-pages-deploy.yml` as a
+workaround — fix the root cause in the dispatch chain.

--- a/plugins/f5xc-repo-governance/.claude-plugin/plugin.json
+++ b/plugins/f5xc-repo-governance/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "f5xc-repo-governance",
+  "description": "Repository governance workflow for f5xc-salesdemos — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos",
+    "url": "https://github.com/f5xc-salesdemos"
+  },
+  "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-repo-governance",
+  "keywords": ["governance", "workflow", "pr", "ci", "rate-limit", "github"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/f5xc-repo-governance/README.md
+++ b/plugins/f5xc-repo-governance/README.md
@@ -1,0 +1,32 @@
+# f5xc-repo-governance
+
+Repository governance workflow plugin for
+`f5xc-salesdemos` — enforces the full task lifecycle
+from issue creation through post-merge verification.
+
+## Skills
+
+### workflow-lifecycle
+
+Full repository workflow: issue creation, branch naming,
+PR lifecycle, CI polling, post-merge monitoring,
+verification, and task completion criteria.
+
+**Activates when:** Starting a new task, creating PRs,
+merging, monitoring CI, verifying outcomes, or
+encountering GitHub API rate limit issues.
+
+**Reference files:**
+
+- `polling-protocol.md` — Single-shot polling patterns
+  for PR checks and workflow runs
+- `rate-limit-management.md` — Consumption zones,
+  banned commands, budget estimates, 403 recovery
+- `task-completion-checklist.md` — Done criteria
+  checklist
+
+## Installation
+
+```bash
+claude /install f5xc-repo-governance@f5xc-salesdemos-marketplace
+```

--- a/plugins/f5xc-repo-governance/skills/workflow-lifecycle/SKILL.md
+++ b/plugins/f5xc-repo-governance/skills/workflow-lifecycle/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: workflow-lifecycle
+description: >-
+  Repository governance workflow for f5xc-salesdemos — issue creation, branch
+  naming, PR workflow, CI polling, post-merge monitoring, verification, and
+  task completion criteria. Use when starting a new task, creating a PR,
+  merging a PR, monitoring CI, verifying outcomes, or checking rate limits.
+  Also activates when encountering HTTP 403/429 from the GitHub API.
+user-invocable: false
+---
+
+# Repository Workflow Lifecycle
+
+This skill defines the full task lifecycle for all
+`f5xc-salesdemos` repositories. **DO NOT STOP after
+creating a PR** — the task is not complete until the PR
+is merged, all post-merge workflows succeed, and local
+branches are cleaned.
+
+## Project-Specific Requirements
+
+These constraints apply on top of any plugin defaults:
+
+1. **Create a GitHub issue** before making any changes
+2. **Sync local main** before branching:
+   `git checkout main && git pull origin main`
+3. **Create a feature branch** from `main` — never
+   commit to `main` directly
+4. **Link PRs to issues** using `Closes #N` in the
+   PR body — fill out the PR template completely
+5. **Conventional commits** — use `feat:`, `fix:`,
+   `docs:` prefixes
+6. **Fix any CI failures** — monitor checks with
+   `gh pr checks <NUMBER>`, fix locally, push to
+   trigger re-runs
+
+## Branch Naming
+
+Use the format `<prefix>/<issue-number>-short-description`:
+
+- `feature/42-add-rate-limiting`
+- `fix/17-correct-threshold`
+- `docs/8-update-guide`
+
+## Merging
+
+Merge after CI passes. Do not wait for manual approval
+(none is required).
+
+Poll PR checks using single-shot queries (never
+`--watch`) per `references/polling-protocol.md`:
+
+```
+gh pr checks <NUMBER> --json bucket \
+  --jq 'map(.bucket) | unique | if . == ["pass"] then "pass"
+  elif any(. == "fail") then "fail" else "pending" end'
+```
+
+Once all checks pass:
+
+```
+gh pr merge <NUMBER> --squash --delete-branch
+```
+
+If the merge fails, check why:
+
+```
+gh pr view <NUMBER> --json mergeable,mergeStateStatus
+```
+
+## Post-Merge Monitoring
+
+Merging to `main` triggers additional workflows (docs
+builds, governance sync, etc.). Discover and poll them
+using single-shot checks (never `--watch`):
+
+```
+git checkout main && git pull origin main
+MERGE_SHA=$(git rev-parse HEAD)
+sleep 15
+gh run list --branch main --commit $MERGE_SHA
+```
+
+Then poll each run per `references/polling-protocol.md`:
+
+```
+gh run view <RUN-ID> --json status,conclusion \
+  --jq '"\(.status) \(.conclusion)"'
+```
+
+Sleep for the interval matching the current consumption
+zone (30s GREEN, 60s YELLOW). Maximum 20 iterations —
+then report to user.
+
+**Failure handling:**
+
+- Focus only on workflows triggered by your merge
+  commit (`$MERGE_SHA`) — ignore historical failures
+- View logs: `gh run view <RUN-ID> --log-failed`
+- Fix the root cause — create a new issue, branch,
+  and PR with the fix
+- Report to user what failed and what you did to fix it
+- Do not investigate or report on workflow failures
+  from other commits
+
+## Verification
+
+Apply `superpowers:verification-before-completion`
+before any completion claims. Then run these
+project-specific checks:
+
+Always check:
+
+```
+# Issue was closed by the PR
+gh issue view <NUMBER> --json state --jq '.state'
+
+# Branch protection matches expected state
+gh api repos/{owner}/{repo}/branches/main/protection \
+  --jq '.required_status_checks.contexts'
+```
+
+If `docs/**` changed:
+
+```
+# Docs site is accessible
+REPO=$(basename $(pwd))
+curl -sf "https://f5xc-salesdemos.github.io/${REPO}/" \
+  && echo "OK" || echo "FAIL"
+```
+
+If governance or config files changed, check rate
+limits first (read `references/rate-limit-management.md`)
+and adapt scope:
+
+- **GREEN** (>1,000 remaining): check all repos
+- **YELLOW** (200–1,000): spot-check 3 repos
+  (first, middle, last from the list)
+- **RED** (<200): skip entirely, report deferral
+  to user
+
+```
+# Downstream repos were dispatched successfully
+for repo in $(jq -r '.[]' .github/config/downstream-repos.json); do
+  echo "$repo:"
+  gh run list --repo "$repo" \
+    --workflow enforce-repo-settings.yml --limit 1
+done
+```
+
+**Repository health** — after your task is fully done:
+
+```
+# Open issues
+gh issue list --state open
+
+# Unmerged PRs
+gh pr list --state open
+```
+
+If any open issues or stale PRs are found, report
+them to the user.
+
+## Task Completion
+
+Read `references/task-completion-checklist.md` for the
+full checklist. A task is NOT complete until all items
+are verified.
+
+## Cleanup
+
+Use `/clean_gone` to remove stale branches and
+worktrees proactively. Do not ignore workspace issues
+because they predate your task.
+
+## Rate Limit Management
+
+Read `references/rate-limit-management.md` for the
+full rate limit protocol including consumption zones,
+banned commands, budget estimates, and 403 recovery.
+
+## Rules
+
+- Never push directly to `main`
+- Never force push
+- Every PR must link to an issue
+- Fill out the PR template completely
+- Follow conventional commit messages (`feat:`, `fix:`, `docs:`)
+- Never consider a task complete until post-merge workflows pass

--- a/plugins/f5xc-repo-governance/skills/workflow-lifecycle/references/polling-protocol.md
+++ b/plugins/f5xc-repo-governance/skills/workflow-lifecycle/references/polling-protocol.md
@@ -1,0 +1,34 @@
+# Polling Protocol
+
+Replace all `--watch` patterns with single-shot checks
+in a sleep loop.
+
+## PR Checks
+
+Pass/fail/pending in one call:
+
+```
+gh pr checks <NUMBER> --json bucket \
+  --jq 'map(.bucket) | unique | if . == ["pass"] then "pass"
+  elif any(. == "fail") then "fail" else "pending" end'
+```
+
+## Workflow Run Status
+
+One call per run:
+
+```
+gh run view <RUN-ID> --json status,conclusion \
+  --jq '"\(.status) \(.conclusion)"'
+```
+
+## Loop Rules
+
+- Sleep for the interval defined by the current
+  consumption zone (30s GREEN, 60s YELLOW)
+- Maximum 20 iterations per polling loop — if still
+  pending, report status to user and ask whether to
+  continue
+- Poll all triggered workflows in one iteration before
+  sleeping (batch, not sequential)
+- Re-check rate limit every 5 iterations

--- a/plugins/f5xc-repo-governance/skills/workflow-lifecycle/references/rate-limit-management.md
+++ b/plugins/f5xc-repo-governance/skills/workflow-lifecycle/references/rate-limit-management.md
@@ -1,0 +1,78 @@
+# GitHub API Rate Limit Management
+
+The GitHub REST API allows 5,000 calls per hour.
+Unthrottled polling (`--watch` flags) can consume
+hundreds to thousands of calls per task cycle,
+triggering HTTP 403 errors that block all further
+operations until the hourly window resets.
+
+## Rate Limit Check
+
+Run this before any polling loop or when budget is
+uncertain (costs 1 API call):
+
+```
+gh api rate_limit --jq '{
+  remaining: .rate.remaining,
+  limit: .rate.limit,
+  reset_minutes: ((.rate.reset - now) / 60 | ceil)
+}'
+```
+
+## When to Check
+
+Check rate limits at exactly these 4 points:
+
+1. **Before starting any new task**
+2. **Before entering a polling loop** (merging,
+   post-merge monitoring)
+3. **Before the downstream verification loop**
+4. **After any HTTP 403 or 429 response**
+
+## Consumption Zones
+
+| Zone | Remaining | Poll Interval | Behavior |
+| ---- | --------- | ------------- | -------- |
+| GREEN | >1,000 | 30s | Normal operation |
+| YELLOW | 200-1,000 | 60s | Spot-check 3 downstream repos (first, middle, last); skip redundant verification |
+| RED | <200 | No polling | Stop and report to user; wait for reset if <15 min away |
+
+## Banned Commands
+
+Never use these — they poll every 3-10 seconds and
+consume API calls rapidly:
+
+- `gh pr checks <NUMBER> --watch`
+- `gh run watch <RUN-ID>`
+- `gh run watch <RUN-ID> --exit-status`
+
+## Budget Estimates
+
+Approximate API calls per operation:
+
+| Operation | Calls |
+| --------- | ----- |
+| Rate limit check | 1 |
+| PR checks (single-shot) | 1 |
+| Workflow run status | 1 |
+| PR merge | 1 |
+| Run list (discover workflows) | 1 |
+| Run view (logs) | 1 |
+| Issue view | 1 |
+| Branch protection check | 1 |
+| Downstream repo check (per repo) | 1 |
+| Full polling loop (20 iter, 3 runs) | ~65 |
+| Full task cycle (standard) | ~100 |
+| Full task cycle (governance, 18 repos) | ~150 |
+
+## 403 Recovery Protocol
+
+When an HTTP 403 or 429 response is encountered:
+
+1. Run the rate limit check to extract reset time
+2. Calculate minutes until reset
+3. Report to user: remaining calls, reset time, and
+   what operation was blocked
+4. If reset is <15 minutes away, recommend waiting
+5. If reset is >15 minutes away, stop all `gh`
+   operations and ask user how to proceed

--- a/plugins/f5xc-repo-governance/skills/workflow-lifecycle/references/task-completion-checklist.md
+++ b/plugins/f5xc-repo-governance/skills/workflow-lifecycle/references/task-completion-checklist.md
@@ -1,0 +1,21 @@
+# Task Completion Checklist
+
+A task is **not complete** until ALL of the following
+are true:
+
+- [ ] GitHub issue created and linked to PR
+- [ ] PR merged to `main`
+- [ ] All post-merge workflows completed successfully
+- [ ] GitHub issue is in `closed` state
+- [ ] Outcome verification passed:
+  - Settings applied (if governance changed)
+  - Docs accessible (if docs changed)
+  - Downstream dispatched (if config changed)
+- [ ] Repository health checked (open issues and
+  unmerged PRs reported)
+- [ ] Local branches cleaned up (use `/clean_gone`)
+- [ ] Current branch is `main` with clean working tree
+
+If any post-merge workflow fails due to your changes,
+fix and resubmit. Do not clean up branches until all
+workflows are green.


### PR DESCRIPTION
## Summary

- Add **f5xc-repo-governance** plugin — workflow lifecycle skill with rate limit, polling, and task completion references
- Add **f5xc-docs-pipeline** plugin — pipeline-navigator and content-author skills with config ownership, release chain, and managed files references; plus `/preview-docs` command
- Update marketplace.json with both new plugin entries

## Motivation

Extracts ~470 lines of detailed governance and pipeline instructions from CLAUDE.md into reusable plugins. This enables CLAUDE.md to be reduced to ~80 lines (a thin routing file) while preserving all operational content in plugin skills.

## Test plan

- [ ] Verify plugin directory structure matches existing patterns (f5xc-docs-tools, f5xc-sales-engineer)
- [ ] Verify SKILL.md frontmatter has proper name and description fields
- [ ] Verify marketplace.json is valid JSON with all 4 plugin entries
- [ ] Verify all reference files are properly linked from their parent skills

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)