### PR TITLE
chore: bump all plugin versions and add f5xc-firecrawl LICENSE/hooks/docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "f5xc-docs-tools",
       "description": "MDX content validation and review tools for f5xc-salesdemos docs repos",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -28,7 +28,7 @@
     {
       "name": "f5xc-sales-engineer",
       "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -43,7 +43,7 @@
     {
       "name": "f5xc-github-ops",
       "description": "GitHub operations automation — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -58,7 +58,7 @@
     {
       "name": "f5xc-docs-pipeline",
       "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -73,7 +73,7 @@
     {
       "name": "f5xc-brand",
       "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -88,7 +88,7 @@
     {
       "name": "f5xc-meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -113,7 +113,7 @@
     {
       "name": "f5xc-devcontainer",
       "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -128,7 +128,7 @@
     {
       "name": "f5xc-platform",
       "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -157,7 +157,7 @@
     {
       "name": "osint-framework",
       "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -172,7 +172,7 @@
     {
       "name": "f5xc-firecrawl",
       "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/docs/plugins/f5xc-brand.mdx
+++ b/docs/plugins/f5xc-brand.mdx
@@ -12,7 +12,7 @@ typography rules (Neusa Next Pro Wide headlines, Proxima Nova
 body), SVG-only logo usage, icon pack selection, WCAG AA
 accessibility, and product terminology.
 
-<Badge text="v1.0.1" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.0.2" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-devcontainer.mdx
+++ b/docs/plugins/f5xc-devcontainer.mdx
@@ -12,7 +12,7 @@ comprehensive tool catalog, enables live container introspection,
 and handles tool installation with persistence tracking via
 GitHub issues.
 
-<Badge text="v1.1.5" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.1.6" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-docs-pipeline.mdx
+++ b/docs/plugins/f5xc-docs-pipeline.mdx
@@ -11,7 +11,7 @@ architecture knowledge for f5xc-salesdemos repositories. It guides
 content authoring, clarifies config ownership across multi-repo
 builds, and provides local Docker-based preview.
 
-<Badge text="v1.0.1" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.0.2" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-docs-tools.mdx
+++ b/docs/plugins/f5xc-docs-tools.mdx
@@ -12,7 +12,7 @@ build-breaking issues before they reach CI, including bare JSX
 characters, invalid imports, broken image references, and
 incomplete frontmatter.
 
-<Badge text="v1.1.1" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.1.2" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-firecrawl.mdx
+++ b/docs/plugins/f5xc-firecrawl.mdx
@@ -1,0 +1,147 @@
+---
+title: f5xc-firecrawl
+sidebar:
+  order: 13
+---
+
+import { Aside, Badge } from '@astrojs/starlight/components';
+
+The **f5xc-firecrawl** plugin provides local self-hosted web scraping
+via the open-source [firecrawl](https://github.com/mendableai/firecrawl)
+engine. No API keys, no subscriptions, no cloud dependency. All
+operations run against the local firecrawl instance on `localhost:3002`
+inside the devcontainer.
+
+<Badge text="v1.1.0" variant="note" /> <Badge text="Productivity" variant="tip" />
+
+## Installation
+
+```
+/plugin install f5xc-firecrawl@f5xc-salesdemos-marketplace
+```
+
+## Commands
+
+### /scrape
+
+Scrape a single URL and extract content as markdown.
+
+```
+/scrape https://docs.example.com/getting-started
+/scrape https://example.com --format markdown,links --wait 2000
+```
+
+### /batch-scrape
+
+Scrape multiple URLs at once.
+
+```
+/batch-scrape https://example.com https://example.org https://example.net
+```
+
+### /crawl
+
+Crawl multiple pages from a starting URL.
+
+```
+/crawl https://docs.example.com --limit 20 --depth 2
+/crawl https://docs.example.com --include /api/* --exclude /blog/*
+```
+
+### /map
+
+Discover all URLs on a website.
+
+```
+/map https://docs.example.com
+/map https://docs.example.com --search api --subdomains
+```
+
+### /search
+
+Search the web and optionally scrape results.
+
+```
+/search "firecrawl web scraping" --limit 10
+/search "AI tools 2026" --scrape --time month
+```
+
+### /extract
+
+LLM-powered structured data extraction from web pages.
+
+```
+/extract https://example.com "Extract the main heading and any links"
+/extract https://example.com/pricing --schema '{"plans": [{"name": "string", "price": "string"}]}'
+```
+
+<Aside type="note">
+  The extract command requires an OpenAI-compatible LLM proxy
+  configured via `OPENAI_BASE_URL` and `OPENAI_API_KEY`.
+</Aside>
+
+### /llmstxt
+
+Generate an llms.txt file for a site.
+
+```
+/llmstxt https://docs.example.com
+```
+
+## Skills
+
+### web-scraper
+
+Auto-activates when you ask to scrape a URL, crawl a website, map
+site URLs, search the web, extract structured data, generate llms.txt,
+batch scrape multiple URLs, or convert a web page to markdown.
+Delegates immediately to the firecrawl-operator agent.
+
+## Agents
+
+### firecrawl-operator
+
+Autonomous web scraping agent that executes `curl` + `jq` sequences
+against the local firecrawl API. Supports 11 protocols covering all
+v1 endpoints. Read-only agent (no Write, Edit, or Agent tools).
+
+| Protocol | Endpoint | Type |
+|----------|----------|------|
+| HEALTH | `GET /` | Sync |
+| SCRAPE | `POST /v1/scrape` | Sync |
+| BATCH_SCRAPE | `POST /v1/batch/scrape` | Async |
+| CRAWL | `POST /v1/crawl` | Async |
+| CRAWL_CANCEL | `DELETE /v1/crawl/:id` | Sync |
+| CRAWL_ACTIVE | `GET /v1/crawl/active` | Sync |
+| CRAWL_ERRORS | `GET /v1/crawl/:id/errors` | Sync |
+| MAP | `POST /v1/map` | Sync |
+| SEARCH | `POST /v1/search` | Sync |
+| EXTRACT | `POST /v1/extract` | Async |
+| LLMSTXT | `POST /v1/llmstxt` | Async |
+
+## Infrastructure
+
+The plugin requires the firecrawl stack running in the devcontainer:
+
+| Component | Port | Purpose |
+|-----------|------|---------|
+| Firecrawl API | 3002 | All scrape/crawl/map/search/extract endpoints |
+| Playwright | 3000 | JavaScript rendering engine |
+| Redis | 6379 | Job queue backend |
+| PostgreSQL | socket | Crawl/batch job persistence |
+| LiteLLM proxy | OPENAI_BASE_URL | LLM backend for extract (optional) |
+
+The stack starts automatically when `ENABLE_FIRECRAWL=true` (the
+default). A SessionStart hook checks that the API is reachable and
+warns if the service is down.
+
+## Differences from Cloud Firecrawl
+
+This plugin uses the self-hosted open-source version:
+
+- No authentication or API keys required for scraping
+- No credit limits or rate limiting
+- Uses v1 API endpoints (not v2)
+- Browser sessions and deep research not available
+- Extract uses your own LLM proxy instead of hosted models
+- Runs entirely within the local container network

--- a/docs/plugins/f5xc-github-ops.mdx
+++ b/docs/plugins/f5xc-github-ops.mdx
@@ -12,7 +12,7 @@ Git and GitHub lifecycle from issue creation through post-merge
 monitoring, enforcing issue-driven development and pre-commit
 lint gates.
 
-<Badge text="v2.2.1" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v2.2.2" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-meddpicc.mdx
+++ b/docs/plugins/f5xc-meddpicc.mdx
@@ -12,7 +12,7 @@ sales. It transforms MEDDPICC from a checkbox exercise into a living
 deal execution system with evidence-based qualification, structured
 deal reviews, and actionable coaching.
 
-<Badge text="v1.0.3" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.0.4" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-platform.mdx
+++ b/docs/plugins/f5xc-platform.mdx
@@ -12,7 +12,7 @@ Chrome DevTools MCP, spec-aware REST API operations via cURL,
 multi-provider authentication, and configuration analysis across
 98 resource types in 38 domains.
 
-<Badge text="v3.1.0" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v3.1.1" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/f5xc-sales-engineer.mdx
+++ b/docs/plugins/f5xc-sales-engineer.mdx
@@ -11,7 +11,7 @@ persona framework for F5 XC demo repositories. It handles the full
 demo meeting lifecycle — from pre-meeting verification through live
 execution, Q&A, and teardown.
 
-<Badge text="v1.0.5" variant="note" /> <Badge text="Productivity" variant="tip" />
+<Badge text="v1.0.6" variant="note" /> <Badge text="Productivity" variant="tip" />
 
 ## Installation
 

--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -13,15 +13,16 @@ branding, and development operations.
 
 | Plugin | Version | Category | Description |
 |--------|---------|----------|-------------|
-| [f5xc-docs-tools](/marketplace/plugins/f5xc-docs-tools/) | 1.1.1 | Productivity | MDX content validation and review tools |
-| [f5xc-sales-engineer](/marketplace/plugins/f5xc-sales-engineer/) | 1.0.5 | Productivity | Sales Engineer persona framework — demo execution, presentation, Q&A, environment management |
-| [f5xc-github-ops](/marketplace/plugins/f5xc-github-ops/) | 2.2.1 | Productivity | GitHub operations automation — issue-driven development, PR lifecycle, CI polling |
-| [f5xc-docs-pipeline](/marketplace/plugins/f5xc-docs-pipeline/) | 1.0.1 | Productivity | Documentation pipeline architecture — content authoring, local preview, config ownership |
-| [f5xc-brand](/marketplace/plugins/f5xc-brand/) | 1.0.1 | Productivity | F5 corporate branding enforcement — colors, typography, logos, icons, accessibility |
-| [f5xc-meddpicc](/marketplace/plugins/f5xc-meddpicc/) | 1.0.3 | Productivity | MEDDPICC sales qualification and deal-execution framework |
-| [f5xc-devcontainer](/marketplace/plugins/f5xc-devcontainer/) | 1.1.5 | Productivity | Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance |
-| [f5xc-platform](/marketplace/plugins/f5xc-platform/) | 3.1.0 | Productivity | F5 XC platform automation — console, REST API, config analysis across 98 resource types |
-| [osint-framework](/marketplace/plugins/osint-framework/) | 1.0.0 | Security | OSINT tool catalog and investigation skills — 1,064 free tools across 34 categories, investigation pipelines, correlation engine |
+| [f5xc-docs-tools](/marketplace/plugins/f5xc-docs-tools/) | 1.1.2 | Productivity | MDX content validation and review tools |
+| [f5xc-sales-engineer](/marketplace/plugins/f5xc-sales-engineer/) | 1.0.6 | Productivity | Sales Engineer persona framework — demo execution, presentation, Q&A, environment management |
+| [f5xc-github-ops](/marketplace/plugins/f5xc-github-ops/) | 2.2.2 | Productivity | GitHub operations automation — issue-driven development, PR lifecycle, CI polling |
+| [f5xc-docs-pipeline](/marketplace/plugins/f5xc-docs-pipeline/) | 1.0.2 | Productivity | Documentation pipeline architecture — content authoring, local preview, config ownership |
+| [f5xc-brand](/marketplace/plugins/f5xc-brand/) | 1.0.2 | Productivity | F5 corporate branding enforcement — colors, typography, logos, icons, accessibility |
+| [f5xc-meddpicc](/marketplace/plugins/f5xc-meddpicc/) | 1.0.4 | Productivity | MEDDPICC sales qualification and deal-execution framework |
+| [f5xc-devcontainer](/marketplace/plugins/f5xc-devcontainer/) | 1.1.6 | Productivity | Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance |
+| [f5xc-platform](/marketplace/plugins/f5xc-platform/) | 3.1.1 | Productivity | F5 XC platform automation — console, REST API, config analysis across 98 resource types |
+| [osint-framework](/marketplace/plugins/osint-framework/) | 1.0.1 | Security | OSINT tool catalog and investigation skills — 1,064 free tools across 34 categories, investigation pipelines, correlation engine |
+| [f5xc-firecrawl](/marketplace/plugins/f5xc-firecrawl/) | 1.1.0 | Productivity | Local self-hosted web scraping — scrape, crawl, map, search, extract via firecrawl on localhost:3002 |
 
 ## What's in a Plugin?
 
@@ -45,6 +46,7 @@ Each plugin can include:
 /plugin install f5xc-devcontainer@f5xc-salesdemos-marketplace
 /plugin install f5xc-platform@f5xc-salesdemos-marketplace
 /plugin install osint-framework@f5xc-salesdemos-marketplace
+/plugin install f5xc-firecrawl@f5xc-salesdemos-marketplace
 ```
 
 See [Getting Started](/marketplace/getting-started/) for the

--- a/docs/plugins/osint-framework.mdx
+++ b/docs/plugins/osint-framework.mdx
@@ -13,7 +13,7 @@ It includes category-based skills, executable investigation pipelines,
 CLI tool execution, OPSEC-aware workflows, and a persistent entity
 graph for cross-investigation correlation.
 
-<Badge text="v1.0.0" variant="note" /> <Badge text="Security" variant="tip" />
+<Badge text="v1.0.1" variant="note" /> <Badge text="Security" variant="tip" />
 
 ## Installation
 

--- a/plugins/f5xc-brand/.claude-plugin/plugin.json
+++ b/plugins/f5xc-brand/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-brand",
   "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "f5xc-salesdemos"
   },

--- a/plugins/f5xc-devcontainer/.claude-plugin/plugin.json
+++ b/plugins/f5xc-devcontainer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-devcontainer",
   "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-docs-pipeline/.claude-plugin/plugin.json
+++ b/plugins/f5xc-docs-pipeline/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-docs-pipeline",
   "description": "Documentation pipeline architecture for f5xc-salesdemos — config ownership, release dispatch chain, content authoring, managed files, local preview",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-docs-tools/.claude-plugin/plugin.json
+++ b/plugins/f5xc-docs-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-docs-tools",
   "description": "MDX content validation and review tools for f5xc-salesdemos documentation repositories",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-firecrawl/.claude-plugin/plugin.json
+++ b/plugins/f5xc-firecrawl/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-firecrawl",
   "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-firecrawl/LICENSE
+++ b/plugins/f5xc-firecrawl/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2025 f5xc-salesdemos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/f5xc-firecrawl/README.md
+++ b/plugins/f5xc-firecrawl/README.md
@@ -112,6 +112,9 @@ This plugin requires the firecrawl stack running in the devcontainer:
 The stack starts automatically via `entrypoint.sh` when `ENABLE_FIRECRAWL=true`
 (the default).
 
+A `SessionStart` hook checks that the firecrawl API is reachable on
+`localhost:3002` and prints a warning if the service is down.
+
 ## Extract LLM Configuration
 
 The extract endpoint requires an OpenAI-compatible LLM proxy. Set these

--- a/plugins/f5xc-firecrawl/hooks/hooks.json
+++ b/plugins/f5xc-firecrawl/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sf http://localhost:3002/ > /dev/null 2>&1 || echo 'WARNING: Firecrawl API not reachable on localhost:3002. Web scraping commands will fail. Check that ENABLE_FIRECRAWL=true in your devcontainer.'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/f5xc-github-ops/.claude-plugin/plugin.json
+++ b/plugins/f5xc-github-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-github-ops",
   "description": "GitHub operations automation for f5xc-salesdemos — issue-driven development, pre-commit lint gate, PR lifecycle, CI polling with error feedback to issues, post-merge monitoring, verification, rate limit management, upstream contribution workflow for fork-based development, and exclusive github-ops agent for all Git operations. Covers commit, push, branch, merge, squash, pull request, issue creation, repository settings, and fork-to-upstream contributions.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-meddpicc/.claude-plugin/plugin.json
+++ b/plugins/f5xc-meddpicc/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-platform/.claude-plugin/plugin.json
+++ b/plugins/f5xc-platform/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-platform",
   "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-sales-engineer/.claude-plugin/plugin.json
+++ b/plugins/f5xc-sales-engineer/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-sales-engineer",
   "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/osint-framework/.claude-plugin/plugin.json
+++ b/plugins/osint-framework/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "osint-framework",
   "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"


### PR DESCRIPTION
## Summary

- Add missing LICENSE file and health-check hook (hooks.json) to f5xc-firecrawl plugin
- Add new documentation page for f5xc-firecrawl and update the plugins index
- Bump versions across all plugin.json files, marketplace.json, and docs version badges

Closes #193

## Test plan

- [ ] CI checks pass (lint, linked issue check)
- [ ] All plugin.json files have updated versions
- [ ] docs/plugins/f5xc-firecrawl.mdx renders correctly
- [ ] f5xc-firecrawl LICENSE and hooks/hooks.json are present