### PR TITLE
fix: zsh compat — rename local `status` in github-ops libs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "f5xc-github-ops",
       "description": "GitHub operations automation \u2014 issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **f5xc-github-ops** bumped to v2.3.1 — rename `local status` to
+  `local http_status` in the sourced `gh-poll.sh` and `retry.sh`
+  libs so the agent's polling and backoff helpers no longer fail
+  with "read-only variable: status" when the calling shell is zsh
+
 - **f5xc-firecrawl** added v1.1.0 — self-hosted Firecrawl web scraping plugin with
   7 commands (scrape, batch-scrape, crawl, map, search, extract, llmstxt), a
   `web-scraper` skill, and a `firecrawl-operator` agent; no API keys required,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 - **f5xc-github-ops** bumped to v2.3.1 — rename `local status` to
   `local http_status` in the sourced `gh-poll.sh` and `retry.sh`
   libs so the agent's polling and backoff helpers no longer fail
-  with "read-only variable: status" when the calling shell is zsh
+  with "read-only variable: status" when the calling shell is Zsh
 
 - **f5xc-firecrawl** added v1.1.0 — self-hosted Firecrawl web scraping plugin with
   7 commands (scrape, batch-scrape, crawl, map, search, extract, llmstxt), a

--- a/plugins/f5xc-github-ops/.claude-plugin/plugin.json
+++ b/plugins/f5xc-github-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-github-ops",
   "description": "GitHub operations automation for f5xc-salesdemos — issue-driven development, pre-commit lint gate, PR lifecycle, CI polling with error feedback to issues, post-merge monitoring, verification, rate limit management, upstream contribution workflow for fork-based development, and exclusive github-ops agent for all Git operations. Covers commit, push, branch, merge, squash, pull request, issue creation, repository settings, and fork-to-upstream contributions.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-github-ops/scripts/libs/gh-poll.sh
+++ b/plugins/f5xc-github-ops/scripts/libs/gh-poll.sh
@@ -71,8 +71,9 @@ gh_poll() {
 
   local raw
   raw="$(gh "${args[@]}" 2>&1 || true)"
-  local status remaining reset etag retry_after
-  status="$(parse_status "$raw")"
+  # `http_status` — not `status` — because zsh aliases $status to $? (readonly).
+  local http_status remaining reset etag retry_after
+  http_status="$(parse_status "$raw")"
   remaining="$(parse_rate_header "$raw" "X-RateLimit-Remaining")"
   reset="$(parse_rate_header "$raw" "X-RateLimit-Reset")"
   etag="$(parse_rate_header "$raw" "ETag")"
@@ -81,7 +82,7 @@ gh_poll() {
   local body_path
   body_path="$(mktemp "$cache_dir/$key.out.XXXXXX")"
 
-  case "$status" in
+  case "$http_status" in
   200)
     local body
     body="$(parse_body "$raw")"
@@ -102,11 +103,11 @@ gh_poll() {
   mkdir -p "$(dirname -- "$log_file")"
   printf '%s %s %s %s %s %s\n' \
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$$" "$url" \
-    "${status:-0}" "${remaining:-}" "$etag_hit" >>"$log_file" 2>/dev/null || true
+    "${http_status:-0}" "${remaining:-}" "$etag_hit" >>"$log_file" 2>/dev/null || true
 
-  # TSV output: status, remaining, reset, etag_hit, body_path, retry_after
+  # TSV output: http_status, remaining, reset, etag_hit, body_path, retry_after
   printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-    "${status:-0}" "${remaining:-}" "${reset:-}" "$etag_hit" "$body_path" "${retry_after:-}"
+    "${http_status:-0}" "${remaining:-}" "${reset:-}" "$etag_hit" "$body_path" "${retry_after:-}"
 }
 
 poll_until() {
@@ -129,14 +130,15 @@ poll_until() {
 
     local line
     line="$(gh_poll "$url")"
-    local status remaining reset body_path retry_after_s
-    status="$(echo "$line" | awk -F'\t' '{print $1}')"
+    # `http_status` — not `status` — because zsh aliases $status to $? (readonly).
+    local http_status remaining reset body_path retry_after_s
+    http_status="$(echo "$line" | awk -F'\t' '{print $1}')"
     remaining="$(echo "$line" | awk -F'\t' '{print $2}')"
     reset="$(echo "$line" | awk -F'\t' '{print $3}')"
     body_path="$(echo "$line" | awk -F'\t' '{print $5}')"
     retry_after_s="$(echo "$line" | awk -F'\t' '{print $6}')"
 
-    case "$status" in
+    case "$http_status" in
     200) paid=$((paid + 1)) ;;
     304) free=$((free + 1)) ;;
     403 | 429)
@@ -144,7 +146,7 @@ poll_until() {
       [ -z "$ra" ] && ra=60
       if [ "$retried" -eq 0 ]; then
         retried=1
-        retry_with_backoff "$status" "$ra" "$url"
+        retry_with_backoff "$http_status" "$ra" "$url"
         sleep "$ra"
         rm -f "$body_path"
         continue
@@ -155,7 +157,7 @@ poll_until() {
       fi
       ;;
     *)
-      printf 'Status: FAILED http_status=%s free_polls=%s paid_polls=%s\n' "$status" "$free" "$paid"
+      printf 'Status: FAILED http_status=%s free_polls=%s paid_polls=%s\n' "$http_status" "$free" "$paid"
       rm -f "$body_path"
       return 1
       ;;

--- a/plugins/f5xc-github-ops/scripts/libs/retry.sh
+++ b/plugins/f5xc-github-ops/scripts/libs/retry.sh
@@ -41,13 +41,14 @@ wait_out_cooldown() {
 }
 
 retry_with_backoff() {
-  local status="$1" retry_after="$2" url="$3"
+  # `http_status` — not `status` — because zsh aliases $status to $? (readonly).
+  local http_status="$1" retry_after="$2" url="$3"
   local seconds="${retry_after:-60}"
   local now
   now="$(date +%s)"
   cooldown_set $((now + seconds))
   printf 'Status: RATE_LIMIT_BACKOFF http_status=%s retry_after_seconds=%s url=%s\n' \
-    "$status" "$seconds" "$url" >&2
+    "$http_status" "$seconds" "$url" >&2
   return 0
 }
 

--- a/plugins/f5xc-github-ops/scripts/tests/test_zsh_compat.sh
+++ b/plugins/f5xc-github-ops/scripts/tests/test_zsh_compat.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Shell-portability smoke tests for the github-ops libs.
+#
+# The libs are bash scripts but they are `source`d, not executed, so
+# their shebang is advisory. When the calling shell is zsh, any
+# `local status=...` assignment triggers "read-only variable: status"
+# because zsh exposes $status as a readonly alias for $?.
+#
+# These tests shell out to zsh and assert that the libs run clean.
+
+ZSH_BIN="$(command -v zsh 2>/dev/null || true)"
+
+_skip_if_no_zsh() {
+  if [ -z "$ZSH_BIN" ]; then
+    echo "SKIP: zsh not installed"
+    return 0
+  fi
+  return 1
+}
+
+test_retry_with_backoff_runs_clean_in_zsh() {
+  _skip_if_no_zsh && return 0
+  local out
+  out=$(GITHUB_OPS_LIB="$GITHUB_OPS_LIB" GITHUB_OPS_HOME="$GITHUB_OPS_HOME" \
+    "$ZSH_BIN" -c '
+      source "$GITHUB_OPS_LIB/retry.sh"
+      retry_with_backoff 429 30 https://example.com/api
+    ' 2>&1 || true)
+  if echo "$out" | grep -q 'read-only'; then
+    echo "zsh readonly error: $out"
+    return 1
+  fi
+  echo "$out" | grep -q 'http_status=429' || {
+    echo "expected http_status=429 in stderr output, got: $out"
+    return 1
+  }
+}
+
+test_gh_poll_runs_clean_in_zsh() {
+  _skip_if_no_zsh && return 0
+  local out
+  out=$(PATH="$PATH" GITHUB_OPS_LIB="$GITHUB_OPS_LIB" GITHUB_OPS_HOME="$GITHUB_OPS_HOME" \
+    STUB_STATUS=200 STUB_ETAG='"abc"' STUB_BODY='{"check_runs":[]}' \
+    "$ZSH_BIN" -c '
+      source "$GITHUB_OPS_LIB/gh-poll.sh"
+      gh_poll "/repos/foo/bar/commits/abc/check-runs" >/dev/null
+    ' 2>&1 || true)
+  if echo "$out" | grep -q 'read-only'; then
+    echo "zsh readonly error: $out"
+    return 1
+  fi
+}


### PR DESCRIPTION
## Summary

Fixes the zsh-incompatibility bug that made `gh-poll.sh` and
`retry.sh` unusable when sourced from a zsh shell.

- Renamed `local status` → `local http_status` in `gh_poll`,
  `poll_until`, and `retry_with_backoff`. In zsh, `$status` is a
  readonly special parameter (alias for `$?`), so `local status=...`
  aborted every call with `read-only variable: status`.
- Output key `http_status=` is unchanged — no downstream parser change.
- Added `scripts/tests/test_zsh_compat.sh` with two regression tests
  that shell out to `zsh -c 'source ...; <fn>'` and assert both the
  absence of the readonly error and the continued emission of
  `http_status=`.
- Patch-bumped plugin v2.3.0 → v2.3.1 in `plugin.json` and
  `marketplace.json`, plus a CHANGELOG Unreleased entry.

Closes #286

## Test plan

- [x] Full test suite: 58 passed, 0 failed (56 original + 2 new)
- [x] `pre-commit` clean on all staged files
- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)
- [ ] Manual verification: `zsh -c 'source plugins/f5xc-github-ops/scripts/libs/gh-poll.sh; type gh_poll'` returns cleanly