### PR TITLE
fix: add mode bypassPermissions to github-ops delegation pattern

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "f5xc-github-ops",
       "description": "GitHub operations automation — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, and autonomous workflow operations agent",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-github-ops** bumped to v2.1.3
+
 - **f5xc-github-ops** bumped to v2.1.2
 
 - **f5xc-github-ops** bumped to v2.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Never run `git commit`, `git push`, `gh pr create` directly.
 ```
 Agent(
   subagent_type="f5xc-github-ops:github-ops",
+  mode="bypassPermissions",
   prompt="<type>: <desc>\n\nFiles:\n- <list>\n\nWhy: <reason>"
 )
 ```

--- a/plugins/f5xc-github-ops/.claude-plugin/plugin.json
+++ b/plugins/f5xc-github-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-github-ops",
   "description": "GitHub operations automation for f5xc-salesdemos — issue-driven development, pre-commit lint gate, PR lifecycle, CI polling with error feedback to issues, post-merge monitoring, verification, rate limit management, and exclusive github-ops agent for all Git operations. Covers commit, push, branch, merge, squash, pull request, issue creation, and repository settings.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-github-ops/README.md
+++ b/plugins/f5xc-github-ops/README.md
@@ -71,9 +71,15 @@ or `Write`)
 ```
 Agent(
   subagent_type="f5xc-github-ops:github-ops",
+  mode="bypassPermissions",
   prompt="<type>: <description>\n\nFiles to stage:\n- <file-list>\n\nWhy: <motivation>"
 )
 ```
+
+> `mode: bypassPermissions` is required — the agent
+> executes a multi-step workflow that needs uninterrupted
+> Bash access. Without it, plan mode can re-engage
+> mid-workflow and block execution.
 
 ## Installation
 

--- a/plugins/f5xc-github-ops/skills/workflow-lifecycle/SKILL.md
+++ b/plugins/f5xc-github-ops/skills/workflow-lifecycle/SKILL.md
@@ -29,11 +29,17 @@ pre-commit.
 
 ## How to Delegate
 
-After making code changes, spawn the agent:
+After making code changes, spawn the agent with `mode: bypassPermissions`.
+This is required because the agent executes a multi-step Git workflow
+(issue, branch, commit, push, PR, CI poll, merge) that requires
+uninterrupted Bash access. Without bypass mode, plan mode can re-engage
+mid-workflow and strip Bash access, leaving the agent stuck after
+completing only the first step.
 
 ```
 Agent(
   subagent_type="f5xc-github-ops:github-ops",
+  mode="bypassPermissions",
   prompt="<type>: <description>\n\nFiles:\n- <file-list>\n\nWhy: <motivation>"
 )
 ```


### PR DESCRIPTION
## Summary

- Add `mode="bypassPermissions"` to the Agent() delegation pattern in all three documentation locations (CLAUDE.md, plugin README, skill SKILL.md)
- The github-ops agent executes a 10-step Git workflow requiring uninterrupted Bash access; without bypass mode, plan mode can re-engage mid-workflow and strip Bash access
- This was observed in production where the agent created an issue then got blocked

Closes #154

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify all three delegation snippets include `mode="bypassPermissions"`
- [ ] Confirm explanatory text added to README and SKILL.md