### PR TITLE
refactor: update convention file references to use DEMO_ prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,7 +28,7 @@
     {
       "name": "f5xc-sales-engineer",
       "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-sales-engineer** bumped to v1.0.3
+
 - **f5xc-sales-engineer** bumped to v1.0.2
 
 - **f5xc-sales-engineer** bumped to v1.0.1

--- a/docs/plugins/f5xc-sales-engineer.mdx
+++ b/docs/plugins/f5xc-sales-engineer.mdx
@@ -32,14 +32,14 @@ API-driven demo execution with a four-stage meeting lifecycle:
 3. **Q&A** — improvisational mode with live environment
 4. **Teardown** — post-meeting cleanup via `demo-housekeeping` agent
 
-Reads product-specific content from `PRODUCT_EXPERTISE.md` and demo
+Reads product-specific content from `DEMO_PRODUCT_EXPERTISE.md` and demo
 commands from `docs/demo/`.
 
 ### presenter
 
 As-built walkthrough presentation using a pre-configured demo
 environment. Follows a show → narrate → connect → pause pattern at
-each step. Reads walkthrough order from `WALKTHROUGH_CONFIG.md`.
+each step. Reads walkthrough order from `DEMO_WALKTHROUGH_CONFIG.md`.
 
 ### subject-matter-expert
 
@@ -59,14 +59,14 @@ specific trigger phrase.
 
 Autonomous agent for pre-meeting verification and post-meeting
 teardown. Runs the Readiness Verification Matrix (T0–T5) defined
-in `READINESS_MATRIX.md` and executes teardown commands from
+in `DEMO_READINESS_MATRIX.md` and executes teardown commands from
 `docs/demo/phase-4-teardown.mdx`.
 
 ### demo-researcher
 
 Read-only research librarian that finds verified answers with
 citations. Searches local `docs/` first, then indexed external
-sources from `SOURCE_INDEX.md`, with WebSearch as fallback.
+sources from `DEMO_SOURCE_INDEX.md`, with WebSearch as fallback.
 
 ## Convention Files
 
@@ -79,10 +79,10 @@ Create these files in your repository root to configure the plugin:
 
 | File | Purpose | Required For |
 | ---- | ------- | ------------ |
-| `PRODUCT_EXPERTISE.md` | Product capabilities, detection signals, threat coverage, compliance alignment, API reference | All skills |
-| `WALKTHROUGH_CONFIG.md` | Demo app URL, walkthrough order, detection timing | presenter |
-| `SOURCE_INDEX.md` | Research source catalog with local docs and external URLs | demo-researcher |
-| `READINESS_MATRIX.md` | Required/optional variables, readiness checks (T0–T5), API endpoints | demo-housekeeping |
+| `DEMO_PRODUCT_EXPERTISE.md` | Product capabilities, detection signals, threat coverage, compliance alignment, API reference | All skills |
+| `DEMO_WALKTHROUGH_CONFIG.md` | Demo app URL, walkthrough order, detection timing | presenter |
+| `DEMO_SOURCE_INDEX.md` | Research source catalog with local docs and external URLs | demo-researcher |
+| `DEMO_READINESS_MATRIX.md` | Required/optional variables, readiness checks (T0–T5), API endpoints | demo-housekeeping |
 | `docs/demo/` | Phase files with cURL commands and evidence gates | demo-executor |
 
 ## Trigger Phrases

--- a/plugins/f5xc-sales-engineer/.claude-plugin/plugin.json
+++ b/plugins/f5xc-sales-engineer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-sales-engineer",
   "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-sales-engineer/README.md
+++ b/plugins/f5xc-sales-engineer/README.md
@@ -56,10 +56,10 @@ for your product:
 
 | File | Purpose | Required |
 | --- | --- | --- |
-| `PRODUCT_EXPERTISE.md` | Product capabilities, API reference | Yes |
-| `WALKTHROUGH_CONFIG.md` | Demo app URL, walkthrough order, timing | For presenter |
-| `SOURCE_INDEX.md` | Research source catalog (local docs + external) | For Q&A |
-| `READINESS_MATRIX.md` | Required/optional variables, readiness checks | For demo-ops |
+| `DEMO_PRODUCT_EXPERTISE.md` | Product capabilities, API reference | Yes |
+| `DEMO_WALKTHROUGH_CONFIG.md` | Demo app URL, walkthrough order, timing | For presenter |
+| `DEMO_SOURCE_INDEX.md` | Research source catalog (local docs + external) | For Q&A |
+| `DEMO_READINESS_MATRIX.md` | Required/optional variables, readiness checks | For demo-ops |
 | `docs/demo/` | Phase files with cURL commands | For demo-executor |
 
 ## Trigger Phrases

--- a/plugins/f5xc-sales-engineer/agents/demo-housekeeping.md
+++ b/plugins/f5xc-sales-engineer/agents/demo-housekeeping.md
@@ -26,7 +26,7 @@ and return a structured report.
 
 ## Initialization
 
-**Before any operation**, read `READINESS_MATRIX.md` from the
+**Before any operation**, read `DEMO_READINESS_MATRIX.md` from the
 repository root. This file defines:
 
 - Required and optional variables (names, defaults, placeholders)
@@ -43,7 +43,7 @@ that provides a non-placeholder value:
 2. **Check shell environment** — run `env | grep F5XC_` to find any
    values already exported in the current session.
 3. **Identify missing values** — compare resolved values against the
-   required/optional table in `READINESS_MATRIX.md`. A value is
+   required/optional table in `DEMO_READINESS_MATRIX.md`. A value is
    "missing" if it is absent, empty, or still set to a placeholder
    default (e.g., `example-api-token`, `example-tenant`,
    `example-namespace`, `app.example.com`, `user@example.com`).
@@ -51,7 +51,7 @@ that provides a non-placeholder value:
    variable cannot be resolved, report what is missing and stop. Do not
    prompt the operator (the main session handles that).
 5. **Apply defaults** — for each missing optional variable, use the
-   default from the `READINESS_MATRIX.md` table.
+   default from the `DEMO_READINESS_MATRIX.md` table.
 6. **Display the resolved variable table** — show the final values for
    the record, then proceed immediately (no wait for approval during
    Prepare).
@@ -78,7 +78,7 @@ Run `git pull` to ensure the latest documentation is available.
 Execute the tiered checks sequentially — a FAIL in an earlier tier
 blocks later tiers.
 
-Read `READINESS_MATRIX.md` for tier behavior rules (which tiers
+Read `DEMO_READINESS_MATRIX.md` for tier behavior rules (which tiers
 block, PASS/FAIL criteria, skip conditions). Read the executable
 commands from `docs/demo/index.mdx` — the "Readiness
 Verification Matrix" section contains the exact Bash commands with
@@ -126,7 +126,7 @@ before spawning this agent — do not ask for confirmation again.
 2. **Execute Phase 4** — read `docs/demo/phase-4-teardown.mdx`
    and execute all delete commands in the documented order.
 3. **Verify clean state** — run the pre-flight checks from
-   `READINESS_MATRIX.md` (T4 tier) to confirm all objects are deleted.
+   `DEMO_READINESS_MATRIX.md` (T4 tier) to confirm all objects are deleted.
 4. **Return cleanup report** — output the structured report per the
    Output Contract below.
 
@@ -145,19 +145,19 @@ format. Prepare uses the full readiness format.
 ## Resolved Variables
 | Variable | Value |
 |---|---|
-| (from READINESS_MATRIX.md variable table) |
+| (from DEMO_READINESS_MATRIX.md variable table) |
 
 ### T0: Connectivity & Auth
 | Check | Result | Status |
 |---|---|---|
-| (checks from READINESS_MATRIX.md T0 section) |
+| (checks from DEMO_READINESS_MATRIX.md T0 section) |
 
 ### T1: Quotas & Capacity
 | Check | Result | Status |
 |---|---|---|
-| (checks from READINESS_MATRIX.md T1 section) |
+| (checks from DEMO_READINESS_MATRIX.md T1 section) |
 
-(continue for each tier defined in READINESS_MATRIX.md)
+(continue for each tier defined in DEMO_READINESS_MATRIX.md)
 
 ### Warnings
 - (list any WARN or INFO items with context and remediation)
@@ -179,7 +179,7 @@ format. Prepare uses the full readiness format.
 ## Post-Teardown Verification
 | Object | HTTP Status |
 |---|---|
-| (verification checks from READINESS_MATRIX.md T4) |
+| (verification checks from DEMO_READINESS_MATRIX.md T4) |
 
 ## Warnings (if any)
 - (list any non-blocking issues encountered)
@@ -204,7 +204,7 @@ show `***` instead to avoid leaking credentials.
   construct your own cURL, jq, or shell commands — the documented
   commands contain validated field paths and deterministic jq filters.
   Substitute only `xPLACEHOLDERx` tokens with resolved variable values.
-- **Read phase files at runtime** — use `READINESS_MATRIX.md` for
+- **Read phase files at runtime** — use `DEMO_READINESS_MATRIX.md` for
   tier behavior rules, `docs/demo/index.mdx` for readiness
   check commands (Readiness Verification Matrix section), and
   `docs/demo/phase-4-teardown.mdx` for teardown commands.

--- a/plugins/f5xc-sales-engineer/agents/demo-researcher.md
+++ b/plugins/f5xc-sales-engineer/agents/demo-researcher.md
@@ -33,7 +33,7 @@ find, verify, and report answers with citations — nothing else.
 
 ## Initialization
 
-**Before researching**, read `SOURCE_INDEX.md` from the repository
+**Before researching**, read `DEMO_SOURCE_INDEX.md` from the repository
 root. This file defines:
 
 - Local Knowledge Base — docs files and their topics
@@ -49,7 +49,7 @@ Follow these steps in order for every research question:
 ### Step 1 — Classify the question
 
 Identify the topic and match it to source categories using the
-topic tags in `SOURCE_INDEX.md`. Determine which sources are most
+topic tags in `DEMO_SOURCE_INDEX.md`. Determine which sources are most
 likely to contain the answer. Use the Question Routing Guide if the
 question matches a documented pattern.
 

--- a/plugins/f5xc-sales-engineer/skills/demo-executor/SKILL.md
+++ b/plugins/f5xc-sales-engineer/skills/demo-executor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Three-stage demo lifecycle (Execute, Q&A, Debrief). Use when the user
   says "run the demo", "execute the demo", "start the demo", "API demo",
   "Q&A", "question and answer", "debrief", or "lessons learned". Reads
-  product-specific content from PRODUCT_EXPERTISE.md and demo commands
+  product-specific content from DEMO_PRODUCT_EXPERTISE.md and demo commands
   from docs/demo/.
 ---
 
@@ -29,7 +29,7 @@ explanations and showing proof/verification evidence after every action.
 
 **Before any stage**, read these files:
 
-1. **`PRODUCT_EXPERTISE.md`** (repo root) — product capabilities,
+1. **`DEMO_PRODUCT_EXPERTISE.md`** (repo root) — product capabilities,
    detection signals, threat coverage, compliance alignment, API
    reference. This replaces inline product expertise.
 2. **`docs/demo/index.mdx`** — execution protocol, variable
@@ -79,7 +79,7 @@ Normal or Debug mode.
 **Sequence:**
 
 1. **Introduction** — introduce yourself as an F5 Sales Engineer,
-   state the demo's outcome goals (read from `PRODUCT_EXPERTISE.md`
+   state the demo's outcome goals (read from `DEMO_PRODUCT_EXPERTISE.md`
    to tailor the introduction to this product's value proposition)
 2. **Demo phases** — execute Phases 1–3 following the existing
    deterministic protocol (variable resolution, evidence display,
@@ -104,7 +104,7 @@ improvisational behavior is explicitly allowed.
   diagnostic commands, navigating to unscripted pages, and modifying
   the demo environment to illustrate answers are all permitted
 - **Self-contained** — use the product expertise from
-  `PRODUCT_EXPERTISE.md` as the knowledge base
+  `DEMO_PRODUCT_EXPERTISE.md` as the knowledge base
 - **Audience prompt** — open with: "We'd love to hear your questions.
   And if I may ask — have you been experiencing any challenges with
   [product-relevant concern] on your properties?"
@@ -116,7 +116,7 @@ improvisational behavior is explicitly allowed.
 
 **Research delegation:**
 
-When a question cannot be answered from `PRODUCT_EXPERTISE.md` or
+When a question cannot be answered from `DEMO_PRODUCT_EXPERTISE.md` or
 the local `docs/` knowledge base, spawn the `demo-researcher`
 subagent with the research question. Wait for the structured report,
 then relay the findings to the audience in your own persona voice —
@@ -139,7 +139,7 @@ and demo materials.
    confidently, which required research delegation, and which
    revealed gaps
 2. **Categorize findings** into:
-   - **Knowledge gaps** — topics not covered in `PRODUCT_EXPERTISE.md`
+   - **Knowledge gaps** — topics not covered in `DEMO_PRODUCT_EXPERTISE.md`
      or `docs/` that audience members asked about
    - **Narration improvements** — phases where explanations could be
      stronger, evidence more compelling, or pacing better
@@ -148,13 +148,13 @@ and demo materials.
    - **Documentation corrections** — any inaccuracies discovered
      during Q&A or live demo execution
    - **Source gaps** — external references or documentation that
-     should be added to `SOURCE_INDEX.md`
+     should be added to `DEMO_SOURCE_INDEX.md`
 3. **Draft concrete improvements** — for each finding, propose a
    specific change:
-   - Additions or edits to `PRODUCT_EXPERTISE.md`
+   - Additions or edits to `DEMO_PRODUCT_EXPERTISE.md`
    - Narration text improvements for phase files
-   - New entries for `SOURCE_INDEX.md`
-   - New walkthrough stops for `WALKTHROUGH_CONFIG.md`
+   - New entries for `DEMO_SOURCE_INDEX.md`
+   - New walkthrough stops for `DEMO_WALKTHROUGH_CONFIG.md`
 4. **Output the Debrief Report** — structured report with all
    categories, specific file references, and proposed changes
 
@@ -165,8 +165,8 @@ handle issue creation, branching, PRs, CI polling, and merging.
 
 **Graceful fallback:** If no Q&A session is found in the current
 context (e.g., debrief triggered in a new conversation), note this
-and offer to review `PRODUCT_EXPERTISE.md`, phase files, and
-`SOURCE_INDEX.md` for general improvement opportunities instead.
+and offer to review `DEMO_PRODUCT_EXPERTISE.md`, phase files, and
+`DEMO_SOURCE_INDEX.md` for general improvement opportunities instead.
 
 **Debrief Report format:**
 
@@ -182,7 +182,7 @@ and offer to review `PRODUCT_EXPERTISE.md`, phase files, and
 ### Knowledge Gaps
 | Topic | Source File | Proposed Addition |
 |-------|-----------|-------------------|
-| <topic> | PRODUCT_EXPERTISE.md | <draft text> |
+| <topic> | DEMO_PRODUCT_EXPERTISE.md | <draft text> |
 
 ### Narration Improvements
 | Phase | Section | Current | Proposed |
@@ -200,7 +200,7 @@ and offer to review `PRODUCT_EXPERTISE.md`, phase files, and
 | <file> | <what's wrong> | <correction> |
 
 ### Source Gaps
-| Topic | Recommended Source | For SOURCE_INDEX.md |
+| Topic | Recommended Source | For DEMO_SOURCE_INDEX.md |
 |-------|-------------------|---------------------|
 | <topic> | <url or reference> | <catalog entry> |
 ```
@@ -222,7 +222,7 @@ audience can see on screen, and always tied to a customer concern.
   _What is this?_, _Why does it matter?_, or _What should I do about
   it?_
 - **Name the signal** — explicitly call out which detection signal
-  or capability (from `PRODUCT_EXPERTISE.md`) is at work
+  or capability (from `DEMO_PRODUCT_EXPERTISE.md`) is at work
 - **Compliance hook when relevant** — mention compliance alignment
   if the current step directly supports it; do not force it every time
 - **Invite engagement** — end with a short rhetorical invitation: "Any

--- a/plugins/f5xc-sales-engineer/skills/demo-ops/SKILL.md
+++ b/plugins/f5xc-sales-engineer/skills/demo-ops/SKILL.md
@@ -27,9 +27,9 @@ cleaned up after.
 
 **Before any stage**, read these files:
 
-1. **`READINESS_MATRIX.md`** (repo root) — required/optional variables,
+1. **`DEMO_READINESS_MATRIX.md`** (repo root) — required/optional variables,
    readiness verification checks (T0–T5), API endpoints
-2. **`PRODUCT_EXPERTISE.md`** (repo root) — product name only, for
+2. **`DEMO_PRODUCT_EXPERTISE.md`** (repo root) — product name only, for
    operator-facing messages
 
 ## Stages
@@ -43,7 +43,7 @@ demo", "is the demo environment ready", "is the demo ready",
 
 Run before the meeting starts to verify everything works. This stage
 runs the full **Readiness Verification Matrix** defined in
-`docs/demo/index.mdx` and `READINESS_MATRIX.md`. It is
+`docs/demo/index.mdx` and `DEMO_READINESS_MATRIX.md`. It is
 delegated to the `demo-housekeeping` subagent to preserve main
 session context for the live demo.
 

--- a/plugins/f5xc-sales-engineer/skills/presenter/SKILL.md
+++ b/plugins/f5xc-sales-engineer/skills/presenter/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   As-built walkthrough presentation using pre-configured demo environment.
   Use when the user says "walk through the demo", "present the demo",
   "show the demo", or "walkthrough". Reads walkthrough order from
-  WALKTHROUGH_CONFIG.md and product expertise from PRODUCT_EXPERTISE.md.
+  DEMO_WALKTHROUGH_CONFIG.md and product expertise from DEMO_PRODUCT_EXPERTISE.md.
 ---
 
 # As-Built Walkthrough Presentation
@@ -28,19 +28,19 @@ your visual guide.
 
 **Before starting the walkthrough**, read these files:
 
-1. **`PRODUCT_EXPERTISE.md`** (repo root) — product capabilities,
+1. **`DEMO_PRODUCT_EXPERTISE.md`** (repo root) — product capabilities,
    detection signals, threat coverage, compliance alignment. This
    is your inline expertise for narration.
-2. **`WALKTHROUGH_CONFIG.md`** (repo root) — demo app URL, walkthrough
+2. **`DEMO_WALKTHROUGH_CONFIG.md`** (repo root) — demo app URL, walkthrough
    order, attack simulation instructions, detection timing.
 
 ## Demo App
 
-Read the demo app URL from `WALKTHROUGH_CONFIG.md`.
+Read the demo app URL from `DEMO_WALKTHROUGH_CONFIG.md`.
 
 ## Walkthrough Order
 
-Read the walkthrough sequence from `WALKTHROUGH_CONFIG.md`. At each
+Read the walkthrough sequence from `DEMO_WALKTHROUGH_CONFIG.md`. At each
 step: **(1) show the screen**, **(2) narrate what we're looking at in
 plain language**, **(3) connect it to the customer's concern**,
 **(4) pause for questions** before moving on.
@@ -63,7 +63,7 @@ concern.
   *What is this?*, *Why does it matter?*, or *What should I do about
   it?*
 - **Name the signal** — explicitly call out which detection signal
-  or capability (from `PRODUCT_EXPERTISE.md`) is at work
+  or capability (from `DEMO_PRODUCT_EXPERTISE.md`) is at work
 - **Compliance hook when relevant** — mention compliance alignment
   if the current step directly supports it; do not force it every time
 - **Invite engagement** — end with a short rhetorical invitation: "Any
@@ -89,7 +89,7 @@ concern.
 
 ## Attack Simulation
 
-Read attack simulation instructions from `WALKTHROUGH_CONFIG.md`.
+Read attack simulation instructions from `DEMO_WALKTHROUGH_CONFIG.md`.
 Follow the documented procedure for triggering detections, including
 any timing expectations for when results appear.
 

--- a/plugins/f5xc-sales-engineer/skills/sales-engineer/SKILL.md
+++ b/plugins/f5xc-sales-engineer/skills/sales-engineer/SKILL.md
@@ -15,7 +15,7 @@ It determines which task-specific persona to activate based on user intent.
 
 ## Initialization
 
-Read `PRODUCT_EXPERTISE.md` from the repository root to identify the
+Read `DEMO_PRODUCT_EXPERTISE.md` from the repository root to identify the
 product name and context for this repository.
 
 ## Roles
@@ -29,7 +29,7 @@ product name and context for this repository.
 
 ## Routing Logic
 
-1. Read `PRODUCT_EXPERTISE.md` to understand the product context
+1. Read `DEMO_PRODUCT_EXPERTISE.md` to understand the product context
 2. Evaluate the user's request against the trigger phrases in
    `.claude/CLAUDE.md`
 3. Invoke the matching skill

--- a/plugins/f5xc-sales-engineer/skills/subject-matter-expert/SKILL.md
+++ b/plugins/f5xc-sales-engineer/skills/subject-matter-expert/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   F5 XC product capabilities, compliance alignment, threat coverage,
   and platform operations. Use when the user says "answer questions",
   "question about", "explain", "what does", or asks technical product
-  questions. Reads product expertise from PRODUCT_EXPERTISE.md.
+  questions. Reads product expertise from DEMO_PRODUCT_EXPERTISE.md.
 ---
 
 # Subject Matter Expert
@@ -18,7 +18,7 @@ capabilities, compliance alignment, threat coverage, and F5 XC
 platform operations. You never guess — every answer includes a
 reference or proof.
 
-- Draw answers from `PRODUCT_EXPERTISE.md` and the `docs/` knowledge
+- Draw answers from `DEMO_PRODUCT_EXPERTISE.md` and the `docs/` knowledge
   base
 - Be precise about what the product **can and cannot do** — never
   overstate capabilities; honest expectations build trust
@@ -28,7 +28,7 @@ reference or proof.
 
 **Before answering any questions**, read:
 
-1. **`PRODUCT_EXPERTISE.md`** (repo root) — product capabilities,
+1. **`DEMO_PRODUCT_EXPERTISE.md`** (repo root) — product capabilities,
    detection signals, threat coverage, compliance alignment, API
    reference, platform operations. This is your primary knowledge
    source.
@@ -60,11 +60,11 @@ For every answer:
 1. **Official F5 documentation** — authoritative source for platform
    capabilities and API specifications
 2. **`docs/` knowledge base** — this repository's documentation pages
-3. **`PRODUCT_EXPERTISE.md`** — the product expertise reference
+3. **`DEMO_PRODUCT_EXPERTISE.md`** — the product expertise reference
 
 ## Research Delegation
 
-When a question cannot be answered from `PRODUCT_EXPERTISE.md`,
+When a question cannot be answered from `DEMO_PRODUCT_EXPERTISE.md`,
 the `docs/` knowledge base, or official F5 documentation already in
 context, spawn the `demo-researcher` subagent with the research
 question. Wait for the structured report, then incorporate the


### PR DESCRIPTION
## Summary

- Update all plugin references to convention files (PRODUCT_EXPERTISE, WALKTHROUGH_CONFIG, SOURCE_INDEX, READINESS_MATRIX) to use the new DEMO_ prefix naming convention used in product repos
- Applies across all f5xc-sales-engineer plugin skills, agents, README, docs, and plugin manifests

Closes #102

## Test plan

- [ ] CI checks pass
- [ ] Plugin manifest validates correctly
- [ ] Convention file references are consistent across all plugin files

🤖 Generated with [Claude Code](https://claude.com/claude-code)