### PR TITLE
fix: bump f5xc-repo-governance to v1.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "f5xc-repo-governance",
       "description": "Repository governance workflow — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, and autonomous workflow operations agent",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-repo-governance** bumped to v1.3.1
+
 ## [1.0.0] - 2025-06-01
 
 ### Added

--- a/plugins/f5xc-repo-governance/.claude-plugin/plugin.json
+++ b/plugins/f5xc-repo-governance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-repo-governance",
   "description": "Repository governance workflow for f5xc-salesdemos — issue-driven development, pre-commit lint gate, PR lifecycle, CI polling with error feedback to issues, post-merge monitoring, verification, rate limit management, and exclusive github-ops agent for all Git operations",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "hooks": "../hooks/hooks.json",
   "author": {
     "name": "f5xc-salesdemos",


### PR DESCRIPTION
## Summary
- Bumps f5xc-repo-governance plugin from v1.3.0 to v1.3.1
- PR #87 merged a fix to the github-ops agent (literal block scalar for discoverability) but did not include a version bump
- The release workflow only publishes when `marketplace.json` has a version change, so v1.3.1 was never created

## Test plan
- [ ] CI passes (lint, validation)
- [ ] Release workflow creates `f5xc-repo-governance/v1.3.1` tag and release after merge

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)