### PR TITLE
refactor: enforce subagent-first architecture and document auth validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -128,7 +128,7 @@
     {
       "name": "f5xc-console",
       "description": "F5 Distributed Cloud web console automation via Chrome DevTools MCP — Azure SSO authentication, deterministic navigation, and workflow execution",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-console** bumped to v1.0.5
+
 - **f5xc-console** bumped to v1.0.4
 
 - **f5xc-console** bumped to v1.0.3

--- a/plugins/f5xc-console/.claude-plugin/plugin.json
+++ b/plugins/f5xc-console/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-console",
   "description": "F5 Distributed Cloud web console automation via Chrome DevTools MCP — Azure SSO authentication, deterministic navigation, and workflow execution",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-console/agents/console-operator.md
+++ b/plugins/f5xc-console/agents/console-operator.md
@@ -7,11 +7,7 @@ description: >-
   this agent — never run MCP browser tools in the main session.
   This keeps the main session context lean since browser
   snapshots are token-heavy.
-tools:
-  - Read
-  - Bash
-  - Glob
-  - Grep
+disallowedTools: Write, Edit, Agent
 ---
 
 # Console Operator Agent

--- a/plugins/f5xc-console/skills/console-auth/SKILL.md
+++ b/plugins/f5xc-console/skills/console-auth/SKILL.md
@@ -104,7 +104,17 @@ take_snapshot()
 ```
 
 If "Invalid" credentials text appears, report error and stop.
-Otherwise jump to **Verification**.
+
+**Post-login redirect quirk**: After native login, the browser
+may redirect to `chrome://new-tab-page/` instead of the
+console. The session cookie IS valid — navigate directly to
+`${F5XC_API_URL}/web/home` to recover.
+
+**SPA load failure**: If the console returns
+`ERR_INSUFFICIENT_RESOURCES`, retry with a hard reload
+(`navigate_page` type=reload, `ignoreCache: true`).
+
+Jump to **Verification**.
 
 ---
 

--- a/plugins/f5xc-console/skills/console-auth/references/azure-sso-flow.md
+++ b/plugins/f5xc-console/skills/console-auth/references/azure-sso-flow.md
@@ -174,3 +174,41 @@ elements using this priority:
 - DUO uses verified push (3-digit code entry) not simple push
 - Console SPA loads at `/web/home` and takes 15-30 seconds
 - Page reports as `busy` during SPA initialization
+
+## Subagent Validation Results (2026-03-26)
+
+Validated via `f5xc-console:console-operator` subagent:
+
+### Path N — Native Login
+
+- Agent correctly detected native login from page content
+- Used `fill_form` for both email and password fields
+- **Post-login redirect quirk**: browser may redirect to
+  `chrome://new-tab-page/` instead of the console after native
+  login. The session cookie IS set correctly — navigate
+  directly to `${F5XC_API_URL}/web/home` to recover.
+- **SPA resource errors**: first load may hit
+  `ERR_INSUFFICIENT_RESOURCES`. Retry with a hard reload
+  (`navigate_page` with `ignoreCache: true`) to recover.
+
+### Path A — Azure SSO Cached Session
+
+- Agent correctly detected "Sign In with Azure" link
+- Clicked the link and the cached session auto-completed
+- No DUO MFA was required (session from previous "Stay
+  signed in: Yes" persisted across browser restarts)
+- Auth succeeded (redirect back with valid auth code)
+- SPA may fail to load in resource-constrained environments
+
+### Recovery Procedures
+
+- **Post-login redirect to chrome://new-tab-page**: Navigate
+  directly to `${F5XC_API_URL}/web/home`
+- **ERR_INSUFFICIENT_RESOURCES**: Hard reload with
+  `ignoreCache: true`. If that fails, the browser needs more
+  memory — this is an infrastructure constraint, not an auth
+  issue.
+- **SPA stuck on busy**: Wait up to 30 seconds. If still
+  blank, hard reload once. Verify the page title is
+  "F5 Distributed Cloud Console" (auth succeeded) vs
+  a login page title (auth failed).


### PR DESCRIPTION
## Summary

- Agent uses `disallowedTools` instead of `tools` allowlist so it inherits MCP browser tools from the session
- Added subagent validation results documenting tested auth paths (native login and Azure SSO cached session)
- Added post-login recovery procedures for redirect quirks and SPA resource errors discovered during live testing
- Documented that plugin agents must NOT use `tools:` allowlist if they need MCP access

Closes #126

## Test plan

- [ ] CI checks pass
- [ ] Pre-commit hooks pass (verified locally)
- [ ] Plugin version auto-bumped correctly