### PR TITLE
fix: add toml-lsp to marketplace.json manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "f5xc-sales-engineer",
-      "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
+      "description": "Sales Engineer persona framework for F5 XC demo repositories \u2014 demo execution, environment operations, presentation, Q&A, post-session debrief",
       "version": "1.0.6",
       "author": {
         "name": "f5xc-salesdemos"
@@ -42,7 +42,7 @@
     },
     {
       "name": "f5xc-github-ops",
-      "description": "GitHub operations automation — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
+      "description": "GitHub operations automation \u2014 issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
       "version": "2.2.2",
       "author": {
         "name": "f5xc-salesdemos"
@@ -57,7 +57,7 @@
     },
     {
       "name": "f5xc-docs-pipeline",
-      "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
+      "description": "Documentation pipeline architecture \u2014 config ownership, release dispatch chain, content authoring, managed files, local preview",
       "version": "1.0.2",
       "author": {
         "name": "f5xc-salesdemos"
@@ -72,7 +72,7 @@
     },
     {
       "name": "f5xc-brand",
-      "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
+      "description": "F5 corporate branding enforcement \u2014 colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
       "version": "1.0.2",
       "author": {
         "name": "f5xc-salesdemos"
@@ -87,7 +87,7 @@
     },
     {
       "name": "f5xc-meddpicc",
-      "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
+      "description": "MEDDPICC sales qualification and deal-execution framework \u2014 evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
       "version": "1.0.4",
       "author": {
         "name": "f5xc-salesdemos"
@@ -112,7 +112,7 @@
     },
     {
       "name": "f5xc-devcontainer",
-      "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
+      "description": "Container awareness \u2014 tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
       "version": "1.1.6",
       "author": {
         "name": "f5xc-salesdemos"
@@ -127,7 +127,7 @@
     },
     {
       "name": "f5xc-platform",
-      "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
+      "description": "F5 Distributed Cloud platform automation \u2014 web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
       "version": "3.1.1",
       "author": {
         "name": "f5xc-salesdemos"
@@ -156,7 +156,7 @@
     },
     {
       "name": "osint-framework",
-      "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
+      "description": "OSINT Framework tool catalog and investigation skills \u2014 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
       "version": "1.0.1",
       "author": {
         "name": "f5xc-salesdemos"
@@ -171,7 +171,7 @@
     },
     {
       "name": "f5xc-firecrawl",
-      "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
+      "description": "Local self-hosted firecrawl web scraping \u2014 scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
       "version": "1.1.0",
       "author": {
         "name": "f5xc-salesdemos"
@@ -240,7 +240,9 @@
       "name": "bash-lsp",
       "description": "Bash/Shell language server for script intelligence via bash-language-server",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/bash-lsp",
       "category": "development",
       "strict": false,
@@ -264,7 +266,9 @@
       "name": "yaml-lsp",
       "description": "YAML language server for schema validation and code intelligence via yaml-language-server",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/yaml-lsp",
       "category": "development",
       "strict": false,
@@ -286,7 +290,9 @@
       "name": "css-lsp",
       "description": "CSS/SCSS/Less language server for style intelligence via vscode-css-language-server",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/css-lsp",
       "category": "development",
       "strict": false,
@@ -309,7 +315,9 @@
       "name": "html-lsp",
       "description": "HTML language server for markup intelligence via vscode-html-language-server",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/html-lsp",
       "category": "development",
       "strict": false,
@@ -331,7 +339,9 @@
       "name": "eslint-lsp",
       "description": "ESLint language server for JavaScript/TypeScript linting via vscode-eslint-language-server",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/eslint-lsp",
       "category": "development",
       "strict": false,
@@ -357,7 +367,9 @@
       "name": "markdown-lsp",
       "description": "Markdown language server for documentation intelligence via vscode-markdown-language-server",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/markdown-lsp",
       "category": "development",
       "strict": false,
@@ -378,7 +390,9 @@
       "name": "mdx-lsp",
       "description": "MDX language server for MDX document intelligence via mdx-language-server",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/mdx-lsp",
       "category": "development",
       "strict": false,
@@ -391,6 +405,29 @@
           "args": ["--stdio"],
           "extensionToLanguage": {
             ".mdx": "mdx"
+          }
+        }
+      }
+    },
+    {
+      "name": "toml-lsp",
+      "description": "TOML language server for configuration file intelligence via taplo",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/toml-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["toml", "taplo", "lsp", "configuration"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "taplo": {
+          "command": "taplo",
+          "args": ["lsp", "stdio"],
+          "extensionToLanguage": {
+            ".toml": "toml"
           }
         }
       }


### PR DESCRIPTION
## Summary

- Add the missing `toml-lsp` entry to `.claude-plugin/marketplace.json`
- PR #232 added the `plugins/toml-lsp/` directory but missed updating the manifest
- Claude Code reads marketplace.json as the authoritative plugin registry, so toml-lsp was invisible at runtime

Closes #233

## Test plan

- [x] JSON is valid (validated with python3 json.load)
- [x] Biome formatting passes
- [x] Pre-commit hooks pass locally
- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Plugin count is 20 (was 19)