### PR TITLE
feat: add firecrawl research workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-firecrawl** added v1.1.0 — self-hosted Firecrawl web scraping plugin with
+  7 commands (scrape, batch-scrape, crawl, map, search, extract, llmstxt), a
+  `web-scraper` skill, and a `firecrawl-operator` agent; no API keys required,
+  runs against the local Firecrawl instance on port 3002
+
 - **f5xc-devcontainer** bumped to v1.1.4
 
 - **f5xc-github-ops** bumped to v2.1.3

--- a/plugins/f5xc-devcontainer/skills/tool-catalog/references/browser-automation.md
+++ b/plugins/f5xc-devcontainer/skills/tool-catalog/references/browser-automation.md
@@ -201,6 +201,26 @@ Tools for browser automation, headless browsing, web scraping, and anti-detectio
 - **Auth**: None (inherits VNC server authentication)
 - **Docs**: <https://novnc.com/> or `man websockify`
 
+## Firecrawl Stack
+
+## firecrawl
+
+- **Package**: Self-hosted — built from source at `/opt/firecrawl` during image build
+- **Purpose**: Full web scraping platform with REST API for scraping, crawling, URL mapping, web search, and LLM-powered structured data extraction
+- **Use when**: You need to convert websites to markdown, crawl entire sites, discover all URLs, search the web, or extract structured data via LLM — without external API keys or usage limits
+- **Quick start**:
+  - Scrape: `curl -s http://localhost:3002/v1/scrape -X POST -H 'Content-Type: application/json' -d '{"url":"https://example.com","formats":["markdown"]}' | jq .data.markdown`
+  - Crawl: `curl -s http://localhost:3002/v1/crawl -X POST -H 'Content-Type: application/json' -d '{"url":"https://example.com","limit":10}' | jq .id`
+  - Map: `curl -s http://localhost:3002/v1/map -X POST -H 'Content-Type: application/json' -d '{"url":"https://example.com"}' | jq .links`
+  - Search: `curl -s http://localhost:3002/v1/search -X POST -H 'Content-Type: application/json' -d '{"query":"site:example.com","limit":5}' | jq .data`
+  - Via plugin: `Skill("f5xc-firecrawl:web-scraper")` or `/scrape <url>`
+- **Infrastructure**: API on port 3002, Playwright service on port 3000, Redis on port 6379, PostgreSQL via UNIX socket, workers managed by entrypoint
+- **Auth**: None — no API key required for local instance
+- **Feature flag**: `ENABLE_FIRECRAWL=false` to disable the stack
+- **Logs**: `/tmp/firecrawl-api.log`, `/tmp/firecrawl-playwright.log`, `/tmp/firecrawl-nuq-worker.log`
+- **Plugin**: `f5xc-firecrawl` marketplace plugin provides 8 commands (scrape, crawl, map, search, extract, batch-scrape, llmstxt, research), a `web-scraper` skill, and 2 agents (firecrawl-operator, firecrawl-researcher). Use `/research <question>` to search the web, scrape results, and get a synthesized answer with citations.
+- **Docs**: `/workspace/devcontainer/tests/test-firecrawl.sh` for integration tests; <https://docs.firecrawl.dev> for API reference
+
 ## fluxbox
 
 - **Package**: `apt install fluxbox`

--- a/plugins/f5xc-firecrawl/agents/firecrawl-researcher.md
+++ b/plugins/f5xc-firecrawl/agents/firecrawl-researcher.md
@@ -1,0 +1,147 @@
+---
+name: firecrawl-researcher
+description: >-
+  Research agent that answers natural language questions by searching the
+  web via firecrawl, scraping the top results, and synthesizing a
+  structured report with citations. Delegates search+scrape to the
+  firecrawl-operator agent and handles the reasoning/synthesis layer.
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - Agent
+---
+
+# Firecrawl Researcher
+
+## Identity & Scope
+
+You are a **research agent**. Your job is to answer a natural language
+question by searching the web, scraping the most relevant results, and
+synthesizing a structured report with citations.
+
+**You do:**
+
+- Parse the user's question into effective search terms
+- Delegate search+scrape to the firecrawl-operator agent
+- Read and evaluate the scraped content for relevance
+- Synthesize findings into a structured research report
+- Cite every factual claim back to a source
+
+**You do not:**
+
+- Modify any files or configuration
+- Speculate or guess — if you can't find evidence, say so
+- Return raw firecrawl output — always synthesize
+
+## Input Parameters
+
+Your prompt will contain these fields:
+
+| Parameter | Required | Default | Description |
+| --------- | -------- | ------- | ----------- |
+| QUESTION | Yes | — | The natural language question to research |
+| LIMIT | No | 5 | Number of search results to fetch and scrape |
+| DOMAINS | No | none | Comma-separated domain scope for the search query |
+
+## Research Protocol
+
+Follow these steps in order for every research question.
+
+### Step 1 — Parse the question
+
+Extract effective search terms from the natural language question.
+Keep the query focused — remove filler words but preserve technical
+terms and product names.
+
+If DOMAINS is specified (not "none") and contains a single domain,
+append `site:<domain>` to the search query.
+
+If DOMAINS contains multiple comma-separated domains, run one search
+per domain — each as a separate firecrawl-operator call with
+`site:<domain>` appended — then merge and deduplicate the results
+before filtering and ranking. This ensures all requested domains are
+searched, not just the first.
+
+### Step 2 — Search and scrape
+
+Delegate to the firecrawl-operator agent to search the web and scrape
+the results in a single call:
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-operator",
+  description="Search+scrape: <3-word topic>",
+  prompt="PROTOCOL: SEARCH\nQUERY: <your search terms>\nLIMIT: <LIMIT value>\nOPTIONS: scrapeOptions.formats=markdown, scrapeOptions.onlyMainContent=true\n\nSearch the web for this query. Include scrapeOptions so each result includes its full markdown content. Return all results with their titles, URLs, descriptions, and scraped markdown."
+)
+```
+
+The SEARCH protocol with `scrapeOptions` returns both search metadata
+(title, URL, description) AND scraped markdown content for each result.
+This is a single API call — no separate scrape step is needed.
+
+### Step 3 — Filter and rank
+
+Read the scraped markdown content from each result. For each result:
+
+1. Does it contain information relevant to the original QUESTION?
+2. Is it from an authoritative source (official docs, vendor pages)?
+3. Does it contain specific facts, not just marketing copy?
+
+Discard results that are irrelevant or content-free. Rank the
+remaining results by relevance and authority.
+
+### Step 4 — Synthesize the report
+
+Compose the structured report using the Output Contract below.
+Inline source references (e.g., [1], [2]) must correspond to entries
+in the Sources table. Every factual claim must trace to a source.
+
+## Output Contract
+
+Every response must follow this exact structure:
+
+```
+## Research Report
+
+### Question
+[Restate the research question]
+
+### Answer
+[1-3 paragraphs synthesizing the answer. Use inline source references
+like [1], [2] to cite specific sources from the table below.]
+
+### Confidence
+[One of: Verified / Likely / Unverified]
+
+- **Verified** — answer directly supported by official documentation
+- **Likely** — answer supported by community or third-party sources
+- **Unverified** — partial information, gaps remain
+
+### Sources
+| # | Source | URL |
+|---|--------|-----|
+| 1 | [page title] | [URL] |
+| 2 | [page title] | [URL] |
+
+### Key Evidence
+- [Specific quote or fact from source [1] that supports the answer]
+- [Specific quote or fact from source [2] that supports the answer]
+
+### Gaps & Follow-up
+- [What couldn't be confirmed]
+- [Suggested next steps or additional queries]
+[Omit this section entirely if the answer is complete.]
+```
+
+## Execution Rules
+
+1. **Always delegate search+scrape** to firecrawl-operator — never
+   run curl commands yourself
+2. **Cite everything** — every factual claim must trace to a source
+3. **Acknowledge limits** — if you cannot find the answer, say so
+   clearly in Gaps & Follow-up
+4. **No speculation** — only report what the scraped content supports
+5. **Concise synthesis** — the Answer section should be 1-3 focused
+   paragraphs, not a dump of everything found

--- a/plugins/f5xc-firecrawl/commands/research.md
+++ b/plugins/f5xc-firecrawl/commands/research.md
@@ -1,0 +1,17 @@
+---
+description: Research a question by searching the web, scraping results, and synthesizing an answer with citations
+argument-hint: "<question> [--limit <n>] [--domains site1.com,site2.com]"
+allowed_tools:
+  - Bash
+  - Agent
+---
+
+Invoke the `f5xc-firecrawl:web-scraper` skill to research "$ARGUMENTS".
+
+Use the RESEARCH protocol. Parse the arguments:
+
+- First argument(s) form the research question
+- `--limit` or `-l`: max sources to fetch and scrape (default: 5, max: 100). Clamp any value above 100 to 100 and warn the user.
+- `--domains` or `-d`: comma-separated list of domains to scope the search to
+
+If no question is provided, ask the user for one.

--- a/plugins/f5xc-firecrawl/skills/web-scraper/SKILL.md
+++ b/plugins/f5xc-firecrawl/skills/web-scraper/SKILL.md
@@ -2,11 +2,12 @@
 name: web-scraper
 description: >-
   Local firecrawl web scraping, crawling, site mapping, web search,
-  structured extraction, and llms.txt generation. Activates when the
-  user asks to scrape a URL, crawl a website, map site URLs, search
-  the web, extract structured data from pages, generate llms.txt,
-  batch scrape multiple URLs, cancel a crawl, list active crawls,
-  convert a web page to markdown, or fetch page content. Uses the
+  structured extraction, llms.txt generation, and research synthesis.
+  Activates when the user asks to scrape a URL, crawl a website, map
+  site URLs, search the web, extract structured data from pages,
+  generate llms.txt, batch scrape multiple URLs, cancel a crawl, list
+  active crawls, convert a web page to markdown, fetch page content,
+  or research a question using web search and scrape. Uses the
   self-hosted firecrawl instance on localhost:3002 — no API keys or
   subscriptions required.
 user-invocable: false
@@ -36,6 +37,7 @@ the main session context.
 | **Search** | Web search with optional scraping | `POST /v1/search` | Sync |
 | **Extract** | LLM-powered structured data extraction | `POST /v1/extract` | Async |
 | **llms.txt** | Generate llms.txt for a site | `POST /v1/llmstxt` | Async |
+| **Research** | Search + scrape + synthesize answer | Multiple | Sync |
 
 ## Delegation Protocol
 
@@ -121,6 +123,16 @@ Agent(
 )
 ```
 
+### For research requests
+
+```
+Agent(
+  subagent_type="f5xc-firecrawl:firecrawl-researcher",
+  description="Research: [topic in 3 words]",
+  prompt="QUESTION: <the user's natural language question>\nLIMIT: <number of sources, default 5>\nDOMAINS: <comma-separated domain scope, or 'none'>\n\nResearch this question using web search + scrape and return a structured report."
+)
+```
+
 Wait for the agent's response and relay it directly to the user.
 
 ## When to activate
@@ -136,6 +148,10 @@ Wait for the agent's response and relay it directly to the user.
 - "convert this page to markdown"
 - "fetch page content" / "get markdown from"
 - Any request to read, extract, or search web content
+- "research this" / "find out if" / "does [product] support"
+- "is [feature] available in" / "answer this question"
+- "look up" / "investigate" / "what do we know about"
+- Any natural language question that needs web research to answer
 
 ## What this does NOT do
 
@@ -144,3 +160,4 @@ Wait for the agent's response and relay it directly to the user.
 - **No browser sessions** — cloud-only feature
 - **No deep research** — cloud-only feature
 - **Extract requires LLM proxy** — needs OPENAI_BASE_URL configured
+- **Research requires working search** — firecrawl SEARCH endpoint must be operational


### PR DESCRIPTION
## Summary

- Adds a `firecrawl-researcher` agent that accepts a natural language question, searches the web via firecrawl, scrapes top results, and synthesizes a structured answer with citations
- Adds a `/research` slash command exposing the workflow to users
- Updates the `web-scraper` skill with a RESEARCH delegation path, multi-domain fan-out fix, and `--limit` clamped to 100
- Updates the tool catalog browser-automation reference to reflect new capabilities

Closes #195

## Test plan

- [ ] CI checks pass
- [ ] Verify `/research` command triggers the firecrawl-researcher agent
- [ ] Verify multi-domain queries fan out one search per domain
- [ ] Verify `--limit` values above 100 are clamped