### PR TITLE
fix: address Codex review findings for Salesforce plugin

### DIFF
--- a/docs/plugins/salesforce.mdx
+++ b/docs/plugins/salesforce.mdx
@@ -9,10 +9,12 @@ sidebar:
 import { Aside, Badge } from '@astrojs/starlight/components';
 
 The **salesforce** plugin integrates Salesforce CLI with Claude Code,
-providing org authentication, account management, opportunity pipeline
-analysis, case tracking, and natural language data queries. It supports
-headless container environments with JWT, access-token, and SFDX URL
-authentication flows.
+providing org authentication and a general-purpose CLI agent that can
+run any `sf` command including SOQL queries. It supports headless
+container environments with JWT, access-token, and SFDX URL
+authentication flows. The usage guide below demonstrates how to use
+natural language to query accounts, opportunities, cases, and contacts
+through the CLI agent.
 
 <Badge text="v1.0.0" variant="note" /> <Badge text="Development" variant="tip" />
 
@@ -203,6 +205,15 @@ keep the main session context lean.
 ```
 
 ## Usage Guide: Account Management
+
+<Aside type="note">
+  The prompts below are not hard-coded features of the plugin. They work
+  because the cli-operator agent can run any `sf` CLI command, including
+  arbitrary SOQL queries. Results depend on your org's data model and
+  your user permissions. The prompts here have been tested and verified
+  to work with standard Salesforce objects (Account, Contact, Case,
+  Opportunity, AccountTeamMember, OpportunityTeamMember).
+</Aside>
 
 These prompts work with any Salesforce org. Replace the placeholder
 values with your own information. Each prompt produces results specific

--- a/plugins/salesforce/README.md
+++ b/plugins/salesforce/README.md
@@ -1,8 +1,8 @@
 # Salesforce Plugin
 
 Container-adapted Salesforce CLI integration for Claude Code. Provides
-org authentication, account management, pipeline analysis, and natural
-language data queries. Bridges to the official
+org authentication and a general-purpose CLI agent that can run any
+`sf` command including SOQL queries. Bridges to the official
 [forcedotcom/afv-library](https://github.com/forcedotcom/afv-library)
 skills for Salesforce development.
 

--- a/plugins/salesforce/agents/cli-operator.md
+++ b/plugins/salesforce/agents/cli-operator.md
@@ -81,9 +81,9 @@ You execute Salesforce CLI (`sf`) commands on behalf of the main session.
 
 ## Error Recovery
 
-| Error                   | Action                                                                 |
-| ----------------------- | ---------------------------------------------------------------------- |
-| `sf: command not found` | Report: sf CLI not installed, suggest `npm install -g @salesforce/cli` |
-| `No default org`        | Report: no authenticated org, suggest using `/sf-login` command        |
-| `INVALID_SESSION_ID`    | Report: session expired, suggest re-authenticating                     |
-| `ECONNREFUSED`          | Report: cannot reach Salesforce, check network and org URL             |
+| Error                   | Action                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| `sf: command not found` | Report: sf CLI not installed, suggest `npm install -g @salesforce/cli`          |
+| `No default org`        | Report: no authenticated org, suggest using `/salesforce:sf-login`              |
+| `INVALID_SESSION_ID`    | Report: session expired, suggest re-authenticating                              |
+| `ECONNREFUSED`          | Report: cannot reach Salesforce, check network and org URL                      |

--- a/plugins/salesforce/commands/sf-login.md
+++ b/plugins/salesforce/commands/sf-login.md
@@ -21,7 +21,7 @@ Spawn the cli-operator agent with the following instructions:
    - `SF_JWT_KEY_FILE` + `SF_CLIENT_ID` + `SF_USERNAME` all set →
      `sf org login jwt`
    - `SFDX_AUTH_URL` set →
-     `echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin`
+     `echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=-`
    - None fully satisfied → suggest `sf org login web`
 5. Do NOT choose an option unless all required env vars are present.
 6. Use the alias in the `--alias` flag.

--- a/plugins/salesforce/commands/sf-status.md
+++ b/plugins/salesforce/commands/sf-status.md
@@ -19,4 +19,4 @@ Spawn the cli-operator agent with the following instructions:
    - Number of authenticated orgs
    - Default org alias, username, instance URL, connected status
    - API version
-5. If no orgs are authenticated, suggest using `/sf-login`
+5. If no orgs are authenticated, suggest using `/salesforce:sf-login`

--- a/plugins/salesforce/scripts/tests/test_cli.sh
+++ b/plugins/salesforce/scripts/tests/test_cli.sh
@@ -153,7 +153,10 @@ test_sfdx_url_stdin_syntax() {
   out=$(echo "" | sf org login sfdx-url --sfdx-url-stdin --json 2>&1) || true
   if echo "$out" | grep -qi 'value\|stdin\|format'; then
     local bare_count
-    bare_count=$(grep -cP -- '--sfdx-url-stdin(?!\s*=)' "$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md" 2>/dev/null || echo 0)
+    local total_count eq_count
+    total_count=$(grep -c -- '--sfdx-url-stdin' "$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md" 2>/dev/null || echo 0)
+    eq_count=$(grep -cE -- '--sfdx-url-stdin[[:space:]]*=' "$PLUGIN_ROOT/skills/salesforce-auth/SKILL.md" 2>/dev/null || echo 0)
+    bare_count=$((total_count - eq_count))
     if [ "$bare_count" -gt 0 ]; then
       echo "WARNING: salesforce-auth/SKILL.md has $bare_count bare --sfdx-url-stdin references (should use --sfdx-url-stdin=-)"
     fi
@@ -177,7 +180,6 @@ test_access_token_login() {
   out=$(sf org login access-token \
     --instance-url "$SF_ORG_INSTANCE_URL" \
     --alias sf-test-org \
-    --set-default \
     --no-prompt \
     --json 2>&1) || true
 
@@ -210,7 +212,6 @@ test_sfdx_url_login() {
   out=$(echo "$SFDX_AUTH_URL" | sf org login sfdx-url \
     --sfdx-url-stdin=- \
     --alias=sf-test-sfdx \
-    --set-default \
     --json 2>&1) || {
     echo "login failed: $out"
     return 1
@@ -306,7 +307,6 @@ test_org_display_fields() {
     sf org login access-token \
       --instance-url "$SF_ORG_INSTANCE_URL" \
       --alias sf-test-display \
-      --set-default \
       --no-prompt \
       --json >/dev/null 2>&1 || {
       echo "SKIP: login failed"

--- a/plugins/salesforce/scripts/tests/test_integration.sh
+++ b/plugins/salesforce/scripts/tests/test_integration.sh
@@ -14,13 +14,14 @@ STATUS_CMD="$PLUGIN_ROOT/commands/sf-status.md"
 test_login_auth_priority_match() {
   local login_order auth_order
 
-  login_order=$(grep -oP 'sf org login \K[a-z-]+' "$LOGIN_CMD" | head -4)
+  login_order=$(grep -oE 'sf org login [a-z-]+' "$LOGIN_CMD" |
+    sed 's/sf org login //' | head -4)
   auth_order=$(grep -A2 'Pick the first\|first fully satisfied' "$AUTH_SKILL" |
-    grep -oP 'sf org login \K[a-z-]+' || true)
+    grep -oE 'sf org login [a-z-]+' | sed 's/sf org login //' || true)
 
   if [ -z "$auth_order" ]; then
     auth_order=$(awk '/## Delegation/,/^##[^#]/' "$AUTH_SKILL" |
-      grep -oP 'sf org login \K[a-z-]+')
+      grep -oE 'sf org login [a-z-]+' | sed 's/sf org login //')
   fi
 
   local login_first auth_first
@@ -38,7 +39,7 @@ test_routing_table_skills_valid() {
   local skills
   skills=$(awk '/afv-library Skill/,/^###/' "$INDEX_SKILL" |
     grep '`' |
-    grep -oP '`\K[a-z][-a-z0-9]*(?=`)' || true)
+    sed -n 's/.*`\([a-z][-a-z0-9]*\)`.*/\1/p' || true)
 
   [ -n "$skills" ] || {
     echo "no skill names found in routing table"
@@ -63,7 +64,7 @@ test_routing_table_skills_valid() {
 # TI.3 — sf-status.md delegation commands are in cli-operator
 test_status_commands_in_agent() {
   local cmds
-  cmds=$(grep -oP 'sf (org|project|apex) \S+' "$STATUS_CMD" | sort -u)
+  cmds=$(grep -oE 'sf (org|project|apex) [a-z-]+' "$STATUS_CMD" | sort -u)
 
   while IFS= read -r cmd; do
     [ -z "$cmd" ] && continue
@@ -80,7 +81,7 @@ test_status_commands_in_agent() {
 # TI.4 — sf-login.md delegation commands reference valid sf subcommands
 test_login_commands_in_agent() {
   local login_cmds
-  login_cmds=$(grep -oP 'sf org (login \S+|list|display)' "$LOGIN_CMD" | sort -u)
+  login_cmds=$(grep -oE 'sf org (login [a-z-]+|list|display)' "$LOGIN_CMD" | sort -u)
 
   [ -n "$login_cmds" ] || {
     echo "no sf commands found in sf-login.md"
@@ -132,8 +133,7 @@ test_delegation_sf_commands_valid() {
 
   local subcommands
   subcommands=$(cat "$LOGIN_CMD" "$STATUS_CMD" "$AUTH_SKILL" |
-    grep -oP 'sf (org|project|apex) \S+' |
-    sed 's/ --.*//; s/ \\$//' |
+    grep -oE 'sf (org|project|apex) [a-z-]+' |
     sort -u)
 
   while IFS= read -r cmd; do
@@ -153,9 +153,9 @@ test_delegation_sf_commands_valid() {
 
 # TI.8 — audit --sfdx-url-stdin usage across plugin
 test_sfdx_url_stdin_syntax_audit() {
-  local total bare correct
+  local total correct bare
   total=$(grep -rc -- '--sfdx-url-stdin' "$PLUGIN_ROOT" --include='*.md' 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
-  correct=$(grep -rcP -- '--sfdx-url-stdin\s*=' "$PLUGIN_ROOT" --include='*.md' 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
+  correct=$(grep -rcE -- '--sfdx-url-stdin[[:space:]]*=' "$PLUGIN_ROOT" --include='*.md' 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')
   bare=$((total - correct))
 
   if [ "$bare" -gt 0 ]; then

--- a/plugins/salesforce/scripts/tests/test_security.sh
+++ b/plugins/salesforce/scripts/tests/test_security.sh
@@ -3,17 +3,23 @@
 
 set -euo pipefail
 
-# T1.11 — no hardcoded credentials in plugin files
+# T1.11 — no hardcoded credentials in plugin or docs files
 test_no_hardcoded_credentials() {
   local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}|force://[A-Za-z0-9]{10,}'
+  local scan_dirs=("$PLUGIN_ROOT")
+  local docs_dir="$MARKETPLACE_ROOT/docs/plugins"
+  [ -f "$docs_dir/salesforce.mdx" ] && scan_dirs+=("$docs_dir/salesforce.mdx")
+
   local matches
-  matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
-    --include='*.md' --include='*.json' |
+  matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --include='*.md' --include='*.json' --include='*.mdx' |
     grep -v 'README.md' |
     grep -v '\$SF_ACCESS_TOKEN' |
     grep -v '\$SFDX_AUTH_URL' |
     grep -v 'force://\.\.\.' |
-    grep -v 'force://fake' ||
+    grep -v 'force://fake' |
+    grep -v 'force://PlatformCLI::YOUR_AUTH_TOKEN' |
+    grep -v 'your-email@company.com' ||
     true)
 
   if [ -n "$matches" ]; then

--- a/plugins/salesforce/skills/salesforce-auth/SKILL.md
+++ b/plugins/salesforce/skills/salesforce-auth/SKILL.md
@@ -75,12 +75,12 @@ export SFDX_AUTH_URL="force://..."
 
 ```bash
 echo "$SFDX_AUTH_URL" | sf org login sfdx-url \
-  --sfdx-url-stdin \
+  --sfdx-url-stdin=- \
   --alias my-dev-org \
   --set-default
 ```
 
-Never write the auth URL to a file — use `--sfdx-url-stdin` with a
+Never write the auth URL to a file — use `--sfdx-url-stdin=-` with a
 pipe to avoid persisting credentials on disk.
 
 ### Method 4: Web Login (Browser Required)
@@ -125,7 +125,7 @@ instructions:
    - `SF_JWT_KEY_FILE` + `SF_CLIENT_ID` + `SF_USERNAME` all set →
      `sf org login jwt`
    - `SFDX_AUTH_URL` set →
-     `echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin`
+     `echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=-`
    - None satisfied → `sf org login web` (requires browser/VNC)
 3. Do NOT choose an option unless all its required env vars are set.
 4. Never echo tokens or auth URLs in output.
@@ -145,5 +145,5 @@ instructions:
 
 - Never echo access tokens, refresh tokens, or auth URLs
 - Use `$SF_ACCESS_TOKEN` placeholder in output
-- Never write credentials to disk — use stdin pipes (`--sfdx-url-stdin`)
+- Never write credentials to disk — use stdin pipes (`--sfdx-url-stdin=-`)
 - Do not store credentials in project files


### PR DESCRIPTION
## Summary

- Fixed markdownlint MD060 table alignment in `cli-operator.md` after `/sf-login` was renamed to `/salesforce:sf-login` (longer text overflowed the column width)
- Addresses all Codex review findings for the Salesforce plugin

Closes #361

## Test plan

- [x] Pre-commit hooks pass (markdown lint, shell lint, spelling, secrets detection)
- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)