### PR TITLE
feat: add terraform-lsp plugin for terraform-ls language server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -183,6 +183,32 @@
       "keywords": ["firecrawl", "scrape", "crawl", "web-scraping", "markdown", "self-hosted", "local", "open-source"],
       "tags": ["firecrawl", "scraping", "web", "local"],
       "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "terraform-lsp",
+      "description": "Terraform language server for infrastructure-as-code intelligence via terraform-ls",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/terraform-lsp",
+      "category": "development",
+      "strict": false,
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/terraform-lsp",
+      "license": "Apache-2.0",
+      "keywords": ["terraform", "lsp", "infrastructure", "iac", "hashicorp"],
+      "tags": ["terraform", "lsp", "language-server"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "terraform-ls": {
+          "command": "terraform-ls",
+          "args": ["serve"],
+          "extensionToLanguage": {
+            ".tf": "terraform",
+            ".tfvars": "terraform-vars"
+          }
+        }
+      }
     }
   ]
 }

--- a/plugins/terraform-lsp/.claude-plugin/plugin.json
+++ b/plugins/terraform-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "terraform-lsp",
+  "description": "Terraform language server for infrastructure-as-code intelligence via terraform-ls",
+  "version": "1.0.0",
+  "lspServers": {
+    "terraform-ls": {
+      "command": "terraform-ls",
+      "args": ["serve"],
+      "extensionToLanguage": {
+        ".tf": "terraform",
+        ".tfvars": "terraform-vars"
+      }
+    }
+  }
+}

--- a/plugins/terraform-lsp/README.md
+++ b/plugins/terraform-lsp/README.md
@@ -1,0 +1,18 @@
+# Terraform LSP
+
+Terraform language server plugin for Claude Code, providing code intelligence for `.tf` and `.tfvars` files via [terraform-ls](https://github.com/hashicorp/terraform-ls).
+
+## Prerequisites
+
+Install `terraform-ls` before enabling this plugin:
+
+- **Via HashiCorp releases (recommended):** Download from https://releases.hashicorp.com/terraform-ls/
+- **Via Homebrew (macOS):** `brew install hashicorp/tap/terraform-ls`
+- **Via package manager (Linux):** See [installation docs](https://github.com/hashicorp/terraform-ls/blob/main/docs/installation.md)
+
+## Features
+
+- Go to Definition for resources, variables, and modules
+- Find References across Terraform configurations
+- Hover documentation for providers, resources, and attributes
+- Real-time diagnostics and validation


### PR DESCRIPTION
## Summary
- Adds a `terraform-lsp` plugin that configures Claude Code to use the pre-installed `terraform-ls` binary for `.tf` and `.tfvars` file intelligence
- Configuration-only plugin (no binary, no hooks) — just an `lspServers` declaration
- The `terraform-ls` binary is already installed in the devcontainer Dockerfile

Closes #224

## Test plan
- [x] Verify marketplace.json is valid JSON
- [ ] Enable plugin in devcontainer settings.json
- [ ] Rebuild container and test LSP features on `.tf` files

Generated with [Claude Code](https://claude.com/claude-code)