### PR TITLE
feat: add toml-lsp plugin for taplo TOML language server

### DIFF
--- a/plugins/toml-lsp/.claude-plugin/plugin.json
+++ b/plugins/toml-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "toml-lsp",
+  "description": "TOML language server for configuration file intelligence via taplo",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "taplo": {
+      "command": "taplo",
+      "args": ["lsp", "stdio"],
+      "extensionToLanguage": {
+        ".toml": "toml"
+      }
+    }
+  }
+}

--- a/plugins/toml-lsp/README.md
+++ b/plugins/toml-lsp/README.md
@@ -1,0 +1,17 @@
+# TOML LSP
+
+TOML language server plugin for Claude Code, providing code intelligence for `.toml` files via [taplo](https://github.com/tamasfe/taplo).
+
+## Prerequisites
+
+Install `taplo` before enabling this plugin:
+
+- **Pre-installed** in the f5xc-salesdemos devcontainer
+- **Manual install:** Download from [taplo releases](https://github.com/tamasfe/taplo/releases)
+
+## Features
+
+- TOML syntax validation and diagnostics
+- Auto-completion for keys and values
+- Hover documentation
+- Schema validation

--- a/plugins/toml-lsp/commands/toml-lsp-status.md
+++ b/plugins/toml-lsp/commands/toml-lsp-status.md
@@ -1,0 +1,10 @@
+---
+name: toml-lsp-status
+description: Check taplo TOML language server status and availability
+---
+
+Check the TOML language server status:
+
+1. Run `which taplo` to verify the binary is available
+2. Run `taplo --version` to report the version
+3. Confirm the LSP plugin is enabled for `.toml` files


### PR DESCRIPTION
## Summary

- Add Claude Code LSP plugin for the taplo TOML language server
- Provides TOML file intelligence (.toml) via `taplo lsp stdio`
- Follows the same structure as existing LSP plugins (json-lsp, bash-lsp, terraform-lsp, etc.)

Closes #231

## Test plan

- [ ] CI checks pass
- [ ] Verify plugin.json has correct LSP server configuration
- [ ] Verify taplo binary is available in devcontainer
- [ ] Confirm .toml file association is correct