### PR TITLE
feat: add tsgo-lsp plugin for TypeScript/JavaScript language server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -431,6 +431,36 @@
           }
         }
       }
+    },
+    {
+      "name": "tsgo-lsp",
+      "description": "TypeScript and JavaScript language server via tsgo (Microsoft's native TypeScript-Go port)",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/tsgo-lsp",
+      "category": "development",
+      "strict": false,
+      "license": "Apache-2.0",
+      "keywords": ["typescript", "javascript", "tsgo", "lsp", "tsserver"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "lspServers": {
+        "tsgo": {
+          "command": "tsgo",
+          "args": ["--lsp", "--stdio"],
+          "extensionToLanguage": {
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".mts": "typescript",
+            ".cts": "typescript",
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mjs": "javascript",
+            ".cjs": "javascript"
+          }
+        }
+      }
     }
   ]
 }

--- a/plugins/tsgo-lsp/.claude-plugin/plugin.json
+++ b/plugins/tsgo-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "tsgo-lsp",
+  "description": "TypeScript and JavaScript language server via tsgo (Microsoft's native TypeScript-Go port)",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos"
+  },
+  "lspServers": {
+    "tsgo": {
+      "command": "tsgo",
+      "args": ["--lsp", "--stdio"],
+      "extensionToLanguage": {
+        ".ts": "typescript",
+        ".tsx": "typescriptreact",
+        ".mts": "typescript",
+        ".cts": "typescript",
+        ".js": "javascript",
+        ".jsx": "javascriptreact",
+        ".mjs": "javascript",
+        ".cjs": "javascript"
+      }
+    }
+  }
+}

--- a/plugins/tsgo-lsp/README.md
+++ b/plugins/tsgo-lsp/README.md
@@ -1,0 +1,22 @@
+# tsgo LSP
+
+TypeScript and JavaScript language server plugin for Claude Code, providing code intelligence via [tsgo](https://github.com/microsoft/typescript-go) — Microsoft's native TypeScript compiler/server ported to Go.
+
+## Prerequisites
+
+Install `tsgo` before enabling this plugin:
+
+- **Pre-installed** in the f5xc-salesdemos devcontainer
+- **Manual install:** `npm install -g @typescript/native-preview` (provides the `tsgo` binary)
+
+## Features
+
+- TypeScript and JavaScript diagnostics
+- Auto-completion for identifiers, imports, and JSX
+- Hover type information and signature help
+- Go-to-definition, find-references, rename
+- JSX / TSX support
+
+## Handled extensions
+
+`.ts`, `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, `.cjs`

--- a/plugins/tsgo-lsp/commands/tsgo-lsp-status.md
+++ b/plugins/tsgo-lsp/commands/tsgo-lsp-status.md
@@ -1,0 +1,10 @@
+---
+name: tsgo-lsp-status
+description: Check tsgo TypeScript/JavaScript language server status and availability
+---
+
+Check the tsgo language server status:
+
+1. Run `which tsgo` to verify the binary is available
+2. Run `tsgo --version` to report the version
+3. Confirm the LSP plugin is enabled for `.ts`, `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, and `.cjs` files


### PR DESCRIPTION
## Summary

- **What:** New LSP plugin wrapping `tsgo --lsp --stdio` (Microsoft's native TypeScript-Go port) to provide TypeScript and JavaScript code intelligence in Claude Code.
- **Why:** The marketplace shipped 10 LSP plugins but had no TypeScript/JavaScript language server. A user hit "Plugin not found" when trying to install `tsgo-lsp@f5xc-salesdemos-marketplace`. The devcontainer already ships the `tsgo` binary (v7.0.0-dev.20260418.1), so the server is immediately usable on install.
- **Pattern:** Mirrors the `toml-lsp` plugin introduced in #232 and registered in the manifest in #234 — same directory layout, same manifest shape, same status-command convention.

## Extensions covered

`.ts`, `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, `.cjs`

## Changes

New:
- `plugins/tsgo-lsp/.claude-plugin/plugin.json`
- `plugins/tsgo-lsp/README.md`
- `plugins/tsgo-lsp/commands/tsgo-lsp-status.md`

Modified:
- `.claude-plugin/marketplace.json` — appended new entry after `toml-lsp` (plugins[] count is now 21)

Closes #284

## Test plan

- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)
- [ ] `marketplace.json` remains valid JSON and passes Biome lint
- [ ] Plugin install flow resolves `tsgo-lsp@f5xc-salesdemos-marketplace` once merged