### PR TITLE
docs: add user-facing documentation for Salesforce plugin

### DIFF
--- a/docs/plugins/salesforce.mdx
+++ b/docs/plugins/salesforce.mdx
@@ -1,0 +1,402 @@
+---
+title: salesforce
+description: Salesforce CLI automation with org authentication, account management, pipeline analysis, and natural language data queries.
+sidebar:
+  label: Salesforce
+  order: 14
+---
+
+import { Aside, Badge } from '@astrojs/starlight/components';
+
+The **salesforce** plugin integrates Salesforce CLI with Claude Code,
+providing org authentication, account management, opportunity pipeline
+analysis, case tracking, and natural language data queries. It supports
+headless container environments with JWT, access-token, and SFDX URL
+authentication flows.
+
+<Badge text="v1.0.0" variant="note" /> <Badge text="Development" variant="tip" />
+
+## Installation
+
+```
+/plugin install salesforce@f5xc-salesdemos-marketplace
+```
+
+## Prerequisites
+
+- **Salesforce CLI** (`@salesforce/cli`)
+- **Salesforce org** with API access
+- A user account with permissions to query objects (Cases, Opportunities, Accounts, Contacts)
+
+Install the Salesforce CLI on your workstation:
+
+```bash
+# macOS
+brew install sf
+
+# npm (any platform)
+npm install -g @salesforce/cli
+```
+
+Verify the installation:
+
+```bash
+sf --version
+```
+
+You should see output like `@salesforce/cli/2.x.x`.
+
+## Authentication Setup
+
+### Step 1: Find your Salesforce domain
+
+Look at your Salesforce URL in the browser. If you access Salesforce at
+`https://acme.lightning.force.com`, your login domain is
+`https://acme.my.salesforce.com`.
+
+<Aside type="tip">
+  If your company uses SSO, you must specify your custom domain with
+  `--instance-url` so the login redirects through your SSO provider
+  instead of the generic Salesforce login page.
+</Aside>
+
+### Step 2: Authenticate via browser
+
+```bash
+sf org login web --alias my-org --set-default --instance-url https://YOUR-DOMAIN.my.salesforce.com
+```
+
+Replace `YOUR-DOMAIN` with your company domain from Step 1. Your browser
+opens — complete the SSO or login flow and authorize the app. You should
+see:
+
+```
+Successfully authorized your-email@company.com with org ID 00DXXXXXXXXXXXXXXX
+```
+
+### Step 3: Verify the connection
+
+```bash
+sf org display --target-org my-org
+```
+
+Confirm the output shows `Connected Status: Connected` with your username
+and instance URL.
+
+### Step 4: Portable auth for containers (optional)
+
+If you need to authenticate in a headless environment (CI/CD, container,
+remote session), export the SFDX auth URL from your workstation:
+
+```bash
+sf org display --verbose --target-org my-org
+```
+
+Copy the **Sfdx Auth Url** value (starts with `force://`). In the
+container, run:
+
+```bash
+export SFDX_AUTH_URL="force://PlatformCLI::YOUR_AUTH_TOKEN@your-domain.my.salesforce.com"
+echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=- --alias=my-org --set-default
+```
+
+<Aside type="caution">
+  The SFDX auth URL is a credential — treat it like a password. Do not
+  commit it to files or paste it into chat. Use environment variables
+  and stdin pipes only.
+</Aside>
+
+### Authentication methods reference
+
+| Method | Best For | Requires |
+|--------|----------|----------|
+| Web Login | Workstations with a browser | Browser + SSO |
+| SFDX URL | Containers, CI/CD, portable auth | Auth URL from an authenticated session |
+| JWT Bearer | Automated pipelines | Connected App + private key + consumer key |
+| Access Token | Environment variable auth | `SF_ACCESS_TOKEN` + `SF_ORG_INSTANCE_URL` |
+
+**Note:** Device flow (`sf org login device`) is blocked since August
+2025 and is not supported.
+
+### Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SF_ACCESS_TOKEN` | Bearer token for access-token auth |
+| `SFDX_AUTH_URL` | Force auth URL for SFDX URL auth |
+| `SF_ORG_INSTANCE_URL` | Org instance URL |
+| `SF_JWT_KEY_FILE` | Path to JWT private key |
+| `SF_CLIENT_ID` | Connected App consumer key |
+| `SF_USERNAME` | Salesforce username for JWT |
+
+## Commands
+
+### /salesforce:sf-status
+
+Check your Salesforce org connection status, CLI version, and
+authenticated orgs.
+
+```
+/salesforce:sf-status
+```
+
+**What to expect:** A table showing your sf CLI version, authenticated
+org alias, username, instance URL, connected status, and API version.
+
+### /salesforce:sf-login
+
+Authenticate to a Salesforce org. Optionally provide an alias.
+
+```
+/salesforce:sf-login
+/salesforce:sf-login my-org
+```
+
+**What to expect:** If an org with that alias is already authenticated,
+it reports the connection details. If not, it checks for available
+credentials (environment variables) and authenticates using the first
+fully satisfied method.
+
+## Skills
+
+### salesforce-index
+
+Top-level intent router. Automatically activates when you mention
+Salesforce, org management, or data queries in natural language.
+
+| You say | Routes to |
+|---------|-----------|
+| "login to salesforce", "authenticate org" | `salesforce-auth` skill |
+| "check org status", "list orgs" | `cli-operator` agent |
+| "show me opportunities", "look up case" | `cli-operator` agent (SOQL query) |
+| "generate Apex class", "create Flow" | afv-library development skills |
+
+### salesforce-auth
+
+Container-adapted authentication skill. Supports four auth methods and
+automatically detects which credentials are available. Prioritizes:
+access-token, then JWT, then SFDX URL, then web login.
+
+## Agents
+
+### cli-operator
+
+Autonomous Salesforce CLI agent that executes `sf` commands with safety
+guardrails. All Salesforce operations are delegated to this agent to
+keep the main session context lean.
+
+**Safety rules:**
+
+- Read-only by default — write operations require explicit approval
+- Never deploys without a preview and confirmation step
+- Never echoes access tokens, auth URLs, or credentials in output
+- Sanitizes all user-provided values (rejects shell metacharacters)
+- Uses `--json` output for structured, parseable results
+
+**Response format:**
+
+```
+## Result: [SUCCESS | FAILURE | PARTIAL]
+### Command Executed
+### Output Summary
+### Issues
+```
+
+## Usage Guide: Account Management
+
+These prompts work with any Salesforce org. Replace the placeholder
+values with your own information. Each prompt produces results specific
+to your role, accounts, and territory.
+
+<Aside type="tip">
+  For best results, include your email address in prompts that need to
+  identify your user record. Salesforce orgs can have multiple users
+  with similar names.
+</Aside>
+
+### Getting started
+
+After authenticating, verify everything works:
+
+```
+/salesforce:sf-status
+```
+
+Then try a simple natural language query:
+
+```
+list my authenticated salesforce orgs
+```
+
+**What to expect:** A table showing all connected orgs with alias,
+username, instance URL, and connection status.
+
+### Find your accounts
+
+Discover which accounts you are assigned to:
+
+```
+what salesforce accounts am I on the account team for? My email is your-email@company.com
+```
+
+**What to expect:** A list of accounts grouped by account owner, showing
+your team member role on each. If most roles show as empty, that is a
+common data hygiene gap — the account team memberships exist but roles
+were not populated.
+
+### Cross-reference coverage with a colleague
+
+Compare your account coverage with a teammate to find gaps:
+
+```
+In salesforce, find all accounts where Colleague Name is on the account team. Then for each of those accounts, check if your-email@company.com is also on the account team. Show me two lists: accounts where we are BOTH tagged, and accounts where only my colleague is tagged but I am missing.
+```
+
+**What to expect:** A summary table showing overlap count and gap count,
+followed by two lists. If you recently changed roles, you may find zero
+overlap — this reveals which accounts you need to be added to.
+
+<Aside type="note">
+  You can also check for a predecessor by adding: "Also check if
+  Previous Person Name appears on any of those accounts." This helps
+  identify handoff gaps when replacing someone on a territory.
+</Aside>
+
+### Territory pipeline overview
+
+See all open opportunities across your accounts:
+
+```
+show me all open salesforce opportunities on Colleague Name's account team accounts, sorted by close date, include the stage, amount, and probability
+```
+
+**What to expect:** A summary with total opportunity count, raw pipeline,
+and weighted pipeline. Then a stage distribution table and a list of top
+opportunities by amount. The output flags data hygiene issues like
+past-due close dates or null amounts.
+
+### Opportunity deep dive
+
+Get the full picture on a specific deal:
+
+```
+show me a detailed view of the OPPORTUNITY NAME opportunity in salesforce - include the opportunity team members, any activities or tasks, and the account contacts
+```
+
+**What to expect:** The opportunity overview (stage, amount, close date,
+probability, forecast category, owner), opportunity team members with
+roles, tagged contacts, recent tasks and events, and field change
+history showing how the deal amount and close date have moved over time.
+
+### Support cases across territory
+
+Check for open support cases on your accounts:
+
+```
+show me all open salesforce cases across Colleague Name's account team accounts, grouped by account, sorted by most recent first
+```
+
+**What to expect:** A count of open cases with priority and status
+breakdown, then case details grouped by account. Stale cases (months or
+years old with no activity) are flagged as hygiene candidates.
+
+### Quarterly pipeline forecast
+
+Get a forecast-ready view of your pipeline:
+
+```
+for Colleague Name's accounts, show me a quarterly pipeline summary - group the open opportunities by close date quarter with count, total amount, and weighted amount for each quarter
+```
+
+**What to expect:** A table with one row per quarter showing opportunity
+count, total pipeline, and weighted pipeline. Includes a stage mix
+breakdown per quarter and highlights the top weighted deals. Past-due
+opportunities are grouped separately.
+
+### Full account overview
+
+Deep dive into a specific customer:
+
+```
+give me a full account overview for ACCOUNT NAME in salesforce including contacts, open opportunities, and recent cases
+```
+
+**What to expect:** Company profile (industry, revenue, employees,
+location), key contacts with titles and email, open opportunities with
+stages and amounts, and recent support cases with status.
+
+### Case lookup
+
+Look up a specific support case by number:
+
+```
+look up salesforce case CASE-NUMBER and show me the case details, the customer account, and who owns it
+```
+
+**What to expect:** Case subject, status, priority, description, the
+customer account profile, and the case owner with contact information.
+
+## Usage Guide: Data Queries
+
+For power users, you can ask for specific SOQL-style queries in natural
+language. The plugin translates your request into the appropriate SOQL
+and runs it.
+
+### Specific fields
+
+```
+query salesforce for all Contacts at ACCOUNT NAME - show Name, Title, Email, Phone, and Department
+```
+
+### Date filtering
+
+```
+show me all salesforce opportunities that closed won in the last 90 days on ACCOUNT NAME
+```
+
+### Aggregation
+
+```
+count all open salesforce cases grouped by priority and status across my accounts
+```
+
+### Custom objects
+
+```
+query the CUSTOM_OBJECT__c object in salesforce for records where Status__c = 'Active'
+```
+
+<Aside type="tip">
+  If a query fails because a field does not exist, the plugin
+  automatically retries without that field. Custom fields in your org
+  may use different names — check your Salesforce Setup if a field
+  is not found.
+</Aside>
+
+## Development Skills
+
+The 30 Salesforce development skills from the
+[forcedotcom/afv-library](https://github.com/forcedotcom/afv-library)
+activate automatically for Apex, Flow, LWC, SOQL, metadata, Agentforce,
+and deployment tasks. Install them separately:
+
+```bash
+npx skills add forcedotcom/afv-library
+```
+
+| Topic | Skill |
+|-------|-------|
+| Apex classes and services | `generating-apex` |
+| Apex tests | `generating-apex-test` |
+| Flows | `generating-flow` |
+| LWC and UI bundles | `building-ui-bundle-app` |
+| Custom objects | `generating-custom-object` |
+| Custom fields | `generating-custom-field` |
+| Validation rules | `generating-validation-rule` |
+| Permission sets | `generating-permission-set` |
+| FlexiPages | `generating-flexipage` |
+| Agentforce agents | `developing-agentforce` |
+| Agentforce testing | `testing-agentforce` |
+| Deployment | `deploying-ui-bundle` |
+| SLDS2 migration | `uplifting-components-to-slds2` |
+| Trigger refactoring | `trigger-refactor-pipeline` |

--- a/plugins/salesforce/README.md
+++ b/plugins/salesforce/README.md
@@ -1,40 +1,65 @@
 # Salesforce Plugin
 
 Container-adapted Salesforce CLI integration for Claude Code. Provides
-org authentication, org management, and bridges to the official
+org authentication, account management, pipeline analysis, and natural
+language data queries. Bridges to the official
 [forcedotcom/afv-library](https://github.com/forcedotcom/afv-library)
 skills for Salesforce development.
 
 ## Prerequisites
 
-- **Salesforce CLI** (`@salesforce/cli`): `npm install -g @salesforce/cli`
-- **afv-library skills**: `npx skills add forcedotcom/afv-library`
+- **Salesforce CLI** (`@salesforce/cli`): `brew install sf` or
+  `npm install -g @salesforce/cli`
+- **afv-library skills** (optional): `npx skills add forcedotcom/afv-library`
 - **Salesforce org** with API access
 
 ## Quick Start
 
 ```bash
 # Check CLI and org status
-/sf-status
+/salesforce:sf-status
 
 # Authenticate to an org
-/sf-login my-dev-org
+/salesforce:sf-login my-org
 ```
 
-## Authentication Methods
+## Authentication
 
-This plugin adapts Salesforce authentication for headless container
-environments:
+### Workstation (browser available)
 
-| Method       | Best For                   | Command                     |
-| ------------ | -------------------------- | --------------------------- |
-| JWT Bearer   | CI/CD, automation          | `sf org login jwt`          |
-| Access Token | Environment variable auth  | `sf org login access-token` |
-| SFDX URL     | Portable auth URLs         | `sf org login sfdx-url`     |
-| Web Login    | Interactive (VNC required) | `sf org login web`          |
+Find your Salesforce domain from your browser URL
+(`https://acme.lightning.force.com` means your domain is
+`acme.my.salesforce.com`), then run:
+
+```bash
+sf org login web --alias my-org --set-default --instance-url https://YOUR-DOMAIN.my.salesforce.com
+```
+
+### Container / headless (no browser)
+
+Export the SFDX auth URL from an authenticated workstation:
+
+```bash
+sf org display --verbose --target-org my-org
+```
+
+Copy the `Sfdx Auth Url` value, then in the container:
+
+```bash
+echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=- --alias=my-org --set-default
+```
+
+### All authentication methods
+
+| Method       | Best For                      | Command                     |
+| ------------ | ----------------------------- | --------------------------- |
+| Web Login    | Workstations with browser/SSO | `sf org login web`          |
+| SFDX URL     | Containers, CI/CD             | `sf org login sfdx-url`     |
+| JWT Bearer   | Automated pipelines           | `sf org login jwt`          |
+| Access Token | Environment variable auth     | `sf org login access-token` |
 
 **Note:** Device flow (`sf org login device`) is blocked since August
-2025 and is not supported.
+2025.
 
 ## Environment Variables
 
@@ -47,6 +72,59 @@ environments:
 | `SF_CLIENT_ID`        | Connected App consumer key         |
 | `SF_USERNAME`         | Salesforce username for JWT        |
 
+## Usage Examples
+
+After authenticating, use natural language to query your Salesforce
+data. Replace placeholder values with your own information.
+
+### Account discovery
+
+```
+what salesforce accounts am I on the account team for? My email is your-email@company.com
+```
+
+### Coverage cross-reference
+
+```
+find all accounts where Colleague Name is on the account team, then check if your-email@company.com is also tagged on each one
+```
+
+### Opportunity pipeline
+
+```
+show me all open salesforce opportunities on Colleague Name's accounts, sorted by amount
+```
+
+### Quarterly forecast
+
+```
+group open opportunities by close date quarter with count, total amount, and weighted amount
+```
+
+### Opportunity deep dive
+
+```
+show me a detailed view of the OPPORTUNITY NAME opportunity including team members, activities, and contacts
+```
+
+### Support cases
+
+```
+show me all open salesforce cases across Colleague Name's accounts, grouped by account
+```
+
+### Case lookup
+
+```
+look up salesforce case CASE-NUMBER and show me the details, customer account, and owner
+```
+
+### Account overview
+
+```
+give me a full account overview for ACCOUNT NAME including contacts, open opportunities, and recent cases
+```
+
 ## Skills
 
 | Skill              | Purpose                                     |
@@ -54,15 +132,15 @@ environments:
 | `salesforce-index` | Routes requests to the right skill or agent |
 | `salesforce-auth`  | Container-adapted org authentication        |
 
+## Commands
+
+| Command                 | Purpose                          |
+| ----------------------- | -------------------------------- |
+| `/salesforce:sf-login`  | Authenticate to a Salesforce org |
+| `/salesforce:sf-status` | Check org connection status      |
+
 ## Development Skills (via afv-library)
 
 The 30 Salesforce development skills from `forcedotcom/afv-library` are
 installed separately and activate automatically for Apex, Flow, LWC,
 SOQL, metadata, Agentforce, and deployment tasks.
-
-## Commands
-
-| Command      | Purpose                          |
-| ------------ | -------------------------------- |
-| `/sf-login`  | Authenticate to a Salesforce org |
-| `/sf-status` | Check org connection status      |


### PR DESCRIPTION
## Summary

- Add new user-facing documentation page for the Salesforce plugin (`docs/plugins/salesforce.mdx`) covering authentication, configuration, natural language usage, and available commands
- Fix MD060 table column alignment in `plugins/salesforce/README.md` Commands table — expanded header column width to match content width

Closes #359

## Test plan

- [ ] CI checks pass
- [ ] Markdown lint passes (MD060 table alignment verified)
- [ ] Documentation page renders correctly