### PR TITLE
docs: remove environment-specific language from console-auth skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -128,7 +128,7 @@
     {
       "name": "f5xc-console",
       "description": "F5 Distributed Cloud web console automation via Chrome DevTools MCP — Azure SSO authentication, deterministic navigation, and workflow execution",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-console** bumped to v1.0.3
+
 - **f5xc-console** bumped to v1.0.2
 
 - **f5xc-console** bumped to v1.0.1

--- a/plugins/f5xc-console/.claude-plugin/plugin.json
+++ b/plugins/f5xc-console/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-console",
   "description": "F5 Distributed Cloud web console automation via Chrome DevTools MCP — Azure SSO authentication, deterministic navigation, and workflow execution",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-console/skills/console-auth/SKILL.md
+++ b/plugins/f5xc-console/skills/console-auth/SKILL.md
@@ -16,7 +16,7 @@ Authenticate to the F5 Distributed Cloud console. Supports
 multiple auth providers automatically detected at runtime:
 
 - **Native Volterra login** — email + password on a single
-  form (staging tenants, tenant-owner accounts)
+  form (some tenants present credentials directly)
 - **Azure SSO cached session** — user previously selected
   "Stay signed in: Yes"; single click auto-completes login
 - **Azure SSO full MFA** — username → password → DUO verified
@@ -56,9 +56,9 @@ Use `take_snapshot` on the current browser page.
 - **Other page** — navigate to the login URL, then proceed
 
 Note: `${F5XC_API_URL}/web/login` redirects to an auth host.
-Production tenants (`*.console.ves.volterra.io`) redirect to
-an SSO provider selection page. Staging tenants
-(`*.staging.volterra.us`) redirect to a native login form.
+Different tenants use different login hosts and auth methods.
+The plugin auto-detects the auth type from the login page
+content — no manual configuration is needed.
 
 ### Step 3: Detect auth provider
 
@@ -80,8 +80,8 @@ Examine the login page to determine the auth type:
 
 ## Path A: Native Volterra Login
 
-Single-screen email + password form. Used by staging tenants
-and tenant-owner accounts.
+Single-screen email + password form. Some tenants present
+credentials directly without an SSO provider selection.
 
 ### A1: Fill credentials
 

--- a/plugins/f5xc-console/skills/console-auth/references/azure-sso-flow.md
+++ b/plugins/f5xc-console/skills/console-auth/references/azure-sso-flow.md
@@ -1,21 +1,18 @@
 # Authentication Flows — MCP Tool Sequences
 
 Detailed Chrome DevTools MCP tool call sequences for each
-authentication path. Validated against live tenants on
-2026-03-26.
+authentication path. Validated against multiple tenants with
+different login configurations on 2026-03-26.
 
 ## Path N: Native Volterra Login
 
 Precondition: Tenant uses native email/password authentication
-(no SSO provider). Common on staging tenants and for tenant
-owner accounts.
-
-Validated against a staging tenant.
+(no SSO provider). Some tenants present credentials directly
+on the login page.
 
 ```
 1. navigate_page(url="${F5XC_API_URL}/web/login")
-   # Redirects to login-staging.volterra.us (staging)
-   # or login.ves.volterra.io with native form
+   # Redirects to the tenant's login host
 2. take_snapshot()
    # Detect: page shows email + password fields directly
    # with "Please enter your email address and password"
@@ -42,11 +39,9 @@ and password to log in." and a "Sign In" button. There is no
 Precondition: User previously authenticated and selected
 "Stay signed in: Yes".
 
-Validated against a production tenant.
-
 ```
 1. navigate_page(url="${F5XC_API_URL}/web/login")
-   # Redirects to login.ves.volterra.io
+   # Redirects to the tenant's login host
 2. wait_for(text=["Sign In with Azure"])
 3. take_snapshot()
 4. click(uid=<sign-in-with-azure-link>)
@@ -76,14 +71,12 @@ Precondition: Multiple Azure AD accounts cached in browser.
 
 ## Path C: Azure SSO Full MFA Flow
 
-Precondition: No cached session or session expired.
-
-Validated against a production tenant.
-with Azure AD and DUO verified push.
+Precondition: No cached session or session expired. Tenant
+uses Azure AD with DUO verified push MFA.
 
 ```
  1. navigate_page(url="${F5XC_API_URL}/web/login")
-    # Redirects to login.ves.volterra.io with SSO options
+    # Redirects to the tenant's login host with SSO options
  2. wait_for(text=["Sign In with Azure"])
  3. take_snapshot()
  4. click(uid=<sign-in-with-azure-link>)
@@ -142,16 +135,18 @@ After navigating to the login URL and taking a snapshot:
 
 ## URL Patterns Observed
 
+Different tenants redirect to different login hosts. The
+plugin does not rely on URL patterns for auth detection —
+it uses page content instead. These patterns are documented
+for debugging reference only:
+
 | URL Pattern | Meaning |
 | ------------- | --------- |
-| `login.ves.volterra.io/auth/realms/*` | Production SSO selection |
-| `login-staging.volterra.us/auth/realms/*` | Staging native login |
+| `login*.volterra.*/auth/realms/*` | Volterra login host |
 | `login.microsoftonline.com/*` | Azure AD login screens |
-| `login.microsoftonline.com/*/login` | Azure AD DUO redirect |
 | `api-*.duosecurity.com/frame/*` | DUO MFA challenge |
 | `login.microsoftonline.com/common/federation/*` | "Stay signed in" prompt |
-| `*.console.ves.volterra.io/web/home*` | Production console loaded |
-| `*.staging.volterra.us/web/home*` | Staging console loaded |
+| `*/web/home*` | Console loaded (authenticated) |
 
 ## Element Identification Strategy
 
@@ -163,16 +158,14 @@ elements using this priority:
 2. **Input type** — textbox with description containing
    "email" for username, "password" for password
 3. **Link text** — "Sign In with Azure" is a link, not a
-   button, on the production Volterra login page
+   button, on SSO-enabled Volterra login pages
 4. **Button text** — "Next", "Sign in", "Continue", "Yes",
    "Try again"
 
 ## Key Observations from Live Testing
 
-- Production (`*.console.ves.volterra.io`) redirects to
-  `login.ves.volterra.io` for SSO provider selection
-- Staging (`*.staging.volterra.us`) redirects to
-  `login-staging.volterra.us` for native email/password login
+- Different tenants use different login hosts and auth methods
+- The plugin detects auth type from page content, not URLs
 - Native login uses a single form with both email and password
   fields visible simultaneously
 - Azure SSO uses a multi-screen flow (email → password → DUO)

--- a/plugins/f5xc-console/skills/console-auth/references/session-detection.md
+++ b/plugins/f5xc-console/skills/console-auth/references/session-detection.md
@@ -25,8 +25,8 @@ Check the following indicators in order:
 
 **Expired session (re-auth needed):**
 
-- URL contains `/web/login` or `login.ves.volterra.io` or
-  `login-staging.volterra.us`
+- URL contains `/web/login` or a Volterra login host
+  (`login*.volterra.*`)
 - Snapshot contains "Sign in" or "Session Expired" text
 - Modal overlay with "Sign in again" or "Your session has
   expired"


### PR DESCRIPTION
## Summary

- Removed all "production" and "staging" labels from the f5xc-console auth plugin documentation
- The plugin auto-detects auth type from page content, not environment labels — these labels were misleading and leaked internal infrastructure details
- Keeps the public repo neutral across different tenant configurations

Closes #122

## Test plan

- [ ] CI checks pass
- [ ] Verify no remaining environment-specific labels in changed files
- [ ] Confirm plugin skill documentation reads correctly without environment references