### PR TITLE
feat: add Salesforce CLI plugin for container-adapted org authentication

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -466,6 +466,21 @@
           }
         }
       }
+    },
+    {
+      "name": "salesforce",
+      "description": "Salesforce CLI automation — container-adapted org authentication (JWT, access-token, SFDX URL), org management, and bridge to the official forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/salesforce",
+      "category": "development",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/salesforce",
+      "license": "Apache-2.0",
+      "keywords": ["salesforce", "sf", "apex", "lwc", "soql", "metadata", "deploy", "testing", "sfdx", "agentforce"],
+      "tags": ["salesforce", "development", "cli", "crm"],
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
     }
   ]
 }

--- a/plugins/salesforce/.claude-plugin/plugin.json
+++ b/plugins/salesforce/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "salesforce",
+  "description": "Salesforce CLI automation — container-adapted org authentication (JWT, access-token, SFDX URL), org management, and bridge to the official forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos",
+    "url": "https://github.com/f5xc-salesdemos"
+  },
+  "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/salesforce",
+  "keywords": ["salesforce", "sf", "apex", "lwc", "soql", "metadata", "deploy", "testing", "sfdx", "agentforce"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/salesforce/README.md
+++ b/plugins/salesforce/README.md
@@ -1,0 +1,68 @@
+# Salesforce Plugin
+
+Container-adapted Salesforce CLI integration for Claude Code. Provides
+org authentication, org management, and bridges to the official
+[forcedotcom/afv-library](https://github.com/forcedotcom/afv-library)
+skills for Salesforce development.
+
+## Prerequisites
+
+- **Salesforce CLI** (`@salesforce/cli`): `npm install -g @salesforce/cli`
+- **afv-library skills**: `npx skills add forcedotcom/afv-library`
+- **Salesforce org** with API access
+
+## Quick Start
+
+```bash
+# Check CLI and org status
+/sf-status
+
+# Authenticate to an org
+/sf-login my-dev-org
+```
+
+## Authentication Methods
+
+This plugin adapts Salesforce authentication for headless container
+environments:
+
+| Method       | Best For                   | Command                     |
+| ------------ | -------------------------- | --------------------------- |
+| JWT Bearer   | CI/CD, automation          | `sf org login jwt`          |
+| Access Token | Environment variable auth  | `sf org login access-token` |
+| SFDX URL     | Portable auth URLs         | `sf org login sfdx-url`     |
+| Web Login    | Interactive (VNC required) | `sf org login web`          |
+
+**Note:** Device flow (`sf org login device`) is blocked since August
+2025 and is not supported.
+
+## Environment Variables
+
+| Variable              | Purpose                            |
+| --------------------- | ---------------------------------- |
+| `SF_ACCESS_TOKEN`     | Bearer token for access-token auth |
+| `SFDX_AUTH_URL`       | Force auth URL for sfdx-url auth   |
+| `SF_ORG_INSTANCE_URL` | Org instance URL                   |
+| `SF_JWT_KEY_FILE`     | Path to JWT private key            |
+| `SF_CLIENT_ID`        | Connected App consumer key         |
+| `SF_USERNAME`         | Salesforce username for JWT        |
+
+## Skills
+
+| Skill              | Purpose                                     |
+| ------------------ | ------------------------------------------- |
+| `salesforce-index` | Routes requests to the right skill or agent |
+| `salesforce-auth`  | Container-adapted org authentication        |
+
+## Development Skills (via afv-library)
+
+The 30 Salesforce development skills from `forcedotcom/afv-library` are
+installed separately and activate automatically for Apex, Flow, LWC,
+SOQL, metadata, Agentforce, and deployment tasks.
+
+## Commands
+
+| Command      | Purpose                          |
+| ------------ | -------------------------------- |
+| `/sf-login`  | Authenticate to a Salesforce org |
+| `/sf-status` | Check org connection status      |

--- a/plugins/salesforce/agents/cli-operator.md
+++ b/plugins/salesforce/agents/cli-operator.md
@@ -1,0 +1,89 @@
+---
+name: cli-operator
+description: >-
+  Autonomous Salesforce CLI agent for org management, metadata operations,
+  and deployment. Executes sf CLI commands with safety guardrails.
+  Skills MUST delegate to this agent — never run sf commands in the main
+  session. This keeps the main session context lean since sf CLI output
+  can be verbose.
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+disallowedTools:
+  - Write
+  - Edit
+  - Agent
+---
+
+# Salesforce CLI Operator Agent
+
+You execute Salesforce CLI (`sf`) commands on behalf of the main session.
+
+## Safety Rules
+
+1. **Read-only by default.** Use read-only commands (`sf org list`,
+   `sf org display`, `sf project deploy preview`, `sf apex run test`)
+   unless the caller explicitly requests a write operation.
+
+2. **Never deploy without confirmation.** If the caller asks to deploy,
+   run `sf project deploy preview` first, report the changes, and ask
+   the caller to confirm before running `sf project deploy start`.
+
+3. **Never run destructive changes** (`--purge-on-delete`,
+   `sf project delete source`) unless the caller explicitly approves.
+
+4. **Never echo credentials.** Do not print auth URLs, access tokens,
+   refresh tokens, or client secrets. Use `$SF_ACCESS_TOKEN` or
+   `$SFDX_AUTH_URL` placeholders in output.
+
+5. **Sanitize user-provided values.** Org aliases, usernames, and other
+   user-supplied strings MUST match `^[a-zA-Z0-9._-]+$` before use in
+   shell commands. Reject any value containing spaces, quotes, backticks,
+   semicolons, pipes, `$`, or other shell metacharacters.
+
+6. **Prefer `--json` output** for structured results, parse with `jq`.
+
+## Standard Response Format
+
+```
+## Result: [SUCCESS | FAILURE | PARTIAL]
+
+### Command Executed
+<the exact sf command run>
+
+### Output Summary
+<key findings, formatted for readability>
+
+### Issues
+<any errors, warnings, or items needing attention>
+```
+
+## Environment Variables
+
+| Variable              | Purpose                                                   |
+| --------------------- | --------------------------------------------------------- |
+| `SF_ACCESS_TOKEN`     | Bearer token for access-token auth                        |
+| `SFDX_AUTH_URL`       | Force auth URL for sfdx-url auth                          |
+| `SF_ORG_INSTANCE_URL` | Org instance URL (e.g. `https://myorg.my.salesforce.com`) |
+
+## Common Commands
+
+| Operation           | Command                                                                      |
+| ------------------- | ---------------------------------------------------------------------------- |
+| List orgs           | `sf org list --json`                                                         |
+| Org info            | `sf org display --target-org <alias> --json`                                 |
+| Deploy preview      | `sf project deploy preview --target-org <alias>`                             |
+| Run tests           | `sf apex run test --target-org <alias> --result-format json --code-coverage` |
+| Retrieve metadata   | `sf project retrieve start --target-org <alias> --metadata <types>`          |
+| List metadata types | `sf org list metadata-types --target-org <alias> --json`                     |
+
+## Error Recovery
+
+| Error                   | Action                                                                 |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `sf: command not found` | Report: sf CLI not installed, suggest `npm install -g @salesforce/cli` |
+| `No default org`        | Report: no authenticated org, suggest using `/sf-login` command        |
+| `INVALID_SESSION_ID`    | Report: session expired, suggest re-authenticating                     |
+| `ECONNREFUSED`          | Report: cannot reach Salesforce, check network and org URL             |

--- a/plugins/salesforce/commands/sf-login.md
+++ b/plugins/salesforce/commands/sf-login.md
@@ -1,5 +1,7 @@
 ---
-description: Authenticate to a Salesforce org using container-adapted auth methods (JWT, access-token, SFDX URL, or web login)
+description: >-
+  Authenticate to a Salesforce org using container-adapted
+  auth methods (JWT, access-token, SFDX URL, or web login)
 argument-hint: "[org-alias]"
 ---
 
@@ -7,18 +9,30 @@ Delegate to the cli-operator agent to handle Salesforce authentication.
 
 ## Delegation
 
-```
-Agent(
-  subagent_type="salesforce:cli-operator",
-  description="Authenticate to Salesforce org",
-  prompt="Help the user authenticate to a Salesforce org. The user-provided alias is: $ARGUMENTS (use 'my-dev-org' if empty).\n\n1. Run: sf org list --json\n2. If orgs exist, report them and ask if the user wants to use an existing org or add a new one.\n3. For a new org, check credentials in order and use the first fully satisfied option:\n   - SF_ACCESS_TOKEN + SF_ORG_INSTANCE_URL both set → sf org login access-token --instance-url $SF_ORG_INSTANCE_URL --no-prompt\n   - SF_JWT_KEY_FILE + SF_CLIENT_ID + SF_USERNAME all set → sf org login jwt\n   - SFDX_AUTH_URL set → echo $SFDX_AUTH_URL | sf org login sfdx-url --sfdx-url-stdin\n   - None fully satisfied → suggest sf org login web (requires browser/VNC)\n   Do NOT choose an option unless all required env vars for that option are present.\n4. Use the alias from above in --alias flag.\n5. After auth, run sf org display --target-org <alias> --json to confirm the newly authenticated org specifically.\n6. Never echo tokens or auth URLs in output."
-)
-```
+Spawn the cli-operator agent with the following instructions:
+
+1. The user-provided alias is `$ARGUMENTS` (use `my-dev-org` if empty).
+2. Run `sf org list --json` to check existing orgs.
+3. If orgs exist, report them and ask if the user wants to reuse one.
+4. For a new org, check credentials in order — use the first fully
+   satisfied option:
+   - `SF_ACCESS_TOKEN` + `SF_ORG_INSTANCE_URL` both set →
+     `sf org login access-token`
+   - `SF_JWT_KEY_FILE` + `SF_CLIENT_ID` + `SF_USERNAME` all set →
+     `sf org login jwt`
+   - `SFDX_AUTH_URL` set →
+     `echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin`
+   - None fully satisfied → suggest `sf org login web`
+5. Do NOT choose an option unless all required env vars are present.
+6. Use the alias in the `--alias` flag.
+7. After auth, run
+   `sf org display --target-org <alias> --json` to confirm.
+8. Never echo tokens or auth URLs in output.
 
 ## After Authentication
 
 Report the result:
 
 - **Connected:** Show org alias, username, instance URL, and API version
-- **Failed:** Show the error and suggest checking credentials or trying a different auth method
-- **No credentials:** Explain how to set up environment variables for headless auth
+- **Failed:** Show the error and suggest checking credentials
+- **No credentials:** Explain how to set up environment variables

--- a/plugins/salesforce/commands/sf-login.md
+++ b/plugins/salesforce/commands/sf-login.md
@@ -1,0 +1,24 @@
+---
+description: Authenticate to a Salesforce org using container-adapted auth methods (JWT, access-token, SFDX URL, or web login)
+argument-hint: "[org-alias]"
+---
+
+Delegate to the cli-operator agent to handle Salesforce authentication.
+
+## Delegation
+
+```
+Agent(
+  subagent_type="salesforce:cli-operator",
+  description="Authenticate to Salesforce org",
+  prompt="Help the user authenticate to a Salesforce org. The user-provided alias is: $ARGUMENTS (use 'my-dev-org' if empty).\n\n1. Run: sf org list --json\n2. If orgs exist, report them and ask if the user wants to use an existing org or add a new one.\n3. For a new org, check credentials in order and use the first fully satisfied option:\n   - SF_ACCESS_TOKEN + SF_ORG_INSTANCE_URL both set → sf org login access-token --instance-url $SF_ORG_INSTANCE_URL --no-prompt\n   - SF_JWT_KEY_FILE + SF_CLIENT_ID + SF_USERNAME all set → sf org login jwt\n   - SFDX_AUTH_URL set → echo $SFDX_AUTH_URL | sf org login sfdx-url --sfdx-url-stdin\n   - None fully satisfied → suggest sf org login web (requires browser/VNC)\n   Do NOT choose an option unless all required env vars for that option are present.\n4. Use the alias from above in --alias flag.\n5. After auth, run sf org display --target-org <alias> --json to confirm the newly authenticated org specifically.\n6. Never echo tokens or auth URLs in output."
+)
+```
+
+## After Authentication
+
+Report the result:
+
+- **Connected:** Show org alias, username, instance URL, and API version
+- **Failed:** Show the error and suggest checking credentials or trying a different auth method
+- **No credentials:** Explain how to set up environment variables for headless auth

--- a/plugins/salesforce/commands/sf-status.md
+++ b/plugins/salesforce/commands/sf-status.md
@@ -1,0 +1,15 @@
+---
+description: Check Salesforce org connection status and list authenticated orgs
+---
+
+Delegate to the cli-operator agent to check Salesforce connectivity.
+
+## Delegation
+
+```
+Agent(
+  subagent_type="salesforce:cli-operator",
+  description="Check Salesforce org status",
+  prompt="Check Salesforce org connectivity:\n\n1. Verify sf CLI is installed: sf --version\n2. List authenticated orgs: sf org list --json\n3. For the default org (if set), run: sf org display --json\n4. Report:\n   - sf CLI version\n   - Number of authenticated orgs\n   - Default org alias, username, instance URL, connected status\n   - API version\n5. If no orgs are authenticated, suggest using /sf-login"
+)
+```

--- a/plugins/salesforce/commands/sf-status.md
+++ b/plugins/salesforce/commands/sf-status.md
@@ -1,15 +1,22 @@
 ---
-description: Check Salesforce org connection status and list authenticated orgs
+description: >-
+  Check Salesforce org connection status and list
+  authenticated orgs
 ---
 
 Delegate to the cli-operator agent to check Salesforce connectivity.
 
 ## Delegation
 
-```
-Agent(
-  subagent_type="salesforce:cli-operator",
-  description="Check Salesforce org status",
-  prompt="Check Salesforce org connectivity:\n\n1. Verify sf CLI is installed: sf --version\n2. List authenticated orgs: sf org list --json\n3. For the default org (if set), run: sf org display --json\n4. Report:\n   - sf CLI version\n   - Number of authenticated orgs\n   - Default org alias, username, instance URL, connected status\n   - API version\n5. If no orgs are authenticated, suggest using /sf-login"
-)
-```
+Spawn the cli-operator agent with the following instructions:
+
+1. Verify sf CLI is installed: `sf --version`
+2. List authenticated orgs: `sf org list --json`
+3. For the default org (if set), run:
+   `sf org display --json`
+4. Report:
+   - sf CLI version
+   - Number of authenticated orgs
+   - Default org alias, username, instance URL, connected status
+   - API version
+5. If no orgs are authenticated, suggest using `/sf-login`

--- a/plugins/salesforce/hooks/hooks.json
+++ b/plugins/salesforce/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v sf > /dev/null 2>&1 || echo 'WARNING: Salesforce CLI (sf) is not installed. Run: npm install -g @salesforce/cli'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/salesforce/skills/salesforce-auth/SKILL.md
+++ b/plugins/salesforce/skills/salesforce-auth/SKILL.md
@@ -115,15 +115,20 @@ A successful response shows `connectedStatus: "Connected"`.
 
 ## Delegation
 
-When executing auth commands, delegate to the cli-operator agent:
+When executing auth commands, spawn the cli-operator agent with these
+instructions:
 
-```text
-Agent(
-  subagent_type="salesforce:cli-operator",
-  description="Authenticate to Salesforce org",
-  prompt="The user wants to authenticate to a Salesforce org. Check sf org list first to see if any orgs are already connected. Then guide through the appropriate auth method based on available credentials — check them in order, use the first fully satisfied option:\n  1. SF_ACCESS_TOKEN + SF_ORG_INSTANCE_URL both set → sf org login access-token --instance-url $SF_ORG_INSTANCE_URL --no-prompt\n  2. SF_JWT_KEY_FILE + SF_CLIENT_ID + SF_USERNAME all set → sf org login jwt\n  3. SFDX_AUTH_URL set → echo $SFDX_AUTH_URL | sf org login sfdx-url --sfdx-url-stdin\n  4. None of the above fully satisfied → sf org login web (requires browser/VNC)\nDo NOT choose an option unless all required env vars for that option are present. Never echo tokens or auth URLs in output."
-)
-```
+1. Run `sf org list --json` to check existing connections.
+2. Pick the first fully satisfied auth method in order:
+   - `SF_ACCESS_TOKEN` + `SF_ORG_INSTANCE_URL` both set →
+     `sf org login access-token`
+   - `SF_JWT_KEY_FILE` + `SF_CLIENT_ID` + `SF_USERNAME` all set →
+     `sf org login jwt`
+   - `SFDX_AUTH_URL` set →
+     `echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin`
+   - None satisfied → `sf org login web` (requires browser/VNC)
+3. Do NOT choose an option unless all its required env vars are set.
+4. Never echo tokens or auth URLs in output.
 
 ## Environment Variables
 

--- a/plugins/salesforce/skills/salesforce-auth/SKILL.md
+++ b/plugins/salesforce/skills/salesforce-auth/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: salesforce-auth
+description: >-
+  Container-adapted Salesforce org authentication. Supports JWT Bearer,
+  access-token, and SFDX URL flows for headless environments. Also
+  supports web login when a browser is available (VNC enabled). Use when
+  the user says "login to salesforce", "authenticate org", "connect org",
+  "sf login", or when any Salesforce operation fails with auth errors.
+  Note: device flow (sf org login device) is BLOCKED since August 2025.
+user-invocable: false
+---
+
+# Salesforce Org Authentication (Container-Adapted)
+
+This skill guides authentication for headless container environments
+where browser-based login may not be available.
+
+## Authentication Methods
+
+### Method 1: JWT Bearer Flow (Recommended for Automation)
+
+Best for CI/CD and automated environments. Requires a connected app
+with a digital certificate configured in the Salesforce org.
+
+**Prerequisites:**
+
+- Connected App with OAuth enabled and digital certificate uploaded
+- Private key file (`.key` or `.pem`) accessible in the container
+- Consumer Key (Client ID) from the Connected App
+
+**Command:**
+
+```bash
+sf org login jwt \
+  --client-id <CONSUMER_KEY> \
+  --jwt-key-file <PATH_TO_PRIVATE_KEY> \
+  --username <USERNAME> \
+  --alias my-dev-org \
+  --set-default \
+  --instance-url https://login.salesforce.com
+```
+
+### Method 2: Access Token (Environment Variable)
+
+Use when an access token is available via environment variable.
+
+**Setup:**
+
+```bash
+export SF_ACCESS_TOKEN="<your-access-token>"
+export SF_ORG_INSTANCE_URL="https://myorg.my.salesforce.com"
+```
+
+**Command:**
+
+```bash
+sf org login access-token \
+  --instance-url "$SF_ORG_INSTANCE_URL" \
+  --alias my-dev-org \
+  --set-default \
+  --no-prompt
+```
+
+### Method 3: SFDX Auth URL
+
+Use the force auth URL obtained from `sf org display --verbose`.
+
+**Setup:**
+
+```bash
+export SFDX_AUTH_URL="force://..."
+```
+
+**Command:**
+
+```bash
+echo "$SFDX_AUTH_URL" | sf org login sfdx-url \
+  --sfdx-url-stdin \
+  --alias my-dev-org \
+  --set-default
+```
+
+Never write the auth URL to a file — use `--sfdx-url-stdin` with a
+pipe to avoid persisting credentials on disk.
+
+### Method 4: Web Login (Browser Required)
+
+Works when VNC is enabled (`ENABLE_VNC=true`) or a browser is
+available. Opens a browser window for OAuth consent.
+
+**Command:**
+
+```bash
+sf org login web \
+  --alias my-dev-org \
+  --set-default \
+  --instance-url https://login.salesforce.com
+```
+
+### BLOCKED: Device Flow
+
+`sf org login device` is **blocked since August 2025**. Salesforce
+removed support for the default connected app's device flow. Use one
+of the methods above instead.
+
+## Validation
+
+After authenticating, verify the connection:
+
+```bash
+sf org display --target-org my-dev-org --json
+```
+
+A successful response shows `connectedStatus: "Connected"`.
+
+## Delegation
+
+When executing auth commands, delegate to the cli-operator agent:
+
+```text
+Agent(
+  subagent_type="salesforce:cli-operator",
+  description="Authenticate to Salesforce org",
+  prompt="The user wants to authenticate to a Salesforce org. Check sf org list first to see if any orgs are already connected. Then guide through the appropriate auth method based on available credentials — check them in order, use the first fully satisfied option:\n  1. SF_ACCESS_TOKEN + SF_ORG_INSTANCE_URL both set → sf org login access-token --instance-url $SF_ORG_INSTANCE_URL --no-prompt\n  2. SF_JWT_KEY_FILE + SF_CLIENT_ID + SF_USERNAME all set → sf org login jwt\n  3. SFDX_AUTH_URL set → echo $SFDX_AUTH_URL | sf org login sfdx-url --sfdx-url-stdin\n  4. None of the above fully satisfied → sf org login web (requires browser/VNC)\nDo NOT choose an option unless all required env vars for that option are present. Never echo tokens or auth URLs in output."
+)
+```
+
+## Environment Variables
+
+| Variable              | Purpose                                                          |
+| --------------------- | ---------------------------------------------------------------- |
+| `SF_ACCESS_TOKEN`     | Bearer token for Method 2                                        |
+| `SFDX_AUTH_URL`       | Force auth URL for Method 3                                      |
+| `SF_ORG_INSTANCE_URL` | Org instance URL (default: `https://login.salesforce.com`)       |
+| `SF_JWT_KEY_FILE`     | Path to JWT private key for Method 1                             |
+| `SF_CLIENT_ID`        | Connected App consumer key for Method 1                          |
+| `SF_USERNAME`         | Salesforce username for Method 1                                 |
+
+## Security Rules
+
+- Never echo access tokens, refresh tokens, or auth URLs
+- Use `$SF_ACCESS_TOKEN` placeholder in output
+- Never write credentials to disk — use stdin pipes (`--sfdx-url-stdin`)
+- Do not store credentials in project files

--- a/plugins/salesforce/skills/salesforce-index/SKILL.md
+++ b/plugins/salesforce/skills/salesforce-index/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: salesforce-index
+description: >-
+  Top-level intent router for Salesforce operations. Routes auth requests
+  to salesforce-auth, org management to the cli-operator agent, and
+  development tasks (Apex, Flow, LWC, SOQL, metadata, deployment) to the
+  official forcedotcom/afv-library skills. Use when the user mentions
+  Salesforce, sf CLI, orgs, or any Salesforce development topic but the
+  request does not clearly match a specific skill trigger.
+user-invocable: false
+---
+
+# Salesforce Intent Router
+
+Route the user's request to the correct skill or agent.
+
+## Routing Rules
+
+### Authentication and Org Management
+
+Keywords: "login", "authenticate", "connect org", "sf org", "org list",
+"check org", "switch org"
+
+- Auth setup → invoke `salesforce:salesforce-auth` skill
+- Org switching → invoke `switching-org` skill (afv-library)
+- Org status check → delegate to `salesforce:cli-operator` agent:
+
+  ```text
+  Agent(
+    subagent_type="salesforce:cli-operator",
+    description="Check Salesforce org status",
+    prompt="Run sf org list --json and sf org display --json for the default org. Report which orgs are authenticated and their status."
+  )
+  ```
+
+### Salesforce Development (afv-library skills)
+
+These requests should be routed to the installed afv-library skills,
+which activate automatically based on their trigger descriptions:
+
+| Topic                         | afv-library Skill               |
+| ----------------------------- | ------------------------------- |
+| Apex classes, services, batch | `generating-apex`               |
+| Apex tests                    | `generating-apex-test`          |
+| Flows                         | `generating-flow`               |
+| LWC / UI bundles              | `building-ui-bundle-app`        |
+| Custom objects                | `generating-custom-object`      |
+| Custom fields                 | `generating-custom-field`       |
+| Validation rules              | `generating-validation-rule`    |
+| Permission sets               | `generating-permission-set`     |
+| FlexiPages                    | `generating-flexipage`          |
+| Agentforce agents             | `developing-agentforce`         |
+| Agentforce testing            | `testing-agentforce`            |
+| Deployment                    | `deploying-ui-bundle`           |
+| SLDS2 migration               | `uplifting-components-to-slds2` |
+| Trigger refactoring           | `trigger-refactor-pipeline`     |
+
+If the user's request matches one of these topics, the afv-library skill
+will activate automatically — no explicit delegation needed.
+
+### CLI Operations (not covered by afv-library)
+
+For direct sf CLI operations like listing metadata types, running SOQL
+queries, or inspecting org limits, delegate to the cli-operator agent:
+
+```text
+Agent(
+  subagent_type="salesforce:cli-operator",
+  description="<brief description of the operation>",
+  prompt="<specific sf CLI commands to execute and what to report>"
+)
+```
+
+## Important Notes
+
+- The forcedotcom/afv-library provides 30 Salesforce development skills
+  that are already installed and activate automatically
+- This plugin adds container-specific auth and org management on top
+- Always check org authentication status before development operations


### PR DESCRIPTION
## Summary

- Adds a new Salesforce CLI plugin with container-adapted org authentication (JWT, access-token, SFDX URL — device flow blocked since Aug 2025)
- Provides org management commands (`/sf-login`, `/sf-status`) and a cli-operator agent for executing `sf` commands
- Includes a router skill (`salesforce-index`) that bridges to forcedotcom/afv-library Salesforce development skills
- Registers the plugin in the marketplace index

Closes #345

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify `plugin.json` schema is valid and marketplace registration is correct
- [ ] Verify skill and command markdown renders correctly
- [ ] Confirm hooks.json declares correct trigger patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)