### PR TITLE
fix: terraform-lsp plugin validation and lint fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -183,6 +183,32 @@
       "keywords": ["firecrawl", "scrape", "crawl", "web-scraping", "markdown", "self-hosted", "local", "open-source"],
       "tags": ["firecrawl", "scraping", "web", "local"],
       "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "terraform-lsp",
+      "description": "Terraform language server for infrastructure-as-code intelligence via terraform-ls",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/terraform-lsp",
+      "category": "development",
+      "strict": false,
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/terraform-lsp",
+      "license": "Apache-2.0",
+      "keywords": ["terraform", "lsp", "infrastructure", "iac", "hashicorp"],
+      "tags": ["terraform", "lsp", "language-server"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "terraform-ls": {
+          "command": "terraform-ls",
+          "args": ["serve"],
+          "extensionToLanguage": {
+            ".tf": "terraform",
+            ".tfvars": "terraform-vars"
+          }
+        }
+      }
     }
   ]
 }

--- a/plugins/terraform-lsp/.claude-plugin/plugin.json
+++ b/plugins/terraform-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "terraform-lsp",
+  "description": "Terraform language server for infrastructure-as-code intelligence via terraform-ls",
+  "version": "1.0.0",
+  "lspServers": {
+    "terraform-ls": {
+      "command": "terraform-ls",
+      "args": ["serve"],
+      "extensionToLanguage": {
+        ".tf": "terraform",
+        ".tfvars": "terraform-vars"
+      }
+    }
+  }
+}

--- a/plugins/terraform-lsp/.claude-plugin/plugin.json
+++ b/plugins/terraform-lsp/.claude-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "terraform-lsp",
   "description": "Terraform language server for infrastructure-as-code intelligence via terraform-ls",
   "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
   "lspServers": {
     "terraform-ls": {
       "command": "terraform-ls",

--- a/plugins/terraform-lsp/README.md
+++ b/plugins/terraform-lsp/README.md
@@ -1,0 +1,18 @@
+# Terraform LSP
+
+Terraform language server plugin for Claude Code, providing code intelligence for `.tf` and `.tfvars` files via [terraform-ls](https://github.com/hashicorp/terraform-ls).
+
+## Prerequisites
+
+Install `terraform-ls` before enabling this plugin:
+
+- **Via HashiCorp releases (recommended):** Download from https://releases.hashicorp.com/terraform-ls/
+- **Via Homebrew (macOS):** `brew install hashicorp/tap/terraform-ls`
+- **Via package manager (Linux):** See [installation docs](https://github.com/hashicorp/terraform-ls/blob/main/docs/installation.md)
+
+## Features
+
+- Go to Definition for resources, variables, and modules
+- Find References across Terraform configurations
+- Hover documentation for providers, resources, and attributes
+- Real-time diagnostics and validation

--- a/plugins/terraform-lsp/commands/terraform-lsp-status.md
+++ b/plugins/terraform-lsp/commands/terraform-lsp-status.md
@@ -1,0 +1,10 @@
+---
+name: terraform-lsp-status
+description: Check terraform-ls language server status and version
+---
+
+Check the terraform-ls language server status:
+
+1. Run `terraform-ls --version` to verify the binary is available
+2. Report the version and installation path
+3. Confirm the LSP plugin is enabled for `.tf` and `.tfvars` files


### PR DESCRIPTION
## Summary
- Adds missing `author.name` field to plugin.json (CI validation requirement)
- Adds minimal status command (CI requires at least one skill/command/agent)

Closes #224

Generated with [Claude Code](https://claude.com/claude-code)