### PR TITLE
fix: use pre-installed binaries instead of npx in tool catalog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -113,7 +113,7 @@
     {
       "name": "f5xc-devcontainer",
       "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-devcontainer** bumped to v1.1.4
+
 - **f5xc-github-ops** bumped to v2.1.3
 
 - **f5xc-github-ops** bumped to v2.1.2

--- a/plugins/f5xc-devcontainer/.claude-plugin/plugin.json
+++ b/plugins/f5xc-devcontainer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-devcontainer",
   "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-devcontainer/skills/tool-catalog/references/code-quality.md
+++ b/plugins/f5xc-devcontainer/skills/tool-catalog/references/code-quality.md
@@ -4,25 +4,25 @@
 
 ## prettier
 
-- **Package**: `prettier` via npm
+- **Package**: `prettier` (pre-installed binary at `/usr/bin/prettier`)
 - **Purpose**: Opinionated code formatter for JS, TS, CSS, HTML, JSON, YAML, Markdown, and more
 - **Use when**: Enforcing consistent formatting across a project, running in CI or pre-commit hooks
 - **Quick start**:
-  - `npx prettier --check .`
-  - `npx prettier --write "src/**/*.ts"`
-  - `npx prettier --write "*.{json,yaml,md}"`
+  - `prettier --check .`
+  - `prettier --write "src/**/*.ts"`
+  - `prettier --write "*.{json,yaml,md}"`
 - **Auth**: None
 - **Docs**: <https://prettier.io/docs/en/>
 
 ## biome
 
-- **Package**: `@biomejs/biome` via npm
+- **Package**: `biome` (pre-installed binary at `/usr/bin/biome`)
 - **Purpose**: Extremely fast JS/TS formatter and linter (Rust-based Prettier/ESLint alternative)
 - **Use when**: Wanting a single tool for formatting and linting JS/TS with near-instant execution
 - **Quick start**:
-  - `npx @biomejs/biome check .`
-  - `npx @biomejs/biome format --write .`
-  - `npx @biomejs/biome lint .`
+  - `biome check .`
+  - `biome format --write .`
+  - `biome lint .`
 - **Auth**: None
 - **Docs**: <https://biomejs.dev/reference/cli/>
 
@@ -40,13 +40,13 @@
 
 ## jscpd
 
-- **Package**: `jscpd` via npm
+- **Package**: `jscpd` (pre-installed binary at `/usr/bin/jscpd`)
 - **Purpose**: Copy/paste detection across 150+ languages
 - **Use when**: Finding duplicated code blocks, enforcing DRY principles in CI
 - **Quick start**:
-  - `npx jscpd src/`
-  - `npx jscpd --min-lines 5 --min-tokens 50 .`
-  - `npx jscpd --reporters html --output report/`
+  - `jscpd src/`
+  - `jscpd --min-lines 5 --min-tokens 50 .`
+  - `jscpd --reporters html --output report/`
 - **Auth**: None
 - **Docs**: <https://github.com/kucherenko/jscpd>
 


### PR DESCRIPTION
## Summary

- Replace `npx` invocations for biome, prettier, and jscpd in the tool catalog with direct binary calls (`/usr/bin/biome`, `/usr/bin/prettier`, `/usr/bin/jscpd`)
- Eliminates unnecessary npm package downloads on every invocation, reducing latency
- Other npx references in the catalog were audited and confirmed NOT pre-installed, so they correctly remain as npx

Closes #158

Related: f5xc-salesdemos/devcontainer#719

## Test plan

- [ ] CI checks pass
- [ ] Verify biome, prettier, and jscpd entries no longer reference npx
- [ ] Verify other npx references in the file are unchanged