### PR TITLE
feat: add json-lsp plugin for vscode-json-language-server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -209,6 +209,32 @@
           }
         }
       }
+    },
+    {
+      "name": "json-lsp",
+      "description": "JSON language server for schema validation and code intelligence via vscode-json-language-server",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/json-lsp",
+      "category": "development",
+      "strict": false,
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/json-lsp",
+      "license": "Apache-2.0",
+      "keywords": ["json", "jsonc", "lsp", "schema", "validation"],
+      "tags": ["json", "lsp", "language-server"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "json": {
+          "command": "vscode-json-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".json": "json",
+            ".jsonc": "jsonc"
+          }
+        }
+      }
     }
   ]
 }

--- a/plugins/json-lsp/.claude-plugin/plugin.json
+++ b/plugins/json-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "json-lsp",
+  "description": "JSON language server for schema validation and code intelligence",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "json": {
+      "command": "vscode-json-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {
+        ".json": "json",
+        ".jsonc": "jsonc"
+      }
+    }
+  }
+}

--- a/plugins/json-lsp/README.md
+++ b/plugins/json-lsp/README.md
@@ -1,0 +1,16 @@
+# JSON LSP
+
+JSON language server plugin for Claude Code, providing schema validation and code intelligence for `.json` and `.jsonc` files via [vscode-json-language-server](https://github.com/microsoft/vscode/tree/main/extensions/json-language-features/server).
+
+## Prerequisites
+
+Install `vscode-json-language-server` before enabling this plugin:
+
+- **Via npm:** `npm install -g vscode-langservers-extracted`
+
+## Features
+
+- JSON schema validation
+- Auto-completion for JSON keys and values
+- Hover documentation from JSON schemas
+- Diagnostics for syntax errors

--- a/plugins/json-lsp/commands/json-lsp-status.md
+++ b/plugins/json-lsp/commands/json-lsp-status.md
@@ -1,0 +1,10 @@
+---
+name: json-lsp-status
+description: Check JSON language server status and availability
+---
+
+Check the JSON language server status:
+
+1. Run `which vscode-json-language-server` to verify the binary is available
+2. Report the installation path
+3. Confirm the LSP plugin is enabled for `.json` and `.jsonc` files


### PR DESCRIPTION
## Summary
- Adds a `json-lsp` plugin that configures Claude Code to use `vscode-json-language-server --stdio` for `.json` and `.jsonc` file intelligence
- Configuration-only plugin (no binary, no hooks)
- The binary is already installed in the devcontainer via `npm install -g vscode-langservers-extracted`

Closes #226

## Test plan
- [x] Validate marketplace.json is valid JSON
- [ ] Enable plugin in devcontainer settings.json
- [ ] Rebuild container and test LSP features on `.json` files

Generated with [Claude Code](https://claude.com/claude-code)