### PR TITLE
fix: github-ops agent not discoverable due to YAML >- block scalar

### DIFF
--- a/plugins/f5xc-repo-governance/agents/github-ops.md
+++ b/plugins/f5xc-repo-governance/agents/github-ops.md
@@ -1,12 +1,10 @@
 ---
 name: github-ops
-description: >-
+description: |
   Exclusive GitHub operations agent for f5xc-salesdemos repositories —
-  idempotent pre-commit installation, fast lint gate, issue creation,
-  branch naming, commits, PR creation, CI polling, CI error feedback
-  to issues, post-merge monitoring, and branch cleanup. Does NOT edit
-  code — stages and commits changes decided by the calling session,
-  reports errors back for the caller to fix.
+  pre-commit installation, lint gate, issue/branch/commit/PR lifecycle,
+  CI polling, error feedback, and post-merge monitoring. Does NOT edit
+  code — stages, commits, and reports errors back to caller.
 tools:
   - Read
   - Bash
@@ -150,6 +148,7 @@ SKIP=super-linter pre-commit run --files <staged-files>
 ```
 
 This executes:
+
 - Governance check (no-commit-to-branch)
 - Repository-specific local hooks (if present)
 - Large file check (>1024 KB)
@@ -239,7 +238,7 @@ gh pr checks <NUMBER> --json bucket \
 1. Capture failed logs: `gh run view <RUN-ID> --log-failed`
 2. Post failure summary as a comment on the linked **issue**:
 
-```
+````
 gh issue comment <ISSUE-NUMBER> --body "$(cat <<'EOF'
 ## CI Failure Report
 
@@ -259,7 +258,7 @@ gh issue comment <ISSUE-NUMBER> --body "$(cat <<'EOF'
 Fix the issues above and push a new commit to the PR branch.
 EOF
 )"
-```
+````
 
 3. Return a report with `Status: CI_FAILED` including the full
    error context. Do NOT attempt to fix the code.


### PR DESCRIPTION
## Summary

- Changed YAML frontmatter `description` from `>-` (folded block scalar) to `|` (literal block scalar) in `github-ops` agent definition
- Fixed MD031/MD032 markdown lint errors in the agent file (blank lines around lists and nested code fences)

## Root Cause

Claude Code's agent parser does not support `>-` in YAML frontmatter. All working agents across every plugin use either single-line descriptions or `|` (literal block). The `github-ops` agent was the only one using `>-`, causing it to not appear in the available agents list.

## Test plan

- [ ] After publishing, verify `f5xc-repo-governance:github-ops` appears in the available agents list
- [ ] Test delegation: `Agent(subagent_type="f5xc-repo-governance:github-ops", prompt="...")`
- [ ] Confirm agent installs pre-commit and runs lint gate as expected

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)