### PR TITLE
fix: add codespell exceptions for nd and edn false positives

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = aks,datas,hcl,iterm,uncomplete,ves
+ignore-words-list = aks,datas,edn,hcl,iterm,nd,uncomplete,ves


### PR DESCRIPTION
## Summary

Add `nd` and `edn` to `.codespellrc` ignore list — both are false positives from the tool catalog (nodriver Python alias and Clojure EDN format).

Closes #160

## Test plan

- [x] `codespell` passes locally with zero findings