### PR TITLE
fix: replace npm install recommendation with brew install sf

### DIFF
--- a/docs/plugins/salesforce.mdx
+++ b/docs/plugins/salesforce.mdx
@@ -33,11 +33,7 @@ through the CLI agent.
 Install the Salesforce CLI on your workstation:
 
 ```bash
-# macOS
 brew install sf
-
-# npm (any platform)
-npm install -g @salesforce/cli
 ```
 
 Verify the installation:

--- a/plugins/salesforce/README.md
+++ b/plugins/salesforce/README.md
@@ -8,8 +8,7 @@ skills for Salesforce development.
 
 ## Prerequisites
 
-- **Salesforce CLI** (`@salesforce/cli`): `brew install sf` or
-  `npm install -g @salesforce/cli`
+- **Salesforce CLI** (`@salesforce/cli`): `brew install sf`
 - **afv-library skills** (optional): `npx skills add forcedotcom/afv-library`
 - **Salesforce org** with API access
 

--- a/plugins/salesforce/agents/cli-operator.md
+++ b/plugins/salesforce/agents/cli-operator.md
@@ -83,7 +83,7 @@ You execute Salesforce CLI (`sf`) commands on behalf of the main session.
 
 | Error                   | Action                                                                          |
 | ----------------------- | ------------------------------------------------------------------------------- |
-| `sf: command not found` | Report: sf CLI not installed, suggest `npm install -g @salesforce/cli`          |
+| `sf: command not found` | Report: sf CLI not installed, suggest `brew install sf`                         |
 | `No default org`        | Report: no authenticated org, suggest using `/salesforce:sf-login`              |
 | `INVALID_SESSION_ID`    | Report: session expired, suggest re-authenticating                              |
 | `ECONNREFUSED`          | Report: cannot reach Salesforce, check network and org URL                      |

--- a/plugins/salesforce/hooks/hooks.json
+++ b/plugins/salesforce/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v sf > /dev/null 2>&1 || echo 'WARNING: Salesforce CLI (sf) is not installed. Run: npm install -g @salesforce/cli'",
+            "command": "command -v sf > /dev/null 2>&1 || echo 'WARNING: Salesforce CLI (sf) is not installed. Run: brew install sf'",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary

- Replaced all `npm install -g @salesforce/cli` recommendations with `brew install sf` across four files in the Salesforce plugin
- Removed the npm code block from the docs prerequisites section, keeping brew-only guidance
- Aligns installation guidance with the corporate standard IT-managed brew toolchain

Closes #363

## Test plan

- [ ] CI checks pass
- [ ] Verify `docs/plugins/salesforce.mdx` no longer contains npm install reference
- [ ] Verify `plugins/salesforce/README.md` prerequisites show brew only
- [ ] Verify `plugins/salesforce/agents/cli-operator.md` error recovery suggests brew
- [ ] Verify `plugins/salesforce/hooks/hooks.json` warning message suggests brew