### PR TITLE
feat: add 7 LSP plugins (bash, yaml, css, html, eslint, markdown, mdx)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -235,6 +235,165 @@
           }
         }
       }
+    },
+    {
+      "name": "bash-lsp",
+      "description": "Bash/Shell language server for script intelligence via bash-language-server",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/bash-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["bash", "shell", "zsh", "lsp"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "bash-language-server": {
+          "command": "bash-language-server",
+          "args": ["start"],
+          "extensionToLanguage": {
+            ".sh": "bash",
+            ".bash": "bash",
+            ".zsh": "zsh",
+            ".bats": "bash"
+          }
+        }
+      }
+    },
+    {
+      "name": "yaml-lsp",
+      "description": "YAML language server for schema validation and code intelligence via yaml-language-server",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/yaml-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["yaml", "yml", "kubernetes", "lsp"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "yaml-language-server": {
+          "command": "yaml-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".yml": "yaml",
+            ".yaml": "yaml"
+          }
+        }
+      }
+    },
+    {
+      "name": "css-lsp",
+      "description": "CSS/SCSS/Less language server for style intelligence via vscode-css-language-server",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/css-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["css", "scss", "less", "lsp"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "vscode-css-language-server": {
+          "command": "vscode-css-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".css": "css",
+            ".scss": "scss",
+            ".less": "less"
+          }
+        }
+      }
+    },
+    {
+      "name": "html-lsp",
+      "description": "HTML language server for markup intelligence via vscode-html-language-server",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/html-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["html", "htm", "lsp"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "vscode-html-language-server": {
+          "command": "vscode-html-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".html": "html",
+            ".htm": "html"
+          }
+        }
+      }
+    },
+    {
+      "name": "eslint-lsp",
+      "description": "ESLint language server for JavaScript/TypeScript linting via vscode-eslint-language-server",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/eslint-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["eslint", "javascript", "typescript", "lsp", "linting"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "vscode-eslint-language-server": {
+          "command": "vscode-eslint-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".mjs": "javascript",
+            ".cjs": "javascript"
+          }
+        }
+      }
+    },
+    {
+      "name": "markdown-lsp",
+      "description": "Markdown language server for documentation intelligence via vscode-markdown-language-server",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/markdown-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["markdown", "md", "lsp", "documentation"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "vscode-markdown-language-server": {
+          "command": "vscode-markdown-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".md": "markdown"
+          }
+        }
+      }
+    },
+    {
+      "name": "mdx-lsp",
+      "description": "MDX language server for MDX document intelligence via mdx-language-server",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/mdx-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["mdx", "markdown", "jsx", "lsp"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "mdx-language-server": {
+          "command": "mdx-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".mdx": "mdx"
+          }
+        }
+      }
     }
   ]
 }

--- a/plugins/bash-lsp/.claude-plugin/plugin.json
+++ b/plugins/bash-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "bash-lsp",
+  "description": "Bash/Shell language server for script intelligence",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "bash-language-server": {
+      "command": "bash-language-server",
+      "args": ["start"],
+      "extensionToLanguage": {".sh":"bash",".bash":"bash",".zsh":"zsh",".bats":"bash"}
+    }
+  }
+}

--- a/plugins/bash-lsp/README.md
+++ b/plugins/bash-lsp/README.md
@@ -1,0 +1,13 @@
+# bash-lsp
+
+Bash/Shell language server for script intelligence via [bash-language-server](https://www.npmjs.com/package/bash-language-server).
+
+## Prerequisites
+
+`npm install -g bash-language-server`
+
+## Features
+
+- Go to Definition and Find References
+- Hover documentation
+- Real-time diagnostics and validation

--- a/plugins/bash-lsp/commands/bash-lsp-status.md
+++ b/plugins/bash-lsp/commands/bash-lsp-status.md
@@ -1,0 +1,9 @@
+---
+name: bash-lsp-status
+description: Check bash-language-server language server status
+---
+
+Check the bash-language-server language server status:
+
+1. Run `which bash-language-server` to verify the binary is available
+2. Report the installation path

--- a/plugins/css-lsp/.claude-plugin/plugin.json
+++ b/plugins/css-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "css-lsp",
+  "description": "CSS/SCSS/Less language server for style intelligence",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "vscode-css-language-server": {
+      "command": "vscode-css-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {".css":"css",".scss":"scss",".less":"less"}
+    }
+  }
+}

--- a/plugins/css-lsp/README.md
+++ b/plugins/css-lsp/README.md
@@ -1,0 +1,13 @@
+# css-lsp
+
+CSS/SCSS/Less language server for style intelligence via [vscode-css-language-server](https://www.npmjs.com/package/vscode-css-language-server).
+
+## Prerequisites
+
+`npm install -g vscode-langservers-extracted`
+
+## Features
+
+- Go to Definition and Find References
+- Hover documentation
+- Real-time diagnostics and validation

--- a/plugins/css-lsp/commands/css-lsp-status.md
+++ b/plugins/css-lsp/commands/css-lsp-status.md
@@ -1,0 +1,9 @@
+---
+name: css-lsp-status
+description: Check vscode-css-language-server language server status
+---
+
+Check the vscode-css-language-server language server status:
+
+1. Run `which vscode-css-language-server` to verify the binary is available
+2. Report the installation path

--- a/plugins/eslint-lsp/.claude-plugin/plugin.json
+++ b/plugins/eslint-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "eslint-lsp",
+  "description": "ESLint language server for JavaScript/TypeScript linting",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "vscode-eslint-language-server": {
+      "command": "vscode-eslint-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {".js":"javascript",".jsx":"javascriptreact",".ts":"typescript",".tsx":"typescriptreact",".mjs":"javascript",".cjs":"javascript"}
+    }
+  }
+}

--- a/plugins/eslint-lsp/README.md
+++ b/plugins/eslint-lsp/README.md
@@ -1,0 +1,13 @@
+# eslint-lsp
+
+ESLint language server for JavaScript/TypeScript linting via [vscode-eslint-language-server](https://www.npmjs.com/package/vscode-eslint-language-server).
+
+## Prerequisites
+
+`npm install -g vscode-langservers-extracted`
+
+## Features
+
+- Go to Definition and Find References
+- Hover documentation
+- Real-time diagnostics and validation

--- a/plugins/eslint-lsp/commands/eslint-lsp-status.md
+++ b/plugins/eslint-lsp/commands/eslint-lsp-status.md
@@ -1,0 +1,9 @@
+---
+name: eslint-lsp-status
+description: Check vscode-eslint-language-server language server status
+---
+
+Check the vscode-eslint-language-server language server status:
+
+1. Run `which vscode-eslint-language-server` to verify the binary is available
+2. Report the installation path

--- a/plugins/html-lsp/.claude-plugin/plugin.json
+++ b/plugins/html-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "html-lsp",
+  "description": "HTML language server for markup intelligence",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "vscode-html-language-server": {
+      "command": "vscode-html-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {".html":"html",".htm":"html"}
+    }
+  }
+}

--- a/plugins/html-lsp/README.md
+++ b/plugins/html-lsp/README.md
@@ -1,0 +1,13 @@
+# html-lsp
+
+HTML language server for markup intelligence via [vscode-html-language-server](https://www.npmjs.com/package/vscode-html-language-server).
+
+## Prerequisites
+
+`npm install -g vscode-langservers-extracted`
+
+## Features
+
+- Go to Definition and Find References
+- Hover documentation
+- Real-time diagnostics and validation

--- a/plugins/html-lsp/commands/html-lsp-status.md
+++ b/plugins/html-lsp/commands/html-lsp-status.md
@@ -1,0 +1,9 @@
+---
+name: html-lsp-status
+description: Check vscode-html-language-server language server status
+---
+
+Check the vscode-html-language-server language server status:
+
+1. Run `which vscode-html-language-server` to verify the binary is available
+2. Report the installation path

--- a/plugins/markdown-lsp/.claude-plugin/plugin.json
+++ b/plugins/markdown-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "markdown-lsp",
+  "description": "Markdown language server for documentation intelligence",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "vscode-markdown-language-server": {
+      "command": "vscode-markdown-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {".md":"markdown"}
+    }
+  }
+}

--- a/plugins/markdown-lsp/README.md
+++ b/plugins/markdown-lsp/README.md
@@ -1,0 +1,13 @@
+# markdown-lsp
+
+Markdown language server for documentation intelligence via [vscode-markdown-language-server](https://www.npmjs.com/package/vscode-markdown-language-server).
+
+## Prerequisites
+
+`npm install -g vscode-langservers-extracted`
+
+## Features
+
+- Go to Definition and Find References
+- Hover documentation
+- Real-time diagnostics and validation

--- a/plugins/markdown-lsp/commands/markdown-lsp-status.md
+++ b/plugins/markdown-lsp/commands/markdown-lsp-status.md
@@ -1,0 +1,9 @@
+---
+name: markdown-lsp-status
+description: Check vscode-markdown-language-server language server status
+---
+
+Check the vscode-markdown-language-server language server status:
+
+1. Run `which vscode-markdown-language-server` to verify the binary is available
+2. Report the installation path

--- a/plugins/mdx-lsp/.claude-plugin/plugin.json
+++ b/plugins/mdx-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "mdx-lsp",
+  "description": "MDX language server for MDX document intelligence",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "mdx-language-server": {
+      "command": "mdx-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {".mdx":"mdx"}
+    }
+  }
+}

--- a/plugins/mdx-lsp/README.md
+++ b/plugins/mdx-lsp/README.md
@@ -1,0 +1,13 @@
+# mdx-lsp
+
+MDX language server for MDX document intelligence via [mdx-language-server](https://www.npmjs.com/package/mdx-language-server).
+
+## Prerequisites
+
+`npm install -g @mdx-js/language-server`
+
+## Features
+
+- Go to Definition and Find References
+- Hover documentation
+- Real-time diagnostics and validation

--- a/plugins/mdx-lsp/commands/mdx-lsp-status.md
+++ b/plugins/mdx-lsp/commands/mdx-lsp-status.md
@@ -1,0 +1,9 @@
+---
+name: mdx-lsp-status
+description: Check mdx-language-server language server status
+---
+
+Check the mdx-language-server language server status:
+
+1. Run `which mdx-language-server` to verify the binary is available
+2. Report the installation path

--- a/plugins/yaml-lsp/.claude-plugin/plugin.json
+++ b/plugins/yaml-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "yaml-lsp",
+  "description": "YAML language server for schema validation and code intelligence",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "yaml-language-server": {
+      "command": "yaml-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {".yml":"yaml",".yaml":"yaml"}
+    }
+  }
+}

--- a/plugins/yaml-lsp/README.md
+++ b/plugins/yaml-lsp/README.md
@@ -1,0 +1,13 @@
+# yaml-lsp
+
+YAML language server for schema validation and code intelligence via [yaml-language-server](https://www.npmjs.com/package/yaml-language-server).
+
+## Prerequisites
+
+`npm install -g yaml-language-server`
+
+## Features
+
+- Go to Definition and Find References
+- Hover documentation
+- Real-time diagnostics and validation

--- a/plugins/yaml-lsp/commands/yaml-lsp-status.md
+++ b/plugins/yaml-lsp/commands/yaml-lsp-status.md
@@ -1,0 +1,9 @@
+---
+name: yaml-lsp-status
+description: Check yaml-language-server language server status
+---
+
+Check the yaml-language-server language server status:
+
+1. Run `which yaml-language-server` to verify the binary is available
+2. Report the installation path


### PR DESCRIPTION
## Summary
Adds LSP plugins for 7 language server binaries pre-installed in the devcontainer:

| Plugin | Binary | File types |
|--------|--------|-----------|
| bash-lsp | bash-language-server | .sh, .bash, .zsh, .bats |
| yaml-lsp | yaml-language-server | .yml, .yaml |
| css-lsp | vscode-css-language-server | .css, .scss, .less |
| html-lsp | vscode-html-language-server | .html, .htm |
| eslint-lsp | vscode-eslint-language-server | .js, .jsx, .ts, .tsx, .mjs, .cjs |
| markdown-lsp | vscode-markdown-language-server | .md |
| mdx-lsp | mdx-language-server | .mdx |

All are configuration-only (no binary, no hooks) — just `lspServers` declarations.

Closes #228

## Test plan
- [x] All plugin.json files validate as JSON
- [x] All binaries verified at /usr/bin/
- [ ] Enable all plugins in devcontainer settings.json
- [ ] Rebuild container and verify LSP features

Generated with [Claude Code](https://claude.com/claude-code)