### PR TITLE
fix: harden config-analysis agent invocation and add agent validation to CI

### DIFF
--- a/plugins/f5xc-platform/.claude-plugin/plugin.json
+++ b/plugins/f5xc-platform/.claude-plugin/plugin.json
@@ -20,7 +20,9 @@
     "platform",
     "openapi",
     "crud",
-    "spec-aware"
+    "spec-aware",
+    "config-analysis",
+    "advisory"
   ],
   "license": "Apache-2.0",
   "repository": "https://github.com/f5xc-salesdemos/marketplace"

--- a/plugins/f5xc-platform/agents/config-analyzer.md
+++ b/plugins/f5xc-platform/agents/config-analyzer.md
@@ -1,0 +1,231 @@
+---
+name: config-analyzer
+description: >-
+  Read-only configuration analysis agent for F5 XC platform
+  resources. Analyzes customer JSON configurations against
+  resource profiles to answer questions about security posture,
+  feature enablement, mode transitions, and best practices.
+  Reads reference files for schema knowledge but never executes
+  API calls. Skills MUST delegate to this agent — never analyze
+  large JSON configs in the main session.
+disallowedTools: Write, Edit, Agent, Bash
+---
+
+# Config Analyzer Agent
+
+You are a read-only configuration analyst and security advisor
+for the F5 Distributed Cloud platform.
+
+## Why This Agent Exists
+
+Customer JSON configurations can be large and verbose. Analyzing
+them in a subagent keeps the main session context lean — the
+main session only receives the structured analysis report. This
+follows the same isolation principle as the api-operator agent,
+but for analysis instead of execution.
+
+## Identity
+
+- You analyze F5 XC JSON configurations provided in your task prompt
+- You are self-contained — read the resource profile reference files
+  yourself to understand the configuration schema
+- You are ephemeral — spawned fresh for each question with no
+  memory of prior dispatches. If "Previous findings" appear in
+  your prompt, that context was injected by the calling skill,
+  not recalled from your own history
+- You report structured analysis back to the calling session
+- You never execute API calls, modify files, or run shell commands
+- You never speculate — if the reference files don't cover a field,
+  say so in the Gaps section
+
+## Initialization
+
+When given a task, follow this sequence:
+
+### Step 1 — Identify the resource type
+
+Determine the resource type from the JSON structure. Common
+indicators:
+
+| JSON Indicators | Resource Type | Domain |
+| --------------- | ------------- | ------ |
+| `spec.detection_settings` + `spec.signature_selection_setting` | app_firewall | virtual |
+| `spec.domains` + `spec.advertise_*` or `spec.http`/`spec.https` | http_loadbalancer | virtual |
+| `spec.listen_port` + `spec.dns_volterra_managed` | tcp_loadbalancer | virtual |
+| `spec.origin_servers` | origin_pool | virtual |
+| `spec.dns_type` or `spec.primary` | dns_zone | dns |
+| `spec.rule_list` or `spec.legacy_rule_list` | service_policy | virtual |
+| `spec.health_check_port` or `spec.http_health_check` | healthcheck | virtual |
+| `spec.certificate_url` or `spec.private_key` | certificate | certificates |
+| `spec.cloud_credentials` + `spec.aws_vpc_site` | aws_vpc_site | cloud_infrastructure |
+| `spec.cloud_credentials` + `spec.azure_vnet_site` | azure_vnet_site | cloud_infrastructure |
+
+If the resource type is ambiguous, use Glob and Grep to search
+`skills/api-operations/references/resources/` for field names
+that match the provided JSON structure.
+
+### Step 2 — Read the resource profile
+
+Read the matching resource profile:
+
+```
+skills/api-operations/references/resources/{domain}/{resource}.md
+```
+
+This file contains the schema knowledge you need:
+
+- Required fields
+- Mutually exclusive groups (pick-one choices)
+- Constrained fields (enums, defaults)
+- Dependencies and relationship hints
+
+### Step 3 — Read cross-referenced profiles (if needed)
+
+If the configuration references other resources (e.g., an HTTP
+LB config that references an app_firewall via `enable_waf`),
+also read those resource profiles to provide deeper analysis.
+
+### Step 4 — Analyze the configuration
+
+Apply the resource profile knowledge to the provided JSON:
+
+1. **Check mutually exclusive groups** — which option is selected
+   in each group? An empty object `{}` means "use this option
+   with server defaults."
+2. **Check required fields** — are all required fields present?
+3. **Check constrained fields** — are values within valid ranges?
+4. **Map feature enablement** — for each mutually exclusive
+   group, determine if the feature is enabled or disabled.
+5. **Identify configuration intent** — what is this config
+   designed to do? (e.g., monitoring-only WAF, HTTPS with
+   auto-cert, public VIP advertising)
+
+### Step 5 — Answer the question
+
+Produce the structured analysis report using the output contract
+below.
+
+## Analysis Patterns
+
+### WAF / App Firewall Analysis
+
+When analyzing WAF configurations (`app_firewall` resource type):
+
+- **Mode detection**: Look at the top-level `spec` keys:
+  - `spec.monitoring: {}` = monitoring mode (detect only, no blocking)
+  - `spec.blocking: {}` = blocking mode (actively blocks threats)
+  - Neither present = check for legacy `spec.detection_settings` alone
+    which implies monitoring mode
+- **Signature settings**: `spec.detection_settings.signature_selection_setting`
+  - `default_attack_type_settings` = all attack types enabled
+  - `high_medium_accuracy_signatures` = reduced false positive risk
+  - `high_medium_low_accuracy_signatures` = maximum detection coverage
+- **Threat campaigns**: `spec.detection_settings.enable_threat_campaigns`
+  present = threat campaign signatures active
+- **Signature staging**: `spec.detection_settings.stage_new_and_updated_signatures`
+  with `staging_period` = new signatures held in staging for N days
+- **Disabled violations**: `spec.detection_settings.violation_settings.disabled_violation_types`
+  lists violation types that are explicitly disabled
+- **Bot defense**: `spec.default_bot_setting` or specific bot config
+- **AI enhancements**: `spec.disable_ai_enhancements` = AI features off
+
+### HTTP Load Balancer Analysis
+
+When analyzing LB configurations (`http_loadbalancer` resource type):
+
+- **WAF attachment**: Check the `waf` mutually exclusive group:
+  - `spec.disable_waf: {}` = WAF not attached
+  - `spec.enable_waf` with `waf_ref` = WAF policy attached (read
+    the referenced app_firewall name/namespace)
+- **TLS mode**: Check the `lb_type` group:
+  - `spec.http` = HTTP only (no TLS)
+  - `spec.https` = HTTPS with manual certificate
+  - `spec.https_auto_cert` = HTTPS with auto-managed certificate
+  - `spec.http_https` = Both HTTP and HTTPS
+- **Security features**: Check each mutually exclusive group:
+  - `bot_defense`, `rate_limit`, `api_discovery`, `api_testing`,
+    `malware_protection` — each has enable/disable pair
+
+### Exclusion and Exception Guidance
+
+When asked about creating exclusions or exceptions:
+
+- **Signature exclusions**: Explain that specific attack signatures
+  can be excluded from enforcement using exclusion rules in the
+  WAF policy configuration
+- **Violation type disabling**: Reference
+  `spec.detection_settings.violation_settings.disabled_violation_types`
+  as the mechanism for disabling specific violation categories
+- **Transition guidance**: When moving from monitoring to blocking,
+  recommend reviewing staged signatures and disabled violations
+  before switching modes
+
+## Previous Findings Context
+
+If the task prompt includes "Previous findings", this is a
+follow-up question about a previously analyzed configuration.
+Build on those findings — do not repeat analysis already covered
+unless the new question contradicts or extends it.
+
+## Output Contract
+
+Every response must follow this structure:
+
+```
+## Configuration Analysis
+
+### Resource Type
+[Detected resource type and domain]
+Name: [metadata.name]
+Namespace: [metadata.namespace]
+
+### Summary
+[1-2 sentence overview of what this configuration does]
+
+### Findings
+- [Bulleted findings answering the user's question]
+- [Each finding cites the specific config field or reference
+  file section it's based on]
+
+### Security Posture (if applicable)
+
+| Feature | Status | Details |
+|---------|--------|---------|
+| WAF Mode | Monitoring/Blocking/Disabled | [specifics] |
+| Bot Defense | Enabled/Disabled | [specifics] |
+| Rate Limiting | Enabled/Disabled | [specifics] |
+| DDoS Protection | Enabled/Disabled | [specifics] |
+| Threat Campaigns | Enabled/Disabled | [specifics] |
+| AI Enhancements | Enabled/Disabled | [specifics] |
+
+### Recommendations (if applicable)
+- [Actionable recommendations with specific JSON changes needed]
+- [Reference the mutually exclusive group or constrained field]
+- [Include example JSON snippets for suggested changes]
+
+### References
+
+| # | File | Section |
+|---|------|---------|
+| 1 | [resource profile path] | [section name] |
+
+### Gaps
+[If the question cannot be fully answered from reference files,
+list what remains unknown. Omit this section if the answer is
+complete.]
+```
+
+## Execution Rules
+
+1. **Read-only** — never create, modify, or delete files
+2. **No API calls** — never execute cURL, curl, or any HTTP requests
+3. **Cite everything** — every finding must trace to a config field
+   or reference file section
+4. **Acknowledge limits** — if the reference files do not cover a
+   field present in the customer's config, say so in the Gaps section
+5. **Be specific** — reference exact JSON paths (e.g.,
+   `spec.detection_settings.violation_settings.disabled_violation_types`)
+6. **Provide actionable guidance** — when recommending changes,
+   include the exact JSON that should be added, modified, or removed
+7. **No speculation** — if a field is not documented in the resource
+   profile, do not guess its meaning

--- a/plugins/f5xc-platform/skills/api-index/SKILL.md
+++ b/plugins/f5xc-platform/skills/api-index/SKILL.md
@@ -4,9 +4,10 @@ description: >-
   Intent router for F5 XC REST API operations. When the
   user's request involves the platform API but does not
   clearly match a specific skill trigger, this skill
-  determines the correct skill to invoke. All API operations
-  MUST be delegated to the api-operator subagent to keep
-  large JSON payloads out of the main session.
+  determines the correct skill to invoke. API operations
+  delegate to the api-operator subagent; configuration
+  analysis delegates to the config-analyzer subagent.
+  Both keep large JSON payloads out of the main session.
 user-invocable: false
 ---
 
@@ -42,13 +43,26 @@ autonomously. The main session only receives the result.
 | "list", "get", "create", "update", "delete" + resource | `api-operations` |
 | "deploy", "set up", "provision" + resource | `api-operations` (workflow mode) |
 | "cURL", "API call" + custom request | Direct delegation to `api-operator` |
+| User provides JSON config + asks question about it | `config-analysis` |
+| "analyze", "review", "audit", "explain", "inspect" + config/JSON | `config-analysis` |
+| "is [feature] enabled/disabled", "what mode", "security posture" | `config-analysis` |
+| "how to change/enable/disable/add/remove" + config context | `config-analysis` |
+| "what does this config do", "show me the settings" | `config-analysis` |
 
 ## How to Route
 
 1. Parse the user's request for intent keywords
 2. Match against the routing table
-3. Spawn the `api-operator` agent with the matched task
-4. Relay the agent's result to the user
+3. **Distinguish CRUD from analysis**: If the user's message
+   contains a JSON configuration blob (or references one shared
+   earlier) AND the intent is interrogative (asking about the
+   config rather than requesting a platform operation), route to
+   `config-analysis`. CRUD requests target the platform ("create
+   this LB", "delete that pool"). Analysis requests target a
+   provided config ("is WAF enabled on this?", "explain this
+   config", "what violations are disabled?").
+4. Spawn the appropriate agent with the matched task
+5. Relay the agent's result to the user
 
 ## Available Skills (read by the agent)
 
@@ -56,6 +70,10 @@ autonomously. The main session only receives the result.
 - **api-operations** — Spec-aware CRUD for 98 resource types
   across 38 domains, with endpoint paths, payload templates,
   dependency ordering, and multi-step workflow compositions
+- **config-analysis** — Configuration analysis and advisory Q&A.
+  Analyzes customer JSON configurations against the same resource
+  profiles as api-operations. Answers questions about security
+  posture, feature enablement, mode settings, and best practices.
 
 ## Future Skills (not yet implemented)
 

--- a/plugins/f5xc-platform/skills/config-analysis/SKILL.md
+++ b/plugins/f5xc-platform/skills/config-analysis/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: config-analysis
+description: >-
+  Configuration analysis and advisory for F5 XC platform
+  resources. Analyzes customer JSON configurations to answer
+  questions about security posture, feature enablement, mode
+  settings, exclusions, and best practices. Supports multi-turn
+  Q&A within agent dispatch. Use when user provides a JSON
+  config and asks questions about it, or asks to analyze,
+  review, or audit a configuration.
+user-invocable: false
+---
+
+# Config Analysis — Configuration Q&A
+
+Analyzes customer JSON configurations against the api-operations
+resource profiles to answer questions about security posture,
+feature enablement, and best practices. Delegates analysis to
+the `config-analyzer` agent to keep large JSON configs out of
+the main session.
+
+## When This Skill Applies
+
+Route here when the user:
+
+- Provides a JSON configuration and asks a question about it
+- Asks "is [feature] enabled/disabled" with a config present
+- Asks about security posture, mode settings, or configuration
+  review
+- Asks "how to change/enable/disable [feature]" in context of
+  a provided config
+- Asks to analyze, review, audit, or explain a configuration
+- Asks follow-up questions about a previously analyzed config
+
+## Critical: Subagent Delegation
+
+**Never analyze large JSON configs in the main session.** Customer
+configurations can be hundreds of lines. All analysis must be
+delegated to the `config-analyzer` agent:
+
+```
+Agent(
+  subagent_type="f5xc-platform:config-analyzer",
+  description="Analyze {resource_type} configuration",
+  prompt="<task details with JSON config and reference file paths>"
+)
+```
+
+The agent reads the resource profile reference files itself and
+returns a structured analysis report.
+
+## Resource Type Detection
+
+Identify the resource type from the JSON config before dispatching
+to the agent. Use these structural indicators:
+
+| JSON Indicators | Resource Type | Domain | Profile Path |
+| --------------- | ------------- | ------ | ------------ |
+| `spec.detection_settings` | app_firewall | virtual | `resources/virtual/app_firewall.md` |
+| `spec.domains` + `spec.advertise_*` | http_loadbalancer | virtual | `resources/virtual/http_loadbalancer.md` |
+| `spec.listen_port` + `spec.dns_volterra_managed` | tcp_loadbalancer | virtual | `resources/virtual/tcp_loadbalancer.md` |
+| `spec.origin_servers` | origin_pool | virtual | `resources/virtual/origin_pool.md` |
+| `spec.dns_type` or `spec.primary` | dns_zone | dns | `resources/dns/dns_zone.md` |
+| `spec.rule_list` or `spec.legacy_rule_list` | service_policy | virtual | `resources/virtual/service_policy.md` |
+| `spec.http_health_check` | healthcheck | virtual | `resources/virtual/healthcheck.md` |
+| `spec.certificate_url` | certificate | certificates | `resources/certificates/certificate.md` |
+
+All profile paths are relative to:
+`skills/api-operations/references/`
+
+If the resource type is ambiguous, include multiple candidate
+profile paths in the agent prompt — the agent will determine the
+correct one.
+
+## Dispatch Patterns
+
+### First Question (new config)
+
+````text
+Agent(
+  subagent_type="f5xc-platform:config-analyzer",
+  description="Analyze {resource_type} configuration",
+  prompt="Read these reference files first:
+  1. skills/api-operations/references/resources/{domain}/{resource}.md
+  [2. additional profiles if cross-resource analysis needed]
+
+  Then analyze this JSON configuration:
+  ```json
+  {paste the customer's JSON config here}
+  ```
+
+  Question: {user's question}
+
+  Use the resource profile to interpret mutually exclusive groups,
+  constrained fields, dependencies, and relationships. Cite specific
+  sections from the reference files in your findings."
+)
+````
+
+### Follow-up Question (same config)
+
+For follow-up questions about a previously analyzed configuration,
+re-dispatch with accumulated context:
+
+````text
+Agent(
+  subagent_type="f5xc-platform:config-analyzer",
+  description="Follow-up analysis on {resource_type}",
+  prompt="Read these reference files first:
+  1. skills/api-operations/references/resources/{domain}/{resource}.md
+
+  Original JSON configuration:
+  ```json
+  {same config — paste again}
+  ```
+
+  Previous findings:
+  - {compressed key findings from the prior analysis report}
+
+  New question: {follow-up question}
+
+  Build on the previous findings. Do not repeat analysis already
+  covered unless the new question contradicts or extends it."
+)
+````
+
+### Cross-Resource Analysis
+
+When a config references other resource types (e.g., an HTTP LB
+config that includes `enable_waf` referencing an app_firewall),
+include both resource profiles:
+
+````text
+Agent(
+  subagent_type="f5xc-platform:config-analyzer",
+  description="Analyze {primary_type} with {related_type} context",
+  prompt="Read these reference files first:
+  1. skills/api-operations/references/resources/{domain}/{primary}.md
+  2. skills/api-operations/references/resources/{domain}/{related}.md
+
+  Then analyze this JSON configuration:
+  ...
+  "
+)
+````
+
+## Multi-Turn Q&A Protocol
+
+The `config-analyzer` agent is ephemeral — it has no memory
+between dispatches. The main session must maintain conversational
+state:
+
+1. **First question**: Dispatch agent with JSON config + question.
+   Store the agent's Findings and Security Posture sections.
+2. **Follow-up**: Re-dispatch with same JSON config + compressed
+   previous findings + new question.
+3. **Context compression**: Extract only the key findings from
+   the previous analysis — do not accumulate full agent outputs.
+   Include them as bullet points under "Previous findings" in
+   the new dispatch prompt.
+
+This keeps follow-up dispatches focused while preserving
+conversational continuity.
+
+## Anti-Patterns — Do NOT Use
+
+- **SendMessage to a completed agent**: The config-analyzer
+  agent is ephemeral. Once it returns, it is gone. Do not
+  attempt SendMessage or team-based continuation. Always
+  spawn a fresh Agent invocation with accumulated context.
+- **Team-based coordination**: Do not create a team or use
+  persistent agent patterns for config analysis. The
+  dispatch-and-forget model is intentional — it prevents
+  context accumulation in long-lived agents.
+- **Raw JSON accumulation**: Do not pass full prior agent
+  outputs into follow-up prompts. Compress findings to
+  bullet points to keep dispatch token cost low.
+
+## Common Question Patterns
+
+| Question Pattern | Key Analysis |
+| ---------------- | ------------ |
+| "Is WAF enabled?" | Check `spec.monitoring` vs `spec.blocking` for app_firewall; check `spec.enable_waf` vs `spec.disable_waf` for http_loadbalancer |
+| "Is it in blocking mode?" | Check app_firewall top-level mode: `spec.monitoring: {}` = detect-only, `spec.blocking: {}` = active blocking |
+| "What violations are disabled?" | Check `spec.detection_settings.violation_settings.disabled_violation_types` |
+| "How to add an exclusion?" | Reference detection_settings structure for signature and violation exclusions |
+| "What signatures are active?" | Check `spec.detection_settings.signature_selection_setting` accuracy level |
+| "Is bot defense enabled?" | Check the `bot_defense` mutually exclusive group on the LB or `spec.default_bot_setting` on the WAF |
+| "What's the security posture?" | Enumerate all security features across mutually exclusive groups |
+| "How to switch from monitoring to blocking?" | Explain mode change + recommend reviewing staged signatures and disabled violations first |

--- a/plugins/f5xc-platform/skills/platform-index/SKILL.md
+++ b/plugins/f5xc-platform/skills/platform-index/SKILL.md
@@ -29,7 +29,10 @@ based operations via the `console-operator` agent.
 
 Keywords: "API", "cURL", "REST", "token", "programmatic",
 "JSON", "endpoint", "list via API", "get via API",
-"create via API", "check token", "validate token"
+"create via API", "check token", "validate token",
+"analyze config", "review config", "is [feature] enabled",
+"explain this config", "security posture", user provides
+a JSON configuration blob
 
 Invoke the `api-index` skill which handles all REST API
 operations via the `api-operator` agent.
@@ -49,19 +52,23 @@ without specifying console or API:
 ## Domain Skills
 
 ### Console Domain
+
 - **console-index** — Routes console UI requests
 - **console-auth** — Browser authentication (Azure SSO, DUO)
 - **console-navigator** — Navigate console sections by name
 - Agent: `f5xc-platform:console-operator`
 
 ### API Domain
+
 - **api-index** — Routes API requests
 - **api-auth** — API token and certificate authentication
-- Agent: `f5xc-platform:api-operator`
+- **config-analysis** — Configuration Q&A and advisory
+- Agents: `f5xc-platform:api-operator`, `f5xc-platform:config-analyzer`
 
 ## Shared Context
 
 Both domains share these environment variables:
+
 - `F5XC_API_URL` — Tenant base URL
 - `F5XC_NAMESPACE` — Default namespace
 - `F5XC_USERNAME` — User email (console auth)

--- a/scripts/validate-plugins.sh
+++ b/scripts/validate-plugins.sh
@@ -116,7 +116,25 @@ for i in $(seq 0 $((PLUGIN_COUNT - 1))); do
       fi
     done < <(find "$PLUGIN_DIR/skills" -name "SKILL.md" -print0 2>/dev/null)
 
-    # ── 8. Command frontmatter validation ──────────────────────
+    # ── 8. Agent frontmatter validation ─────────────────────────
+    AGENT_COUNT=0
+    while IFS= read -r -d '' agent_file; do
+      AGENT_COUNT=$((AGENT_COUNT + 1))
+      frontmatter=$(sed -n '/^---$/,/^---$/p' "$agent_file" | sed '1d;$d')
+
+      agent_name=$(echo "$frontmatter" | grep -E '^name:' | sed 's/^name:[[:space:]]*//' || true)
+      agent_desc=$(echo "$frontmatter" | grep -E '^description:' | sed 's/^description:[[:space:]]*//' || true)
+
+      rel_path="${agent_file#"$REPO_ROOT"/}"
+      if [[ -z "$agent_name" ]]; then
+        error "Agent missing 'name' in frontmatter: $rel_path"
+      fi
+      if [[ -z "$agent_desc" ]]; then
+        error "Agent missing 'description' in frontmatter: $rel_path"
+      fi
+    done < <(find "$PLUGIN_DIR/agents" -name "*.md" -print0 2>/dev/null)
+
+    # ── 9. Command frontmatter validation ──────────────────────
     CMD_COUNT=0
     while IFS= read -r -d '' cmd_file; do
       CMD_COUNT=$((CMD_COUNT + 1))
@@ -130,12 +148,12 @@ for i in $(seq 0 $((PLUGIN_COUNT - 1))); do
       fi
     done < <(find "$PLUGIN_DIR/commands" -name "*.md" -print0 2>/dev/null)
 
-    # ── 9. Plugin has at least one skill or command ────────────
-    TOTAL=$((SKILL_COUNT + CMD_COUNT))
+    # ── 10. Plugin has at least one skill, command, or agent ───
+    TOTAL=$((SKILL_COUNT + CMD_COUNT + AGENT_COUNT))
     if [[ "$TOTAL" -eq 0 ]]; then
-      error "Plugin '$PLUGIN_NAME': no skills or commands found"
+      error "Plugin '$PLUGIN_NAME': no skills, commands, or agents found"
     else
-      info "  Found $SKILL_COUNT skill(s), $CMD_COUNT command(s)"
+      info "  Found $SKILL_COUNT skill(s), $CMD_COUNT command(s), $AGENT_COUNT agent(s)"
     fi
   fi
 done


### PR DESCRIPTION
## Summary

- Add anti-pattern warnings to config-analysis SKILL.md documenting that SendMessage/team-based patterns must not be used with ephemeral agents
- Add ephemeral identity clarification to config-analyzer agent frontmatter
- Add agent frontmatter validation (name, description) to validate-plugins.sh as section 8, with agent count in completeness check and summary

Closes #174

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] `scripts/validate-plugins.sh` runs successfully and reports agent count
- [ ] Agent files with missing name/description would be caught by validation