### PR TITLE
docs: add frontmatter descriptions and llms-config for llms.txt hierarchy

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,5 +1,6 @@
 ---
 title: Changelog
+description: Release history and notable changes for f5xc-salesdemos marketplace plugins.
 sidebar:
   order: 8
 ---

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contributing a Plugin
+description: Guide to creating, structuring, and publishing plugins for the f5xc-salesdemos marketplace.
 sidebar:
   order: 6
 ---

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: Step-by-step guide to adding the f5xc-salesdemos marketplace and installing your first plugin.
 sidebar:
   order: 2
 ---

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Marketplace
+description: Plugins, skills, and tools for the F5 Distributed Cloud documentation platform.
 hero:
   tagline: Plugins, skills, and tools for the F5 Distributed Cloud documentation platform.
   image:

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,0 +1,11 @@
+{
+  "customSets": [
+    {
+      "label": "Plugins",
+      "description": "Individual plugin documentation for all marketplace offerings",
+      "paths": ["plugins/**"]
+    }
+  ],
+  "promote": ["index*", "overview*", "getting-started*"],
+  "demote": ["changelog*", "reference*"]
+}

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: How the Claude Code plugin marketplace works — adding sources, installing plugins, and using shared tooling.
 sidebar:
   order: 1
 ---

--- a/docs/plugins/f5xc-brand.mdx
+++ b/docs/plugins/f5xc-brand.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-brand
+description: F5 corporate brand identity enforcement — colors, typography, logos, icons, and WCAG AA accessibility.
 sidebar:
   order: 9
 ---

--- a/docs/plugins/f5xc-devcontainer.mdx
+++ b/docs/plugins/f5xc-devcontainer.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-devcontainer
+description: Container awareness plugin for tool catalog, live introspection, and tool installation with persistence tracking.
 sidebar:
   order: 10
 ---

--- a/docs/plugins/f5xc-docs-pipeline.mdx
+++ b/docs/plugins/f5xc-docs-pipeline.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-docs-pipeline
+description: Documentation pipeline architecture knowledge for multi-repo builds, content authoring, and local preview.
 sidebar:
   order: 8
 ---

--- a/docs/plugins/f5xc-docs-tools.mdx
+++ b/docs/plugins/f5xc-docs-tools.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-docs-tools
+description: MDX content validation and quality checks for the f5xc-salesdemos documentation pipeline.
 sidebar:
   order: 4
 ---

--- a/docs/plugins/f5xc-firecrawl.mdx
+++ b/docs/plugins/f5xc-firecrawl.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-firecrawl
+description: Local self-hosted web scraping and crawling via the open-source Firecrawl engine.
 sidebar:
   order: 13
 ---

--- a/docs/plugins/f5xc-github-ops.mdx
+++ b/docs/plugins/f5xc-github-ops.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-github-ops
+description: GitHub operations automation for issue-driven development, PR workflow, and CI monitoring.
 sidebar:
   order: 7
 ---

--- a/docs/plugins/f5xc-meddpicc.mdx
+++ b/docs/plugins/f5xc-meddpicc.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-meddpicc
+description: MEDDPICC sales qualification and deal-execution framework for complex enterprise B2B sales.
 sidebar:
   order: 6
 ---

--- a/docs/plugins/f5xc-platform.mdx
+++ b/docs/plugins/f5xc-platform.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-platform
+description: F5 Distributed Cloud platform automation — console operations, REST API, authentication, and config analysis.
 sidebar:
   order: 11
 ---

--- a/docs/plugins/f5xc-sales-engineer.mdx
+++ b/docs/plugins/f5xc-sales-engineer.mdx
@@ -1,5 +1,6 @@
 ---
 title: f5xc-sales-engineer
+description: Sales Engineer persona framework for demo execution, presentations, Q&A, and teardown.
 sidebar:
   order: 5
 ---

--- a/docs/plugins/index.mdx
+++ b/docs/plugins/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Plugins
+description: Catalog of available plugins in the f5xc-salesdemos marketplace with versions and categories.
 sidebar:
   order: 3
 ---

--- a/docs/plugins/osint-framework.mdx
+++ b/docs/plugins/osint-framework.mdx
@@ -1,5 +1,6 @@
 ---
 title: osint-framework
+description: OSINT tool catalog and investigation skills with 1,064 intelligence-gathering tools across 34 categories.
 sidebar:
   order: 12
 ---

--- a/docs/reference.mdx
+++ b/docs/reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reference
+description: marketplace.json schema reference with field definitions, skill configuration, and validation rules.
 sidebar:
   order: 7
 ---


### PR DESCRIPTION
## Summary

- Add `description:` frontmatter field to all 17 documentation pages under `docs/`
- Create `docs/llms-config.json` with Plugins custom set configuration for cascading llms.txt generation

Refs f5xc-salesdemos/xcsh#223

Step 5 of the cascading llms.txt knowledge hierarchy — adds descriptions to all 17 doc pages and creates llms-config.json with Plugins custom set.

Closes #323

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] All 17 `.mdx` files have valid `description:` frontmatter
- [ ] `docs/llms-config.json` is valid JSON and passes Biome lint
- [ ] Docs site builds successfully