### PR TITLE
refactor: standardize demo content path and trim Convention Files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,7 +28,7 @@
     {
       "name": "f5xc-sales-engineer",
       "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,18 +26,6 @@ follow its instructions exactly**.
 4. **Read convention files** — skills read product-specific content
    from standardized files in the repository root
 
-## Convention Files
-
-Skills read product-specific content from these repo-local files:
-
-| File | Purpose | Required By |
-| ---- | ------- | ----------- |
-| `PRODUCT_EXPERTISE.md` | Product capabilities, detection signals, threat coverage, compliance alignment, API reference | All skills |
-| `WALKTHROUGH_CONFIG.md` | Demo app URL, walkthrough order, detection timing | presenter |
-| `SOURCE_INDEX.md` | Research source catalog for demo-researcher agent | demo-executor (Q&A), subject-matter-expert |
-| `READINESS_MATRIX.md` | Required/optional variables, readiness checks (T0–T5), API endpoints | demo-executor (Prepare/Teardown) |
-| `docs/api-automation/` | Phase files with cURL commands and evidence gates | demo-executor (Execute) |
-
 ## Ambiguous Intent
 
 If the user's request relates to the demo but does not clearly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-sales-engineer** bumped to v1.0.2
+
 - **f5xc-sales-engineer** bumped to v1.0.1
 
 - **f5xc-repo-governance** renamed to **f5xc-github-ops** v2.0.0 —

--- a/docs/plugins/f5xc-sales-engineer.mdx
+++ b/docs/plugins/f5xc-sales-engineer.mdx
@@ -33,7 +33,7 @@ API-driven demo execution with a four-stage meeting lifecycle:
 4. **Teardown** — post-meeting cleanup via `demo-housekeeping` agent
 
 Reads product-specific content from `PRODUCT_EXPERTISE.md` and demo
-commands from `docs/api-automation/`.
+commands from `docs/demo/`.
 
 ### presenter
 
@@ -60,7 +60,7 @@ specific trigger phrase.
 Autonomous agent for pre-meeting verification and post-meeting
 teardown. Runs the Readiness Verification Matrix (T0–T5) defined
 in `READINESS_MATRIX.md` and executes teardown commands from
-`docs/api-automation/phase-4-teardown.mdx`.
+`docs/demo/phase-4-teardown.mdx`.
 
 ### demo-researcher
 
@@ -83,7 +83,7 @@ Create these files in your repository root to configure the plugin:
 | `WALKTHROUGH_CONFIG.md` | Demo app URL, walkthrough order, detection timing | presenter |
 | `SOURCE_INDEX.md` | Research source catalog with local docs and external URLs | demo-researcher |
 | `READINESS_MATRIX.md` | Required/optional variables, readiness checks (T0–T5), API endpoints | demo-housekeeping |
-| `docs/api-automation/` | Phase files with cURL commands and evidence gates | demo-executor |
+| `docs/demo/` | Phase files with cURL commands and evidence gates | demo-executor |
 
 ## Trigger Phrases
 

--- a/plugins/f5xc-sales-engineer/.claude-plugin/plugin.json
+++ b/plugins/f5xc-sales-engineer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-sales-engineer",
   "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-sales-engineer/README.md
+++ b/plugins/f5xc-sales-engineer/README.md
@@ -60,7 +60,7 @@ for your product:
 | `WALKTHROUGH_CONFIG.md` | Demo app URL, walkthrough order, timing | For presenter |
 | `SOURCE_INDEX.md` | Research source catalog (local docs + external) | For Q&A |
 | `READINESS_MATRIX.md` | Required/optional variables, readiness checks | For demo-ops |
-| `docs/api-automation/` | Phase files with cURL commands | For demo-executor |
+| `docs/demo/` | Phase files with cURL commands | For demo-executor |
 
 ## Trigger Phrases
 

--- a/plugins/f5xc-sales-engineer/agents/demo-housekeeping.md
+++ b/plugins/f5xc-sales-engineer/agents/demo-housekeeping.md
@@ -80,7 +80,7 @@ blocks later tiers.
 
 Read `READINESS_MATRIX.md` for tier behavior rules (which tiers
 block, PASS/FAIL criteria, skip conditions). Read the executable
-commands from `docs/api-automation/index.mdx` — the "Readiness
+commands from `docs/demo/index.mdx` — the "Readiness
 Verification Matrix" section contains the exact Bash commands with
 deterministic jq filters for every check.
 
@@ -108,7 +108,7 @@ interpret raw HTTP codes or response fields yourself.
   routable.
 - **T4: Environment Clean** — Check for leftover demo objects. If
   found, auto-teardown by reading and executing commands from
-  `docs/api-automation/phase-4-teardown.mdx`, then re-check.
+  `docs/demo/phase-4-teardown.mdx`, then re-check.
 - **T5: Additional Checks** — Product-specific extras. INFO only.
 
 ### Step 4: Return Readiness Report
@@ -123,7 +123,7 @@ before spawning this agent — do not ask for confirmation again.
 
 1. **Resolve variables** — follow the Variable Resolution Protocol
    (same as Prepare). Stop if required variables are missing.
-2. **Execute Phase 4** — read `docs/api-automation/phase-4-teardown.mdx`
+2. **Execute Phase 4** — read `docs/demo/phase-4-teardown.mdx`
    and execute all delete commands in the documented order.
 3. **Verify clean state** — run the pre-flight checks from
    `READINESS_MATRIX.md` (T4 tier) to confirm all objects are deleted.
@@ -200,14 +200,14 @@ show `***` instead to avoid leaking credentials.
 ## Execution Rules
 
 - **Normal mode only** — copy and execute the exact fenced code blocks
-  from `docs/api-automation/index.mdx` and phase files. Do not
+  from `docs/demo/index.mdx` and phase files. Do not
   construct your own cURL, jq, or shell commands — the documented
   commands contain validated field paths and deterministic jq filters.
   Substitute only `xPLACEHOLDERx` tokens with resolved variable values.
 - **Read phase files at runtime** — use `READINESS_MATRIX.md` for
-  tier behavior rules, `docs/api-automation/index.mdx` for readiness
+  tier behavior rules, `docs/demo/index.mdx` for readiness
   check commands (Readiness Verification Matrix section), and
-  `docs/api-automation/phase-4-teardown.mdx` for teardown commands.
+  `docs/demo/phase-4-teardown.mdx` for teardown commands.
 - **If a command fails** — report the failure in the structured report
   with the HTTP status, response body, and which step failed. Set
   status to FAILED and stop. Do **not** enter Debug mode — that is the

--- a/plugins/f5xc-sales-engineer/skills/demo-executor/SKILL.md
+++ b/plugins/f5xc-sales-engineer/skills/demo-executor/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   says "run the demo", "execute the demo", "start the demo", "API demo",
   "Q&A", "question and answer", "debrief", or "lessons learned". Reads
   product-specific content from PRODUCT_EXPERTISE.md and demo commands
-  from docs/api-automation/.
+  from docs/demo/.
 ---
 
 # API-Driven Demo Execution
@@ -32,16 +32,16 @@ explanations and showing proof/verification evidence after every action.
 1. **`PRODUCT_EXPERTISE.md`** (repo root) — product capabilities,
    detection signals, threat coverage, compliance alignment, API
    reference. This replaces inline product expertise.
-2. **`docs/api-automation/index.mdx`** — execution protocol, variable
+2. **`docs/demo/index.mdx`** — execution protocol, variable
    resolution, evidence gates, error handling
 
 ## Execution Protocol
 
 The complete execution protocol — variable resolution, phase
 instructions, evidence gates, error handling, and troubleshooting —
-is defined in `docs/api-automation/`.
+is defined in `docs/demo/`.
 
-**Read `docs/api-automation/index.mdx` before executing any phase.**
+**Read `docs/demo/index.mdx` before executing any phase.**
 That document is the single source of truth for all deterministic
 demo steps. **In normal execution, use only the commands documented
 in the phase files and pre-flight section** — do not construct API
@@ -52,14 +52,14 @@ documentation so the fix becomes deterministic for future runs. The
 phase files contain every cURL command, jq filter, evidence table,
 and PASS/FAIL gate needed for the complete demo:
 
-- `docs/api-automation/phase-1-build.mdx` — Build
-- `docs/api-automation/phase-2-attack.mdx` — Attack
-- `docs/api-automation/phase-3-mitigate.mdx` — Mitigate
+- `docs/demo/phase-1-build.mdx` — Build
+- `docs/demo/phase-2-attack.mdx` — Attack
+- `docs/demo/phase-3-mitigate.mdx` — Mitigate
 
 ## Variable Resolution
 
 Resolve variables from `.env` and shell environment at the start of
-each stage. Read `docs/api-automation/index.mdx` for the full
+each stage. Read `docs/demo/index.mdx` for the full
 variable resolution protocol. If any required variable is missing,
 report to the operator and stop.
 
@@ -252,5 +252,5 @@ chrome-devtools MCP tools:
 ## Error Handling
 
 Follow the error handling and troubleshooting patterns documented in
-`docs/api-automation/index.mdx`. Use diagnostics test case IDs for
+`docs/demo/index.mdx`. Use diagnostics test case IDs for
 systematic verification.

--- a/plugins/f5xc-sales-engineer/skills/demo-ops/SKILL.md
+++ b/plugins/f5xc-sales-engineer/skills/demo-ops/SKILL.md
@@ -43,7 +43,7 @@ demo", "is the demo environment ready", "is the demo ready",
 
 Run before the meeting starts to verify everything works. This stage
 runs the full **Readiness Verification Matrix** defined in
-`docs/api-automation/index.mdx` and `READINESS_MATRIX.md`. It is
+`docs/demo/index.mdx` and `READINESS_MATRIX.md`. It is
 delegated to the `demo-housekeeping` subagent to preserve main
 session context for the live demo.
 

--- a/plugins/f5xc-sales-engineer/skills/sales-engineer/SKILL.md
+++ b/plugins/f5xc-sales-engineer/skills/sales-engineer/SKILL.md
@@ -48,7 +48,7 @@ Each repository has two distinct documentation types:
 - **As-Built Reference** (`docs/*.mdx`) — static, screenshot-illustrated
   pages documenting the pre-configured demo environment
 
-- **API Automation Exercise** (`docs/api-automation/`) — AI-executable
+- **API Automation Exercise** (`docs/demo/`) — AI-executable
   provisioning instructions with ready-to-run cURL commands and
   evidence-based PASS/FAIL validation
 


### PR DESCRIPTION
## Summary

- Standardize demo content path from `docs/api-automation/` to `docs/demo/` across all f5xc-sales-engineer plugin files
- Remove redundant Convention Files section from `.claude/CLAUDE.md` (content repos define their own convention files)
- Fix Biome formatting in JSON plugin manifests

Closes #100

## Test plan

- [ ] CI checks pass
- [ ] Plugin references resolve correctly with new `docs/demo/` path convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)