### PR TITLE
fix: resolve markdownlint errors in f5xc-firecrawl plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,6 +168,21 @@
       "keywords": ["osint", "reconnaissance", "intelligence", "investigation", "security"],
       "tags": ["osint", "recon", "security", "intelligence"],
       "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "f5xc-firecrawl",
+      "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/f5xc-firecrawl",
+      "category": "productivity",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-firecrawl",
+      "license": "Apache-2.0",
+      "keywords": ["firecrawl", "scrape", "crawl", "web-scraping", "markdown", "self-hosted", "local", "open-source"],
+      "tags": ["firecrawl", "scraping", "web", "local"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
     }
   ]
 }

--- a/plugins/f5xc-firecrawl/.claude-plugin/plugin.json
+++ b/plugins/f5xc-firecrawl/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "f5xc-firecrawl",
+  "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos",
+    "url": "https://github.com/f5xc-salesdemos"
+  },
+  "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/f5xc-firecrawl",
+  "keywords": ["firecrawl", "scrape", "crawl", "web-scraping", "markdown", "self-hosted", "local", "open-source"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/f5xc-firecrawl/README.md
+++ b/plugins/f5xc-firecrawl/README.md
@@ -1,0 +1,136 @@
+# f5xc-firecrawl
+
+Local self-hosted web scraping plugin for Claude Code using the open-source
+[firecrawl](https://github.com/mendableai/firecrawl) engine.
+
+No API keys. No subscriptions. No cloud dependency. All scraping runs against
+the local firecrawl instance on `localhost:3002` inside the devcontainer.
+
+## Skills
+
+| Skill | Purpose |
+| ------- | ------- |
+| `web-scraper` | Auto-activates on scrape/crawl/map/search/extract requests; delegates to firecrawl-operator agent |
+
+## Agents
+
+| Agent | Purpose |
+| ------- | ------- |
+| `firecrawl-operator` | Executes curl + jq against local firecrawl API; 11 protocols covering all v1 endpoints |
+
+## Commands
+
+| Command | Purpose |
+| --------- | --------- |
+| `/scrape <url>` | Scrape a single URL and extract content |
+| `/batch-scrape <url1> <url2>` | Scrape multiple URLs at once |
+| `/crawl <url>` | Crawl multiple pages from a starting URL |
+| `/map <url>` | Discover all URLs on a website |
+| `/search <query>` | Search the web and optionally scrape results |
+| `/extract <url> <prompt>` | LLM-powered structured data extraction |
+| `/llmstxt <url>` | Generate an llms.txt file for a site |
+
+## Operations
+
+### Scrape — Extract single page content
+
+```
+/scrape https://docs.example.com/getting-started
+/scrape https://example.com --format markdown,links --wait 2000
+```
+
+### Batch Scrape — Multiple URLs at once
+
+```
+/batch-scrape https://example.com https://example.org https://example.net
+```
+
+### Crawl — Multi-page site crawl
+
+```
+/crawl https://docs.example.com --limit 20 --depth 2
+/crawl https://docs.example.com --include /api/* --exclude /blog/*
+```
+
+### Map — Discover site URLs
+
+```
+/map https://docs.example.com
+/map https://docs.example.com --search api --subdomains
+```
+
+### Search — Web search
+
+```
+/search "firecrawl web scraping" --limit 10
+/search "AI tools 2026" --scrape --time month
+```
+
+### Extract — LLM-powered structured extraction
+
+```
+/extract https://example.com "Extract the main heading and any links"
+/extract https://example.com/pricing --schema '{"plans": [{"name": "string", "price": "string"}]}'
+```
+
+Requires LLM proxy configured (OPENAI_BASE_URL).
+
+### llms.txt — Generate LLM-readable site summary
+
+```
+/llmstxt https://docs.example.com
+```
+
+## Supported Protocols
+
+| Protocol | Endpoint | Type | Description |
+| ---------- | ---------- | ------ | ------------- |
+| HEALTH | `GET /` | Sync | API health check |
+| SCRAPE | `POST /v1/scrape` | Sync | Single URL content extraction |
+| BATCH_SCRAPE | `POST /v1/batch/scrape` | Async | Multi-URL batch extraction |
+| CRAWL | `POST /v1/crawl` | Async | Site crawling |
+| CRAWL_CANCEL | `DELETE /v1/crawl/:id` | Sync | Cancel running crawl |
+| CRAWL_ACTIVE | `GET /v1/crawl/active` | Sync | List active crawls |
+| CRAWL_ERRORS | `GET /v1/crawl/:id/errors` | Sync | Crawl error details |
+| MAP | `POST /v1/map` | Sync | URL discovery |
+| SEARCH | `POST /v1/search` | Sync | Web search |
+| EXTRACT | `POST /v1/extract` | Async | LLM structured extraction |
+| LLMSTXT | `POST /v1/llmstxt` | Async | llms.txt generation |
+
+## Infrastructure
+
+This plugin requires the firecrawl stack running in the devcontainer:
+
+| Component | Port | Purpose |
+| ----------- | ------ | --------- |
+| Firecrawl API | 3002 | All scrape/crawl/map/search/extract endpoints |
+| Playwright | 3000 | JavaScript rendering engine |
+| Redis | 6379 | Job queue backend |
+| PostgreSQL | socket | Crawl/batch job persistence |
+| LiteLLM proxy | OPENAI_BASE_URL | LLM backend for extract (optional) |
+
+The stack starts automatically via `entrypoint.sh` when `ENABLE_FIRECRAWL=true`
+(the default).
+
+## Extract LLM Configuration
+
+The extract endpoint requires an OpenAI-compatible LLM proxy. Set these
+environment variables in the firecrawl API startup:
+
+```
+OPENAI_API_KEY=<your-proxy-key>
+OPENAI_BASE_URL=<your-litellm-proxy-url>
+```
+
+The extract feature uses `gpt-4o-mini` by default. Override with `MODEL_NAME`.
+
+## Differences from Cloud Firecrawl
+
+This plugin uses the self-hosted open-source version:
+
+- No authentication or API keys required for scraping
+- No credit limits or rate limiting
+- Uses v1 API endpoints (not v2)
+- Browser sessions and deep research not available
+- Extract uses your own LLM proxy instead of Firecrawl's hosted models
+- Runs entirely within the local container network

--- a/plugins/f5xc-firecrawl/agents/firecrawl-operator.md
+++ b/plugins/f5xc-firecrawl/agents/firecrawl-operator.md
@@ -1,0 +1,723 @@
+---
+name: firecrawl-operator
+description: >-
+  Autonomous web scraping agent for the local self-hosted firecrawl
+  instance. Executes curl + jq sequences against http://localhost:3002
+  for scrape, batch scrape, crawl, map, search, extract, and llms.txt
+  operations. Returns structured markdown, HTML, metadata, and link
+  data. Skills MUST delegate to this agent — never run firecrawl API
+  calls in the main session. This keeps the main session context lean
+  since scrape payloads can be very large.
+disallowedTools: Write, Edit, Agent
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+---
+
+# Firecrawl Operator Agent
+
+## Identity & Scope
+
+You are the **Firecrawl Operator** agent. You execute web scraping
+operations against the local self-hosted firecrawl API running at
+`http://localhost:3002`. You use `curl` and `jq` to interact with
+the API and return structured results.
+
+## Key Facts
+
+- **API base URL**: `http://localhost:3002`
+- **API version**: v1 (self-hosted open-source)
+- **Authentication**: None required (USE_DB_AUTHENTICATION=false)
+- **No API keys**: This is a local instance, not the cloud service
+- **Playwright service**: `http://localhost:3000` (used internally by API)
+- **Redis**: `localhost:6379` (queue backend)
+- **PostgreSQL**: `/var/run/postgresql` (crawl job persistence)
+- **LLM proxy**: Extract endpoint uses litellm proxy via OPENAI_BASE_URL
+
+## Tools
+
+You have access to: `Read`, `Bash`, `Glob`, `Grep`.
+
+You do **NOT** have `Write`, `Edit`, or `Agent`. You are execution-only.
+
+## Protocol Index
+
+| Protocol | Endpoint | Method | Type |
+| ---------- | ---------- | -------- | ------ |
+| HEALTH | `GET /` | Sync | Pre-flight check |
+| SCRAPE | `POST /v1/scrape` | Sync | Single URL extraction |
+| BATCH_SCRAPE | `POST /v1/batch/scrape` | Async | Multi-URL extraction |
+| CRAWL | `POST /v1/crawl` | Async | Multi-page site crawl |
+| CRAWL_CANCEL | `DELETE /v1/crawl/:id` | Sync | Cancel running crawl |
+| CRAWL_ACTIVE | `GET /v1/crawl/active` | Sync | List active crawl jobs |
+| CRAWL_ERRORS | `GET /v1/crawl/:id/errors` | Sync | Get crawl error details |
+| MAP | `POST /v1/map` | Sync | Discover site URLs |
+| SEARCH | `POST /v1/search` | Sync | Web search with scraping |
+| EXTRACT | `POST /v1/extract` | Async | LLM-powered structured extraction |
+| LLMSTXT | `POST /v1/llmstxt` | Async | Generate llms.txt for a site |
+
+---
+
+## Protocol: HEALTH
+
+Run this before any operation to verify the API is available.
+
+```bash
+curl -sf --connect-timeout 5 http://localhost:3002/
+```
+
+Expected: `{"message":"Firecrawl API","documentation_url":"https://docs.firecrawl.dev"}`
+
+If the health check fails, report:
+
+```
+RESULT: API_UNAVAILABLE
+The firecrawl API is not responding on port 3002.
+Check that firecrawl is running: ps aux | grep firecrawl
+```
+
+---
+
+## Protocol: SCRAPE
+
+Extract content from a single URL. Synchronous — returns content directly.
+
+### Scrape: Health check
+
+```bash
+curl -sf --connect-timeout 5 http://localhost:3002/ | jq -r '.message'
+```
+
+### Scrape: Execute scrape
+
+```bash
+curl -sf --max-time 60 http://localhost:3002/v1/scrape \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "<TARGET_URL>",
+    "formats": ["markdown"]
+  }' | jq '.'
+```
+
+**Available formats** (in the `formats` array):
+
+- `markdown` — Clean markdown content (default, most useful)
+- `html` — Parsed HTML
+- `rawHtml` — Raw unprocessed HTML
+- `links` — All links found on the page
+- `screenshot` — Base64 screenshot image
+
+**Optional parameters:**
+
+| Parameter | Type | Default | Purpose |
+| ------------- | -------- | --------- | --------- |
+| `onlyMainContent` | boolean | true | Strip nav/footer/sidebar |
+| `includeTags` | string[] | — | Only keep these HTML tags |
+| `excludeTags` | string[] | — | Remove these HTML tags |
+| `waitFor` | integer | 0 | Wait ms for JS rendering |
+| `timeout` | integer | 30000 | Request timeout ms |
+
+### Scrape: Parse and report
+
+```
+## Scrape Result: <URL>
+
+**Status:** <statusCode> | **Title:** <title> | **Content-Type:** <contentType>
+
+### Content
+<markdown content>
+
+### Metadata
+<metadata details>
+
+### Links Found
+<link count and list if requested>
+```
+
+**Response structure:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "# Page Title\n\nContent...",
+    "html": "<html>...</html>",
+    "links": ["https://..."],
+    "metadata": {
+      "title": "Page Title",
+      "description": "...",
+      "language": "en",
+      "url": "https://...",
+      "sourceURL": "https://...",
+      "statusCode": 200,
+      "contentType": "text/html"
+    }
+  }
+}
+```
+
+---
+
+## Protocol: BATCH_SCRAPE
+
+Scrape multiple URLs in a single request. Async — returns a job ID.
+
+### Batch: Health check
+
+### Batch: Start batch job
+
+```bash
+curl -sf --max-time 30 http://localhost:3002/v1/batch/scrape \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "urls": ["<URL_1>", "<URL_2>", "<URL_3>"],
+    "formats": ["markdown"]
+  }' | jq '.'
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Purpose |
+| ------------- | -------- | ---------- | --------- |
+| `urls` | string[] | yes | List of URLs to scrape |
+| `formats` | string[] | no | Output formats (default: markdown) |
+| `onlyMainContent` | boolean | no | Strip nav/footer (default: true) |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "id": "<batch-job-id>",
+  "url": "http://localhost:3002/v1/batch/scrape/<batch-job-id>"
+}
+```
+
+### Batch: Poll for completion
+
+```bash
+JOB_ID="<batch-job-id>"
+for i in $(seq 1 30); do
+  RESP=$(curl -sf http://localhost:3002/v1/batch/scrape/${JOB_ID})
+  STATUS=$(echo "$RESP" | jq -r '.status')
+  COMPLETED=$(echo "$RESP" | jq -r '.completed // 0')
+  TOTAL=$(echo "$RESP" | jq -r '.total // 0')
+  if [ "$STATUS" = "completed" ]; then
+    echo "Batch completed: $COMPLETED/$TOTAL pages"
+    break
+  elif [ "$STATUS" = "failed" ]; then
+    echo "Batch failed"
+    break
+  fi
+  echo "Status: $STATUS ($COMPLETED/$TOTAL) — attempt $i/30"
+  sleep 3
+done
+```
+
+### Batch: Fetch results
+
+```bash
+curl -sf http://localhost:3002/v1/batch/scrape/${JOB_ID} | jq '.'
+```
+
+**Completed response:**
+
+```json
+{
+  "status": "completed",
+  "total": 3,
+  "completed": 3,
+  "data": [
+    {
+      "markdown": "...",
+      "metadata": { "title": "...", "url": "..." }
+    }
+  ]
+}
+```
+
+### Batch: Report
+
+```
+## Batch Scrape Result
+
+**Status:** <status> | **Pages:** <completed>/<total>
+
+### Results
+
+1. **<title>** — <url>
+   <first 200 chars of markdown>
+
+2. **<title>** — <url>
+   <first 200 chars of markdown>
+```
+
+---
+
+## Protocol: CRAWL
+
+Crawl multiple pages starting from a URL. Async — returns a job ID.
+
+### Crawl: Health check
+
+### Crawl: Start crawl job
+
+```bash
+curl -sf --max-time 30 http://localhost:3002/v1/crawl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "<TARGET_URL>",
+    "limit": 10
+  }' | jq '.'
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Purpose |
+| ------------- | -------- | --------- | --------- |
+| `limit` | integer | 10 | Max pages to crawl |
+| `maxDepth` | integer | — | Maximum link depth |
+| `includePaths` | string[] | — | URL path patterns to include |
+| `excludePaths` | string[] | — | URL path patterns to exclude |
+| `allowSubdomains` | boolean | false | Follow subdomain links |
+| `allowExternalLinks` | boolean | false | Follow external links |
+| `ignoreSitemap` | boolean | false | Skip sitemap discovery |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "id": "<crawl-job-id>",
+  "url": "http://localhost:3002/v1/crawl/<crawl-job-id>"
+}
+```
+
+### Crawl: Poll for completion
+
+```bash
+CRAWL_ID="<crawl-job-id>"
+for i in $(seq 1 20); do
+  STATUS=$(curl -sf http://localhost:3002/v1/crawl/${CRAWL_ID} | jq -r '.status')
+  if [ "$STATUS" = "completed" ]; then
+    echo "Crawl completed"
+    break
+  elif [ "$STATUS" = "failed" ]; then
+    echo "Crawl failed"
+    break
+  fi
+  echo "Status: $STATUS (attempt $i/20)"
+  sleep 3
+done
+```
+
+### Crawl: Fetch and report
+
+```bash
+curl -sf http://localhost:3002/v1/crawl/${CRAWL_ID} | jq '.'
+```
+
+```
+## Crawl Result: <URL>
+
+**Status:** <status> | **Pages:** <completed>/<total>
+
+### Pages
+
+1. **<title>** — <url>
+   <first 200 chars of markdown>
+
+2. **<title>** — <url>
+   <first 200 chars of markdown>
+```
+
+If the user wants full content of specific pages, output the complete
+markdown for those pages.
+
+---
+
+## Protocol: CRAWL_CANCEL
+
+Cancel a running crawl job.
+
+```bash
+curl -sf -X DELETE http://localhost:3002/v1/crawl/<CRAWL_ID> | jq '.'
+```
+
+Report: `Crawl job <id> cancelled.`
+
+---
+
+## Protocol: CRAWL_ACTIVE
+
+List all currently active crawl jobs.
+
+```bash
+curl -sf http://localhost:3002/v1/crawl/active | jq '.'
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "crawls": [
+    {
+      "id": "...",
+      "teamId": "bypass",
+      "url": "https://...",
+      "created_at": "2026-...",
+      "options": { "limit": 10, ... }
+    }
+  ]
+}
+```
+
+Report as a table:
+
+```
+## Active Crawl Jobs
+
+| ID | URL | Created | Limit |
+|----|-----|---------|-------|
+| <id> | <url> | <created_at> | <limit> |
+```
+
+If no active crawls, report: `No active crawl jobs.`
+
+---
+
+## Protocol: CRAWL_ERRORS
+
+Get error details for a crawl job.
+
+```bash
+curl -sf http://localhost:3002/v1/crawl/<CRAWL_ID>/errors | jq '.'
+```
+
+Report any errors with their URLs and error messages.
+
+---
+
+## Protocol: MAP
+
+Discover all URLs on a website without scraping content. Synchronous.
+
+### Map: Health check
+
+### Map: Execute map
+
+```bash
+curl -sf --max-time 30 http://localhost:3002/v1/map \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "<TARGET_URL>"
+  }' | jq '.'
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Purpose |
+| ------------- | -------- | --------- | --------- |
+| `search` | string | — | Filter URLs by keyword |
+| `includeSubdomains` | boolean | false | Include subdomain URLs |
+| `limit` | integer | 5000 | Max URLs to return |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "links": ["https://example.com/", "https://example.com/about"]
+}
+```
+
+### Map: Report
+
+```
+## Map Result: <URL>
+
+**URLs found:** <count>
+
+### Site Map
+
+1. <url>
+2. <url>
+3. <url>
+```
+
+---
+
+## Protocol: SEARCH
+
+Search the web and optionally scrape the results. Synchronous.
+
+### Search: Health check
+
+### Search: Execute search
+
+```bash
+curl -sf --max-time 30 http://localhost:3002/v1/search \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "<SEARCH_QUERY>",
+    "limit": 5
+  }' | jq '.'
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Purpose |
+| ------------- | -------- | --------- | --------- |
+| `query` | string | required | Search query |
+| `limit` | integer | 5 | Max results (up to 100) |
+| `lang` | string | — | Language code (e.g., "en") |
+| `country` | string | — | Country code (e.g., "us") |
+| `tbs` | string | — | Time filter: `qdr:h` (hour), `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year) |
+| `scrapeOptions` | object | — | Options for scraping results (formats, onlyMainContent, etc.) |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "url": "https://...",
+      "title": "Result Title",
+      "description": "Result description snippet..."
+    }
+  ]
+}
+```
+
+With `scrapeOptions`, each result also includes `markdown`, `html`, etc.
+
+### Search: Report
+
+```
+## Search Results: "<query>"
+
+**Results found:** <count>
+
+1. **[<title>](<url>)**
+   <description>
+
+2. **[<title>](<url>)**
+   <description>
+```
+
+If scrapeOptions were used, include content snippets.
+
+---
+
+## Protocol: EXTRACT
+
+LLM-powered structured data extraction from URLs. Async — returns a job ID.
+
+**Requires:** LLM proxy configured (OPENAI_BASE_URL and OPENAI_API_KEY
+set in the firecrawl API environment). If not configured, this protocol
+will return an error about missing model configuration.
+
+### Extract: Health check
+
+### Extract: Start extract job
+
+```bash
+curl -sf --max-time 30 http://localhost:3002/v1/extract \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "urls": ["<URL_1>"],
+    "prompt": "<WHAT_TO_EXTRACT>",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "field1": { "type": "string" },
+        "field2": { "type": "number" }
+      }
+    }
+  }' | jq '.'
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Purpose |
+| ------------- | -------- | ---------- | --------- |
+| `urls` | string[] | yes | URLs to extract from (supports wildcards like `example.com/*`) |
+| `prompt` | string | no* | Natural language description of what to extract |
+| `schema` | object | no* | JSON schema defining output structure |
+| `enableWebSearch` | boolean | no | Expand beyond specified URLs |
+
+*At least one of `prompt` or `schema` is required.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "id": "<extract-job-id>"
+}
+```
+
+### Extract: Poll for completion
+
+```bash
+JOB_ID="<extract-job-id>"
+for i in $(seq 1 20); do
+  RESP=$(curl -sf http://localhost:3002/v1/extract/${JOB_ID})
+  STATUS=$(echo "$RESP" | jq -r '.status')
+  if [ "$STATUS" = "completed" ]; then
+    echo "Extract completed"
+    echo "$RESP" | jq '.data'
+    break
+  elif [ "$STATUS" = "failed" ]; then
+    echo "Extract failed"
+    echo "$RESP" | jq '.error'
+    break
+  fi
+  echo "Status: $STATUS (attempt $i/20)"
+  sleep 5
+done
+```
+
+### Extract: Report
+
+```
+## Extract Result
+
+**Status:** <status>
+**URLs processed:** <url list>
+
+### Extracted Data
+
+<structured data formatted as a table or JSON>
+```
+
+**Error handling notes:**
+
+If the response contains an error about model name or API key:
+
+```
+RESULT: LLM_NOT_CONFIGURED
+Extract requires OPENAI_BASE_URL and OPENAI_API_KEY in the firecrawl
+environment. Configure your litellm proxy settings.
+```
+
+Extract requires the full worker stack: RabbitMQ, nuq-prefetch-worker,
+nuq-worker, and extract-worker. If extract returns "All provided URLs
+are invalid", check that all worker processes are running:
+
+```bash
+pgrep -af "nuq-prefetch-worker\|nuq-worker\|extract-worker"
+sudo rabbitmqctl status
+```
+
+---
+
+## Protocol: LLMSTXT
+
+Generate an llms.txt file for a website. This creates a machine-readable
+summary of a site optimized for LLM consumption. Async — returns a job ID.
+
+### LLMSTXT: Health check
+
+### LLMSTXT: Start llms.txt generation
+
+```bash
+curl -sf --max-time 30 http://localhost:3002/v1/llmstxt \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "<TARGET_URL>"
+  }' | jq '.'
+```
+
+**Parameters:**
+
+| Parameter | Type | Required | Purpose |
+| ------------- | -------- | ---------- | --------- |
+| `url` | string | yes | Target website URL |
+| `maxUrls` | integer | no | Max URLs to process |
+| `showFullText` | boolean | no | Include full content in output |
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "id": "<llmstxt-job-id>"
+}
+```
+
+### LLMSTXT: Poll for completion
+
+```bash
+JOB_ID="<llmstxt-job-id>"
+for i in $(seq 1 30); do
+  RESP=$(curl -sf http://localhost:3002/v1/llmstxt/${JOB_ID})
+  STATUS=$(echo "$RESP" | jq -r '.status')
+  if [ "$STATUS" = "completed" ]; then
+    echo "llms.txt generation completed"
+    echo "$RESP" | jq -r '.data'
+    break
+  elif [ "$STATUS" = "failed" ]; then
+    echo "llms.txt generation failed"
+    break
+  fi
+  echo "Status: $STATUS (attempt $i/30)"
+  sleep 3
+done
+```
+
+### LLMSTXT: Report
+
+```
+## llms.txt Result: <URL>
+
+**Status:** <status>
+
+### Generated llms.txt
+
+<llms.txt content>
+```
+
+---
+
+## Async Job Polling Pattern
+
+Several protocols (BATCH_SCRAPE, CRAWL, EXTRACT, LLMSTXT) use async jobs.
+The standard polling pattern:
+
+1. POST to start the job — get back `{ "id": "..." }`
+2. GET the status endpoint every 3-5 seconds
+3. Check `status` field: `"completed"`, `"failed"`, `"scraping"`, `"processing"`
+4. Maximum 30 poll attempts (90-150 seconds depending on interval)
+5. On completion, extract `data` from the response
+6. On failure, extract and report the error
+
+---
+
+## Error Handling
+
+- If `curl` returns non-zero, report the HTTP status and error body
+- If `jq` fails to parse, report raw response
+- If the API returns `{"success": false, ...}`, extract and report the error message
+- Never retry silently — report failures clearly
+- For timeout errors, suggest increasing the `--max-time` value
+
+## Output Rules
+
+- Keep output concise — summarize large content unless full output requested
+- For scrape results over 5000 characters, show first 3000 chars with a note about truncation
+- Always include metadata (title, URL, status code) when available
+- Format links as markdown links: `[text](url)`
+- Use fenced code blocks for HTML/raw content
+- For batch/crawl results, show summaries per page unless full content is requested

--- a/plugins/f5xc-firecrawl/commands/batch-scrape.md
+++ b/plugins/f5xc-firecrawl/commands/batch-scrape.md
@@ -1,0 +1,17 @@
+---
+description: Batch scrape multiple URLs at once using local firecrawl
+argument-hint: "<url1> <url2> [<url3>...] [--format markdown,html]"
+allowed_tools:
+  - Bash
+  - Agent
+---
+
+Invoke the `f5xc-firecrawl:web-scraper` skill to batch scrape "$ARGUMENTS".
+
+Use the BATCH_SCRAPE protocol. Parse the arguments:
+
+- All URL arguments (space-separated) form the URL list
+- `--format` or `-f`: output formats (comma-separated)
+- `--full`: disable onlyMainContent
+
+If no URLs are provided, ask the user for them.

--- a/plugins/f5xc-firecrawl/commands/crawl.md
+++ b/plugins/f5xc-firecrawl/commands/crawl.md
@@ -1,0 +1,20 @@
+---
+description: Crawl a website and extract content from multiple pages using local firecrawl
+argument-hint: "<url> [--limit <n>] [--depth <n>] [--include <paths>]"
+allowed_tools:
+  - Bash
+  - Agent
+---
+
+Invoke the `f5xc-firecrawl:web-scraper` skill to crawl "$ARGUMENTS".
+
+Use the CRAWL protocol. Parse the arguments:
+
+- First argument is the starting URL
+- `--limit` or `-l`: max pages to crawl (default: 10)
+- `--depth`: maximum link depth
+- `--include`: URL path patterns to include (comma-separated)
+- `--exclude`: URL path patterns to exclude (comma-separated)
+- `--subdomains`: include subdomain links
+
+If no URL is provided, ask the user for one.

--- a/plugins/f5xc-firecrawl/commands/extract.md
+++ b/plugins/f5xc-firecrawl/commands/extract.md
@@ -1,0 +1,24 @@
+---
+description: Extract structured data from URLs using LLM-powered extraction via local firecrawl
+argument-hint: "<url> [<prompt>] [--schema <json>]"
+allowed_tools:
+  - Bash
+  - Agent
+---
+
+Invoke the `f5xc-firecrawl:web-scraper` skill to extract data from "$ARGUMENTS".
+
+Use the EXTRACT protocol. Parse the arguments:
+
+- First argument is the URL (or comma-separated URLs)
+- Remaining text (if any) is the extraction prompt
+- `--schema`: JSON schema for structured output
+- `--schema-file`: path to a JSON schema file
+
+At least one of prompt or schema is required. Schema-only usage is valid:
+`/extract https://example.com --schema '{"name":"string","price":"number"}'`
+
+Requires LLM proxy (OPENAI_BASE_URL) configured in the firecrawl environment.
+
+If no URL is provided, ask the user for one.
+If neither prompt nor schema is provided, ask the user for at least one.

--- a/plugins/f5xc-firecrawl/commands/llmstxt.md
+++ b/plugins/f5xc-firecrawl/commands/llmstxt.md
@@ -1,0 +1,17 @@
+---
+description: Generate an llms.txt file for a website using local firecrawl
+argument-hint: "<url>"
+allowed_tools:
+  - Bash
+  - Agent
+---
+
+Invoke the `f5xc-firecrawl:web-scraper` skill to generate llms.txt for "$ARGUMENTS".
+
+Use the LLMSTXT protocol. Parse the arguments:
+
+- First argument is the target URL
+- `--max-urls`: max URLs to process
+- `--full`: include full text content
+
+If no URL is provided, ask the user for one.

--- a/plugins/f5xc-firecrawl/commands/map.md
+++ b/plugins/f5xc-firecrawl/commands/map.md
@@ -1,0 +1,18 @@
+---
+description: Discover all URLs on a website using local firecrawl
+argument-hint: "<url> [--search <query>] [--subdomains]"
+allowed_tools:
+  - Bash
+  - Agent
+---
+
+Invoke the `f5xc-firecrawl:web-scraper` skill to map "$ARGUMENTS".
+
+Use the MAP protocol. Parse the arguments:
+
+- First argument is the target URL
+- `--search` or `-s`: filter URLs by keyword
+- `--subdomains`: include subdomain URLs
+- `--limit`: max URLs to return
+
+If no URL is provided, ask the user for one.

--- a/plugins/f5xc-firecrawl/commands/scrape.md
+++ b/plugins/f5xc-firecrawl/commands/scrape.md
@@ -1,0 +1,19 @@
+---
+description: Scrape a URL and extract content as markdown using local firecrawl
+argument-hint: "<url> [--format markdown,html,links] [--wait <ms>]"
+allowed_tools:
+  - Bash
+  - Agent
+---
+
+Invoke the `f5xc-firecrawl:web-scraper` skill to scrape "$ARGUMENTS".
+
+Use the SCRAPE protocol. Parse the arguments:
+
+- First argument is the URL
+- `--format` or `-f`: output formats (comma-separated)
+- `--wait`: milliseconds to wait for JavaScript rendering
+- `--html`: shortcut for format html
+- `--full`: disable onlyMainContent (include nav/footer)
+
+If no URL is provided, ask the user for one.

--- a/plugins/f5xc-firecrawl/commands/search.md
+++ b/plugins/f5xc-firecrawl/commands/search.md
@@ -1,0 +1,20 @@
+---
+description: Search the web and optionally scrape results using local firecrawl
+argument-hint: "<query> [--limit <n>] [--scrape]"
+allowed_tools:
+  - Bash
+  - Agent
+---
+
+Invoke the `f5xc-firecrawl:web-scraper` skill to search "$ARGUMENTS".
+
+Use the SEARCH protocol. Parse the arguments:
+
+- First argument(s) form the search query
+- `--limit` or `-l`: max results (default: 5, max: 100)
+- `--scrape`: also scrape content from result URLs
+- `--lang`: language code (e.g., "en")
+- `--country`: country code (e.g., "us")
+- `--time`: time filter — `hour`, `day`, `week`, `month`, `year`
+
+If no query is provided, ask the user for one.

--- a/plugins/f5xc-firecrawl/skills/web-scraper/SKILL.md
+++ b/plugins/f5xc-firecrawl/skills/web-scraper/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: web-scraper
+description: >-
+  Local firecrawl web scraping, crawling, site mapping, web search,
+  structured extraction, and llms.txt generation. Activates when the
+  user asks to scrape a URL, crawl a website, map site URLs, search
+  the web, extract structured data from pages, generate llms.txt,
+  batch scrape multiple URLs, cancel a crawl, list active crawls,
+  convert a web page to markdown, or fetch page content. Uses the
+  self-hosted firecrawl instance on localhost:3002 — no API keys or
+  subscriptions required.
+user-invocable: false
+---
+
+# Web Scraper (Local Firecrawl)
+
+This skill provides web scraping, crawling, URL mapping, web search,
+LLM-powered extraction, and llms.txt generation via the local
+self-hosted firecrawl API. All operations run against
+`http://localhost:3002` with no authentication required.
+
+Delegate to the firecrawl-operator agent to keep API payloads out of
+the main session context.
+
+## Capabilities
+
+| Operation | What it does | Endpoint | Type |
+| ----------- | ------------- | ---------- | ------ |
+| **Scrape** | Extract content from a single URL | `POST /v1/scrape` | Sync |
+| **Batch Scrape** | Scrape multiple URLs at once | `POST /v1/batch/scrape` | Async |
+| **Crawl** | Crawl multiple pages from a starting URL | `POST /v1/crawl` | Async |
+| **Crawl Cancel** | Cancel a running crawl job | `DELETE /v1/crawl/:id` | Sync |
+| **Crawl Active** | List all active crawl jobs | `GET /v1/crawl/active` | Sync |
+| **Crawl Errors** | Get error details for a crawl | `GET /v1/crawl/:id/errors` | Sync |
+| **Map** | Discover all URLs on a website | `POST /v1/map` | Sync |
+| **Search** | Web search with optional scraping | `POST /v1/search` | Sync |
+| **Extract** | LLM-powered structured data extraction | `POST /v1/extract` | Async |
+| **llms.txt** | Generate llms.txt for a site | `POST /v1/llmstxt` | Async |
+
+## Delegation Protocol
+
+When this skill activates, delegate immediately to the firecrawl-operator agent.
+
+### For scrape requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="Scrape: [URL in 3 words]",
+  prompt="PROTOCOL: SCRAPE\nURL: <the target URL>\nFORMATS: <requested formats or 'markdown'>\nOPTIONS: <any user-specified options like onlyMainContent, waitFor, etc.>\n\nScrape this URL and return the content."
+)
+```
+
+### For batch scrape requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="Batch scrape: [count] URLs",
+  prompt="PROTOCOL: BATCH_SCRAPE\nURLS: <comma-separated list of URLs>\nFORMATS: <requested formats or 'markdown'>\n\nBatch scrape these URLs and return results."
+)
+```
+
+### For crawl requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="Crawl: [URL in 3 words]",
+  prompt="PROTOCOL: CRAWL\nURL: <the target URL>\nLIMIT: <page limit, default 10>\nOPTIONS: <any user-specified options like maxDepth, includePaths, etc.>\n\nCrawl this site and return page summaries."
+)
+```
+
+### For crawl management requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="Crawl mgmt: [action]",
+  prompt="PROTOCOL: CRAWL_CANCEL|CRAWL_ACTIVE|CRAWL_ERRORS\nJOB_ID: <if applicable>\n\nExecute the requested crawl management operation."
+)
+```
+
+### For map requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="Map: [URL in 3 words]",
+  prompt="PROTOCOL: MAP\nURL: <the target URL>\nOPTIONS: <any user-specified options like search, includeSubdomains, etc.>\n\nMap all URLs on this site."
+)
+```
+
+### For search requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="Search: [query in 3 words]",
+  prompt="PROTOCOL: SEARCH\nQUERY: <the search query>\nLIMIT: <result limit, default 5>\nOPTIONS: <any options like lang, country, tbs, scrapeOptions>\n\nSearch the web and return results."
+)
+```
+
+### For extract requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="Extract: [what] from [URL]",
+  prompt="PROTOCOL: EXTRACT\nURLS: <target URLs>\nPROMPT: <what to extract>\nSCHEMA: <JSON schema if user specified one>\n\nExtract structured data from these URLs."
+)
+```
+
+### For llms.txt requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="llms.txt: [URL in 3 words]",
+  prompt="PROTOCOL: LLMSTXT\nURL: <the target URL>\n\nGenerate an llms.txt file for this site."
+)
+```
+
+Wait for the agent's response and relay it directly to the user.
+
+## When to activate
+
+- "scrape this URL" / "scrape https://..."
+- "batch scrape" / "scrape these URLs" / "scrape multiple pages"
+- "crawl this website" / "crawl https://..."
+- "cancel the crawl" / "stop the crawl" / "list active crawls"
+- "map this site" / "find all URLs on"
+- "search for" / "search the web for" / "web search"
+- "extract data from" / "extract structured data" / "pull fields from"
+- "generate llms.txt" / "create llms.txt" / "make an llms.txt"
+- "convert this page to markdown"
+- "fetch page content" / "get markdown from"
+- Any request to read, extract, or search web content
+
+## What this does NOT do
+
+- **No cloud API** — uses local self-hosted instance only
+- **No API keys** — no FIRECRAWL_API_KEY needed
+- **No browser sessions** — cloud-only feature
+- **No deep research** — cloud-only feature
+- **Extract requires LLM proxy** — needs OPENAI_BASE_URL configured

--- a/plugins/f5xc-firecrawl/skills/web-scraper/references/api-reference.md
+++ b/plugins/f5xc-firecrawl/skills/web-scraper/references/api-reference.md
@@ -1,0 +1,404 @@
+# Firecrawl Local API Reference (v1)
+
+Base URL: `http://localhost:3002`
+
+## Endpoints
+
+### GET /
+
+Health check. Returns:
+
+```json
+{"message": "Firecrawl API", "documentation_url": "https://docs.firecrawl.dev"}
+```
+
+---
+
+### POST /v1/scrape
+
+Scrape a single URL and extract content. Synchronous.
+
+**Request:**
+
+```json
+{
+  "url": "https://example.com",
+  "formats": ["markdown"],
+  "onlyMainContent": true,
+  "includeTags": ["article", "main"],
+  "excludeTags": ["nav", "footer"],
+  "waitFor": 0,
+  "timeout": 30000
+}
+```
+
+| Field | Type | Required | Default | Description |
+| ------- | -------- | ---------- | --------- | ------------- |
+| url | string | yes | — | Target URL to scrape |
+| formats | string[] | no | ["markdown"] | Output formats: markdown, html, rawHtml, links, screenshot |
+| onlyMainContent | boolean | no | true | Strip navigation, footer, sidebar |
+| includeTags | string[] | no | — | Only keep content in these HTML tags |
+| excludeTags | string[] | no | — | Remove content in these HTML tags |
+| waitFor | integer | no | 0 | Wait ms for JavaScript rendering |
+| timeout | integer | no | 30000 | Request timeout in ms |
+
+**Response (200):**
+
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "# Title\n\nContent...",
+    "html": "<html>...</html>",
+    "rawHtml": "<html>...</html>",
+    "links": ["https://..."],
+    "metadata": {
+      "title": "Page Title",
+      "description": "Meta description",
+      "language": "en",
+      "url": "https://example.com",
+      "sourceURL": "https://example.com",
+      "statusCode": 200,
+      "contentType": "text/html"
+    }
+  }
+}
+```
+
+---
+
+### POST /v1/batch/scrape
+
+Scrape multiple URLs in one request. Async — returns job ID.
+
+**Request:**
+
+```json
+{
+  "urls": ["https://example.com", "https://example.org"],
+  "formats": ["markdown"]
+}
+```
+
+| Field | Type | Required | Default | Description |
+| ------- | -------- | ---------- | --------- | ------------- |
+| urls | string[] | yes | — | List of URLs to scrape |
+| formats | string[] | no | ["markdown"] | Output formats |
+| onlyMainContent | boolean | no | true | Strip nav/footer |
+
+**Response (200):**
+
+```json
+{
+  "success": true,
+  "id": "<job-id>",
+  "url": "http://localhost:3002/v1/batch/scrape/<job-id>"
+}
+```
+
+### GET /v1/batch/scrape/:id
+
+Check batch scrape job status.
+
+**Response (completed):**
+
+```json
+{
+  "status": "completed",
+  "total": 2,
+  "completed": 2,
+  "data": [
+    { "markdown": "...", "metadata": { "title": "...", "url": "..." } }
+  ]
+}
+```
+
+---
+
+### POST /v1/crawl
+
+Start an async crawl job for multiple pages.
+
+**Request:**
+
+```json
+{
+  "url": "https://example.com",
+  "limit": 10,
+  "maxDepth": 3,
+  "includePaths": ["/docs/*"],
+  "excludePaths": ["/blog/*"],
+  "allowSubdomains": false,
+  "allowExternalLinks": false,
+  "ignoreSitemap": false
+}
+```
+
+| Field | Type | Required | Default | Description |
+| ------- | -------- | ---------- | --------- | ------------- |
+| url | string | yes | — | Starting URL |
+| limit | integer | no | 10 | Max pages to crawl |
+| maxDepth | integer | no | — | Maximum link depth |
+| includePaths | string[] | no | — | URL path patterns to include |
+| excludePaths | string[] | no | — | URL path patterns to exclude |
+| allowSubdomains | boolean | no | false | Follow subdomain links |
+| allowExternalLinks | boolean | no | false | Follow external links |
+| ignoreSitemap | boolean | no | false | Skip sitemap.xml discovery |
+
+**Response (200):**
+
+```json
+{
+  "success": true,
+  "id": "<crawl-job-id>",
+  "url": "http://localhost:3002/v1/crawl/<crawl-job-id>"
+}
+```
+
+### GET /v1/crawl/:id
+
+Check crawl job status and retrieve results.
+
+**Response (in progress):**
+
+```json
+{ "status": "scraping", "total": 10, "completed": 3 }
+```
+
+**Response (completed):**
+
+```json
+{
+  "status": "completed",
+  "total": 5,
+  "completed": 5,
+  "data": [
+    { "markdown": "...", "metadata": { "title": "...", "url": "..." } }
+  ]
+}
+```
+
+### DELETE /v1/crawl/:id
+
+Cancel a running crawl job.
+
+### GET /v1/crawl/active
+
+List all active crawl jobs.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "crawls": [
+    {
+      "id": "...",
+      "url": "https://...",
+      "created_at": "2026-...",
+      "options": { "limit": 10 }
+    }
+  ]
+}
+```
+
+### GET /v1/crawl/:id/errors
+
+Get error details for a crawl job.
+
+---
+
+### POST /v1/map
+
+Discover all URLs on a website without scraping content. Synchronous.
+
+**Request:**
+
+```json
+{
+  "url": "https://example.com",
+  "search": "pricing",
+  "includeSubdomains": false,
+  "limit": 5000
+}
+```
+
+| Field | Type | Required | Default | Description |
+| ------- | -------- | ---------- | --------- | ------------- |
+| url | string | yes | — | Target website |
+| search | string | no | — | Filter URLs by keyword |
+| includeSubdomains | boolean | no | false | Include subdomain URLs |
+| limit | integer | no | 5000 | Max URLs to return |
+
+**Response (200):**
+
+```json
+{
+  "success": true,
+  "links": ["https://example.com/", "https://example.com/about"]
+}
+```
+
+---
+
+### POST /v1/search
+
+Search the web and optionally scrape results. Synchronous.
+
+**Request:**
+
+```json
+{
+  "query": "web scraping tutorials",
+  "limit": 5,
+  "lang": "en",
+  "country": "us",
+  "tbs": "qdr:m",
+  "scrapeOptions": {
+    "formats": ["markdown"],
+    "onlyMainContent": true
+  }
+}
+```
+
+| Field | Type | Required | Default | Description |
+| ------- | -------- | ---------- | --------- | ------------- |
+| query | string | yes | — | Search query |
+| limit | integer | no | 5 | Max results (up to 100) |
+| lang | string | no | — | Language code |
+| country | string | no | — | Country code |
+| tbs | string | no | — | Time filter: qdr:h/d/w/m/y |
+| scrapeOptions | object | no | — | Scrape result pages (formats, onlyMainContent, etc.) |
+
+**Response (200):**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "url": "https://...",
+      "title": "Result Title",
+      "description": "Result description..."
+    }
+  ]
+}
+```
+
+With `scrapeOptions`, each result also includes `markdown`, `html`, etc.
+
+---
+
+### POST /v1/extract
+
+LLM-powered structured data extraction. Async — returns job ID.
+Requires OPENAI_BASE_URL and OPENAI_API_KEY configured.
+
+**Request:**
+
+```json
+{
+  "urls": ["https://example.com"],
+  "prompt": "Extract the main topic and any contact information",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "topic": { "type": "string" },
+      "email": { "type": "string" }
+    }
+  }
+}
+```
+
+| Field | Type | Required | Default | Description |
+| ------- | -------- | ---------- | --------- | ------------- |
+| urls | string[] | yes | — | URLs to extract from (supports wildcards) |
+| prompt | string | no* | — | What to extract (natural language) |
+| schema | object | no* | — | JSON schema for structured output |
+| enableWebSearch | boolean | no | false | Expand beyond specified URLs |
+
+*At least one of `prompt` or `schema` is required.
+
+**Response (200):**
+
+```json
+{ "success": true, "id": "<extract-job-id>" }
+```
+
+### GET /v1/extract/:id
+
+Check extract job status.
+
+**Response (completed):**
+
+```json
+{
+  "success": true,
+  "status": "completed",
+  "data": { "topic": "...", "email": "..." }
+}
+```
+
+---
+
+### POST /v1/llmstxt
+
+Generate an llms.txt file for a website. Async — returns job ID.
+
+**Request:**
+
+```json
+{
+  "url": "https://example.com",
+  "maxUrls": 100,
+  "showFullText": false
+}
+```
+
+| Field | Type | Required | Default | Description |
+| ------- | -------- | ---------- | --------- | ------------- |
+| url | string | yes | — | Target website URL |
+| maxUrls | integer | no | — | Max URLs to process |
+| showFullText | boolean | no | false | Include full content |
+
+**Response (200):**
+
+```json
+{ "success": true, "id": "<llmstxt-job-id>" }
+```
+
+### GET /v1/llmstxt/:id
+
+Check llms.txt job status.
+
+**Response (completed):**
+
+```json
+{
+  "status": "completed",
+  "data": "# example.com\n\n> Description...\n\n## Pages\n..."
+}
+```
+
+---
+
+## Infrastructure
+
+| Component | Address | Purpose |
+| ----------- | --------- | --------- |
+| Firecrawl API | localhost:3002 | Main API |
+| Playwright | localhost:3000 | JavaScript rendering |
+| Redis | localhost:6379 | Job queue |
+| PostgreSQL | /var/run/postgresql | Crawl persistence |
+| LiteLLM proxy | OPENAI_BASE_URL | LLM for extract (optional) |
+
+## Differences from Cloud API
+
+| Feature | Cloud (v2) | Local (v1) |
+| --------- | ----------- | ------------ |
+| Authentication | Bearer token required | None needed |
+| Browser sessions | Available | Not available |
+| Deep research | Available | Not available |
+| Rate limits | Per-plan credits | Unlimited (local) |
+| Endpoint prefix | /v2/ | /v1/ |
+| Extract LLM | Hosted by Firecrawl | Your own LLM proxy |


### PR DESCRIPTION
## Summary

- Fix all 235 markdownlint violations (MD060, MD031, MD001, MD024, MD032, MD009) across 12 markdown files in the f5xc-firecrawl plugin
- Add `Agent` to `allowed_tools` in all 7 command files per Codex review P1 finding
- Fix extract command to accept schema-only invocations per Codex review P2 finding
- Add `plugin.json` and marketplace registry entry for f5xc-firecrawl

Closes #191

## Test plan

- [x] Pre-commit hooks pass (markdownlint, Biome, spelling, secrets, editorconfig)
- [ ] CI checks pass
- [ ] Plugin structure validates against marketplace schema