### PR TITLE
fix: use single-line description for github-ops agent discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "f5xc-repo-governance",
       "description": "Repository governance workflow — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, and autonomous workflow operations agent",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-repo-governance** bumped to v1.3.2
+
 - **f5xc-repo-governance** bumped to v1.3.1
 
 ## [1.0.0] - 2025-06-01

--- a/plugins/f5xc-repo-governance/.claude-plugin/plugin.json
+++ b/plugins/f5xc-repo-governance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-repo-governance",
   "description": "Repository governance workflow for f5xc-salesdemos — issue-driven development, pre-commit lint gate, PR lifecycle, CI polling with error feedback to issues, post-merge monitoring, verification, rate limit management, and exclusive github-ops agent for all Git operations",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "hooks": "../hooks/hooks.json",
   "author": {
     "name": "f5xc-salesdemos",

--- a/plugins/f5xc-repo-governance/agents/github-ops.md
+++ b/plugins/f5xc-repo-governance/agents/github-ops.md
@@ -1,10 +1,6 @@
 ---
 name: github-ops
-description: |
-  Exclusive GitHub operations agent for f5xc-salesdemos repositories —
-  pre-commit installation, lint gate, issue/branch/commit/PR lifecycle,
-  CI polling, error feedback, and post-merge monitoring. Does NOT edit
-  code — stages, commits, and reports errors back to caller.
+description: Exclusive GitHub operations agent for f5xc-salesdemos repositories — pre-commit installation, lint gate, issue/branch/commit/PR lifecycle, CI polling, error feedback, and post-merge monitoring
 tools:
   - Read
   - Bash


### PR DESCRIPTION
## Summary
- Claude Code agent discovery requires single-line YAML description values
- The multiline `|` block scalar in github-ops prevented it from appearing in available agents
- Both working agents (demo-housekeeping, demo-researcher) use single-line descriptions
- Collapses the description to a single line and bumps to v1.3.2

## Test plan
- [ ] CI passes
- [ ] After plugin update, `f5xc-repo-governance:github-ops` appears in available agents list in a new session

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)