### PR TITLE
fix: remove hooks field from plugin.json for auto-discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "f5xc-repo-governance",
       "description": "Repository governance workflow — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, and autonomous workflow operations agent",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-repo-governance** bumped to v1.3.3
+
 - **f5xc-repo-governance** bumped to v1.3.2
 
 - **f5xc-repo-governance** bumped to v1.3.1

--- a/plugins/f5xc-repo-governance/.claude-plugin/plugin.json
+++ b/plugins/f5xc-repo-governance/.claude-plugin/plugin.json
@@ -1,8 +1,7 @@
 {
   "name": "f5xc-repo-governance",
   "description": "Repository governance workflow for f5xc-salesdemos — issue-driven development, pre-commit lint gate, PR lifecycle, CI polling with error feedback to issues, post-merge monitoring, verification, rate limit management, and exclusive github-ops agent for all Git operations",
-  "version": "1.3.2",
-  "hooks": "../hooks/hooks.json",
+  "version": "1.3.3",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"


### PR DESCRIPTION
## Summary
- Removes `"hooks": "../hooks/hooks.json"` from plugin.json
- All working plugins with hooks (hookify, ralph-loop, security-guidance) rely on auto-discovery from `hooks/hooks.json` — none reference hooks in plugin.json
- The unrecognized field may prevent plugin loading and agent registration, explaining why github-ops was never discoverable
- Bumps to v1.3.3

## Test plan
- [ ] CI passes
- [ ] In a new session, `f5xc-repo-governance:github-ops` appears in available agents
- [ ] Hooks still fire on Bash tool use (auto-discovery from hooks/hooks.json)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)