### PR TITLE
chore: bump all plugin versions and add missing documentation pages

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "f5xc-docs-tools",
       "description": "MDX content validation and review tools for f5xc-salesdemos docs repos",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -28,7 +28,7 @@
     {
       "name": "f5xc-sales-engineer",
       "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -43,7 +43,7 @@
     {
       "name": "f5xc-github-ops",
       "description": "GitHub operations automation — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -58,7 +58,7 @@
     {
       "name": "f5xc-docs-pipeline",
       "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -73,7 +73,7 @@
     {
       "name": "f5xc-brand",
       "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -88,7 +88,7 @@
     {
       "name": "f5xc-meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -113,7 +113,7 @@
     {
       "name": "f5xc-devcontainer",
       "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/docs/plugins/f5xc-brand.mdx
+++ b/docs/plugins/f5xc-brand.mdx
@@ -1,0 +1,58 @@
+---
+title: f5xc-brand
+sidebar:
+  order: 9
+---
+
+import { Badge } from '@astrojs/starlight/components';
+
+The **f5xc-brand** plugin enforces F5 corporate brand identity
+across all content types. It covers the 45-color F5 palette,
+typography rules (Neusa Next Pro Wide headlines, Proxima Nova
+body), SVG-only logo usage, icon pack selection, WCAG AA
+accessibility, and product terminology.
+
+<Badge text="v1.0.1" variant="note" /> <Badge text="Productivity" variant="tip" />
+
+## Installation
+
+```
+/plugin install f5xc-brand@f5xc-salesdemos-marketplace
+```
+
+## Skills
+
+### brand-guardian
+
+Proactive brand identity enforcement for all content creation.
+Activates automatically when creating documentation, diagrams,
+presentations, video thumbnails, social media graphics, Mermaid
+charts, or Excalidraw drawings. Ensures correct use of F5 colors,
+typography, logos, icons, tone of voice, and accessibility.
+
+### brand-reviewer
+
+Reviews existing content for F5 brand compliance. Audits colors,
+typography, logo format, icon selection, alt text, contrast ratios,
+and product terminology. Produces structured reports with
+VIOLATIONS, WARNINGS, and SUGGESTIONS.
+
+### visual-content
+
+Format-specific rules for branded visual content. Provides
+guidance for Mermaid diagrams, Excalidraw drawings, screenshots,
+PowerPoint presentations, YouTube thumbnails, video scripts, and
+social media graphics with icon pack selection, slide layouts,
+font fallbacks, and platform-specific dimensions.
+
+## Commands
+
+### /review-brand
+
+```
+/f5xc-brand:review-brand [path-or-glob]
+```
+
+Reviews content for F5 brand compliance. Accepts an optional path
+or glob pattern to scope the review. Without arguments, reviews
+all content in the current directory.

--- a/docs/plugins/f5xc-devcontainer.mdx
+++ b/docs/plugins/f5xc-devcontainer.mdx
@@ -1,0 +1,71 @@
+---
+title: f5xc-devcontainer
+sidebar:
+  order: 10
+---
+
+import { Aside, Badge } from '@astrojs/starlight/components';
+
+The **f5xc-devcontainer** plugin provides container awareness for
+the f5xc-salesdemos development environment. It maintains a
+comprehensive tool catalog, enables live container introspection,
+and handles tool installation with persistence tracking via
+GitHub issues.
+
+<Badge text="v1.1.5" variant="note" /> <Badge text="Productivity" variant="tip" />
+
+## Installation
+
+```
+/plugin install f5xc-devcontainer@f5xc-salesdemos-marketplace
+```
+
+## Skills
+
+### tool-catalog
+
+Knowledge base of every CLI tool installed in the devcontainer,
+organized by category (cloud, networking, security, development,
+etc.). Activates when you ask which tool to use, how to use a
+tool, whether something is installed, or need help with a
+specific operation.
+
+### self-awareness
+
+Container identity and self-diagnosis skill. Provides live
+introspection of the running container via GitHub API and local
+build metadata. Activates for identity, version, build info,
+health checks, and contributor history questions.
+
+<Aside type="tip">
+  Ask "who are you?" or "what version am I running?" to trigger
+  self-awareness.
+</Aside>
+
+## Agents
+
+### tool-advisor
+
+Reads the tool catalog and returns recommendations with purpose,
+quick-start commands, and authentication requirements for any CLI
+tool question.
+
+### tool-auditor
+
+Audits the devcontainer Dockerfile against the tool catalog
+reference files to detect drift &mdash; tools added to the image
+but not cataloged, or catalog entries for tools that have been
+removed.
+
+### container-introspector
+
+Performs live container introspection via GitHub API and local
+metadata for identity, genealogy, self-diagnosis, contributor
+history, and build lineage. Read-only operations only.
+
+### container-maintainer
+
+Installs, removes, searches, and updates CLI tools in the running
+container using correct package manager patterns. Files GitHub
+issues against the devcontainer repository for persistence
+tracking.

--- a/docs/plugins/f5xc-docs-pipeline.mdx
+++ b/docs/plugins/f5xc-docs-pipeline.mdx
@@ -1,0 +1,54 @@
+---
+title: f5xc-docs-pipeline
+sidebar:
+  order: 8
+---
+
+import { Aside, Badge } from '@astrojs/starlight/components';
+
+The **f5xc-docs-pipeline** plugin provides documentation pipeline
+architecture knowledge for f5xc-salesdemos repositories. It guides
+content authoring, clarifies config ownership across multi-repo
+builds, and provides local Docker-based preview.
+
+<Badge text="v1.0.1" variant="note" /> <Badge text="Productivity" variant="tip" />
+
+## Installation
+
+```
+/plugin install f5xc-docs-pipeline@f5xc-salesdemos-marketplace
+```
+
+## Skills
+
+### content-author
+
+Content authoring guide covering file structure, MDX syntax rules,
+frontmatter requirements, image references, and local Docker
+preview. Activates when creating or editing `docs/` content,
+working with MDX files, or setting up local preview.
+
+### pipeline-navigator
+
+Documentation pipeline architecture explaining where to make
+changes across the four upstream repositories: docs-theme,
+docs-builder, docs-control, and docs-icons. Clarifies config
+ownership (`astro.config.mjs`, `content.config.ts`), the release
+dispatch chain, and managed file tracking.
+
+<Aside type="tip">
+  Use pipeline-navigator when you need to understand which
+  repository owns a specific configuration file or component.
+</Aside>
+
+## Commands
+
+### /preview-docs
+
+```
+/f5xc-docs-pipeline:preview-docs
+```
+
+Starts a local Docker dev server to preview documentation. Runs
+the shared Docker build image with your local `docs/` directory
+mounted for live preview.

--- a/docs/plugins/f5xc-docs-tools.mdx
+++ b/docs/plugins/f5xc-docs-tools.mdx
@@ -12,7 +12,7 @@ build-breaking issues before they reach CI, including bare JSX
 characters, invalid imports, broken image references, and
 incomplete frontmatter.
 
-<Badge text="v1.0.0" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.1.1" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-github-ops.mdx
+++ b/docs/plugins/f5xc-github-ops.mdx
@@ -1,0 +1,58 @@
+---
+title: f5xc-github-ops
+sidebar:
+  order: 7
+---
+
+import { Aside, Badge } from '@astrojs/starlight/components';
+
+The **f5xc-github-ops** plugin provides exclusive GitHub operations
+automation for f5xc-salesdemos repositories. It handles the full
+Git and GitHub lifecycle from issue creation through post-merge
+monitoring, enforcing issue-driven development and pre-commit
+lint gates.
+
+<Badge text="v2.2.1" variant="note" /> <Badge text="Productivity" variant="tip" />
+
+## Installation
+
+```
+/plugin install f5xc-github-ops@f5xc-salesdemos-marketplace
+```
+
+## Skills
+
+### workflow-lifecycle
+
+Repository governance workflow handling issue creation, branch
+naming conventions, PR creation, CI polling with error feedback
+to issues, post-merge monitoring, verification, and task
+completion criteria. Activates when you say "commit", "push",
+"create a PR", "merge", or perform any Git operation.
+
+### upstream-contribution
+
+Upstream contribution workflow for fork-based development. Handles
+fork detection, upstream research (issues, PRs, CONTRIBUTING.md,
+CI patterns), cross-repo issue and PR creation, local tracking
+issue management, upstream CI monitoring, and guided resolution.
+
+## Agents
+
+### github-ops
+
+Exclusive agent for all mechanical Git and GitHub operations.
+Handles pre-commit lint gates, issue creation, branch creation,
+staging, committing, pushing, PR creation, CI polling with error
+feedback, infrastructure failure retry, post-merge monitoring,
+branch cleanup, and repository settings management via the
+GitHub API.
+
+Returns structured status reports: `COMPLETE`,
+`PRE_COMMIT_FAILED`, `CI_FAILED`, `BLOCKED`, or `FAILED`.
+
+<Aside type="caution">
+  This agent is the **exclusive** handler for Git operations.
+  Never run `git commit`, `git push`, or `gh pr create` directly
+  in repositories that use this plugin.
+</Aside>

--- a/docs/plugins/f5xc-meddpicc.mdx
+++ b/docs/plugins/f5xc-meddpicc.mdx
@@ -12,7 +12,7 @@ sales. It transforms MEDDPICC from a checkbox exercise into a living
 deal execution system with evidence-based qualification, structured
 deal reviews, and actionable coaching.
 
-<Badge text="v1.0.0" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.0.3" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-platform.mdx
+++ b/docs/plugins/f5xc-platform.mdx
@@ -1,0 +1,111 @@
+---
+title: f5xc-platform
+sidebar:
+  order: 11
+---
+
+import { Aside, Badge } from '@astrojs/starlight/components';
+
+The **f5xc-platform** plugin provides full automation for the F5
+Distributed Cloud platform. It covers web console operations via
+Chrome DevTools MCP, spec-aware REST API operations via cURL,
+multi-provider authentication, and configuration analysis across
+98 resource types in 38 domains.
+
+<Badge text="v3.1.0" variant="note" /> <Badge text="Productivity" variant="tip" />
+
+## Installation
+
+```
+/plugin install f5xc-platform@f5xc-salesdemos-marketplace
+```
+
+## Skills
+
+### api-operations
+
+Spec-aware API CRUD operations covering 98 resource types across
+38 domains. Provides precise endpoints, payload templates,
+dependency ordering, and multi-step workflow compositions for
+HTTP load balancers, origin pools, WAF policies, DNS zones,
+certificates, cloud sites, and more.
+
+### config-analysis
+
+Configuration analysis and advisory capability. Analyzes customer
+JSON configurations to answer questions about security posture,
+feature enablement, mode settings, exclusions, and best practices.
+Supports multi-turn Q&A with compressed context between dispatches.
+
+### api-auth
+
+API authentication supporting API token header authentication and
+P12 certificate authentication with token validation procedures.
+
+### console-auth
+
+Multi-provider authentication for the F5 XC web console.
+Auto-detects login type: native F5 XC login, Azure SSO with
+cached session, or Azure SSO with DUO verified push MFA.
+
+### console-navigator
+
+Deterministic navigation to F5 XC console sections. Translates
+section names to URL paths, verifies session health, and confirms
+page load.
+
+### platform-index / api-index / console-index
+
+Intent routers that classify user requests and delegate to the
+appropriate skill and agent. These activate automatically and are
+not user-invocable.
+
+## Commands
+
+### /check-api-token
+
+```
+/f5xc-platform:check-api-token
+```
+
+Validates your F5 XC API token by delegating to the api-operator
+agent.
+
+### /login-console
+
+```
+/f5xc-platform:login-console
+```
+
+Authenticates to the F5 Distributed Cloud console via the
+console-operator agent.
+
+## Agents
+
+### api-operator
+
+Autonomous REST API agent executing cURL and jq sequences for
+resource CRUD, token validation, and configuration operations.
+Runs in a subagent to keep verbose API JSON payloads out of the
+main session context.
+
+### console-operator
+
+Autonomous browser automation agent executing Chrome DevTools MCP
+tool sequences for authentication, navigation, and form
+interactions. Runs in a subagent to keep token-heavy browser
+snapshots out of the main session.
+
+### config-analyzer
+
+Read-only configuration analysis agent. Analyzes customer JSON
+configurations against resource profile reference files to answer
+questions about security posture, feature enablement, mode
+transitions, and best practices.
+
+<Aside type="caution">
+  The config-analyzer agent is **ephemeral** &mdash; spawned fresh
+  for each question with no memory between dispatches. Follow-up
+  questions must include compressed previous findings in the
+  dispatch prompt.
+</Aside>

--- a/docs/plugins/f5xc-sales-engineer.mdx
+++ b/docs/plugins/f5xc-sales-engineer.mdx
@@ -11,7 +11,7 @@ persona framework for F5 XC demo repositories. It handles the full
 demo meeting lifecycle — from pre-meeting verification through live
 execution, Q&A, and teardown.
 
-<Badge text="v1.0.0" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.0.5" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -13,12 +13,14 @@ branding, and development operations.
 
 | Plugin | Version | Category | Description |
 |--------|---------|----------|-------------|
-| [f5xc-docs-tools](/marketplace/plugins/f5xc-docs-tools/) | 1.1.0 | Productivity | MDX content validation and review tools |
-| [f5xc-sales-engineer](/marketplace/plugins/f5xc-sales-engineer/) | 1.0.3 | Productivity | Sales Engineer persona framework — demo execution, presentation, Q&A, environment management |
-| [f5xc-github-ops](/marketplace/plugins/f5xc-github-ops/) | 2.0.0 | Productivity | GitHub operations automation — issue-driven development, PR lifecycle, CI polling |
-| [f5xc-docs-pipeline](/marketplace/plugins/f5xc-docs-pipeline/) | 1.0.0 | Productivity | Documentation pipeline architecture — content authoring, local preview, config ownership |
-| [f5xc-brand](/marketplace/plugins/f5xc-brand/) | 1.0.0 | Productivity | F5 corporate branding enforcement — colors, typography, logos, icons, accessibility |
-| [f5xc-meddpicc](/marketplace/plugins/f5xc-meddpicc/) | 1.0.0 | Productivity | MEDDPICC sales qualification and deal-execution framework |
+| [f5xc-docs-tools](/marketplace/plugins/f5xc-docs-tools/) | 1.1.1 | Productivity | MDX content validation and review tools |
+| [f5xc-sales-engineer](/marketplace/plugins/f5xc-sales-engineer/) | 1.0.5 | Productivity | Sales Engineer persona framework — demo execution, presentation, Q&A, environment management |
+| [f5xc-github-ops](/marketplace/plugins/f5xc-github-ops/) | 2.2.1 | Productivity | GitHub operations automation — issue-driven development, PR lifecycle, CI polling |
+| [f5xc-docs-pipeline](/marketplace/plugins/f5xc-docs-pipeline/) | 1.0.1 | Productivity | Documentation pipeline architecture — content authoring, local preview, config ownership |
+| [f5xc-brand](/marketplace/plugins/f5xc-brand/) | 1.0.1 | Productivity | F5 corporate branding enforcement — colors, typography, logos, icons, accessibility |
+| [f5xc-meddpicc](/marketplace/plugins/f5xc-meddpicc/) | 1.0.3 | Productivity | MEDDPICC sales qualification and deal-execution framework |
+| [f5xc-devcontainer](/marketplace/plugins/f5xc-devcontainer/) | 1.1.5 | Productivity | Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance |
+| [f5xc-platform](/marketplace/plugins/f5xc-platform/) | 3.1.0 | Productivity | F5 XC platform automation — console, REST API, config analysis across 98 resource types |
 
 ## What's in a Plugin?
 
@@ -39,6 +41,8 @@ Each plugin can include:
 /plugin install f5xc-docs-pipeline@f5xc-salesdemos-marketplace
 /plugin install f5xc-brand@f5xc-salesdemos-marketplace
 /plugin install f5xc-meddpicc@f5xc-salesdemos-marketplace
+/plugin install f5xc-devcontainer@f5xc-salesdemos-marketplace
+/plugin install f5xc-platform@f5xc-salesdemos-marketplace
 ```
 
 See [Getting Started](/marketplace/getting-started/) for the

--- a/plugins/f5xc-brand/.claude-plugin/plugin.json
+++ b/plugins/f5xc-brand/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-brand",
   "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "f5xc-salesdemos"
   },

--- a/plugins/f5xc-devcontainer/.claude-plugin/plugin.json
+++ b/plugins/f5xc-devcontainer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-devcontainer",
   "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-docs-pipeline/.claude-plugin/plugin.json
+++ b/plugins/f5xc-docs-pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-docs-pipeline",
   "description": "Documentation pipeline architecture for f5xc-salesdemos — config ownership, release dispatch chain, content authoring, managed files, local preview",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-docs-tools/.claude-plugin/plugin.json
+++ b/plugins/f5xc-docs-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-docs-tools",
   "description": "MDX content validation and review tools for f5xc-salesdemos documentation repositories",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-github-ops/.claude-plugin/plugin.json
+++ b/plugins/f5xc-github-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-github-ops",
   "description": "GitHub operations automation for f5xc-salesdemos — issue-driven development, pre-commit lint gate, PR lifecycle, CI polling with error feedback to issues, post-merge monitoring, verification, rate limit management, upstream contribution workflow for fork-based development, and exclusive github-ops agent for all Git operations. Covers commit, push, branch, merge, squash, pull request, issue creation, repository settings, and fork-to-upstream contributions.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-meddpicc/.claude-plugin/plugin.json
+++ b/plugins/f5xc-meddpicc/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-platform/agents/config-analyzer.md
+++ b/plugins/f5xc-platform/agents/config-analyzer.md
@@ -53,7 +53,7 @@ indicators:
 | `spec.domains` + `spec.advertise_*` or `spec.http`/`spec.https` | http_loadbalancer | virtual |
 | `spec.listen_port` + `spec.dns_volterra_managed` | tcp_loadbalancer | virtual |
 | `spec.origin_servers` | origin_pool | virtual |
-| `spec.dns_type` or `spec.primary` | dns_zone | dns |
+| `spec.dns_type` or `spec.primary` | dns_zone | DNS |
 | `spec.rule_list` or `spec.legacy_rule_list` | service_policy | virtual |
 | `spec.health_check_port` or `spec.http_health_check` | healthcheck | virtual |
 | `spec.certificate_url` or `spec.private_key` | certificate | certificates |
@@ -218,7 +218,7 @@ complete.]
 ## Execution Rules
 
 1. **Read-only** — never create, modify, or delete files
-2. **No API calls** — never execute cURL, curl, or any HTTP requests
+2. **No API calls** — never execute cURL or any HTTP requests
 3. **Cite everything** — every finding must trace to a config field
    or reference file section
 4. **Acknowledge limits** — if the reference files do not cover a

--- a/plugins/f5xc-platform/skills/config-analysis/SKILL.md
+++ b/plugins/f5xc-platform/skills/config-analysis/SKILL.md
@@ -60,7 +60,7 @@ to the agent. Use these structural indicators:
 | `spec.domains` + `spec.advertise_*` | http_loadbalancer | virtual | `resources/virtual/http_loadbalancer.md` |
 | `spec.listen_port` + `spec.dns_volterra_managed` | tcp_loadbalancer | virtual | `resources/virtual/tcp_loadbalancer.md` |
 | `spec.origin_servers` | origin_pool | virtual | `resources/virtual/origin_pool.md` |
-| `spec.dns_type` or `spec.primary` | dns_zone | dns | `resources/dns/dns_zone.md` |
+| `spec.dns_type` or `spec.primary` | dns_zone | DNS | `resources/dns/dns_zone.md` |
 | `spec.rule_list` or `spec.legacy_rule_list` | service_policy | virtual | `resources/virtual/service_policy.md` |
 | `spec.http_health_check` | healthcheck | virtual | `resources/virtual/healthcheck.md` |
 | `spec.certificate_url` | certificate | certificates | `resources/certificates/certificate.md` |
@@ -162,7 +162,7 @@ state:
 This keeps follow-up dispatches focused while preserving
 conversational continuity.
 
-## Anti-Patterns — Do NOT Use
+## Antipatterns — Do NOT Use
 
 - **SendMessage to a completed agent**: The config-analyzer
   agent is ephemeral. Once it returns, it is gone. Do not

--- a/plugins/f5xc-sales-engineer/.claude-plugin/plugin.json
+++ b/plugins/f5xc-sales-engineer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-sales-engineer",
   "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"


### PR DESCRIPTION
## Summary

- Patch-bump 7 plugin versions to force downstream auto-updaters to sync
- Add 5 missing documentation pages for plugins that had none
- Update index.mdx catalog with all 8 plugins and correct versions

Closes #178

## Test plan

- [ ] CI checks pass
- [ ] Documentation site builds successfully
- [ ] Version badges display correctly in docs pages