### PR TITLE
fix: add initializationOptions to mdx-lsp plugin config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -389,7 +389,7 @@
     {
       "name": "mdx-lsp",
       "description": "MDX language server for MDX document intelligence via mdx-language-server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "f5xc-salesdemos"
       },
@@ -405,6 +405,11 @@
           "args": ["--stdio"],
           "extensionToLanguage": {
             ".mdx": "mdx"
+          },
+          "initializationOptions": {
+            "typescript": {
+              "tsdk": "/usr/lib/node_modules/typescript/lib"
+            }
           }
         }
       }

--- a/plugins/mdx-lsp/.claude-plugin/plugin.json
+++ b/plugins/mdx-lsp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mdx-lsp",
   "description": "MDX language server for MDX document intelligence",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "f5xc-salesdemos"
   },
@@ -9,7 +9,12 @@
     "mdx-language-server": {
       "command": "mdx-language-server",
       "args": ["--stdio"],
-      "extensionToLanguage": { ".mdx": "mdx" }
+      "extensionToLanguage": { ".mdx": "mdx" },
+      "initializationOptions": {
+        "typescript": {
+          "tsdk": "/usr/lib/node_modules/typescript/lib"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `initializationOptions.typescript.tsdk` to the mdx-lsp plugin configuration in both `plugins/mdx-lsp/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- Bump plugin version from 1.0.0 to 1.0.1
- Fixes the MDX language server crash on initialization caused by a missing required `tsdk` path (`assert.ok()` failure in `@mdx-js/language-server@0.6.3`)

Closes #310

## Test plan

- [ ] CI checks pass (`Check linked issues` and `Lint Code Base`)
- [ ] Verify MDX language server initializes successfully with the new `initializationOptions`
- [ ] Confirm `tsdk` path `/usr/lib/node_modules/typescript/lib` resolves correctly in the devcontainer environment