### PR TITLE
chore(f5xc-platform): bump version to 3.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -128,7 +128,7 @@
     {
       "name": "f5xc-platform",
       "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/plugins/f5xc-platform/.claude-plugin/plugin.json
+++ b/plugins/f5xc-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-platform",
   "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"


### PR DESCRIPTION
## Summary

- Bump f5xc-platform plugin version from 3.0.0 to 3.1.0 in both the plugin manifest and the marketplace registry
- Publishes hardened config-analysis skill and agent definitions (anti-pattern warnings, ephemeral identity, agent CI validation)

Closes #176

## Test plan

- [ ] CI checks pass
- [ ] Marketplace registry entry version matches plugin manifest version