### PR TITLE
refactor: enforce F5 XC branding and subagent-first architecture

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -128,7 +128,7 @@
     {
       "name": "f5xc-console",
       "description": "F5 Distributed Cloud web console automation via Chrome DevTools MCP — Azure SSO authentication, deterministic navigation, and workflow execution",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-console** bumped to v1.0.4
+
 - **f5xc-console** bumped to v1.0.3
 
 - **f5xc-console** bumped to v1.0.2

--- a/plugins/f5xc-console/.claude-plugin/plugin.json
+++ b/plugins/f5xc-console/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-console",
   "description": "F5 Distributed Cloud web console automation via Chrome DevTools MCP — Azure SSO authentication, deterministic navigation, and workflow execution",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-console/agents/console-operator.md
+++ b/plugins/f5xc-console/agents/console-operator.md
@@ -3,9 +3,10 @@ name: console-operator
 description: >-
   Autonomous browser automation agent for F5 XC console
   operations. Executes MCP tool sequences for authentication,
-  navigation, and form interactions. Skills delegate to this
-  agent to keep mechanical browser interactions out of the
-  main session context.
+  navigation, and form interactions. Skills MUST delegate to
+  this agent — never run MCP browser tools in the main session.
+  This keeps the main session context lean since browser
+  snapshots are token-heavy.
 tools:
   - Read
   - Bash
@@ -19,12 +20,41 @@ You are an autonomous browser automation agent that executes
 Chrome DevTools MCP tool sequences against the F5 Distributed
 Cloud web console.
 
+## Why This Agent Exists
+
+Browser automation consumes significant tokens — each
+`take_snapshot` returns the full page accessibility tree.
+Running these operations in a subagent keeps the main session
+context lean and allows the browser work to be discarded after
+completion. The main session only receives the structured
+result report.
+
 ## Identity
 
 - You operate the browser on behalf of the user
-- You execute step-by-step MCP tool instructions provided by
-  skills (console-auth, console-navigator, workflow skills)
-- You report structured results back to the calling skill
+- You are self-contained — read the skill reference files
+  yourself to get the detailed step-by-step instructions
+- You report structured results back to the calling session
+- You never ask the main session for guidance mid-task —
+  only report back when done or when user input is needed
+  (e.g., DUO MFA code relay)
+
+## Initialization
+
+When given a task, first read the relevant reference files
+from the plugin's skills directory:
+
+- **Authentication**: Read
+  `plugins/f5xc-console/skills/console-auth/SKILL.md` and
+  `plugins/f5xc-console/skills/console-auth/references/azure-sso-flow.md`
+- **Navigation**: Read
+  `plugins/f5xc-console/skills/console-navigator/SKILL.md` and
+  `plugins/f5xc-console/skills/console-navigator/references/url-patterns.md`
+- **Session check**: Read
+  `plugins/f5xc-console/skills/console-auth/references/session-detection.md`
+
+These files contain the exact MCP tool sequences, detection
+logic, and error handling for each operation.
 
 ## Available MCP Tools
 
@@ -68,8 +98,13 @@ These Chrome DevTools MCP tools are available in the session:
 
 5. **Report credentials safely** — never echo, log, or
    include passwords in your output. When filling a password
-   field, use the environment variable reference, not the
-   literal value.
+   field, use the environment variable value but never
+   include it in your response text.
+
+6. **DUO MFA code relay** — when DUO shows a verification
+   code, you MUST include it prominently in your response
+   so the main session can relay it to the user. Format:
+   `DUO verification code: [CODE]`
 
 ## Element Discovery Priority
 
@@ -87,18 +122,26 @@ When looking for elements in a snapshot:
 After completing a task, report:
 
 ```
-## Result: [SUCCESS | FAILURE | PARTIAL]
+## Result: [SUCCESS | FAILURE | NEEDS_USER_INPUT]
 
 ### Actions Taken
-- <numbered list of MCP tool calls made>
+- <numbered list of key actions>
 
 ### Final State
 - URL: <current URL>
 - Page: <detected page/section name>
 
+### User Action Required (if any)
+- <e.g., DUO verification code: 403>
+
 ### Issues (if any)
 - <any errors, unexpected states, or warnings>
 ```
+
+Use `NEEDS_USER_INPUT` when the flow requires user
+interaction (e.g., DUO MFA code approval). The main
+session will relay the information to the user and
+re-invoke you to continue.
 
 ## Timeout Guidance
 
@@ -108,6 +151,7 @@ After completing a task, report:
 | Element appearance after click | 10,000 ms |
 | Azure SSO redirect | 15,000 ms |
 | DUO MFA approval | 60,000 ms |
+| Console SPA load | 30,000 ms |
 | Form submission response | 15,000 ms |
 
 ## Error Recovery
@@ -118,5 +162,7 @@ After completing a task, report:
   take screenshot, report network issues
 - **Unexpected page** — take screenshot, report the actual
   page state vs expected state
-- **Session expired mid-task** — report that re-authentication
-  is needed; the calling skill will handle it
+- **Session expired mid-task** — attempt re-authentication
+  by reading and following the auth skill flow
+- **DUO push timeout** — click "Try again" if available,
+  extract new code, report with NEEDS_USER_INPUT

--- a/plugins/f5xc-console/commands/login-console.md
+++ b/plugins/f5xc-console/commands/login-console.md
@@ -1,15 +1,43 @@
 ---
-description: Authenticate to the F5 Distributed Cloud console via Azure SSO
+description: Authenticate to the F5 Distributed Cloud console
 argument-hint: "[tenant-url]"
 ---
 
-Invoke the `f5xc-console:console-auth` skill to authenticate
-to the F5 XC console.
+Delegate authentication to the `console-operator` subagent.
+Do NOT run browser MCP tools in the main session — browser
+snapshots are token-heavy and must stay in the subagent.
 
-If the user provided a tenant URL as an argument (`$ARGUMENTS`),
-use that as the target tenant instead of the `F5XC_API_URL`
-environment variable.
+## Delegation
 
-Follow the skill's authentication flow exactly — detect session
-state, handle cached or full MFA authentication, and report the
-result.
+Spawn the console-operator agent with:
+
+```
+Agent(
+  subagent_type="f5xc-console:console-operator",
+  description="Authenticate to F5 XC console",
+  prompt="Authenticate to the F5 Distributed Cloud console.\n\n
+    Tenant URL: ${F5XC_API_URL} (or $ARGUMENTS if provided)\n
+    Username: ${F5XC_USERNAME}\n
+    Password: read from F5XC_CONSOLE_PASSWORD env var\n\n
+    Read the auth skill and reference files first, then
+    execute the authentication flow. Auto-detect the login
+    type (native or Azure SSO) from the page content.\n\n
+    If DUO MFA is required, report the 3-digit verification
+    code in your response with NEEDS_USER_INPUT status."
+)
+```
+
+## Handling DUO MFA
+
+If the agent returns `NEEDS_USER_INPUT` with a DUO code:
+
+1. Display the code prominently to the user
+2. Wait for the user to confirm they approved on their phone
+3. Re-invoke the agent to continue the flow (or the agent
+   may have already waited and completed)
+
+## After Authentication
+
+Report the agent's result to the user. If successful, the
+browser is now authenticated and ready for navigation or
+workflow operations.

--- a/plugins/f5xc-console/skills/console-auth/SKILL.md
+++ b/plugins/f5xc-console/skills/console-auth/SKILL.md
@@ -2,7 +2,7 @@
 name: console-auth
 description: >-
   Multi-provider authentication for the F5 Distributed Cloud
-  console. Auto-detects login type: native Volterra login,
+  console. Auto-detects login type: native F5 XC login,
   Azure SSO with cached session, or Azure SSO with DUO verified
   push MFA. Use when the user says "log in", "authenticate",
   "sign in to the console", or when any console workflow
@@ -15,7 +15,7 @@ user-invocable: false
 Authenticate to the F5 Distributed Cloud console. Supports
 multiple auth providers automatically detected at runtime:
 
-- **Native Volterra login** — email + password on a single
+- **Native F5 XC login** — email + password on a single
   form (some tenants present credentials directly)
 - **Azure SSO cached session** — user previously selected
   "Stay signed in: Yes"; single click auto-completes login
@@ -68,7 +68,7 @@ take_snapshot()
 
 Examine the login page to determine the auth type:
 
-- **Native Volterra login** — page shows email and password
+- **Native F5 XC login** — page shows email and password
   fields directly, with a "Sign In" button and text like
   "Please enter your email address and password to log in."
   → Go to **Path A: Native Login**
@@ -78,7 +78,7 @@ Examine the login page to determine the auth type:
 
 ---
 
-## Path A: Native Volterra Login
+## Path A: Native F5 XC Login
 
 Single-screen email + password form. Some tenants present
 credentials directly without an SSO provider selection.

--- a/plugins/f5xc-console/skills/console-auth/references/azure-sso-flow.md
+++ b/plugins/f5xc-console/skills/console-auth/references/azure-sso-flow.md
@@ -4,7 +4,7 @@ Detailed Chrome DevTools MCP tool call sequences for each
 authentication path. Validated against multiple tenants with
 different login configurations on 2026-03-26.
 
-## Path N: Native Volterra Login
+## Path N: Native F5 XC Login
 
 Precondition: Tenant uses native email/password authentication
 (no SSO provider). Some tenants present credentials directly
@@ -129,7 +129,7 @@ After navigating to the login URL and taking a snapshot:
 
 | Page Content | Auth Type | Path |
 | -------------- | ----------- | ------ |
-| "Please enter your email address and password" + email field + password field | Native Volterra | Path N |
+| "Please enter your email address and password" + email field + password field | Native F5 XC | Path N |
 | "Sign In with Azure" link | Azure SSO | Path A/B/C |
 | "Log In as Tenant Owner" link only | Tenant owner (native) | Path N variant |
 
@@ -142,7 +142,7 @@ for debugging reference only:
 
 | URL Pattern | Meaning |
 | ------------- | --------- |
-| `login*.volterra.*/auth/realms/*` | Volterra login host |
+| `login*.volterra.*/auth/realms/*` | F5 XC login host |
 | `login.microsoftonline.com/*` | Azure AD login screens |
 | `api-*.duosecurity.com/frame/*` | DUO MFA challenge |
 | `login.microsoftonline.com/common/federation/*` | "Stay signed in" prompt |
@@ -158,7 +158,7 @@ elements using this priority:
 2. **Input type** — textbox with description containing
    "email" for username, "password" for password
 3. **Link text** — "Sign In with Azure" is a link, not a
-   button, on SSO-enabled Volterra login pages
+   button, on SSO-enabled F5 XC login pages
 4. **Button text** — "Next", "Sign in", "Continue", "Yes",
    "Try again"
 

--- a/plugins/f5xc-console/skills/console-auth/references/session-detection.md
+++ b/plugins/f5xc-console/skills/console-auth/references/session-detection.md
@@ -25,8 +25,8 @@ Check the following indicators in order:
 
 **Expired session (re-auth needed):**
 
-- URL contains `/web/login` or a Volterra login host
-  (`login*.volterra.*`)
+- URL contains `/web/login` or an F5 XC login host
+  (URL patterns: `login*.volterra.*`)
 - Snapshot contains "Sign in" or "Session Expired" text
 - Modal overlay with "Sign in again" or "Your session has
   expired"

--- a/plugins/f5xc-console/skills/console-index/SKILL.md
+++ b/plugins/f5xc-console/skills/console-index/SKILL.md
@@ -4,39 +4,57 @@ description: >-
   Intent router for F5 XC console automation. When the user's
   request involves the console but does not clearly match a
   specific skill trigger, this skill determines the correct
-  skill to invoke. Routes to console-auth for authentication,
-  console-navigator for navigation, or future workflow skills.
+  skill to invoke. All console operations MUST be delegated to
+  the console-operator subagent to keep browser automation
+  tokens out of the main session.
 user-invocable: false
 ---
 
 # Console Index — Intent Router
 
 Routes ambiguous console-related requests to the correct
-skill.
+skill and ensures all browser operations are delegated to
+the `console-operator` subagent.
+
+## Critical: Subagent Delegation
+
+**Never run Chrome DevTools MCP tools in the main session.**
+Browser snapshots are token-heavy. All console operations
+must be delegated to the `console-operator` agent:
+
+```
+Agent(
+  subagent_type="f5xc-console:console-operator",
+  description="<short task description>",
+  prompt="<task details with env var references>"
+)
+```
+
+The agent reads the skill reference files itself and executes
+autonomously. The main session only receives the result.
 
 ## Routing Table
 
-| User Intent | Target Skill |
-| ------------- | -------------- |
-| "log in", "authenticate", "sign in" | `console-auth` |
-| "navigate to", "go to", "open" + section | `console-navigator` |
-| "where am I", "what page" | `console-navigator` (state detection) |
-| "create", "add" + resource type | Future workflow skill |
-| "show", "list" + resource type | `console-navigator` + future list skill |
-| "configure", "edit" + resource | Future workflow skill |
+| User Intent | Target Skill | Agent Prompt |
+| ------------- | -------------- | -------------- |
+| "log in", "authenticate", "sign in" | `console-auth` | "Authenticate to the F5 XC console" |
+| "navigate to", "go to", "open" + section | `console-navigator` | "Navigate to [section] in the F5 XC console" |
+| "where am I", "what page" | `console-navigator` | "Detect current page in the F5 XC console" |
+| "create", "add" + resource type | Future workflow skill | — |
+| "show", "list" + resource type | `console-navigator` | "Navigate to [resource type] list" |
 
 ## How to Route
 
 1. Parse the user's request for intent keywords
 2. Match against the routing table
-3. Invoke the matched skill
-4. If no match, ask the user to clarify what they'd like
-   to do in the console
+3. Spawn the `console-operator` agent with the matched task
+4. Relay the agent's result to the user
+5. If DUO MFA is needed, relay the code and re-invoke
 
-## Available Skills
+## Available Skills (read by the agent)
 
-- **console-auth** — Azure SSO authentication (cached
-  session and full MFA)
+- **console-auth** — Multi-provider authentication (native
+  F5 XC login and Azure SSO with DUO MFA)
 - **console-navigator** — Navigate to console sections
   by name, detect current page
 


### PR DESCRIPTION
## Summary

- Replaced all human-facing "Volterra" references with "F5 XC" or "F5 Distributed Cloud" in the f5xc-console plugin; "volterra" retained only in URL domain patterns
- Restructured for subagent-first execution: console-operator agent is now self-contained (reads skill references itself), all skills/commands explicitly delegate to it, browser MCP tools never run in the main session

Closes #124

## Test plan

- [ ] CI checks pass
- [ ] Verify "Volterra" only appears in URL domain patterns, not in human-facing text
- [ ] Confirm console-auth skill delegates to console-operator agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)