### PR TITLE
test: add comprehensive test suite for Salesforce plugin

### DIFF
--- a/plugins/salesforce/scripts/tests/_helpers.sh
+++ b/plugins/salesforce/scripts/tests/_helpers.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Shared helpers for Salesforce plugin tests.
+# Sourced by test files — not executed directly by run-tests.sh
+# (the _ prefix prevents globbing by test_*.sh pattern).
+
+# Detect any authenticated org via sf org list --json.
+# Prints the alias (or username) of the first available org.
+# Returns 1 if sf CLI is missing or no orgs are authenticated.
+_detect_live_org() {
+  command -v sf >/dev/null 2>&1 || return 1
+  local out
+  out=$(sf org list --json 2>/dev/null) || return 1
+  local alias
+  alias=$(echo "$out" | jq -r '
+    [.result.nonScratchOrgs, .result.devHubs, .result.sandboxes,
+     .result.scratchOrgs, .result.other]
+    | map(select(. != null)) | flatten
+    | map(.alias // .username)
+    | map(select(. != null and . != ""))
+    | first // empty
+  ' 2>/dev/null) || return 1
+  [ -n "$alias" ] && echo "$alias" || return 1
+}

--- a/plugins/salesforce/scripts/tests/run-tests.sh
+++ b/plugins/salesforce/scripts/tests/run-tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Test runner for the Salesforce plugin.
+# Runs every test_*.sh in this directory; each file contains
+# bash functions named test_* that exit non-zero on failure.
+#
+# Usage: ./run-tests.sh [filter-substring]
+
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/salesforce/scripts/tests/test_agent.sh
+++ b/plugins/salesforce/scripts/tests/test_agent.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Phase 2: cli-operator agent contract validation.
+
+set -euo pipefail
+
+AGENT_FILE="$PLUGIN_ROOT/agents/cli-operator.md"
+
+# T2.10 — agent has response format template
+test_agent_response_format() {
+  grep -q '## Result:' "$AGENT_FILE" || { echo "missing '## Result:' template"; return 1; }
+  grep -q '### Command Executed' "$AGENT_FILE" || { echo "missing '### Command Executed' section"; return 1; }
+  grep -q '### Output Summary' "$AGENT_FILE" || { echo "missing '### Output Summary' section"; return 1; }
+  grep -q '### Issues' "$AGENT_FILE" || { echo "missing '### Issues' section"; return 1; }
+}
+
+# T2.11 — agent references --json flag
+test_agent_json_flag() {
+  local count; count=$(grep -c '\-\-json' "$AGENT_FILE")
+  [ "$count" -ge 3 ] || { echo "expected >=3 references to --json, found $count"; return 1; }
+}
+
+# T2.12 — agent has all 4 error recovery patterns
+test_agent_error_recovery() {
+  local patterns=("sf: command not found" "No default org" "INVALID_SESSION_ID" "ECONNREFUSED")
+  for pat in "${patterns[@]}"; do
+    grep -q "$pat" "$AGENT_FILE" || { echo "missing error pattern: $pat"; return 1; }
+  done
+}
+
+# T2.13 — org alias sanitization rejects dangerous input
+test_alias_sanitization() {
+  local regex='^[a-zA-Z0-9._-]+$'
+
+  local safe_inputs=("my-dev-org" "org.prod" "Test_Org123" "a" "org-1.2_3")
+  for input in "${safe_inputs[@]}"; do
+    [[ "$input" =~ $regex ]] || { echo "safe input rejected: $input"; return 1; }
+  done
+
+  local dangerous_inputs=("org; rm -rf /" "\$(whoami)" "org|pipe" "org\`cmd\`" "org name" "org&bg" "org>file")
+  for input in "${dangerous_inputs[@]}"; do
+    if [[ "$input" =~ $regex ]]; then
+      echo "dangerous input accepted: $input"
+      return 1
+    fi
+  done
+}

--- a/plugins/salesforce/scripts/tests/test_agent.sh
+++ b/plugins/salesforce/scripts/tests/test_agent.sh
@@ -7,23 +7,42 @@ AGENT_FILE="$PLUGIN_ROOT/agents/cli-operator.md"
 
 # T2.10 — agent has response format template
 test_agent_response_format() {
-  grep -q '## Result:' "$AGENT_FILE" || { echo "missing '## Result:' template"; return 1; }
-  grep -q '### Command Executed' "$AGENT_FILE" || { echo "missing '### Command Executed' section"; return 1; }
-  grep -q '### Output Summary' "$AGENT_FILE" || { echo "missing '### Output Summary' section"; return 1; }
-  grep -q '### Issues' "$AGENT_FILE" || { echo "missing '### Issues' section"; return 1; }
+  grep -q '## Result:' "$AGENT_FILE" || {
+    echo "missing '## Result:' template"
+    return 1
+  }
+  grep -q '### Command Executed' "$AGENT_FILE" || {
+    echo "missing '### Command Executed' section"
+    return 1
+  }
+  grep -q '### Output Summary' "$AGENT_FILE" || {
+    echo "missing '### Output Summary' section"
+    return 1
+  }
+  grep -q '### Issues' "$AGENT_FILE" || {
+    echo "missing '### Issues' section"
+    return 1
+  }
 }
 
 # T2.11 — agent references --json flag
 test_agent_json_flag() {
-  local count; count=$(grep -c '\-\-json' "$AGENT_FILE")
-  [ "$count" -ge 3 ] || { echo "expected >=3 references to --json, found $count"; return 1; }
+  local count
+  count=$(grep -c '\-\-json' "$AGENT_FILE")
+  [ "$count" -ge 3 ] || {
+    echo "expected >=3 references to --json, found $count"
+    return 1
+  }
 }
 
 # T2.12 — agent has all 4 error recovery patterns
 test_agent_error_recovery() {
   local patterns=("sf: command not found" "No default org" "INVALID_SESSION_ID" "ECONNREFUSED")
   for pat in "${patterns[@]}"; do
-    grep -q "$pat" "$AGENT_FILE" || { echo "missing error pattern: $pat"; return 1; }
+    grep -q "$pat" "$AGENT_FILE" || {
+      echo "missing error pattern: $pat"
+      return 1
+    }
   done
 }
 
@@ -33,7 +52,10 @@ test_alias_sanitization() {
 
   local safe_inputs=("my-dev-org" "org.prod" "Test_Org123" "a" "org-1.2_3")
   for input in "${safe_inputs[@]}"; do
-    [[ "$input" =~ $regex ]] || { echo "safe input rejected: $input"; return 1; }
+    [[ "$input" =~ $regex ]] || {
+      echo "safe input rejected: $input"
+      return 1
+    }
   done
 
   local dangerous_inputs=("org; rm -rf /" "\$(whoami)" "org|pipe" "org\`cmd\`" "org name" "org&bg" "org>file")

--- a/plugins/salesforce/scripts/tests/test_cli.sh
+++ b/plugins/salesforce/scripts/tests/test_cli.sh
@@ -23,18 +23,32 @@ detect_auth_method() {
 
 # T2.3 — sf org list --json returns valid JSON
 test_sf_org_list_json() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
-  local out; out=$(sf org list --json 2>/dev/null) || true
-  echo "$out" | jq -e '.status' >/dev/null || { echo "sf org list did not return valid JSON"; return 1; }
+  local out
+  out=$(sf org list --json 2>/dev/null) || true
+  echo "$out" | jq -e '.status' >/dev/null || {
+    echo "sf org list did not return valid JSON"
+    return 1
+  }
 }
 
 # T2.4 — sf --version returns expected format
 test_sf_version_format() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
-  local ver; ver=$(sf --version 2>/dev/null)
-  [[ "$ver" =~ @salesforce/cli/[0-9]+ ]] || { echo "unexpected version format: $ver"; return 1; }
+  local ver
+  ver=$(sf --version 2>/dev/null)
+  [[ "$ver" =~ @salesforce/cli/[0-9]+ ]] || {
+    echo "unexpected version format: $ver"
+    return 1
+  }
 }
 
 # T2.5 — baseline: report auth env vars (informational, always passes)
@@ -54,13 +68,22 @@ test_access_token_requires_both_vars() {
   local result
 
   result=$(SF_ACCESS_TOKEN=fake SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE='' SF_CLIENT_ID='' SF_USERNAME='' SFDX_AUTH_URL='' detect_auth_method)
-  [ "$result" != "access-token" ] || { echo "access-token should not be selected without SF_ORG_INSTANCE_URL"; return 1; }
+  [ "$result" != "access-token" ] || {
+    echo "access-token should not be selected without SF_ORG_INSTANCE_URL"
+    return 1
+  }
 
   result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL=https://example.com SF_JWT_KEY_FILE='' SF_CLIENT_ID='' SF_USERNAME='' SFDX_AUTH_URL='' detect_auth_method)
-  [ "$result" != "access-token" ] || { echo "access-token should not be selected without SF_ACCESS_TOKEN"; return 1; }
+  [ "$result" != "access-token" ] || {
+    echo "access-token should not be selected without SF_ACCESS_TOKEN"
+    return 1
+  }
 
   result=$(SF_ACCESS_TOKEN=fake SF_ORG_INSTANCE_URL=https://example.com SF_JWT_KEY_FILE='' SF_CLIENT_ID='' SF_USERNAME='' SFDX_AUTH_URL='' detect_auth_method)
-  [ "$result" = "access-token" ] || { echo "access-token should be selected when both vars set, got: $result"; return 1; }
+  [ "$result" = "access-token" ] || {
+    echo "access-token should be selected when both vars set, got: $result"
+    return 1
+  }
 }
 
 # T2.7 — JWT requires ALL THREE vars
@@ -68,23 +91,38 @@ test_jwt_requires_all_three_vars() {
   local result
 
   result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE=/tmp/key SF_CLIENT_ID=id SF_USERNAME='' SFDX_AUTH_URL='' detect_auth_method)
-  [ "$result" != "jwt" ] || { echo "jwt should not be selected without SF_USERNAME"; return 1; }
+  [ "$result" != "jwt" ] || {
+    echo "jwt should not be selected without SF_USERNAME"
+    return 1
+  }
 
   result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE=/tmp/key SF_CLIENT_ID='' SF_USERNAME=user SFDX_AUTH_URL='' detect_auth_method)
-  [ "$result" != "jwt" ] || { echo "jwt should not be selected without SF_CLIENT_ID"; return 1; }
+  [ "$result" != "jwt" ] || {
+    echo "jwt should not be selected without SF_CLIENT_ID"
+    return 1
+  }
 
   result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE='' SF_CLIENT_ID=id SF_USERNAME=user SFDX_AUTH_URL='' detect_auth_method)
-  [ "$result" != "jwt" ] || { echo "jwt should not be selected without SF_JWT_KEY_FILE"; return 1; }
+  [ "$result" != "jwt" ] || {
+    echo "jwt should not be selected without SF_JWT_KEY_FILE"
+    return 1
+  }
 
   result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE=/tmp/key SF_CLIENT_ID=id SF_USERNAME=user SFDX_AUTH_URL='' detect_auth_method)
-  [ "$result" = "jwt" ] || { echo "jwt should be selected when all three set, got: $result"; return 1; }
+  [ "$result" = "jwt" ] || {
+    echo "jwt should be selected when all three set, got: $result"
+    return 1
+  }
 }
 
 # T2.8 — SFDX URL method selected when var set
 test_sfdx_url_selected() {
   local result
   result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE='' SF_CLIENT_ID='' SF_USERNAME='' SFDX_AUTH_URL=force://fake detect_auth_method)
-  [ "$result" = "sfdx-url" ] || { echo "sfdx-url should be selected, got: $result"; return 1; }
+  [ "$result" = "sfdx-url" ] || {
+    echo "sfdx-url should be selected, got: $result"
+    return 1
+  }
 }
 
 # T2.9 — priority: access-token > JWT > SFDX URL
@@ -92,15 +130,24 @@ test_auth_priority_order() {
   local result
 
   result=$(SF_ACCESS_TOKEN=tok SF_ORG_INSTANCE_URL=https://x SF_JWT_KEY_FILE=/k SF_CLIENT_ID=id SF_USERNAME=u SFDX_AUTH_URL=force://x detect_auth_method)
-  [ "$result" = "access-token" ] || { echo "access-token should win when all set, got: $result"; return 1; }
+  [ "$result" = "access-token" ] || {
+    echo "access-token should win when all set, got: $result"
+    return 1
+  }
 
   result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE=/k SF_CLIENT_ID=id SF_USERNAME=u SFDX_AUTH_URL=force://x detect_auth_method)
-  [ "$result" = "jwt" ] || { echo "jwt should win over sfdx-url, got: $result"; return 1; }
+  [ "$result" = "jwt" ] || {
+    echo "jwt should win over sfdx-url, got: $result"
+    return 1
+  }
 }
 
 # T2.14 — --sfdx-url-stdin requires =- value (syntax bug detector)
 test_sfdx_url_stdin_syntax() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
   local out
   out=$(echo "" | sf org login sfdx-url --sfdx-url-stdin --json 2>&1) || true
@@ -118,11 +165,16 @@ test_sfdx_url_stdin_syntax() {
 # T3.1 — access-token login succeeds (requires real credentials)
 test_access_token_login() {
   if [ -z "${SF_ACCESS_TOKEN:-}" ] || [ -z "${SF_ORG_INSTANCE_URL:-}" ]; then
-    echo "SKIP: SF_ACCESS_TOKEN or SF_ORG_INSTANCE_URL not set"; return 0
+    echo "SKIP: SF_ACCESS_TOKEN or SF_ORG_INSTANCE_URL not set"
+    return 0
   fi
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
-  local out; out=$(sf org login access-token \
+  local out
+  out=$(sf org login access-token \
     --instance-url "$SF_ORG_INSTANCE_URL" \
     --alias sf-test-org \
     --set-default \
@@ -145,31 +197,51 @@ test_access_token_login() {
 
 # T3.2 — SFDX URL login succeeds (requires real auth URL)
 test_sfdx_url_login() {
-  [ -n "${SFDX_AUTH_URL:-}" ] || { echo "SKIP: SFDX_AUTH_URL not set"; return 0; }
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  [ -n "${SFDX_AUTH_URL:-}" ] || {
+    echo "SKIP: SFDX_AUTH_URL not set"
+    return 0
+  }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
-  local out; out=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url \
+  local out
+  out=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url \
     --sfdx-url-stdin=- \
     --alias=sf-test-sfdx \
     --set-default \
-    --json 2>&1) || { echo "login failed: $out"; return 1; }
+    --json 2>&1) || {
+    echo "login failed: $out"
+    return 1
+  }
 
-  echo "$out" | jq -e '.status == 0' >/dev/null || { echo "login returned non-zero status"; return 1; }
+  echo "$out" | jq -e '.status == 0' >/dev/null || {
+    echo "login returned non-zero status"
+    return 1
+  }
 
   sf org logout --target-org sf-test-sfdx --no-prompt 2>/dev/null || true
 }
 
 # T3.3 — authenticated org appears in sf org list
 test_org_appears_in_list() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
   local org_alias
   org_alias=$(_detect_live_org 2>/dev/null) || org_alias=""
 
   if [ -n "$org_alias" ]; then
-    local count; count=$(sf org list --json 2>/dev/null \
-      | jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
-    [ "$count" -gt 0 ] || { echo "detected org $org_alias but count is $count"; return 1; }
+    local count
+    count=$(sf org list --json 2>/dev/null |
+      jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
+    [ "$count" -gt 0 ] || {
+      echo "detected org $org_alias but count is $count"
+      return 1
+    }
     return 0
   fi
 
@@ -178,11 +250,19 @@ test_org_appears_in_list() {
       --instance-url "$SF_ORG_INSTANCE_URL" \
       --alias sf-test-list \
       --no-prompt \
-      --json >/dev/null 2>&1 || { echo "SKIP: login failed"; return 0; }
+      --json >/dev/null 2>&1 || {
+      echo "SKIP: login failed"
+      return 0
+    }
 
-    local count; count=$(sf org list --json 2>/dev/null \
-      | jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
-    [ "$count" -gt 0 ] || { echo "expected >0 orgs after login, got $count"; sf org logout --target-org sf-test-list --no-prompt 2>/dev/null || true; return 1; }
+    local count
+    count=$(sf org list --json 2>/dev/null |
+      jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
+    [ "$count" -gt 0 ] || {
+      echo "expected >0 orgs after login, got $count"
+      sf org logout --target-org sf-test-list --no-prompt 2>/dev/null || true
+      return 1
+    }
     sf org logout --target-org sf-test-list --no-prompt 2>/dev/null || true
     return 0
   fi
@@ -193,8 +273,14 @@ test_org_appears_in_list() {
 
 # T3.4 — plugin files do not contain real credential values
 test_credentials_not_in_plugin_files() {
-  [ -n "${SF_ACCESS_TOKEN:-}" ] || { echo "SKIP: SF_ACCESS_TOKEN not set"; return 0; }
-  [ "${#SF_ACCESS_TOKEN}" -gt 20 ] || { echo "SKIP: SF_ACCESS_TOKEN too short to be a real token (${#SF_ACCESS_TOKEN} chars)"; return 0; }
+  [ -n "${SF_ACCESS_TOKEN:-}" ] || {
+    echo "SKIP: SF_ACCESS_TOKEN not set"
+    return 0
+  }
+  [ "${#SF_ACCESS_TOKEN}" -gt 20 ] || {
+    echo "SKIP: SF_ACCESS_TOKEN too short to be a real token (${#SF_ACCESS_TOKEN} chars)"
+    return 0
+  }
 
   local matches
   matches=$(grep -rF "$SF_ACCESS_TOKEN" "$PLUGIN_ROOT" \
@@ -208,7 +294,10 @@ test_credentials_not_in_plugin_files() {
 
 # T3.5 — sf org display returns expected fields
 test_org_display_fields() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
   local org_alias
   org_alias=$(_detect_live_org 2>/dev/null) || org_alias=""
@@ -219,16 +308,29 @@ test_org_display_fields() {
       --alias sf-test-display \
       --set-default \
       --no-prompt \
-      --json >/dev/null 2>&1 || { echo "SKIP: login failed"; return 0; }
+      --json >/dev/null 2>&1 || {
+      echo "SKIP: login failed"
+      return 0
+    }
     org_alias="sf-test-display"
   fi
 
-  [ -n "$org_alias" ] || { echo "SKIP: no authenticated org and no auth env vars set"; return 0; }
+  [ -n "$org_alias" ] || {
+    echo "SKIP: no authenticated org and no auth env vars set"
+    return 0
+  }
 
-  local out; out=$(sf org display --target-org "$org_alias" --json 2>/dev/null) || { echo "org display failed"; return 1; }
+  local out
+  out=$(sf org display --target-org "$org_alias" --json 2>/dev/null) || {
+    echo "org display failed"
+    return 1
+  }
 
   for field in username instanceUrl connectedStatus apiVersion; do
-    echo "$out" | jq -e ".result.$field" >/dev/null 2>&1 || { echo "missing field: $field"; return 1; }
+    echo "$out" | jq -e ".result.$field" >/dev/null 2>&1 || {
+      echo "missing field: $field"
+      return 1
+    }
   done
 
   if [ "$org_alias" = "sf-test-display" ]; then

--- a/plugins/salesforce/scripts/tests/test_cli.sh
+++ b/plugins/salesforce/scripts/tests/test_cli.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Phase 2: sf CLI baseline + env var priority logic.
+# Phase 3: Credential-dependent tests (skip gracefully).
+
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck disable=SC1091
+source "$HERE/_helpers.sh"
+
+# --- auth method detection (mirrors sf-login.md priority logic) ---
+detect_auth_method() {
+  if [ -n "${SF_ACCESS_TOKEN:-}" ] && [ -n "${SF_ORG_INSTANCE_URL:-}" ]; then
+    echo "access-token"
+  elif [ -n "${SF_JWT_KEY_FILE:-}" ] && [ -n "${SF_CLIENT_ID:-}" ] && [ -n "${SF_USERNAME:-}" ]; then
+    echo "jwt"
+  elif [ -n "${SFDX_AUTH_URL:-}" ]; then
+    echo "sfdx-url"
+  else
+    echo "web"
+  fi
+}
+
+# T2.3 — sf org list --json returns valid JSON
+test_sf_org_list_json() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local out; out=$(sf org list --json 2>/dev/null) || true
+  echo "$out" | jq -e '.status' >/dev/null || { echo "sf org list did not return valid JSON"; return 1; }
+}
+
+# T2.4 — sf --version returns expected format
+test_sf_version_format() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local ver; ver=$(sf --version 2>/dev/null)
+  [[ "$ver" =~ @salesforce/cli/[0-9]+ ]] || { echo "unexpected version format: $ver"; return 1; }
+}
+
+# T2.5 — baseline: report auth env vars (informational, always passes)
+test_baseline_no_auth_vars() {
+  local vars=(SF_ACCESS_TOKEN SF_ORG_INSTANCE_URL SFDX_AUTH_URL SF_JWT_KEY_FILE SF_CLIENT_ID SF_USERNAME)
+  local set_vars=()
+  for v in "${vars[@]}"; do
+    [ -n "${!v:-}" ] && set_vars+=("$v")
+  done
+  if [ ${#set_vars[@]} -gt 0 ]; then
+    echo "Note: auth vars set: ${set_vars[*]} (tests will use them)"
+  fi
+}
+
+# T2.6 — access-token requires BOTH vars
+test_access_token_requires_both_vars() {
+  local result
+
+  result=$(SF_ACCESS_TOKEN=fake SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE='' SF_CLIENT_ID='' SF_USERNAME='' SFDX_AUTH_URL='' detect_auth_method)
+  [ "$result" != "access-token" ] || { echo "access-token should not be selected without SF_ORG_INSTANCE_URL"; return 1; }
+
+  result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL=https://example.com SF_JWT_KEY_FILE='' SF_CLIENT_ID='' SF_USERNAME='' SFDX_AUTH_URL='' detect_auth_method)
+  [ "$result" != "access-token" ] || { echo "access-token should not be selected without SF_ACCESS_TOKEN"; return 1; }
+
+  result=$(SF_ACCESS_TOKEN=fake SF_ORG_INSTANCE_URL=https://example.com SF_JWT_KEY_FILE='' SF_CLIENT_ID='' SF_USERNAME='' SFDX_AUTH_URL='' detect_auth_method)
+  [ "$result" = "access-token" ] || { echo "access-token should be selected when both vars set, got: $result"; return 1; }
+}
+
+# T2.7 — JWT requires ALL THREE vars
+test_jwt_requires_all_three_vars() {
+  local result
+
+  result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE=/tmp/key SF_CLIENT_ID=id SF_USERNAME='' SFDX_AUTH_URL='' detect_auth_method)
+  [ "$result" != "jwt" ] || { echo "jwt should not be selected without SF_USERNAME"; return 1; }
+
+  result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE=/tmp/key SF_CLIENT_ID='' SF_USERNAME=user SFDX_AUTH_URL='' detect_auth_method)
+  [ "$result" != "jwt" ] || { echo "jwt should not be selected without SF_CLIENT_ID"; return 1; }
+
+  result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE='' SF_CLIENT_ID=id SF_USERNAME=user SFDX_AUTH_URL='' detect_auth_method)
+  [ "$result" != "jwt" ] || { echo "jwt should not be selected without SF_JWT_KEY_FILE"; return 1; }
+
+  result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE=/tmp/key SF_CLIENT_ID=id SF_USERNAME=user SFDX_AUTH_URL='' detect_auth_method)
+  [ "$result" = "jwt" ] || { echo "jwt should be selected when all three set, got: $result"; return 1; }
+}
+
+# T2.8 — SFDX URL method selected when var set
+test_sfdx_url_selected() {
+  local result
+  result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE='' SF_CLIENT_ID='' SF_USERNAME='' SFDX_AUTH_URL=force://fake detect_auth_method)
+  [ "$result" = "sfdx-url" ] || { echo "sfdx-url should be selected, got: $result"; return 1; }
+}
+
+# T2.9 — priority: access-token > JWT > SFDX URL
+test_auth_priority_order() {
+  local result
+
+  result=$(SF_ACCESS_TOKEN=tok SF_ORG_INSTANCE_URL=https://x SF_JWT_KEY_FILE=/k SF_CLIENT_ID=id SF_USERNAME=u SFDX_AUTH_URL=force://x detect_auth_method)
+  [ "$result" = "access-token" ] || { echo "access-token should win when all set, got: $result"; return 1; }
+
+  result=$(SF_ACCESS_TOKEN='' SF_ORG_INSTANCE_URL='' SF_JWT_KEY_FILE=/k SF_CLIENT_ID=id SF_USERNAME=u SFDX_AUTH_URL=force://x detect_auth_method)
+  [ "$result" = "jwt" ] || { echo "jwt should win over sfdx-url, got: $result"; return 1; }
+}
+
+# T2.14 — --sfdx-url-stdin requires =- value (syntax bug detector)
+test_sfdx_url_stdin_syntax() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local out
+  out=$(echo "" | sf org login sfdx-url --sfdx-url-stdin --json 2>&1) || true
+  if echo "$out" | grep -qi 'value\|stdin\|format'; then
+    local bare_count
+    bare_count=$(grep -cP -- '--sfdx-url-stdin(?!\s*=)' "$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md" 2>/dev/null || echo 0)
+    if [ "$bare_count" -gt 0 ]; then
+      echo "WARNING: salesforce-auth/SKILL.md has $bare_count bare --sfdx-url-stdin references (should use --sfdx-url-stdin=-)"
+    fi
+  fi
+}
+
+# --- Phase 3: Credential-dependent tests ---
+
+# T3.1 — access-token login succeeds (requires real credentials)
+test_access_token_login() {
+  if [ -z "${SF_ACCESS_TOKEN:-}" ] || [ -z "${SF_ORG_INSTANCE_URL:-}" ]; then
+    echo "SKIP: SF_ACCESS_TOKEN or SF_ORG_INSTANCE_URL not set"; return 0
+  fi
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local out; out=$(sf org login access-token \
+    --instance-url "$SF_ORG_INSTANCE_URL" \
+    --alias sf-test-org \
+    --set-default \
+    --no-prompt \
+    --json 2>&1) || true
+
+  if echo "$out" | jq -e '.status == 0' >/dev/null 2>&1; then
+    sf org logout --target-org sf-test-org --no-prompt 2>/dev/null || true
+    return 0
+  fi
+
+  if echo "$out" | grep -q "correct format"; then
+    echo "SKIP: token format not accepted (session tokens require orgId! prefix)"
+    return 0
+  fi
+
+  echo "login failed: $out"
+  return 1
+}
+
+# T3.2 — SFDX URL login succeeds (requires real auth URL)
+test_sfdx_url_login() {
+  [ -n "${SFDX_AUTH_URL:-}" ] || { echo "SKIP: SFDX_AUTH_URL not set"; return 0; }
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local out; out=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url \
+    --sfdx-url-stdin=- \
+    --alias=sf-test-sfdx \
+    --set-default \
+    --json 2>&1) || { echo "login failed: $out"; return 1; }
+
+  echo "$out" | jq -e '.status == 0' >/dev/null || { echo "login returned non-zero status"; return 1; }
+
+  sf org logout --target-org sf-test-sfdx --no-prompt 2>/dev/null || true
+}
+
+# T3.3 — authenticated org appears in sf org list
+test_org_appears_in_list() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local org_alias
+  org_alias=$(_detect_live_org 2>/dev/null) || org_alias=""
+
+  if [ -n "$org_alias" ]; then
+    local count; count=$(sf org list --json 2>/dev/null \
+      | jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
+    [ "$count" -gt 0 ] || { echo "detected org $org_alias but count is $count"; return 1; }
+    return 0
+  fi
+
+  if [ -n "${SF_ACCESS_TOKEN:-}" ] && [ -n "${SF_ORG_INSTANCE_URL:-}" ]; then
+    sf org login access-token \
+      --instance-url "$SF_ORG_INSTANCE_URL" \
+      --alias sf-test-list \
+      --no-prompt \
+      --json >/dev/null 2>&1 || { echo "SKIP: login failed"; return 0; }
+
+    local count; count=$(sf org list --json 2>/dev/null \
+      | jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
+    [ "$count" -gt 0 ] || { echo "expected >0 orgs after login, got $count"; sf org logout --target-org sf-test-list --no-prompt 2>/dev/null || true; return 1; }
+    sf org logout --target-org sf-test-list --no-prompt 2>/dev/null || true
+    return 0
+  fi
+
+  echo "SKIP: no authenticated org and no auth env vars set"
+  return 0
+}
+
+# T3.4 — plugin files do not contain real credential values
+test_credentials_not_in_plugin_files() {
+  [ -n "${SF_ACCESS_TOKEN:-}" ] || { echo "SKIP: SF_ACCESS_TOKEN not set"; return 0; }
+  [ "${#SF_ACCESS_TOKEN}" -gt 20 ] || { echo "SKIP: SF_ACCESS_TOKEN too short to be a real token (${#SF_ACCESS_TOKEN} chars)"; return 0; }
+
+  local matches
+  matches=$(grep -rF "$SF_ACCESS_TOKEN" "$PLUGIN_ROOT" \
+    --include='*.md' --include='*.json' \
+    --exclude-dir='scripts' 2>/dev/null || true)
+  if [ -n "$matches" ]; then
+    echo "SECURITY: access token found in plugin files"
+    return 1
+  fi
+}
+
+# T3.5 — sf org display returns expected fields
+test_org_display_fields() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local org_alias
+  org_alias=$(_detect_live_org 2>/dev/null) || org_alias=""
+
+  if [ -z "$org_alias" ] && [ -n "${SF_ACCESS_TOKEN:-}" ] && [ -n "${SF_ORG_INSTANCE_URL:-}" ]; then
+    sf org login access-token \
+      --instance-url "$SF_ORG_INSTANCE_URL" \
+      --alias sf-test-display \
+      --set-default \
+      --no-prompt \
+      --json >/dev/null 2>&1 || { echo "SKIP: login failed"; return 0; }
+    org_alias="sf-test-display"
+  fi
+
+  [ -n "$org_alias" ] || { echo "SKIP: no authenticated org and no auth env vars set"; return 0; }
+
+  local out; out=$(sf org display --target-org "$org_alias" --json 2>/dev/null) || { echo "org display failed"; return 1; }
+
+  for field in username instanceUrl connectedStatus apiVersion; do
+    echo "$out" | jq -e ".result.$field" >/dev/null 2>&1 || { echo "missing field: $field"; return 1; }
+  done
+
+  if [ "$org_alias" = "sf-test-display" ]; then
+    sf org logout --target-org sf-test-display --no-prompt 2>/dev/null || true
+  fi
+}

--- a/plugins/salesforce/scripts/tests/test_hook.sh
+++ b/plugins/salesforce/scripts/tests/test_hook.sh
@@ -9,20 +9,34 @@ _get_hook_command() {
 
 # T2.1 — hook succeeds with no output when sf is installed
 test_hook_succeeds_when_sf_installed() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
-  local cmd; cmd=$(_get_hook_command)
-  local out; out=$(bash -c "$cmd" 2>&1)
-  [ -z "$out" ] || { echo "expected empty output, got: $out"; return 1; }
+  local cmd
+  cmd=$(_get_hook_command)
+  local out
+  out=$(bash -c "$cmd" 2>&1)
+  [ -z "$out" ] || {
+    echo "expected empty output, got: $out"
+    return 1
+  }
 }
 
 # T2.2 — hook warns when sf is not on PATH
 test_hook_warns_when_sf_missing() {
-  local cmd; cmd=$(_get_hook_command)
-  local tmp; tmp=$(mktemp -d)
+  local cmd
+  cmd=$(_get_hook_command)
+  local tmp
+  tmp=$(mktemp -d)
   ln -s /usr/bin/bash "$tmp/bash"
   ln -s "$(command -v command)" "$tmp/command" 2>/dev/null || true
-  local out; out=$(PATH="$tmp" bash -c "$cmd" 2>&1) || true
+  local out
+  out=$(PATH="$tmp" bash -c "$cmd" 2>&1) || true
   rm -rf "$tmp"
-  echo "$out" | grep -q 'WARNING' || { echo "expected WARNING in output, got: $out"; return 1; }
+  echo "$out" | grep -q 'WARNING' || {
+    echo "expected WARNING in output, got: $out"
+    return 1
+  }
 }

--- a/plugins/salesforce/scripts/tests/test_hook.sh
+++ b/plugins/salesforce/scripts/tests/test_hook.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Phase 2: SessionStart hook behavior — requires sf CLI.
+
+set -euo pipefail
+
+_get_hook_command() {
+  jq -r '.hooks.SessionStart[0].hooks[0].command' "$PLUGIN_ROOT/hooks/hooks.json"
+}
+
+# T2.1 — hook succeeds with no output when sf is installed
+test_hook_succeeds_when_sf_installed() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local cmd; cmd=$(_get_hook_command)
+  local out; out=$(bash -c "$cmd" 2>&1)
+  [ -z "$out" ] || { echo "expected empty output, got: $out"; return 1; }
+}
+
+# T2.2 — hook warns when sf is not on PATH
+test_hook_warns_when_sf_missing() {
+  local cmd; cmd=$(_get_hook_command)
+  local tmp; tmp=$(mktemp -d)
+  ln -s /usr/bin/bash "$tmp/bash"
+  ln -s "$(command -v command)" "$tmp/command" 2>/dev/null || true
+  local out; out=$(PATH="$tmp" bash -c "$cmd" 2>&1) || true
+  rm -rf "$tmp"
+  echo "$out" | grep -q 'WARNING' || { echo "expected WARNING in output, got: $out"; return 1; }
+}

--- a/plugins/salesforce/scripts/tests/test_integration.sh
+++ b/plugins/salesforce/scripts/tests/test_integration.sh
@@ -90,8 +90,7 @@ test_login_commands_in_agent() {
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
     case "$cmd" in
-    "sf org login"* | "sf org list" | "sf org display")
-      ;;
+    "sf org login"* | "sf org list" | "sf org display") ;;
     *)
       echo "unexpected command in sf-login.md: $cmd"
       return 1

--- a/plugins/salesforce/scripts/tests/test_integration.sh
+++ b/plugins/salesforce/scripts/tests/test_integration.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Cross-file consistency tests — no sf CLI or org required
+# (except test_delegation_sf_commands_valid which needs sf CLI).
+
+set -euo pipefail
+
+AUTH_SKILL="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
+INDEX_SKILL="$PLUGIN_ROOT/skills/salesforce-index/SKILL.md"
+AGENT_FILE="$PLUGIN_ROOT/agents/cli-operator.md"
+LOGIN_CMD="$PLUGIN_ROOT/commands/sf-login.md"
+STATUS_CMD="$PLUGIN_ROOT/commands/sf-status.md"
+
+# TI.1 — sf-login.md and salesforce-auth delegation priority order match
+test_login_auth_priority_match() {
+  local login_order auth_order
+
+  login_order=$(grep -oP 'sf org login \K[a-z-]+' "$LOGIN_CMD" | head -4)
+  auth_order=$(grep -A2 'Pick the first\|first fully satisfied' "$AUTH_SKILL" \
+    | grep -oP 'sf org login \K[a-z-]+' || true)
+
+  if [ -z "$auth_order" ]; then
+    auth_order=$(awk '/## Delegation/,/^##[^#]/' "$AUTH_SKILL" \
+      | grep -oP 'sf org login \K[a-z-]+')
+  fi
+
+  local login_first auth_first
+  login_first=$(echo "$login_order" | head -1)
+  auth_first=$(echo "$auth_order" | head -1)
+
+  [ "$login_first" = "$auth_first" ] || { echo "priority mismatch: sf-login starts with '$login_first', salesforce-auth starts with '$auth_first'"; return 1; }
+}
+
+# TI.2 — salesforce-index routing table skill names are valid identifiers
+test_routing_table_skills_valid() {
+  local skills
+  skills=$(awk '/afv-library Skill/,/^###/' "$INDEX_SKILL" \
+    | grep '`' \
+    | grep -oP '`\K[a-z][-a-z0-9]*(?=`)' || true)
+
+  [ -n "$skills" ] || { echo "no skill names found in routing table"; return 1; }
+
+  local count=0
+  while IFS= read -r skill; do
+    [[ "$skill" =~ ^[a-z][-a-z0-9]*$ ]] || { echo "invalid skill name: $skill"; return 1; }
+    count=$((count + 1))
+  done <<< "$skills"
+
+  [ "$count" -ge 10 ] || { echo "expected >=10 skills in routing table, found $count"; return 1; }
+}
+
+# TI.3 — sf-status.md delegation commands are in cli-operator
+test_status_commands_in_agent() {
+  local cmds
+  cmds=$(grep -oP 'sf (org|project|apex) \S+' "$STATUS_CMD" | sort -u)
+
+  while IFS= read -r cmd; do
+    [ -z "$cmd" ] && continue
+    local base; base=$(echo "$cmd" | awk '{print $1, $2, $3}')
+    grep -qF "$base" "$AGENT_FILE" || grep -qF "$(echo "$base" | awk '{print $2, $3}')" "$AGENT_FILE" \
+      || { echo "command '$cmd' from sf-status.md not found in cli-operator agent"; return 1; }
+  done <<< "$cmds"
+}
+
+# TI.4 — sf-login.md delegation commands reference valid sf subcommands
+test_login_commands_in_agent() {
+  local login_cmds
+  login_cmds=$(grep -oP 'sf org (login \S+|list|display)' "$LOGIN_CMD" | sort -u)
+
+  [ -n "$login_cmds" ] || { echo "no sf commands found in sf-login.md"; return 1; }
+
+  while IFS= read -r cmd; do
+    [ -z "$cmd" ] && continue
+    case "$cmd" in
+      "sf org login"*|"sf org list"|"sf org display")
+        ;;
+      *)
+        echo "unexpected command in sf-login.md: $cmd"
+        return 1
+        ;;
+    esac
+  done <<< "$login_cmds"
+}
+
+# TI.5 — both command files reference cli-operator agent
+test_delegations_reference_agent() {
+  grep -qi 'cli-operator' "$LOGIN_CMD" || { echo "sf-login.md does not reference cli-operator"; return 1; }
+  grep -qi 'cli-operator' "$STATUS_CMD" || { echo "sf-status.md does not reference cli-operator"; return 1; }
+}
+
+# TI.6 — salesforce-auth env var table covers all 6 expected variables
+test_auth_env_var_coverage() {
+  local expected_vars=(SF_ACCESS_TOKEN SFDX_AUTH_URL SF_ORG_INSTANCE_URL SF_JWT_KEY_FILE SF_CLIENT_ID SF_USERNAME)
+
+  for var in "${expected_vars[@]}"; do
+    grep -qF "$var" "$AUTH_SKILL" || { echo "salesforce-auth missing env var: $var"; return 1; }
+  done
+}
+
+# TI.7 — sf subcommands referenced in delegation exist in sf CLI
+test_delegation_sf_commands_valid() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local subcommands
+  subcommands=$(cat "$LOGIN_CMD" "$STATUS_CMD" "$AUTH_SKILL" \
+    | grep -oP 'sf (org|project|apex) \S+' \
+    | sed 's/ --.*//; s/ \\$//' \
+    | sort -u)
+
+  while IFS= read -r cmd; do
+    [ -z "$cmd" ] && continue
+    local topic subcmd
+    topic=$(echo "$cmd" | awk '{print $2}')
+    subcmd=$(echo "$cmd" | awk '{print $3}')
+    [ -z "$subcmd" ] && continue
+
+    sf "$topic" "$subcmd" --help >/dev/null 2>&1 \
+      || { echo "sf $topic $subcmd is not a valid sf CLI subcommand"; return 1; }
+  done <<< "$subcommands"
+}
+
+# TI.8 — audit --sfdx-url-stdin usage across plugin
+test_sfdx_url_stdin_syntax_audit() {
+  local total bare correct
+  total=$(grep -rc -- '--sfdx-url-stdin' "$PLUGIN_ROOT" --include='*.md' 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+  correct=$(grep -rcP -- '--sfdx-url-stdin\s*=' "$PLUGIN_ROOT" --include='*.md' 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+  bare=$((total - correct))
+
+  if [ "$bare" -gt 0 ]; then
+    echo "WARNING: $bare bare --sfdx-url-stdin references found (should use --sfdx-url-stdin=-). $correct correct."
+  fi
+}
+
+# TI.9 — cli-operator security rules cover auth skill security rules
+test_auth_security_rules_in_agent() {
+  grep -qi 'echo' "$AGENT_FILE" || { echo "cli-operator missing 'echo' security rule"; return 1; }
+  grep -qi 'credential\|token\|secret' "$AGENT_FILE" || { echo "cli-operator missing credential protection rule"; return 1; }
+  grep -qi 'sanitize' "$AGENT_FILE" || { echo "cli-operator missing sanitization rule"; return 1; }
+  grep -qi 'deploy\|destructive' "$AGENT_FILE" || { echo "cli-operator missing deployment safety rule"; return 1; }
+
+  grep -q 'disallowedTools' "$AGENT_FILE" || { echo "cli-operator missing disallowedTools (prevents file writes)"; return 1; }
+}

--- a/plugins/salesforce/scripts/tests/test_integration.sh
+++ b/plugins/salesforce/scripts/tests/test_integration.sh
@@ -15,37 +15,49 @@ test_login_auth_priority_match() {
   local login_order auth_order
 
   login_order=$(grep -oP 'sf org login \K[a-z-]+' "$LOGIN_CMD" | head -4)
-  auth_order=$(grep -A2 'Pick the first\|first fully satisfied' "$AUTH_SKILL" \
-    | grep -oP 'sf org login \K[a-z-]+' || true)
+  auth_order=$(grep -A2 'Pick the first\|first fully satisfied' "$AUTH_SKILL" |
+    grep -oP 'sf org login \K[a-z-]+' || true)
 
   if [ -z "$auth_order" ]; then
-    auth_order=$(awk '/## Delegation/,/^##[^#]/' "$AUTH_SKILL" \
-      | grep -oP 'sf org login \K[a-z-]+')
+    auth_order=$(awk '/## Delegation/,/^##[^#]/' "$AUTH_SKILL" |
+      grep -oP 'sf org login \K[a-z-]+')
   fi
 
   local login_first auth_first
   login_first=$(echo "$login_order" | head -1)
   auth_first=$(echo "$auth_order" | head -1)
 
-  [ "$login_first" = "$auth_first" ] || { echo "priority mismatch: sf-login starts with '$login_first', salesforce-auth starts with '$auth_first'"; return 1; }
+  [ "$login_first" = "$auth_first" ] || {
+    echo "priority mismatch: sf-login starts with '$login_first', salesforce-auth starts with '$auth_first'"
+    return 1
+  }
 }
 
 # TI.2 — salesforce-index routing table skill names are valid identifiers
 test_routing_table_skills_valid() {
   local skills
-  skills=$(awk '/afv-library Skill/,/^###/' "$INDEX_SKILL" \
-    | grep '`' \
-    | grep -oP '`\K[a-z][-a-z0-9]*(?=`)' || true)
+  skills=$(awk '/afv-library Skill/,/^###/' "$INDEX_SKILL" |
+    grep '`' |
+    grep -oP '`\K[a-z][-a-z0-9]*(?=`)' || true)
 
-  [ -n "$skills" ] || { echo "no skill names found in routing table"; return 1; }
+  [ -n "$skills" ] || {
+    echo "no skill names found in routing table"
+    return 1
+  }
 
   local count=0
   while IFS= read -r skill; do
-    [[ "$skill" =~ ^[a-z][-a-z0-9]*$ ]] || { echo "invalid skill name: $skill"; return 1; }
+    [[ "$skill" =~ ^[a-z][-a-z0-9]*$ ]] || {
+      echo "invalid skill name: $skill"
+      return 1
+    }
     count=$((count + 1))
-  done <<< "$skills"
+  done <<<"$skills"
 
-  [ "$count" -ge 10 ] || { echo "expected >=10 skills in routing table, found $count"; return 1; }
+  [ "$count" -ge 10 ] || {
+    echo "expected >=10 skills in routing table, found $count"
+    return 1
+  }
 }
 
 # TI.3 — sf-status.md delegation commands are in cli-operator
@@ -55,10 +67,14 @@ test_status_commands_in_agent() {
 
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
-    local base; base=$(echo "$cmd" | awk '{print $1, $2, $3}')
-    grep -qF "$base" "$AGENT_FILE" || grep -qF "$(echo "$base" | awk '{print $2, $3}')" "$AGENT_FILE" \
-      || { echo "command '$cmd' from sf-status.md not found in cli-operator agent"; return 1; }
-  done <<< "$cmds"
+    local base
+    base=$(echo "$cmd" | awk '{print $1, $2, $3}')
+    grep -qF "$base" "$AGENT_FILE" || grep -qF "$(echo "$base" | awk '{print $2, $3}')" "$AGENT_FILE" ||
+      {
+        echo "command '$cmd' from sf-status.md not found in cli-operator agent"
+        return 1
+      }
+  done <<<"$cmds"
 }
 
 # TI.4 — sf-login.md delegation commands reference valid sf subcommands
@@ -66,25 +82,34 @@ test_login_commands_in_agent() {
   local login_cmds
   login_cmds=$(grep -oP 'sf org (login \S+|list|display)' "$LOGIN_CMD" | sort -u)
 
-  [ -n "$login_cmds" ] || { echo "no sf commands found in sf-login.md"; return 1; }
+  [ -n "$login_cmds" ] || {
+    echo "no sf commands found in sf-login.md"
+    return 1
+  }
 
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
     case "$cmd" in
-      "sf org login"*|"sf org list"|"sf org display")
-        ;;
-      *)
-        echo "unexpected command in sf-login.md: $cmd"
-        return 1
-        ;;
+    "sf org login"* | "sf org list" | "sf org display")
+      ;;
+    *)
+      echo "unexpected command in sf-login.md: $cmd"
+      return 1
+      ;;
     esac
-  done <<< "$login_cmds"
+  done <<<"$login_cmds"
 }
 
 # TI.5 — both command files reference cli-operator agent
 test_delegations_reference_agent() {
-  grep -qi 'cli-operator' "$LOGIN_CMD" || { echo "sf-login.md does not reference cli-operator"; return 1; }
-  grep -qi 'cli-operator' "$STATUS_CMD" || { echo "sf-status.md does not reference cli-operator"; return 1; }
+  grep -qi 'cli-operator' "$LOGIN_CMD" || {
+    echo "sf-login.md does not reference cli-operator"
+    return 1
+  }
+  grep -qi 'cli-operator' "$STATUS_CMD" || {
+    echo "sf-status.md does not reference cli-operator"
+    return 1
+  }
 }
 
 # TI.6 — salesforce-auth env var table covers all 6 expected variables
@@ -92,19 +117,25 @@ test_auth_env_var_coverage() {
   local expected_vars=(SF_ACCESS_TOKEN SFDX_AUTH_URL SF_ORG_INSTANCE_URL SF_JWT_KEY_FILE SF_CLIENT_ID SF_USERNAME)
 
   for var in "${expected_vars[@]}"; do
-    grep -qF "$var" "$AUTH_SKILL" || { echo "salesforce-auth missing env var: $var"; return 1; }
+    grep -qF "$var" "$AUTH_SKILL" || {
+      echo "salesforce-auth missing env var: $var"
+      return 1
+    }
   done
 }
 
 # TI.7 — sf subcommands referenced in delegation exist in sf CLI
 test_delegation_sf_commands_valid() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
   local subcommands
-  subcommands=$(cat "$LOGIN_CMD" "$STATUS_CMD" "$AUTH_SKILL" \
-    | grep -oP 'sf (org|project|apex) \S+' \
-    | sed 's/ --.*//; s/ \\$//' \
-    | sort -u)
+  subcommands=$(cat "$LOGIN_CMD" "$STATUS_CMD" "$AUTH_SKILL" |
+    grep -oP 'sf (org|project|apex) \S+' |
+    sed 's/ --.*//; s/ \\$//' |
+    sort -u)
 
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
@@ -113,9 +144,12 @@ test_delegation_sf_commands_valid() {
     subcmd=$(echo "$cmd" | awk '{print $3}')
     [ -z "$subcmd" ] && continue
 
-    sf "$topic" "$subcmd" --help >/dev/null 2>&1 \
-      || { echo "sf $topic $subcmd is not a valid sf CLI subcommand"; return 1; }
-  done <<< "$subcommands"
+    sf "$topic" "$subcmd" --help >/dev/null 2>&1 ||
+      {
+        echo "sf $topic $subcmd is not a valid sf CLI subcommand"
+        return 1
+      }
+  done <<<"$subcommands"
 }
 
 # TI.8 — audit --sfdx-url-stdin usage across plugin
@@ -132,10 +166,25 @@ test_sfdx_url_stdin_syntax_audit() {
 
 # TI.9 — cli-operator security rules cover auth skill security rules
 test_auth_security_rules_in_agent() {
-  grep -qi 'echo' "$AGENT_FILE" || { echo "cli-operator missing 'echo' security rule"; return 1; }
-  grep -qi 'credential\|token\|secret' "$AGENT_FILE" || { echo "cli-operator missing credential protection rule"; return 1; }
-  grep -qi 'sanitize' "$AGENT_FILE" || { echo "cli-operator missing sanitization rule"; return 1; }
-  grep -qi 'deploy\|destructive' "$AGENT_FILE" || { echo "cli-operator missing deployment safety rule"; return 1; }
+  grep -qi 'echo' "$AGENT_FILE" || {
+    echo "cli-operator missing 'echo' security rule"
+    return 1
+  }
+  grep -qi 'credential\|token\|secret' "$AGENT_FILE" || {
+    echo "cli-operator missing credential protection rule"
+    return 1
+  }
+  grep -qi 'sanitize' "$AGENT_FILE" || {
+    echo "cli-operator missing sanitization rule"
+    return 1
+  }
+  grep -qi 'deploy\|destructive' "$AGENT_FILE" || {
+    echo "cli-operator missing deployment safety rule"
+    return 1
+  }
 
-  grep -q 'disallowedTools' "$AGENT_FILE" || { echo "cli-operator missing disallowedTools (prevents file writes)"; return 1; }
+  grep -q 'disallowedTools' "$AGENT_FILE" || {
+    echo "cli-operator missing disallowedTools (prevents file writes)"
+    return 1
+  }
 }

--- a/plugins/salesforce/scripts/tests/test_live.sh
+++ b/plugins/salesforce/scripts/tests/test_live.sh
@@ -9,76 +9,134 @@ source "$HERE/_helpers.sh"
 
 # TL.1 — sf org list returns >0 orgs when one is authenticated
 test_live_org_list_populated() {
-  local org; org=$(_detect_live_org 2>/dev/null) || { echo "SKIP: no authenticated org"; return 0; }
+  local org
+  org=$(_detect_live_org 2>/dev/null) || {
+    echo "SKIP: no authenticated org"
+    return 0
+  }
 
-  local count; count=$(sf org list --json 2>/dev/null \
-    | jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
-  [ "$count" -gt 0 ] || { echo "detected org $org but list count is $count"; return 1; }
+  local count
+  count=$(sf org list --json 2>/dev/null |
+    jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
+  [ "$count" -gt 0 ] || {
+    echo "detected org $org but list count is $count"
+    return 1
+  }
 }
 
 # TL.2 — sf org display returns expected fields
 test_live_org_display_fields() {
-  local org; org=$(_detect_live_org 2>/dev/null) || { echo "SKIP: no authenticated org"; return 0; }
+  local org
+  org=$(_detect_live_org 2>/dev/null) || {
+    echo "SKIP: no authenticated org"
+    return 0
+  }
 
-  local out; out=$(sf org display --target-org "$org" --json 2>/dev/null) \
-    || { echo "sf org display failed for $org"; return 1; }
+  local out
+  out=$(sf org display --target-org "$org" --json 2>/dev/null) ||
+    {
+      echo "sf org display failed for $org"
+      return 1
+    }
 
   for field in username instanceUrl connectedStatus apiVersion; do
-    echo "$out" | jq -e ".result.$field" >/dev/null 2>&1 \
-      || { echo "missing field: $field in org display for $org"; return 1; }
+    echo "$out" | jq -e ".result.$field" >/dev/null 2>&1 ||
+      {
+        echo "missing field: $field in org display for $org"
+        return 1
+      }
   done
 }
 
 # TL.3 — connectedStatus is a recognized value
 test_live_connected_status() {
-  local org; org=$(_detect_live_org 2>/dev/null) || { echo "SKIP: no authenticated org"; return 0; }
+  local org
+  org=$(_detect_live_org 2>/dev/null) || {
+    echo "SKIP: no authenticated org"
+    return 0
+  }
 
-  local status; status=$(sf org display --target-org "$org" --json 2>/dev/null \
-    | jq -r '.result.connectedStatus // empty')
+  local status
+  status=$(sf org display --target-org "$org" --json 2>/dev/null |
+    jq -r '.result.connectedStatus // empty')
 
-  [ -n "$status" ] || { echo "connectedStatus is empty for $org"; return 1; }
+  [ -n "$status" ] || {
+    echo "connectedStatus is empty for $org"
+    return 1
+  }
 
   case "$status" in
-    Connected|Active|Unknown|"RefreshToken has expired"*)
-      ;;
-    *)
-      echo "WARNING: unrecognized connectedStatus '$status' for $org (test still passes)"
-      ;;
+  Connected | Active | Unknown | "RefreshToken has expired"*)
+    ;;
+  *)
+    echo "WARNING: unrecognized connectedStatus '$status' for $org (test still passes)"
+    ;;
   esac
 }
 
 # TL.4 — sf org list JSON has expected schema (works even with 0 orgs)
 test_live_org_list_schema() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
-  local out; out=$(sf org list --json 2>/dev/null) || { echo "sf org list failed"; return 1; }
+  local out
+  out=$(sf org list --json 2>/dev/null) || {
+    echo "sf org list failed"
+    return 1
+  }
 
-  echo "$out" | jq -e '.status == 0' >/dev/null || { echo "status is not 0"; return 1; }
+  echo "$out" | jq -e '.status == 0' >/dev/null || {
+    echo "status is not 0"
+    return 1
+  }
 
   local keys=("other" "nonScratchOrgs" "devHubs" "scratchOrgs" "sandboxes")
   for key in "${keys[@]}"; do
-    echo "$out" | jq -e ".result.$key | type == \"array\"" >/dev/null 2>&1 \
-      || { echo "result.$key is not an array"; return 1; }
+    echo "$out" | jq -e ".result.$key | type == \"array\"" >/dev/null 2>&1 ||
+      {
+        echo "result.$key is not an array"
+        return 1
+      }
   done
 }
 
 # TL.5 — instance URL is valid HTTPS salesforce/force.com domain
 test_live_instance_url_format() {
-  local org; org=$(_detect_live_org 2>/dev/null) || { echo "SKIP: no authenticated org"; return 0; }
+  local org
+  org=$(_detect_live_org 2>/dev/null) || {
+    echo "SKIP: no authenticated org"
+    return 0
+  }
 
-  local url; url=$(sf org display --target-org "$org" --json 2>/dev/null \
-    | jq -r '.result.instanceUrl // empty')
+  local url
+  url=$(sf org display --target-org "$org" --json 2>/dev/null |
+    jq -r '.result.instanceUrl // empty')
 
-  [ -n "$url" ] || { echo "instanceUrl is empty for $org"; return 1; }
-  [[ "$url" =~ ^https://.*\.(salesforce|force)\.com ]] \
-    || { echo "instanceUrl '$url' does not match expected pattern"; return 1; }
+  [ -n "$url" ] || {
+    echo "instanceUrl is empty for $org"
+    return 1
+  }
+  [[ "$url" =~ ^https://.*\.(salesforce|force)\.com ]] ||
+    {
+      echo "instanceUrl '$url' does not match expected pattern"
+      return 1
+    }
 }
 
 # TL.6 — --skip-connection-status flag is accepted
 test_live_skip_connection_flag() {
-  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+  command -v sf >/dev/null 2>&1 || {
+    echo "SKIP: sf CLI not installed"
+    return 0
+  }
 
-  local out; out=$(sf org list --json --skip-connection-status 2>/dev/null) || true
-  echo "$out" | jq -e '.status == 0' >/dev/null 2>&1 \
-    || { echo "--skip-connection-status flag not accepted or returned error"; return 1; }
+  local out
+  out=$(sf org list --json --skip-connection-status 2>/dev/null) || true
+  echo "$out" | jq -e '.status == 0' >/dev/null 2>&1 ||
+    {
+      echo "--skip-connection-status flag not accepted or returned error"
+      return 1
+    }
 }

--- a/plugins/salesforce/scripts/tests/test_live.sh
+++ b/plugins/salesforce/scripts/tests/test_live.sh
@@ -66,8 +66,7 @@ test_live_connected_status() {
   }
 
   case "$status" in
-  Connected | Active | Unknown | "RefreshToken has expired"*)
-    ;;
+  Connected | Active | Unknown | "RefreshToken has expired"*) ;;
   *)
     echo "WARNING: unrecognized connectedStatus '$status' for $org (test still passes)"
     ;;

--- a/plugins/salesforce/scripts/tests/test_live.sh
+++ b/plugins/salesforce/scripts/tests/test_live.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Live org tests — skip gracefully when no org is authenticated.
+
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck disable=SC1091
+source "$HERE/_helpers.sh"
+
+# TL.1 — sf org list returns >0 orgs when one is authenticated
+test_live_org_list_populated() {
+  local org; org=$(_detect_live_org 2>/dev/null) || { echo "SKIP: no authenticated org"; return 0; }
+
+  local count; count=$(sf org list --json 2>/dev/null \
+    | jq '[.result.other, .result.nonScratchOrgs, .result.devHubs, .result.scratchOrgs, .result.sandboxes] | map(length) | add')
+  [ "$count" -gt 0 ] || { echo "detected org $org but list count is $count"; return 1; }
+}
+
+# TL.2 — sf org display returns expected fields
+test_live_org_display_fields() {
+  local org; org=$(_detect_live_org 2>/dev/null) || { echo "SKIP: no authenticated org"; return 0; }
+
+  local out; out=$(sf org display --target-org "$org" --json 2>/dev/null) \
+    || { echo "sf org display failed for $org"; return 1; }
+
+  for field in username instanceUrl connectedStatus apiVersion; do
+    echo "$out" | jq -e ".result.$field" >/dev/null 2>&1 \
+      || { echo "missing field: $field in org display for $org"; return 1; }
+  done
+}
+
+# TL.3 — connectedStatus is a recognized value
+test_live_connected_status() {
+  local org; org=$(_detect_live_org 2>/dev/null) || { echo "SKIP: no authenticated org"; return 0; }
+
+  local status; status=$(sf org display --target-org "$org" --json 2>/dev/null \
+    | jq -r '.result.connectedStatus // empty')
+
+  [ -n "$status" ] || { echo "connectedStatus is empty for $org"; return 1; }
+
+  case "$status" in
+    Connected|Active|Unknown|"RefreshToken has expired"*)
+      ;;
+    *)
+      echo "WARNING: unrecognized connectedStatus '$status' for $org (test still passes)"
+      ;;
+  esac
+}
+
+# TL.4 — sf org list JSON has expected schema (works even with 0 orgs)
+test_live_org_list_schema() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local out; out=$(sf org list --json 2>/dev/null) || { echo "sf org list failed"; return 1; }
+
+  echo "$out" | jq -e '.status == 0' >/dev/null || { echo "status is not 0"; return 1; }
+
+  local keys=("other" "nonScratchOrgs" "devHubs" "scratchOrgs" "sandboxes")
+  for key in "${keys[@]}"; do
+    echo "$out" | jq -e ".result.$key | type == \"array\"" >/dev/null 2>&1 \
+      || { echo "result.$key is not an array"; return 1; }
+  done
+}
+
+# TL.5 — instance URL is valid HTTPS salesforce/force.com domain
+test_live_instance_url_format() {
+  local org; org=$(_detect_live_org 2>/dev/null) || { echo "SKIP: no authenticated org"; return 0; }
+
+  local url; url=$(sf org display --target-org "$org" --json 2>/dev/null \
+    | jq -r '.result.instanceUrl // empty')
+
+  [ -n "$url" ] || { echo "instanceUrl is empty for $org"; return 1; }
+  [[ "$url" =~ ^https://.*\.(salesforce|force)\.com ]] \
+    || { echo "instanceUrl '$url' does not match expected pattern"; return 1; }
+}
+
+# TL.6 — --skip-connection-status flag is accepted
+test_live_skip_connection_flag() {
+  command -v sf >/dev/null 2>&1 || { echo "SKIP: sf CLI not installed"; return 0; }
+
+  local out; out=$(sf org list --json --skip-connection-status 2>/dev/null) || true
+  echo "$out" | jq -e '.status == 0' >/dev/null 2>&1 \
+    || { echo "--skip-connection-status flag not accepted or returned error"; return 1; }
+}

--- a/plugins/salesforce/scripts/tests/test_security.sh
+++ b/plugins/salesforce/scripts/tests/test_security.sh
@@ -8,13 +8,13 @@ test_no_hardcoded_credentials() {
   local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}|force://[A-Za-z0-9]{10,}'
   local matches
   matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
-    --include='*.md' --include='*.json' \
-    | grep -v 'README.md' \
-    | grep -v '\$SF_ACCESS_TOKEN' \
-    | grep -v '\$SFDX_AUTH_URL' \
-    | grep -v 'force://\.\.\.' \
-    | grep -v 'force://fake' \
-    || true)
+    --include='*.md' --include='*.json' |
+    grep -v 'README.md' |
+    grep -v '\$SF_ACCESS_TOKEN' |
+    grep -v '\$SFDX_AUTH_URL' |
+    grep -v 'force://\.\.\.' |
+    grep -v 'force://fake' ||
+    true)
 
   if [ -n "$matches" ]; then
     echo "Possible hardcoded credentials found:"
@@ -26,25 +26,41 @@ test_no_hardcoded_credentials() {
 # T1.12 — auth skill instructs never to echo credentials
 test_auth_skill_no_echo_rule() {
   local skill="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
-  grep -qi 'never echo' "$skill" || { echo "auth skill missing 'Never echo' instruction"; return 1; }
+  grep -qi 'never echo' "$skill" || {
+    echo "auth skill missing 'Never echo' instruction"
+    return 1
+  }
 }
 
 # T1.13 — cli-operator agent has input sanitization regex
 test_agent_sanitization_regex() {
   local agent="$PLUGIN_ROOT/agents/cli-operator.md"
-  grep -q '\^.a-zA-Z0-9._-' "$agent" || { echo "cli-operator missing sanitization regex"; return 1; }
+  grep -q '\^.a-zA-Z0-9._-' "$agent" || {
+    echo "cli-operator missing sanitization regex"
+    return 1
+  }
 }
 
 # T1.14 — auth skill uses --sfdx-url-stdin (not file-based)
 test_auth_uses_stdin_pipe() {
   local skill="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
-  local count; count=$(grep -c 'sfdx-url-stdin' "$skill")
-  [ "$count" -ge 2 ] || { echo "expected >=2 references to --sfdx-url-stdin, found $count"; return 1; }
+  local count
+  count=$(grep -c 'sfdx-url-stdin' "$skill")
+  [ "$count" -ge 2 ] || {
+    echo "expected >=2 references to --sfdx-url-stdin, found $count"
+    return 1
+  }
 }
 
 # T1.15 — device flow documented as blocked
 test_device_flow_blocked() {
   local skill="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
-  grep -qi 'blocked' "$skill" || { echo "device flow not documented as blocked"; return 1; }
-  grep -qi 'device' "$skill" || { echo "no mention of device flow"; return 1; }
+  grep -qi 'blocked' "$skill" || {
+    echo "device flow not documented as blocked"
+    return 1
+  }
+  grep -qi 'device' "$skill" || {
+    echo "no mention of device flow"
+    return 1
+  }
 }

--- a/plugins/salesforce/scripts/tests/test_security.sh
+++ b/plugins/salesforce/scripts/tests/test_security.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no sf CLI or org required.
+
+set -euo pipefail
+
+# T1.11 — no hardcoded credentials in plugin files
+test_no_hardcoded_credentials() {
+  local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}|force://[A-Za-z0-9]{10,}'
+  local matches
+  matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
+    --include='*.md' --include='*.json' \
+    | grep -v 'README.md' \
+    | grep -v '\$SF_ACCESS_TOKEN' \
+    | grep -v '\$SFDX_AUTH_URL' \
+    | grep -v 'force://\.\.\.' \
+    | grep -v 'force://fake' \
+    || true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded credentials found:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.12 — auth skill instructs never to echo credentials
+test_auth_skill_no_echo_rule() {
+  local skill="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
+  grep -qi 'never echo' "$skill" || { echo "auth skill missing 'Never echo' instruction"; return 1; }
+}
+
+# T1.13 — cli-operator agent has input sanitization regex
+test_agent_sanitization_regex() {
+  local agent="$PLUGIN_ROOT/agents/cli-operator.md"
+  grep -q '\^.a-zA-Z0-9._-' "$agent" || { echo "cli-operator missing sanitization regex"; return 1; }
+}
+
+# T1.14 — auth skill uses --sfdx-url-stdin (not file-based)
+test_auth_uses_stdin_pipe() {
+  local skill="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
+  local count; count=$(grep -c 'sfdx-url-stdin' "$skill")
+  [ "$count" -ge 2 ] || { echo "expected >=2 references to --sfdx-url-stdin, found $count"; return 1; }
+}
+
+# T1.15 — device flow documented as blocked
+test_device_flow_blocked() {
+  local skill="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
+  grep -qi 'blocked' "$skill" || { echo "device flow not documented as blocked"; return 1; }
+  grep -qi 'device' "$skill" || { echo "no mention of device flow"; return 1; }
+}

--- a/plugins/salesforce/scripts/tests/test_structure.sh
+++ b/plugins/salesforce/scripts/tests/test_structure.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no sf CLI or org required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.claude-plugin/plugin.json"
+  jq -e '.name'        "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version'     "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name; name=$(jq -r '.name' "$pj")
+  [ "$name" = "salesforce" ] || { echo "name=$name, expected salesforce"; return 1; }
+
+  local ver; ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "bad version: $ver"; return 1; }
+}
+
+# T1.2 — marketplace.json has a matching salesforce entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.claude-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.claude-plugin/plugin.json"
+
+  local mp_name; mp_name=$(jq -r '.plugins[] | select(.name == "salesforce") | .name' "$mj")
+  [ "$mp_name" = "salesforce" ] || { echo "salesforce entry missing from marketplace.json"; return 1; }
+
+  local mp_ver; mp_ver=$(jq -r '.plugins[] | select(.name == "salesforce") | .version' "$mj")
+  local pj_ver; pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || { echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"; return 1; }
+
+  local src; src=$(jq -r '.plugins[] | select(.name == "salesforce") | .source' "$mj")
+  [ "$src" = "./plugins/salesforce" ] || { echo "source=$src, expected ./plugins/salesforce"; return 1; }
+}
+
+# T1.3 — all expected files exist
+test_expected_files_exist() {
+  local files=(
+    ".claude-plugin/plugin.json"
+    "hooks/hooks.json"
+    "skills/salesforce-index/SKILL.md"
+    "skills/salesforce-auth/SKILL.md"
+    "agents/cli-operator.md"
+    "commands/sf-login.md"
+    "commands/sf-status.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || { echo "missing: $f"; return 1; }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  for skill_dir in salesforce-index salesforce-auth; do
+    local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
+    local name_line; name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || { echo "$skill_dir: missing name in frontmatter"; return 1; }
+
+    local desc_line; desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || { echo "$skill_dir: missing description in frontmatter"; return 1; }
+  done
+}
+
+# T1.5 — salesforce-index is not user-invocable
+test_index_not_user_invocable() {
+  local skill="$PLUGIN_ROOT/skills/salesforce-index/SKILL.md"
+  grep -q 'user-invocable: false' "$skill" || { echo "salesforce-index should be user-invocable: false"; return 1; }
+}
+
+# T1.6 — salesforce-auth is not user-invocable
+test_auth_not_user_invocable() {
+  local skill="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
+  grep -q 'user-invocable: false' "$skill" || { echo "salesforce-auth should be user-invocable: false"; return 1; }
+}
+
+# T1.7 — cli-operator.md frontmatter has correct tools and disallowedTools
+test_agent_tools() {
+  local agent="$PLUGIN_ROOT/agents/cli-operator.md"
+  local fm; fm=$(extract_frontmatter "$agent")
+
+  for tool in Read Bash Glob Grep; do
+    echo "$fm" | grep -qF "  - $tool" || { echo "cli-operator missing allowed tool: $tool"; return 1; }
+  done
+
+  echo "$fm" | grep -q 'disallowedTools:' || { echo "cli-operator missing disallowedTools"; return 1; }
+  for tool in Write Edit Agent; do
+    echo "$fm" | grep -qF "  - $tool" || { echo "cli-operator missing disallowed tool: $tool"; return 1; }
+  done
+}
+
+# T1.8 — command files have description in frontmatter
+test_command_frontmatter() {
+  for cmd in sf-login sf-status; do
+    local file="$PLUGIN_ROOT/commands/${cmd}.md"
+    local desc; desc=$(frontmatter_value "$file" "description")
+    [ -n "$desc" ] || { echo "$cmd: missing description"; return 1; }
+  done
+
+  local hint; hint=$(frontmatter_value "$PLUGIN_ROOT/commands/sf-login.md" "argument-hint")
+  [ -n "$hint" ] || { echo "sf-login: missing argument-hint"; return 1; }
+}
+
+# T1.9 — hooks.json is valid JSON with correct structure
+test_hooks_json_structure() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  jq -e '.' "$hj" >/dev/null || { echo "hooks.json is not valid JSON"; return 1; }
+
+  local hook_type; hook_type=$(jq -r '.hooks.SessionStart[0].hooks[0].type' "$hj")
+  [ "$hook_type" = "command" ] || { echo "hook type=$hook_type, expected command"; return 1; }
+
+  local timeout; timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$hj")
+  [[ "$timeout" =~ ^[0-9]+$ ]] || { echo "timeout is not a number: $timeout"; return 1; }
+}
+
+# T1.10 — hook command is syntactically valid shell
+test_hook_command_syntax() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  local cmd; cmd=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$hj")
+  bash -n <<<"$cmd" || { echo "hook command has syntax error"; return 1; }
+}

--- a/plugins/salesforce/scripts/tests/test_structure.sh
+++ b/plugins/salesforce/scripts/tests/test_structure.sh
@@ -15,16 +15,24 @@ frontmatter_value() {
 # T1.1 — plugin.json is valid JSON with required fields
 test_plugin_json_valid() {
   local pj="$PLUGIN_ROOT/.claude-plugin/plugin.json"
-  jq -e '.name'        "$pj" >/dev/null
+  jq -e '.name' "$pj" >/dev/null
   jq -e '.description' "$pj" >/dev/null
-  jq -e '.version'     "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
   jq -e '.author.name' "$pj" >/dev/null
 
-  local name; name=$(jq -r '.name' "$pj")
-  [ "$name" = "salesforce" ] || { echo "name=$name, expected salesforce"; return 1; }
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "salesforce" ] || {
+    echo "name=$name, expected salesforce"
+    return 1
+  }
 
-  local ver; ver=$(jq -r '.version' "$pj")
-  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "bad version: $ver"; return 1; }
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
 }
 
 # T1.2 — marketplace.json has a matching salesforce entry
@@ -32,15 +40,28 @@ test_marketplace_entry() {
   local mj="$MARKETPLACE_ROOT/.claude-plugin/marketplace.json"
   local pj="$PLUGIN_ROOT/.claude-plugin/plugin.json"
 
-  local mp_name; mp_name=$(jq -r '.plugins[] | select(.name == "salesforce") | .name' "$mj")
-  [ "$mp_name" = "salesforce" ] || { echo "salesforce entry missing from marketplace.json"; return 1; }
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "salesforce") | .name' "$mj")
+  [ "$mp_name" = "salesforce" ] || {
+    echo "salesforce entry missing from marketplace.json"
+    return 1
+  }
 
-  local mp_ver; mp_ver=$(jq -r '.plugins[] | select(.name == "salesforce") | .version' "$mj")
-  local pj_ver; pj_ver=$(jq -r '.version' "$pj")
-  [ "$mp_ver" = "$pj_ver" ] || { echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"; return 1; }
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "salesforce") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
 
-  local src; src=$(jq -r '.plugins[] | select(.name == "salesforce") | .source' "$mj")
-  [ "$src" = "./plugins/salesforce" ] || { echo "source=$src, expected ./plugins/salesforce"; return 1; }
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "salesforce") | .source' "$mj")
+  [ "$src" = "./plugins/salesforce" ] || {
+    echo "source=$src, expected ./plugins/salesforce"
+    return 1
+  }
 }
 
 # T1.3 — all expected files exist
@@ -55,7 +76,10 @@ test_expected_files_exist() {
     "commands/sf-status.md"
   )
   for f in "${files[@]}"; do
-    [ -f "$PLUGIN_ROOT/$f" ] || { echo "missing: $f"; return 1; }
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
   done
 }
 
@@ -63,38 +87,62 @@ test_expected_files_exist() {
 test_skill_frontmatter() {
   for skill_dir in salesforce-index salesforce-auth; do
     local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
-    local name_line; name_line=$(frontmatter_value "$skill" "name")
-    [ -n "$name_line" ] || { echo "$skill_dir: missing name in frontmatter"; return 1; }
+    local name_line
+    name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || {
+      echo "$skill_dir: missing name in frontmatter"
+      return 1
+    }
 
-    local desc_line; desc_line=$(frontmatter_value "$skill" "description")
-    [ -n "$desc_line" ] || { echo "$skill_dir: missing description in frontmatter"; return 1; }
+    local desc_line
+    desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || {
+      echo "$skill_dir: missing description in frontmatter"
+      return 1
+    }
   done
 }
 
 # T1.5 — salesforce-index is not user-invocable
 test_index_not_user_invocable() {
   local skill="$PLUGIN_ROOT/skills/salesforce-index/SKILL.md"
-  grep -q 'user-invocable: false' "$skill" || { echo "salesforce-index should be user-invocable: false"; return 1; }
+  grep -q 'user-invocable: false' "$skill" || {
+    echo "salesforce-index should be user-invocable: false"
+    return 1
+  }
 }
 
 # T1.6 — salesforce-auth is not user-invocable
 test_auth_not_user_invocable() {
   local skill="$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md"
-  grep -q 'user-invocable: false' "$skill" || { echo "salesforce-auth should be user-invocable: false"; return 1; }
+  grep -q 'user-invocable: false' "$skill" || {
+    echo "salesforce-auth should be user-invocable: false"
+    return 1
+  }
 }
 
 # T1.7 — cli-operator.md frontmatter has correct tools and disallowedTools
 test_agent_tools() {
   local agent="$PLUGIN_ROOT/agents/cli-operator.md"
-  local fm; fm=$(extract_frontmatter "$agent")
+  local fm
+  fm=$(extract_frontmatter "$agent")
 
   for tool in Read Bash Glob Grep; do
-    echo "$fm" | grep -qF "  - $tool" || { echo "cli-operator missing allowed tool: $tool"; return 1; }
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "cli-operator missing allowed tool: $tool"
+      return 1
+    }
   done
 
-  echo "$fm" | grep -q 'disallowedTools:' || { echo "cli-operator missing disallowedTools"; return 1; }
+  echo "$fm" | grep -q 'disallowedTools:' || {
+    echo "cli-operator missing disallowedTools"
+    return 1
+  }
   for tool in Write Edit Agent; do
-    echo "$fm" | grep -qF "  - $tool" || { echo "cli-operator missing disallowed tool: $tool"; return 1; }
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "cli-operator missing disallowed tool: $tool"
+      return 1
+    }
   done
 }
 
@@ -102,29 +150,52 @@ test_agent_tools() {
 test_command_frontmatter() {
   for cmd in sf-login sf-status; do
     local file="$PLUGIN_ROOT/commands/${cmd}.md"
-    local desc; desc=$(frontmatter_value "$file" "description")
-    [ -n "$desc" ] || { echo "$cmd: missing description"; return 1; }
+    local desc
+    desc=$(frontmatter_value "$file" "description")
+    [ -n "$desc" ] || {
+      echo "$cmd: missing description"
+      return 1
+    }
   done
 
-  local hint; hint=$(frontmatter_value "$PLUGIN_ROOT/commands/sf-login.md" "argument-hint")
-  [ -n "$hint" ] || { echo "sf-login: missing argument-hint"; return 1; }
+  local hint
+  hint=$(frontmatter_value "$PLUGIN_ROOT/commands/sf-login.md" "argument-hint")
+  [ -n "$hint" ] || {
+    echo "sf-login: missing argument-hint"
+    return 1
+  }
 }
 
 # T1.9 — hooks.json is valid JSON with correct structure
 test_hooks_json_structure() {
   local hj="$PLUGIN_ROOT/hooks/hooks.json"
-  jq -e '.' "$hj" >/dev/null || { echo "hooks.json is not valid JSON"; return 1; }
+  jq -e '.' "$hj" >/dev/null || {
+    echo "hooks.json is not valid JSON"
+    return 1
+  }
 
-  local hook_type; hook_type=$(jq -r '.hooks.SessionStart[0].hooks[0].type' "$hj")
-  [ "$hook_type" = "command" ] || { echo "hook type=$hook_type, expected command"; return 1; }
+  local hook_type
+  hook_type=$(jq -r '.hooks.SessionStart[0].hooks[0].type' "$hj")
+  [ "$hook_type" = "command" ] || {
+    echo "hook type=$hook_type, expected command"
+    return 1
+  }
 
-  local timeout; timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$hj")
-  [[ "$timeout" =~ ^[0-9]+$ ]] || { echo "timeout is not a number: $timeout"; return 1; }
+  local timeout
+  timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$hj")
+  [[ "$timeout" =~ ^[0-9]+$ ]] || {
+    echo "timeout is not a number: $timeout"
+    return 1
+  }
 }
 
 # T1.10 — hook command is syntactically valid shell
 test_hook_command_syntax() {
   local hj="$PLUGIN_ROOT/hooks/hooks.json"
-  local cmd; cmd=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$hj")
-  bash -n <<<"$cmd" || { echo "hook command has syntax error"; return 1; }
+  local cmd
+  cmd=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$hj")
+  bash -n <<<"$cmd" || {
+    echo "hook command has syntax error"
+    return 1
+  }
 }


### PR DESCRIPTION
## Summary

- Add a 50-test shell test suite for the Salesforce plugin (v1.0.0) covering structural validation, security rules, auth priority logic, CLI contract, agent contract, cross-file consistency, and live org behavior
- Include shared test helpers (`_helpers.sh`) and a unified test runner (`run-tests.sh`)
- Fix ShellCheck SC2015 finding in `test_cli.sh` from prior pre-commit failure

Closes #357

## Test plan

- [ ] CI checks pass (lint, shellcheck, large file check)
- [ ] `run-tests.sh` executes all test files and reports pass/fail summary
- [ ] Tests are skippable when optional tooling (sf CLI, live org) is unavailable