### PR TITLE
feat: rate-limit-aware polling for github-ops v2.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "f5xc-github-ops",
       "description": "GitHub operations automation \u2014 issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/docs/superpowers/plans/2026-04-20-github-ops-rate-limit-polling.md
+++ b/docs/superpowers/plans/2026-04-20-github-ops-rate-limit-polling.md
@@ -4,6 +4,12 @@
 
 **Goal:** Make `f5xc-github-ops:github-ops` agent polling rate-limit-aware through ETag-cached conditional requests, adaptive intervals, and proper `403`/`429` handling, while being safe under multiple concurrent Claude Code sessions on a single workstation.
 
-**Architecture:** Three composable shell libraries (`gh-poll.sh`, `budget.sh`, `retry.sh`) installed into `~/.claude/github-ops/lib/` by an idempotent `PreToolUse` hook. The agent document routes every polling call site through these libraries. A per-host cache under `~/.claude/github-ops/cache/` holds ETags and response bodies so steady-state polls of unchanged CI state return `304` and do not consume primary rate-limit budget.
+**Architecture:** Three composable shell libraries (`gh-poll.sh`,
+`budget.sh`, `retry.sh`) installed into `~/.claude/github-ops/lib/` by
+an idempotent `PreToolUse` hook. The agent document routes every
+polling call site through these libraries. A per-host cache under
+`~/.claude/github-ops/cache/` holds ETags and response bodies so
+steady-state polls of unchanged CI state return `304` and do not
+consume primary rate-limit budget.
 
 **Tech Stack:** Bash 5, `gh` CLI, `jq`, `sha256sum`, `flock`, `mktemp`, `shellcheck`.

--- a/docs/superpowers/plans/2026-04-20-github-ops-rate-limit-polling.md
+++ b/docs/superpowers/plans/2026-04-20-github-ops-rate-limit-polling.md
@@ -1,0 +1,9 @@
+# github-ops Rate-Limit-Aware Polling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `f5xc-github-ops:github-ops` agent polling rate-limit-aware through ETag-cached conditional requests, adaptive intervals, and proper `403`/`429` handling, while being safe under multiple concurrent Claude Code sessions on a single workstation.
+
+**Architecture:** Three composable shell libraries (`gh-poll.sh`, `budget.sh`, `retry.sh`) installed into `~/.claude/github-ops/lib/` by an idempotent `PreToolUse` hook. The agent document routes every polling call site through these libraries. A per-host cache under `~/.claude/github-ops/cache/` holds ETags and response bodies so steady-state polls of unchanged CI state return `304` and do not consume primary rate-limit budget.
+
+**Tech Stack:** Bash 5, `gh` CLI, `jq`, `sha256sum`, `flock`, `mktemp`, `shellcheck`.

--- a/plugins/bash-lsp/.claude-plugin/plugin.json
+++ b/plugins/bash-lsp/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
     "bash-language-server": {
       "command": "bash-language-server",
       "args": ["start"],
-      "extensionToLanguage": {".sh":"bash",".bash":"bash",".zsh":"zsh",".bats":"bash"}
+      "extensionToLanguage": { ".sh": "bash", ".bash": "bash", ".zsh": "zsh", ".bats": "bash" }
     }
   }
 }

--- a/plugins/css-lsp/.claude-plugin/plugin.json
+++ b/plugins/css-lsp/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
     "vscode-css-language-server": {
       "command": "vscode-css-language-server",
       "args": ["--stdio"],
-      "extensionToLanguage": {".css":"css",".scss":"scss",".less":"less"}
+      "extensionToLanguage": { ".css": "css", ".scss": "scss", ".less": "less" }
     }
   }
 }

--- a/plugins/eslint-lsp/.claude-plugin/plugin.json
+++ b/plugins/eslint-lsp/.claude-plugin/plugin.json
@@ -9,7 +9,14 @@
     "vscode-eslint-language-server": {
       "command": "vscode-eslint-language-server",
       "args": ["--stdio"],
-      "extensionToLanguage": {".js":"javascript",".jsx":"javascriptreact",".ts":"typescript",".tsx":"typescriptreact",".mjs":"javascript",".cjs":"javascript"}
+      "extensionToLanguage": {
+        ".js": "javascript",
+        ".jsx": "javascriptreact",
+        ".ts": "typescript",
+        ".tsx": "typescriptreact",
+        ".mjs": "javascript",
+        ".cjs": "javascript"
+      }
     }
   }
 }

--- a/plugins/f5xc-github-ops/.claude-plugin/plugin.json
+++ b/plugins/f5xc-github-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-github-ops",
   "description": "GitHub operations automation for f5xc-salesdemos — issue-driven development, pre-commit lint gate, PR lifecycle, CI polling with error feedback to issues, post-merge monitoring, verification, rate limit management, upstream contribution workflow for fork-based development, and exclusive github-ops agent for all Git operations. Covers commit, push, branch, merge, squash, pull request, issue creation, repository settings, and fork-to-upstream contributions.",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-github-ops/README.md
+++ b/plugins/f5xc-github-ops/README.md
@@ -81,6 +81,35 @@ Agent(
 > Bash access. Without it, plan mode can re-engage
 > mid-workflow and block execution.
 
+## Rate-limit-aware polling (v2.3+)
+
+All CI/workflow polling in the agent is routed through three
+composable shell libraries installed by a `PreToolUse` hook to
+`~/.claude/github-ops/lib/`:
+
+- **`gh-poll.sh`** — `gh api -i` wrapper that caches ETag+body per
+  URL and sends `If-None-Match` on subsequent requests. A `304`
+  response returns the cached body at zero primary-rate-limit cost,
+  so polling a long-running workflow is nearly free. Exposes
+  `poll_until <url> <predicate>` as the primary entry point.
+- **`budget.sh`** — adaptive poll-interval calculator (20 s / 60 s /
+  180 s based on observed `X-RateLimit-Remaining`), ±25 % jitter,
+  `BUDGET_EXHAUSTED` floor at 200 remaining, and a `gap-wait
+  mutation` subcommand that enforces ≥1 s between mutative calls.
+- **`retry.sh`** — `403`/`429` handling with a host-wide
+  `state/cooldown.json` so every Claude Code session on the same
+  machine courteously waits out any observed `Retry-After` before
+  issuing its next request.
+
+These libraries add two statuses to the agent's return taxonomy:
+`BUDGET_EXHAUSTED` and `RATE_LIMIT_BACKOFF`. Callers use these to
+distinguish recoverable rate-limit events from non-recoverable
+configuration failures.
+
+Concurrency-safe by construction: per-PID log files, atomic-rename
+cache writes, `flock`-guarded installer, no locks held across
+network I/O.
+
 ## Installation
 
 ```bash

--- a/plugins/f5xc-github-ops/agents/github-ops.md
+++ b/plugins/f5xc-github-ops/agents/github-ops.md
@@ -151,8 +151,8 @@ If remaining is in the RED zone, stop and return `BLOCKED`.
 GitHub enforces secondary rate limits separately from primary limits.
 These are triggered by abuse patterns, not by exceeding a counter.
 
-**Detection**: HTTP 403 or 429 with a `retry-after` response header.
-There is no way to check secondary limit budget in advance.
+**Detection**: HTTP 403 or 429 with a `Retry-After` response header.
+There is no way to check secondary-limit budget in advance.
 
 **Triggers** (avoid these):
 
@@ -161,16 +161,21 @@ There is no way to check secondary limit budget in advance.
 - More than 80 content-creation requests/min
 - More than 500 content-creation requests/hr
 
-**Handling**: If you receive a 403 or 429 with `retry-after`:
+**Handling**: `~/.claude/github-ops/lib/retry.sh` parses `Retry-After`,
+writes a host-wide cooldown to `state/cooldown.json`, and
+`poll_until` re-checks the cooldown before every request. If the
+same call fails twice, `poll_until` returns
+`Status: RATE_LIMIT_BACKOFF retry_after_seconds=<N>`.
 
-1. Parse the `retry-after` header (seconds to wait)
-2. Wait the specified duration
-3. Retry the request once
-4. If it fails again, return `BLOCKED` with the retry-after value
+**Mutation throttling**: Before every mutative `gh` call (issue
+create, PR create, comment, merge, branch protection edit) invoke:
 
-**Throttling**: Pause at least 1 second between mutative API calls
-(issue create, PR create, comment, merge). This prevents triggering
-the content-creation secondary limit.
+```bash
+~/.claude/github-ops/lib/budget.sh gap-wait mutation
+```
+
+This enforces a ≥1 s gap between mutations, keeping the workflow
+under the 80 content-creations-per-minute limit.
 
 ## Input Contract
 
@@ -380,29 +385,35 @@ done
 If no checks appear after 50 seconds, report a warning and proceed
 to merge — the repo may have no required checks.
 
-**Poll using single-shot queries** (never `--watch`):
+**Poll via the rate-limit-aware library** (`~/.claude/github-ops/lib/gh-poll.sh`):
 
+```bash
+# shellcheck disable=SC1091
+source ~/.claude/github-ops/lib/gh-poll.sh
+
+OWNER=<owner>; REPO=<repo>; SHA=$(gh pr view <NUMBER> --json headRefOid --jq .headRefOid)
+RESULT=$(poll_until "/repos/$OWNER/$REPO/commits/$SHA/check-runs" predicate_pr_checks_done)
+STATUS=$(echo "$RESULT" | awk '{print $2}')
 ```
-gh pr checks <NUMBER> --required --json bucket \
-  --jq 'map(.bucket) | unique | map(select(. != "skipping")) |
-  if . == ["pass"] then "pass"
-  elif any(. == "fail") then "fail"
-  elif length == 0 then "pass"
-  else "pending" end'
-```
 
-Use `--required` to focus on merge-blocking checks only.
-Skipped checks (bucket `skipping`) are filtered out before
-evaluation — they are non-blocking and must not cause the
-poll loop to wait indefinitely.
+`poll_until` uses ETag-cached `If-None-Match` requests (`304` = free,
+does not consume primary rate-limit budget), adapts its interval
+to the observed `X-RateLimit-Remaining`, applies ±25 % jitter,
+honors a host-wide cooldown on `429`/`403`-with-`Retry-After`, and
+aborts cleanly with `BUDGET_EXHAUSTED` before primary budget drops
+below 200.
 
-**Loop rules:**
+**Possible `STATUS` values from `poll_until`:**
 
-- Sleep for the interval defined by the current consumption zone
-  (30s GREEN, 60s YELLOW)
-- Maximum 20 iterations — if still pending, include status in the
-  report and stop
-- Re-check rate limit every 5 iterations
+- `COMPLETE` — the response body is at the path shown after `body=`;
+  inspect it to decide pass vs. fail (see classification below).
+- `BUDGET_EXHAUSTED` — stop. Return `Status: BUDGET_EXHAUSTED` to
+  the caller with the fields from the library line.
+- `RATE_LIMIT_BACKOFF` — stop. Return `Status: RATE_LIMIT_BACKOFF`
+  with `retry_after_seconds`.
+- `PENDING_TIMEOUT` — include the pending state in the report and
+  proceed to report `Status: CI_PENDING` to the caller.
+- `FAILED` — include the HTTP status and return `Status: FAILED`.
 
 **Zombie check detection**: If a check has been `in_progress` for
 more than 30 minutes, report it as a warning. Use:
@@ -504,24 +515,23 @@ Include merge failure details in the report if unresolvable.
 
 ### Step 9: Post-Merge Monitoring
 
-```
+```bash
 git checkout main && git pull origin main
 MERGE_SHA=$(git rev-parse HEAD)
 sleep 15
-gh run list --branch main --commit $MERGE_SHA
+
+# shellcheck disable=SC1091
+source ~/.claude/github-ops/lib/gh-poll.sh
+
+OWNER=<owner>; REPO=<repo>
+RESULT=$(poll_until "/repos/$OWNER/$REPO/actions/runs?head_sha=$MERGE_SHA" predicate_runs_complete)
+STATUS=$(echo "$RESULT" | awk '{print $2}')
 ```
 
-Poll each discovered workflow run:
-
-```
-gh run view <RUN-ID> --json status,conclusion \
-  --jq '"\(.status) \(.conclusion)"'
-```
-
-Same loop rules as Step 7. If a post-merge workflow fails due to
+Status semantics match Step 7. If a post-merge workflow fails due to
 your changes, include the failure in the report with
-`Status: CI_FAILED` and post a comment on the issue. Do NOT
-attempt to fix — return to the caller.
+`Status: CI_FAILED` and post a comment on the issue. Do NOT attempt
+to fix — return to the caller.
 
 ### Step 10: Verify and Clean Up
 
@@ -800,7 +810,7 @@ When applying settings, always follow this pattern:
 
 Always return a structured report with these sections:
 
-1. **Status** — one of: `COMPLETE`, `PRE_COMMIT_FAILED`, `CI_FAILED`, `FAILED`, `BLOCKED`, `REVIEW_NEEDED`
+1. **Status** — one of: `COMPLETE`, `PRE_COMMIT_FAILED`, `CI_FAILED`, `FAILED`, `BLOCKED`, `REVIEW_NEEDED`, `BUDGET_EXHAUSTED`, `RATE_LIMIT_BACKOFF`
 2. **Operations table** — each step with result and details
 3. **Issue/PR/SHA links** — numbers and URLs
 4. **Errors** — full output for the caller to act on (if any)
@@ -815,6 +825,13 @@ Always return a structured report with these sections:
    - `UPSTREAM_ISSUE_NOT_FOUND` — a provided upstream issue number does not exist
    - `UPSTREAM_PR_CREATION_FAILED` — could not create PR in the upstream repo
    - `UPSTREAM_PR_NOT_FOUND` — a provided upstream PR number does not exist
+   - `BUDGET_EXHAUSTED` — primary GitHub rate limit approached the
+     200-remaining floor mid-workflow. Report includes `remaining`,
+     `reset_at`, `minutes_until_reset`, `polls_used`, `free_polls`,
+     `paid_polls`. Caller should pause until reset and retry.
+   - `RATE_LIMIT_BACKOFF` — secondary rate limit triggered
+     (`Retry-After` observed) and a single retry also failed. Report
+     includes `retry_after_seconds`. Caller should wait and retry.
 
 ## Execution Rules
 
@@ -1064,20 +1081,21 @@ the upstream contribution resolves.
 
 ### Step U4: Monitor Upstream CI
 
-Poll upstream PR checks using the same logic as Step 7, but
-targeting the upstream repo:
+```bash
+# shellcheck disable=SC1091
+source ~/.claude/github-ops/lib/gh-poll.sh
 
-```
-gh pr checks {number} --repo {upstream} --required --json bucket \
-  --jq 'map(.bucket) | unique | map(select(. != "skipping")) |
-  if . == ["pass"] then "pass"
-  elif any(. == "fail") then "fail"
-  elif length == 0 then "pass"
-  else "pending" end'
+UPSTREAM_OWNER=<upstream-owner>; UPSTREAM_REPO=<upstream-repo>
+UPSTREAM_PR=<pr-number>
+SHA=$(gh pr view "$UPSTREAM_PR" --repo "$UPSTREAM_OWNER/$UPSTREAM_REPO" \
+       --json headRefOid --jq .headRefOid)
+RESULT=$(poll_until "/repos/$UPSTREAM_OWNER/$UPSTREAM_REPO/commits/$SHA/check-runs" \
+                    predicate_pr_checks_done)
+STATUS=$(echo "$RESULT" | awk '{print $2}')
 ```
 
-Same polling rules as Step 7 (single-shot, max 20 iterations,
-rate limit awareness).
+Status semantics match Step 7. Bot/automation comment detection
+remains unchanged:
 
 Additionally, detect bot/automation comments on the upstream PR:
 

--- a/plugins/f5xc-github-ops/hooks/hooks.json
+++ b/plugins/f5xc-github-ops/hooks/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-precommit.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/install-github-ops-lib.sh",
+            "timeout": 10
           }
         ]
       }

--- a/plugins/f5xc-github-ops/scripts/install-github-ops-lib.sh
+++ b/plugins/f5xc-github-ops/scripts/install-github-ops-lib.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Idempotent installer for github-ops libs and runtime directories.
+# Safe to run concurrently — uses flock on a lock file, with atomic
+# rename for each installed file.
+#
+# Honors GITHUB_OPS_HOME (defaults to ~/.claude/github-ops).
+# Source libs are located relative to CLAUDE_PLUGIN_ROOT if set,
+# otherwise relative to this script.
+#
+# Exit codes: 0 success, 2 install failed.
+
+set -euo pipefail
+
+: "${GITHUB_OPS_HOME:=$HOME/.claude/github-ops}"
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+src="${CLAUDE_PLUGIN_ROOT:-$(cd -- "$here/.." && pwd -P)}/scripts/libs"
+
+mkdir -p "$GITHUB_OPS_HOME/lib" "$GITHUB_OPS_HOME/cache" "$GITHUB_OPS_HOME/state"
+
+lock="$GITHUB_OPS_HOME/.install.lock"
+exec 9>"$lock"
+
+if ! flock -n 9; then
+  exit 0
+fi
+
+install_one() {
+  local name="$1"
+  local dst="$GITHUB_OPS_HOME/lib/$name"
+  local tmp
+  tmp="$(mktemp "${dst}.XXXXXX")"
+  cp "$src/$name" "$tmp"
+  chmod +x "$tmp"
+  mv -f "$tmp" "$dst"
+}
+
+install_one gh-poll.sh
+install_one budget.sh
+install_one retry.sh
+
+exit 0

--- a/plugins/f5xc-github-ops/scripts/libs/budget.sh
+++ b/plugins/f5xc-github-ops/scripts/libs/budget.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# budget.sh — adaptive poll-interval calculator and mutation gate.
+# Sourceable for testing; CLI entry point for mutation gap-wait.
+
+set -euo pipefail
+
+: "${GITHUB_OPS_HOME:=$HOME/.claude/github-ops}"
+
+# Returns an integer number of seconds to sleep before the next poll
+# given observed X-RateLimit-Remaining and X-RateLimit-Reset headers.
+next_interval() {
+  local remaining="${1:-}" reset="${2:-}"
+  remaining="${remaining:-5000}"
+  if [ "$remaining" -gt 1000 ]; then
+    echo 20
+  elif [ "$remaining" -gt 500 ]; then
+    echo 60
+  elif [ "$remaining" -ge 200 ]; then
+    echo 180
+  # <200 zone: caller is responsible for invoking check_budget_floor first.
+  else echo 180; fi
+}
+
+# Adds 0–25% jitter to an integer interval.
+apply_jitter() {
+  local base="$1"
+  local pct=$((RANDOM % 26))
+  echo $((base + base * pct / 100))
+}
+
+check_budget_floor() {
+  local remaining="$1" reset="$2"
+  if [ "$remaining" -ge 200 ]; then return 0; fi
+  local now mins
+  now=$(date +%s)
+  mins=$(((reset - now + 59) / 60))
+  [ "$mins" -lt 0 ] && mins=0
+  printf 'Status: BUDGET_EXHAUSTED remaining=%s reset_at=%s minutes_until_reset=%s\n' \
+    "$remaining" "$reset" "$mins"
+  return 42
+}
+
+budget_gap_wait_mutation() {
+  local stamp="$GITHUB_OPS_HOME/state/last_mutation"
+  mkdir -p "$(dirname -- "$stamp")"
+  local now last_ms wait_ms
+  now=$(date +%s%3N)
+  last_ms=$(cat "$stamp" 2>/dev/null || echo 0)
+  wait_ms=$((1000 - (now - last_ms)))
+  if [ "$wait_ms" -gt 0 ]; then sleep "$(awk -v ms="$wait_ms" 'BEGIN{print ms/1000}')"; fi
+  date +%s%3N >"$stamp"
+}
+
+if [ "${BASH_SOURCE[0]:-}" = "$0" ]; then
+  case "${1:-}" in
+  gap-wait)
+    case "${2:-}" in
+    mutation) budget_gap_wait_mutation ;;
+    *)
+      echo "unknown gap-wait kind" >&2
+      exit 2
+      ;;
+    esac
+    ;;
+  *)
+    echo "usage: budget.sh gap-wait mutation" >&2
+    exit 2
+    ;;
+  esac
+fi

--- a/plugins/f5xc-github-ops/scripts/libs/gh-poll.sh
+++ b/plugins/f5xc-github-ops/scripts/libs/gh-poll.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# gh-poll.sh — ETag-cached GET wrapper and POLL_UNTIL orchestrator.
+# Sourceable for testing; exports functions when sourced.
+# When executed with subcommand args, acts as a CLI.
+
+set -euo pipefail
+
+: "${GITHUB_OPS_HOME:=$HOME/.claude/github-ops}"
+: "${GITHUB_OPS_LIB:=$GITHUB_OPS_HOME/lib}"
+
+atomic_write() {
+  local dst="$1"
+  local content="$2"
+  local dir
+  dir="$(dirname -- "$dst")"
+  mkdir -p "$dir"
+  local tmp
+  tmp="$(mktemp "${dst}.XXXXXX")"
+  printf '%s' "$content" >"$tmp"
+  mv -f "$tmp" "$dst"
+}
+
+cache_key() {
+  local method="$1" url="$2"
+  printf '%s %s' "$method" "$url" | sha256sum | awk '{print $1}'
+}
+
+parse_status() {
+  # First line of raw response, e.g. "HTTP/2.0 304\r" or "HTTP/2.0 304"
+  local raw="$1"
+  printf '%s' "$raw" | awk 'NR==1 { gsub(/\r/, "", $2); print $2; exit }'
+}
+
+parse_rate_header() {
+  local raw="$1" name="$2"
+  printf '%s' "$raw" | awk -v n="$name" '
+    /^\r?$/ { exit }
+    tolower($0) ~ tolower("^" n ":") {
+      sub(/^[^:]*:[[:space:]]*/, "")
+      sub(/\r$/, "")
+      print
+      exit
+    }
+  '
+}
+
+parse_body() {
+  local raw="$1"
+  printf '%s' "$raw" | awk '
+    found { sub(/\r$/, ""); print; next }
+    /^\r?$/ { found = 1 }
+  ' ORS=
+}
+
+gh_poll() {
+  cache_trim
+  local url="$1"
+  local method="GET"
+  local key
+  key="$(cache_key "$method" "$url")"
+  local cache_dir="$GITHUB_OPS_HOME/cache"
+  local etag_file="$cache_dir/$key.etag"
+  mkdir -p "$cache_dir"
+
+  local -a args=(api -i "$url")
+  local etag_hit="etag-miss"
+  if [ -s "$etag_file" ]; then
+    args+=(--header "If-None-Match: $(cat "$etag_file")")
+    etag_hit="etag-sent"
+  fi
+
+  local raw
+  raw="$(gh "${args[@]}" 2>&1 || true)"
+  local status remaining reset etag retry_after
+  status="$(parse_status "$raw")"
+  remaining="$(parse_rate_header "$raw" "X-RateLimit-Remaining")"
+  reset="$(parse_rate_header "$raw" "X-RateLimit-Reset")"
+  etag="$(parse_rate_header "$raw" "ETag")"
+  retry_after="$(parse_rate_header "$raw" "Retry-After")"
+
+  local body_path
+  body_path="$(mktemp "$cache_dir/$key.out.XXXXXX")"
+
+  case "$status" in
+  200)
+    local body
+    body="$(parse_body "$raw")"
+    printf '%s' "$body" >"$body_path"
+    atomic_write "$cache_dir/$key.body" "$body"
+    [ -n "$etag" ] && atomic_write "$etag_file" "$etag"
+    etag_hit="etag-miss"
+    ;;
+  304)
+    cp "$cache_dir/$key.body" "$body_path"
+    etag_hit="etag-hit"
+    ;;
+  403 | 429 | *) : ;;
+  esac
+
+  # Per-invocation observability log (append-only, per PID).
+  local log_file="$GITHUB_OPS_HOME/state/poll.$$.log"
+  mkdir -p "$(dirname -- "$log_file")"
+  printf '%s %s %s %s %s %s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$$" "$url" \
+    "${status:-0}" "${remaining:-}" "$etag_hit" >>"$log_file" 2>/dev/null || true
+
+  # TSV output: status, remaining, reset, etag_hit, body_path, retry_after
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "${status:-0}" "${remaining:-}" "${reset:-}" "$etag_hit" "$body_path" "${retry_after:-}"
+}
+
+poll_until() {
+  local url="$1" predicate="$2"
+  local deadline=$(($(date +%s) + ${MAX_POLL_WALLCLOCK:-1800}))
+  local free=0 paid=0 retried=0
+
+  # Cross-module deps — source siblings if present.
+  if [ -f "$GITHUB_OPS_LIB/budget.sh" ]; then
+    # shellcheck disable=SC1091
+    source "$GITHUB_OPS_LIB/budget.sh"
+  fi
+  if [ -f "$GITHUB_OPS_LIB/retry.sh" ]; then
+    # shellcheck disable=SC1091
+    source "$GITHUB_OPS_LIB/retry.sh"
+  fi
+
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    command -v wait_out_cooldown >/dev/null && wait_out_cooldown
+
+    local line
+    line="$(gh_poll "$url")"
+    local status remaining reset body_path retry_after_s
+    status="$(echo "$line" | awk -F'\t' '{print $1}')"
+    remaining="$(echo "$line" | awk -F'\t' '{print $2}')"
+    reset="$(echo "$line" | awk -F'\t' '{print $3}')"
+    body_path="$(echo "$line" | awk -F'\t' '{print $5}')"
+    retry_after_s="$(echo "$line" | awk -F'\t' '{print $6}')"
+
+    case "$status" in
+    200) paid=$((paid + 1)) ;;
+    304) free=$((free + 1)) ;;
+    403 | 429)
+      local ra="${retry_after_s:-60}"
+      [ -z "$ra" ] && ra=60
+      if [ "$retried" -eq 0 ]; then
+        retried=1
+        retry_with_backoff "$status" "$ra" "$url"
+        sleep "$ra"
+        rm -f "$body_path"
+        continue
+      else
+        printf 'Status: RATE_LIMIT_BACKOFF retry_after_seconds=%s free_polls=%s paid_polls=%s\n' "$ra" "$free" "$paid"
+        rm -f "$body_path"
+        return 1
+      fi
+      ;;
+    *)
+      printf 'Status: FAILED http_status=%s free_polls=%s paid_polls=%s\n' "$status" "$free" "$paid"
+      rm -f "$body_path"
+      return 1
+      ;;
+    esac
+
+    if "$predicate" "$body_path"; then
+      printf 'Status: COMPLETE free_polls=%s paid_polls=%s body=%s\n' "$free" "$paid" "$body_path"
+      return 0
+    fi
+
+    if [ -n "$remaining" ] && [ "$remaining" -lt 200 ]; then
+      local now mins
+      now=$(date +%s)
+      mins=$(((${reset:-0} - now + 59) / 60))
+      [ "$mins" -lt 0 ] && mins=0
+      printf 'Status: BUDGET_EXHAUSTED remaining=%s reset_at=%s minutes_until_reset=%s free_polls=%s paid_polls=%s\n' \
+        "$remaining" "${reset:-0}" "$mins" "$free" "$paid"
+      rm -f "$body_path"
+      return 42
+    fi
+
+    local base interval
+    base="$(next_interval "${remaining:-5000}" "${reset:-0}")"
+    interval="${POLL_INTERVAL_OVERRIDE:-$(apply_jitter "$base")}"
+    rm -f "$body_path"
+    sleep "$interval"
+  done
+
+  printf 'Status: PENDING_TIMEOUT free_polls=%s paid_polls=%s\n' "$free" "$paid"
+  return 2
+}
+
+predicate_pr_checks_done() {
+  local body="$1"
+  local pending
+  pending="$(jq '[.check_runs[] | select(.status != "completed")] | length' "$body" 2>/dev/null || echo 1)"
+  [ "$pending" = "0" ]
+}
+
+predicate_runs_complete() {
+  local body="$1"
+  local pending
+  pending="$(jq '[.workflow_runs[] | select(.status != "completed")] | length' "$body" 2>/dev/null || echo 1)"
+  [ "$pending" = "0" ]
+}
+
+cache_trim() {
+  local dir="$GITHUB_OPS_HOME/cache"
+  [ -d "$dir" ] || return 0
+  find "$dir" -maxdepth 1 -type f -mtime +1 -delete 2>/dev/null || true
+  local count
+  count=$(find "$dir" -maxdepth 1 -type f | wc -l)
+  if [ "$count" -gt 1000 ]; then
+    find "$dir" -maxdepth 1 -type f -printf '%T@ %p\n' 2>/dev/null |
+      sort -n |
+      head -n $((count - 1000)) |
+      cut -d' ' -f2- |
+      xargs -r rm -f 2>/dev/null || true
+  fi
+}
+
+# CLI entry point (implemented in later tasks).
+if [ "${BASH_SOURCE[0]:-}" = "$0" ]; then
+  echo "gh-poll.sh CLI: not yet implemented" >&2
+  exit 2
+fi

--- a/plugins/f5xc-github-ops/scripts/libs/retry.sh
+++ b/plugins/f5xc-github-ops/scripts/libs/retry.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# retry.sh — 403/429 handling with host-wide cooldown file.
+# Sourceable for testing.
+
+set -euo pipefail
+
+: "${GITHUB_OPS_HOME:=$HOME/.claude/github-ops}"
+
+cooldown_file() { echo "$GITHUB_OPS_HOME/state/cooldown.json"; }
+
+cooldown_get() {
+  local f
+  f="$(cooldown_file)"
+  [ -s "$f" ] || {
+    echo 0
+    return
+  }
+  jq -r '.until // 0' "$f" 2>/dev/null || echo 0
+}
+
+cooldown_set() {
+  local new_until="$1"
+  local f
+  f="$(cooldown_file)"
+  mkdir -p "$(dirname -- "$f")"
+  local current
+  current="$(cooldown_get)"
+  if [ "$new_until" -le "$current" ]; then return 0; fi
+  local tmp
+  tmp="$(mktemp "${f}.XXXXXX")"
+  printf '{"until":%s}\n' "$new_until" >"$tmp"
+  mv -f "$tmp" "$f"
+}
+
+wait_out_cooldown() {
+  local until now sleep_s
+  until="$(cooldown_get)"
+  now="$(date +%s)"
+  sleep_s=$((until - now))
+  if [ "$sleep_s" -gt 0 ]; then sleep "$sleep_s"; fi
+}
+
+retry_with_backoff() {
+  local status="$1" retry_after="$2" url="$3"
+  local seconds="${retry_after:-60}"
+  local now
+  now="$(date +%s)"
+  cooldown_set $((now + seconds))
+  printf 'Status: RATE_LIMIT_BACKOFF http_status=%s retry_after_seconds=%s url=%s\n' \
+    "$status" "$seconds" "$url" >&2
+  return 0
+}
+
+if [ "${BASH_SOURCE[0]:-}" = "$0" ]; then
+  echo "retry.sh CLI: not yet implemented" >&2
+  exit 2
+fi

--- a/plugins/f5xc-github-ops/scripts/tests/run-tests.sh
+++ b/plugins/f5xc-github-ops/scripts/tests/run-tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Test runner for f5xc-github-ops shell libs.
+# Runs every test_*.sh in this directory; each file contains
+# bash functions named test_* that exit non-zero on failure.
+#
+# Usage: ./run-tests.sh [filter-substring]
+#
+# Test authoring note: each test function runs under `set -euo pipefail`.
+# When exercising stubbed non-2xx paths, capture output with explicit
+# failure suppression to avoid premature exits:
+#   out=$(gh api -i /endpoint 2>&1) || true
+
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+STUBS="$HERE/stubs"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+LIB="$PLUGIN_ROOT/scripts/libs"
+
+export PATH="$STUBS:$PATH"
+export GITHUB_OPS_LIB="$LIB"
+filter="${1:-}"
+
+fail=0
+pass=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    export GITHUB_OPS_HOME="$tmp"
+    mkdir -p "$tmp/cache" "$tmp/state" "$tmp/lib"
+    if ("$fn") >"$tmp/out" 2>&1; then
+      pass=$((pass + 1))
+      printf '  PASS  %s\n' "$fn"
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      sed 's/^/    /' "$tmp/out"
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/f5xc-github-ops/scripts/tests/stubs/gh
+++ b/plugins/f5xc-github-ops/scripts/tests/stubs/gh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# gh CLI stub for unit tests. Only implements `gh api -i`.
+# Behavior is driven by env vars set by the calling test.
+#
+#   GH_STUB_STATUS       — HTTP status integer (200, 304, 403, 429, 404)
+#   GH_STUB_ETAG         — ETag header value to echo (e.g. W/"abc")
+#   GH_STUB_BODY         — response body bytes
+#   GH_STUB_REMAINING    — X-RateLimit-Remaining value
+#   GH_STUB_LIMIT        — X-RateLimit-Limit value
+#   GH_STUB_RESET        — X-RateLimit-Reset epoch seconds
+#   GH_STUB_RETRY_AFTER  — Retry-After seconds (403/429 only)
+#   GH_STUB_RECORD       — file path to append each invocation's argv to
+#
+# The test asserts against GH_STUB_RECORD to verify the call shape
+# (including whether If-None-Match was sent).
+
+set -euo pipefail
+
+[ -n "${GH_STUB_RECORD:-}" ] && printf '%s\n' "$*" >>"$GH_STUB_RECORD"
+
+status="${GH_STUB_STATUS:-200}"
+printf 'HTTP/2.0 %s\r\n' "$status"
+[ -n "${GH_STUB_ETAG:-}" ] && printf 'ETag: %s\r\n' "$GH_STUB_ETAG"
+[ -n "${GH_STUB_REMAINING:-}" ] && printf 'X-RateLimit-Remaining: %s\r\n' "$GH_STUB_REMAINING"
+[ -n "${GH_STUB_LIMIT:-}" ] && printf 'X-RateLimit-Limit: %s\r\n' "$GH_STUB_LIMIT"
+[ -n "${GH_STUB_RESET:-}" ] && printf 'X-RateLimit-Reset: %s\r\n' "$GH_STUB_RESET"
+[ -n "${GH_STUB_RETRY_AFTER:-}" ] && printf 'Retry-After: %s\r\n' "$GH_STUB_RETRY_AFTER"
+printf '\r\n'
+[ "$status" = "304" ] || printf '%s' "${GH_STUB_BODY:-}"
+
+case "$status" in
+2?? | 304) exit 0 ;;
+*) exit 1 ;;
+esac

--- a/plugins/f5xc-github-ops/scripts/tests/test_budget.sh
+++ b/plugins/f5xc-github-ops/scripts/tests/test_budget.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+_load_budget() { source "$PLUGIN_ROOT/scripts/libs/budget.sh"; }
+
+test_next_interval_green_zone_is_20() {
+  _load_budget
+  [ "$(next_interval 2000 $(($(date +%s) + 3600)))" = "20" ] || return 1
+}
+
+test_next_interval_yellow_zone_is_60() {
+  _load_budget
+  [ "$(next_interval 800 $(($(date +%s) + 3600)))" = "60" ] || return 1
+}
+
+test_next_interval_orange_zone_is_180() {
+  _load_budget
+  [ "$(next_interval 300 $(($(date +%s) + 3600)))" = "180" ] || return 1
+}
+
+test_jitter_within_expected_range() {
+  _load_budget
+  for _ in $(seq 1 50); do
+    v=$(apply_jitter 100)
+    [ "$v" -ge 100 ] || return 1
+    [ "$v" -le 125 ] || return 1
+  done
+}
+
+test_check_budget_floor_ok_when_above_200() {
+  _load_budget
+  check_budget_floor 250 $(($(date +%s) + 100))
+}
+
+test_check_budget_floor_exits_42_when_below_200() {
+  _load_budget
+  out=$(check_budget_floor 199 $(($(date +%s) + 100)) || echo "rc=$?")
+  echo "$out" | grep -q 'BUDGET_EXHAUSTED' || return 1
+  echo "$out" | grep -q 'rc=42' || return 1
+}
+
+test_check_budget_floor_reports_reset_fields() {
+  _load_budget
+  reset=$(($(date +%s) + 600))
+  out=$(check_budget_floor 199 "$reset" || true)
+  echo "$out" | grep -q "reset_at=$reset" || return 1
+  echo "$out" | grep -q "minutes_until_reset=" || return 1
+}
+
+test_gap_wait_mutation_enforces_1s() {
+  _load_budget
+  rm -f "$GITHUB_OPS_HOME/state/last_mutation"
+  start=$(date +%s%3N)
+  budget_gap_wait_mutation
+  budget_gap_wait_mutation
+  end=$(date +%s%3N)
+  [ $((end - start)) -ge 1000 ] || return 1
+}
+
+test_gap_wait_mutation_cli_ok() {
+  bash "$PLUGIN_ROOT/scripts/libs/budget.sh" gap-wait mutation || return 1
+}

--- a/plugins/f5xc-github-ops/scripts/tests/test_gh_poll.sh
+++ b/plugins/f5xc-github-ops/scripts/tests/test_gh_poll.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+_load() { source "$PLUGIN_ROOT/scripts/libs/gh-poll.sh"; }
+
+test_atomic_write_creates_file_with_exact_content() {
+  _load
+  dst="$GITHUB_OPS_HOME/cache/test.body"
+  atomic_write "$dst" "hello world"
+  [ "$(cat "$dst")" = "hello world" ] || return 1
+}
+
+test_atomic_write_overwrites_existing() {
+  _load
+  dst="$GITHUB_OPS_HOME/cache/test.body"
+  echo "old" >"$dst"
+  atomic_write "$dst" "new"
+  [ "$(cat "$dst")" = "new" ] || return 1
+}
+
+test_atomic_write_leaves_no_tmp_files() {
+  _load
+  dst="$GITHUB_OPS_HOME/cache/test.body"
+  atomic_write "$dst" "payload"
+  find "$GITHUB_OPS_HOME/cache" -name 'test.body.*' | grep -q . && return 1
+  return 0
+}
+
+test_cache_key_is_sha256_hex() {
+  _load
+  k=$(cache_key "GET" "/repos/x/y/commits/abc/check-runs")
+  [ "${#k}" -eq 64 ] || return 1
+  [[ "$k" =~ ^[0-9a-f]+$ ]] || return 1
+}
+
+test_cache_key_stable_for_same_input() {
+  _load
+  a=$(cache_key "GET" "/x")
+  b=$(cache_key "GET" "/x")
+  [ "$a" = "$b" ] || return 1
+}
+
+test_cache_key_differs_across_urls() {
+  _load
+  a=$(cache_key "GET" "/x")
+  b=$(cache_key "GET" "/y")
+  [ "$a" != "$b" ] || return 1
+}
+
+test_parse_status_extracts_http_code() {
+  _load
+  raw=$'HTTP/2.0 304\r\nETag: "abc"\r\n\r\n'
+  [ "$(parse_status "$raw")" = "304" ] || return 1
+}
+
+test_parse_rate_header_returns_value() {
+  _load
+  raw=$'HTTP/2.0 200\r\nX-RateLimit-Remaining: 4321\r\n\r\n{}'
+  [ "$(parse_rate_header "$raw" "X-RateLimit-Remaining")" = "4321" ] || return 1
+}
+
+test_parse_rate_header_case_insensitive() {
+  _load
+  raw=$'HTTP/2.0 200\r\nx-ratelimit-remaining: 99\r\n\r\n{}'
+  [ "$(parse_rate_header "$raw" "X-RateLimit-Remaining")" = "99" ] || return 1
+}
+
+test_parse_body_separates_on_blank_line() {
+  _load
+  raw=$'HTTP/2.0 200\r\nETag: "z"\r\n\r\n{"ok":true}'
+  [ "$(parse_body "$raw")" = '{"ok":true}' ] || return 1
+}
+
+test_parse_body_strips_cr_from_multiline_body() {
+  _load
+  raw=$'HTTP/2.0 200\r\nETag: "z"\r\n\r\n{\r\n  "ok": true\r\n}'
+  body=$(parse_body "$raw")
+  # Body must not contain any \r characters
+  [[ "$body" == *$'\r'* ]] && return 1
+  # And it should still contain the expected JSON content
+  echo "$body" | grep -q '"ok": true' || return 1
+  return 0
+}
+
+test_gh_poll_200_writes_cache() {
+  _load
+  export GH_STUB_STATUS=200
+  export GH_STUB_ETAG='W/"v1"'
+  export GH_STUB_REMAINING=4500
+  export GH_STUB_RESET=$(($(date +%s) + 3600))
+  export GH_STUB_BODY='{"a":1}'
+  out=$(gh_poll /repos/x/y/commits/abc/check-runs)
+  echo "$out" | awk -F'\t' '{exit !($1 == "200" && $4 == "etag-miss")}'
+  k=$(cache_key GET /repos/x/y/commits/abc/check-runs)
+  [ "$(cat "$GITHUB_OPS_HOME/cache/$k.etag")" = 'W/"v1"' ] || return 1
+  [ "$(cat "$GITHUB_OPS_HOME/cache/$k.body")" = '{"a":1}' ] || return 1
+}
+
+test_gh_poll_200_body_file_contains_body() {
+  _load
+  export GH_STUB_STATUS=200
+  export GH_STUB_BODY='{"x":42}'
+  unset GH_STUB_ETAG GH_STUB_REMAINING GH_STUB_RESET
+  out=$(gh_poll /repos/x/y/pulls/1)
+  body_path=$(echo "$out" | awk -F'\t' '{print $5}')
+  [ "$(cat "$body_path")" = '{"x":42}' ] || return 1
+}
+
+test_gh_poll_304_returns_cached_body() {
+  _load
+  k=$(cache_key GET /repos/x/y/commits/abc/check-runs)
+  printf 'W/"v1"' >"$GITHUB_OPS_HOME/cache/$k.etag"
+  printf '{"cached":true}' >"$GITHUB_OPS_HOME/cache/$k.body"
+  rec="$GITHUB_OPS_HOME/gh_record"
+  export GH_STUB_RECORD="$rec"
+  export GH_STUB_STATUS=304
+  export GH_STUB_REMAINING=4499
+  out=$(gh_poll /repos/x/y/commits/abc/check-runs)
+  [ "$(echo "$out" | awk -F'\t' '{print $1}')" = "304" ] || return 1
+  [ "$(echo "$out" | awk -F'\t' '{print $4}')" = "etag-hit" ] || return 1
+  body_path=$(echo "$out" | awk -F'\t' '{print $5}')
+  [ "$(cat "$body_path")" = '{"cached":true}' ] || return 1
+  grep -q -- 'If-None-Match: W/"v1"' "$rec" || return 1
+}
+
+test_gh_poll_304_does_not_rewrite_cache() {
+  _load
+  k=$(cache_key GET /x)
+  printf 'W/"v1"' >"$GITHUB_OPS_HOME/cache/$k.etag"
+  printf 'original' >"$GITHUB_OPS_HOME/cache/$k.body"
+  old_mtime=$(stat -c %Y "$GITHUB_OPS_HOME/cache/$k.body")
+  export GH_STUB_STATUS=304
+  sleep 1
+  gh_poll /x >/dev/null
+  new_mtime=$(stat -c %Y "$GITHUB_OPS_HOME/cache/$k.body")
+  [ "$old_mtime" = "$new_mtime" ] || return 1
+}
+
+test_gh_poll_403_primary_returns_rate_limit() {
+  _load
+  export GH_STUB_STATUS=403
+  export GH_STUB_BODY='API rate limit exceeded for user ID 42.'
+  out=$(gh_poll /x 2>&1) || true
+  [ "$(echo "$out" | awk -F'\t' '{print $1}')" = "403" ] || return 1
+}
+
+test_gh_poll_429_returns_status_429() {
+  _load
+  export GH_STUB_STATUS=429
+  export GH_STUB_RETRY_AFTER=60
+  export GH_STUB_BODY='secondary rate limit'
+  out=$(gh_poll /y 2>&1) || true
+  [ "$(echo "$out" | awk -F'\t' '{print $1}')" = "429" ] || return 1
+}
+
+test_cache_trim_removes_stale_entries() {
+  _load
+  touch -d '2 days ago' "$GITHUB_OPS_HOME/cache/old.body"
+  touch "$GITHUB_OPS_HOME/cache/fresh.body"
+  cache_trim
+  [ ! -f "$GITHUB_OPS_HOME/cache/old.body" ] || return 1
+  [ -f "$GITHUB_OPS_HOME/cache/fresh.body" ] || return 1
+}
+
+test_cache_trim_respects_capacity_cap() {
+  _load
+  for i in $(seq 1 1010); do touch "$GITHUB_OPS_HOME/cache/f$i"; done
+  cache_trim
+  count=$(find "$GITHUB_OPS_HOME/cache" -maxdepth 1 -type f | wc -l)
+  [ "$count" -le 1000 ] || return 1
+}

--- a/plugins/f5xc-github-ops/scripts/tests/test_harness_smoke.sh
+++ b/plugins/f5xc-github-ops/scripts/tests/test_harness_smoke.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+test_harness_stub_returns_configured_status() {
+  export GH_STUB_STATUS=304
+  out=$(gh api -i /foo 2>&1)
+  echo "$out" | grep -q '^HTTP/2.0 304' || return 1
+}
+
+test_harness_records_invocation() {
+  rec="$GITHUB_OPS_HOME/gh_record"
+  export GH_STUB_RECORD="$rec"
+  export GH_STUB_STATUS=200
+  export GH_STUB_BODY='{"ok":true}'
+  gh api -i /bar >/dev/null
+  grep -q -- '-i /bar' "$rec" || return 1
+}

--- a/plugins/f5xc-github-ops/scripts/tests/test_installer.sh
+++ b/plugins/f5xc-github-ops/scripts/tests/test_installer.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+_install() {
+  bash "$PLUGIN_ROOT/scripts/install-github-ops-lib.sh"
+}
+
+test_installer_creates_runtime_dirs() {
+  _install
+  [ -d "$GITHUB_OPS_HOME/lib" ] || return 1
+  [ -d "$GITHUB_OPS_HOME/cache" ] || return 1
+  [ -d "$GITHUB_OPS_HOME/state" ] || return 1
+}
+
+test_installer_copies_three_libs() {
+  _install
+  [ -x "$GITHUB_OPS_HOME/lib/gh-poll.sh" ] || return 1
+  [ -x "$GITHUB_OPS_HOME/lib/budget.sh" ] || return 1
+  [ -x "$GITHUB_OPS_HOME/lib/retry.sh" ] || return 1
+}
+
+test_installer_is_idempotent() {
+  _install
+  _install
+  count=$(find "$GITHUB_OPS_HOME/lib" -type f | wc -l)
+  [ "$count" -eq 3 ] || return 1
+}
+
+test_installer_atomic_rename_no_partial_files() {
+  _install
+  find "$GITHUB_OPS_HOME/lib" -name '*.XXXXXX*' -o -name 'tmp.*' | grep -q . && return 1
+  return 0
+}

--- a/plugins/f5xc-github-ops/scripts/tests/test_poll_until.sh
+++ b/plugins/f5xc-github-ops/scripts/tests/test_poll_until.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+_load_all() {
+  source "$PLUGIN_ROOT/scripts/libs/budget.sh"
+  source "$PLUGIN_ROOT/scripts/libs/retry.sh"
+  source "$PLUGIN_ROOT/scripts/libs/gh-poll.sh"
+}
+
+# Predicate: body must equal `{"state":"done"}`
+_pred_done() { grep -q '"state":"done"' "$1"; }
+
+test_poll_until_returns_done_when_predicate_true_first_call() {
+  _load_all
+  export GH_STUB_STATUS=200
+  export GH_STUB_BODY='{"state":"done"}'
+  export GH_STUB_REMAINING=4000
+  out=$(MAX_POLL_WALLCLOCK=5 POLL_INTERVAL_OVERRIDE=0 poll_until /x _pred_done)
+  echo "$out" | grep -q 'Status: COMPLETE' || return 1
+  echo "$out" | grep -q 'paid_polls=1' || return 1
+}
+
+test_poll_until_aborts_when_budget_exhausted() {
+  _load_all
+  export GH_STUB_STATUS=200
+  export GH_STUB_BODY='{"state":"pending"}'
+  export GH_STUB_REMAINING=100
+  export GH_STUB_RESET=$(($(date +%s) + 600))
+  out=$(MAX_POLL_WALLCLOCK=10 POLL_INTERVAL_OVERRIDE=0 poll_until /x _pred_done || true)
+  echo "$out" | grep -q 'Status: BUDGET_EXHAUSTED' || return 1
+}
+
+test_poll_until_handles_429_via_retry_with_backoff() {
+  _load_all
+  export GH_STUB_STATUS=429
+  export GH_STUB_RETRY_AFTER=1
+  export GH_STUB_BODY='secondary rate limit'
+  out=$(MAX_POLL_WALLCLOCK=3 POLL_INTERVAL_OVERRIDE=0 poll_until /x _pred_done 2>&1 || true)
+  echo "$out" | grep -q 'RATE_LIMIT_BACKOFF' || return 1
+}
+
+test_poll_until_counts_304_as_free_poll() {
+  _load_all
+  k=$(cache_key GET /x)
+  printf 'W/"v"' >"$GITHUB_OPS_HOME/cache/$k.etag"
+  printf '{"state":"pending"}' >"$GITHUB_OPS_HOME/cache/$k.body"
+  export GH_STUB_STATUS=304
+  export GH_STUB_REMAINING=4000
+  out=$(MAX_POLL_WALLCLOCK=2 POLL_INTERVAL_OVERRIDE=0 poll_until /x _pred_done || true)
+  echo "$out" | grep -q 'free_polls=' || return 1
+}
+
+test_predicate_pr_checks_done_pass() {
+  _load_all
+  f=$(mktemp)
+  cat >"$f" <<'EOF'
+{"check_runs":[{"status":"completed","conclusion":"success"}]}
+EOF
+  predicate_pr_checks_done "$f"
+}
+
+test_predicate_pr_checks_done_pending() {
+  _load_all
+  f=$(mktemp)
+  cat >"$f" <<'EOF'
+{"check_runs":[{"status":"in_progress","conclusion":null}]}
+EOF
+  ! predicate_pr_checks_done "$f"
+}
+
+test_predicate_pr_checks_done_failure_terminal() {
+  _load_all
+  f=$(mktemp)
+  cat >"$f" <<'EOF'
+{"check_runs":[{"status":"completed","conclusion":"failure"}]}
+EOF
+  predicate_pr_checks_done "$f"
+}
+
+test_predicate_runs_complete_all_done() {
+  _load_all
+  f=$(mktemp)
+  cat >"$f" <<'EOF'
+{"workflow_runs":[{"status":"completed","conclusion":"success"}]}
+EOF
+  predicate_runs_complete "$f"
+}
+
+test_predicate_runs_complete_some_pending() {
+  _load_all
+  f=$(mktemp)
+  cat >"$f" <<'EOF'
+{"workflow_runs":[{"status":"completed"},{"status":"queued"}]}
+EOF
+  ! predicate_runs_complete "$f"
+}
+
+test_gh_poll_tsv_includes_retry_after_as_6th_field() {
+  _load_all
+  export GH_STUB_STATUS=429
+  export GH_STUB_RETRY_AFTER=42
+  export GH_STUB_BODY='secondary rate limit'
+  line=$(gh_poll /x)
+  ra=$(echo "$line" | awk -F'\t' '{print $6}')
+  [ "$ra" = "42" ] || return 1
+}
+
+test_poll_until_uses_actual_retry_after_on_second_failure() {
+  _load_all
+  export GH_STUB_STATUS=429
+  export GH_STUB_RETRY_AFTER=1
+  export GH_STUB_BODY='secondary rate limit'
+  out=$(MAX_POLL_WALLCLOCK=4 POLL_INTERVAL_OVERRIDE=0 poll_until /x _pred_done 2>&1 || true)
+  echo "$out" | grep -q 'RATE_LIMIT_BACKOFF retry_after_seconds=1 ' || return 1
+}
+
+test_poll_until_budget_exhausted_is_single_line() {
+  _load_all
+  export GH_STUB_STATUS=200
+  export GH_STUB_BODY='{"state":"pending"}'
+  export GH_STUB_REMAINING=100
+  export GH_STUB_RESET=$(($(date +%s) + 600))
+  out=$(MAX_POLL_WALLCLOCK=10 POLL_INTERVAL_OVERRIDE=0 poll_until /x _pred_done || true)
+  line_count=$(echo "$out" | grep -c 'Status:')
+  [ "$line_count" = "1" ] || return 1
+  echo "$out" | grep -q 'BUDGET_EXHAUSTED remaining=100' || return 1
+  echo "$out" | grep -q 'free_polls=' || return 1
+  echo "$out" | grep -q 'paid_polls=' || return 1
+  status_token=$(echo "$out" | awk '{print $2}' | head -n1)
+  [ "$status_token" = "BUDGET_EXHAUSTED" ] || return 1
+}
+
+test_gh_poll_writes_per_pid_log_file() {
+  _load_all
+  export GH_STUB_STATUS=200
+  export GH_STUB_BODY='{"x":1}'
+  gh_poll /x >/dev/null
+  log="$GITHUB_OPS_HOME/state/poll.$$.log"
+  [ -s "$log" ] || return 1
+  grep -q '/x' "$log" || return 1
+}

--- a/plugins/f5xc-github-ops/scripts/tests/test_retry.sh
+++ b/plugins/f5xc-github-ops/scripts/tests/test_retry.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+_load_retry() { source "$PLUGIN_ROOT/scripts/libs/retry.sh"; }
+
+test_cooldown_set_writes_later_until() {
+  _load_retry
+  later=$(($(date +%s) + 60))
+  cooldown_set "$later"
+  jq -e ".until == $later" "$GITHUB_OPS_HOME/state/cooldown.json" >/dev/null
+}
+
+test_cooldown_set_later_wins_over_earlier() {
+  _load_retry
+  first=$(($(date +%s) + 100))
+  second=$(($(date +%s) + 60))
+  cooldown_set "$first"
+  cooldown_set "$second"
+  stored=$(jq -r .until "$GITHUB_OPS_HOME/state/cooldown.json")
+  [ "$stored" = "$first" ] || return 1
+}
+
+test_cooldown_get_returns_0_when_missing() {
+  _load_retry
+  [ "$(cooldown_get)" = "0" ] || return 1
+}
+
+test_cooldown_get_returns_0_on_malformed_json() {
+  _load_retry
+  mkdir -p "$GITHUB_OPS_HOME/state"
+  printf '{truncated' >"$GITHUB_OPS_HOME/state/cooldown.json"
+  [ "$(cooldown_get)" = "0" ] || return 1
+}
+
+test_retry_with_backoff_message_includes_status() {
+  _load_retry
+  msg=$(retry_with_backoff 429 30 /z 2>&1 >/dev/null || true)
+  echo "$msg" | grep -q 'http_status=429' || return 1
+}
+
+test_wait_out_cooldown_noop_when_unset() {
+  _load_retry
+  start=$(date +%s)
+  wait_out_cooldown
+  end=$(date +%s)
+  [ $((end - start)) -lt 2 ] || return 1
+}
+
+test_wait_out_cooldown_sleeps_until_reset() {
+  _load_retry
+  later=$(($(date +%s) + 2))
+  cooldown_set "$later"
+  start=$(date +%s)
+  wait_out_cooldown
+  end=$(date +%s)
+  [ "$end" -ge "$later" ] || return 1
+}
+
+test_retry_with_backoff_writes_cooldown() {
+  _load_retry
+  retry_with_backoff 429 30 /x >/dev/null 2>&1 || true
+  stored=$(jq -r .until "$GITHUB_OPS_HOME/state/cooldown.json")
+  now=$(date +%s)
+  [ "$stored" -ge "$now" ] || return 1
+  [ "$stored" -le $((now + 35)) ] || return 1
+}
+
+test_retry_with_backoff_missing_retry_after_defaults_60() {
+  _load_retry
+  retry_with_backoff 429 "" /x >/dev/null 2>&1 || true
+  stored=$(jq -r .until "$GITHUB_OPS_HOME/state/cooldown.json")
+  now=$(date +%s)
+  [ "$stored" -ge $((now + 55)) ] || return 1
+}

--- a/plugins/f5xc-github-ops/skills/workflow-lifecycle/SKILL.md
+++ b/plugins/f5xc-github-ops/skills/workflow-lifecycle/SKILL.md
@@ -76,6 +76,8 @@ statuses:
 | `PRE_COMMIT_FAILED` | Lint gate failed before commit | Fix linting errors, re-delegate with same files |
 | `CI_FAILED` | CI checks failed after push | Fix CI errors, re-delegate with `Issue:` and `Branch:` to reuse existing PR |
 | `BLOCKED` | Rate limit, missing CLI, or missing config | Resolve blocker, then re-delegate |
+| `BUDGET_EXHAUSTED` | Primary GitHub rate limit neared exhaustion mid-workflow. Pause until `reset_at` and retry. Report includes remaining/reset fields. | Wait until `reset_at`, then re-delegate |
+| `RATE_LIMIT_BACKOFF` | Secondary rate limit triggered and a single retry also failed. Wait `retry_after_seconds` and retry. | Wait `retry_after_seconds`, then re-delegate |
 | `FAILED` | Unrecoverable error (merge conflict, etc.) | Read error details, resolve manually |
 
 When re-delegating after a failure, always include the

--- a/plugins/html-lsp/.claude-plugin/plugin.json
+++ b/plugins/html-lsp/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
     "vscode-html-language-server": {
       "command": "vscode-html-language-server",
       "args": ["--stdio"],
-      "extensionToLanguage": {".html":"html",".htm":"html"}
+      "extensionToLanguage": { ".html": "html", ".htm": "html" }
     }
   }
 }

--- a/plugins/markdown-lsp/.claude-plugin/plugin.json
+++ b/plugins/markdown-lsp/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
     "vscode-markdown-language-server": {
       "command": "vscode-markdown-language-server",
       "args": ["--stdio"],
-      "extensionToLanguage": {".md":"markdown"}
+      "extensionToLanguage": { ".md": "markdown" }
     }
   }
 }

--- a/plugins/mdx-lsp/.claude-plugin/plugin.json
+++ b/plugins/mdx-lsp/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
     "mdx-language-server": {
       "command": "mdx-language-server",
       "args": ["--stdio"],
-      "extensionToLanguage": {".mdx":"mdx"}
+      "extensionToLanguage": { ".mdx": "mdx" }
     }
   }
 }

--- a/plugins/terraform-lsp/README.md
+++ b/plugins/terraform-lsp/README.md
@@ -6,7 +6,7 @@ Terraform language server plugin for Claude Code, providing code intelligence fo
 
 Install `terraform-ls` before enabling this plugin:
 
-- **Via HashiCorp releases (recommended):** Download from https://releases.hashicorp.com/terraform-ls/
+- **Via HashiCorp releases (recommended):** Download from <https://releases.hashicorp.com/terraform-ls/>
 - **Via Homebrew (macOS):** `brew install hashicorp/tap/terraform-ls`
 - **Via package manager (Linux):** See [installation docs](https://github.com/hashicorp/terraform-ls/blob/main/docs/installation.md)
 

--- a/plugins/yaml-lsp/.claude-plugin/plugin.json
+++ b/plugins/yaml-lsp/.claude-plugin/plugin.json
@@ -9,7 +9,7 @@
     "yaml-language-server": {
       "command": "yaml-language-server",
       "args": ["--stdio"],
-      "extensionToLanguage": {".yml":"yaml",".yaml":"yaml"}
+      "extensionToLanguage": { ".yml": "yaml", ".yaml": "yaml" }
     }
   }
 }


### PR DESCRIPTION
## Summary

Introduces three composable shell libraries (`gh-poll.sh`, `budget.sh`, `retry.sh`) installed by a `PreToolUse` hook to `~/.claude/github-ops/lib/`. The agent now routes all CI polling through `poll_until`, which uses ETag-cached conditional requests, adapts poll intervals based on observed rate-limit remaining, aborts cleanly before budget drops below 200, and handles `403`/`429` with `Retry-After`.

Closes #280

## Problem

Steps 7, 9, and U4 polled GitHub at a fixed 30s cadence with every poll costing 1 primary rate-limit unit. Under concurrent Claude Code sessions sharing a single `gh` token, combined polling regularly exhausted the 5000/hr primary limit and produced "HTTP 403 rate limit exceeded" errors (incident observed 2026-04-20 21:55 UTC).

## Key Changes

- **ETag-cached conditional requests** (`If-None-Match`): a `304 Not Modified` response does not consume primary rate-limit budget, making steady-state polling of unchanged CI jobs nearly free.
- **Adaptive poll intervals** (20s / 60s / 180s) based on `X-RateLimit-Remaining`, with plus-or-minus 25% jitter to avoid synchronized polling storms across sessions.
- **Budget guard**: aborts cleanly with `Status: BUDGET_EXHAUSTED` before primary budget drops below 200 (includes `reset_at` and `minutes_until_reset`).
- **Secondary rate-limit handling**: parses `Retry-After`, writes host-wide cooldown in `state/cooldown.json` (atomic rename, "later-wins" semantics), sleeps, retries once, returns `Status: RATE_LIMIT_BACKOFF retry_after_seconds=<N>` on second failure.
- **Concurrency-safe** across multiple Claude Code sessions via atomic-rename cache writes, per-PID log files (`state/poll.<pid>.log`), `flock`-guarded installer, no locks held across network I/O.

## New Status Taxonomy

Two new return statuses for recoverable rate-limit events:

- `BUDGET_EXHAUSTED` — caller should wait `minutes_until_reset` and retry
- `RATE_LIMIT_BACKOFF` — caller should wait `retry_after_seconds` and retry

## Version

`2.2.2` to `2.3.0` (feature-level change).

## Test plan

- [x] 56 unit tests pass via bash test harness with `gh` CLI stub
- [x] `shellcheck` clean on all new and modified scripts
- [x] `shfmt -d` clean on all new and modified scripts
- [x] `pre-commit` hooks pass (markdownlint, shell lint, editorconfig, spelling, secrets)
- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Post-merge workflows succeed on main