### PR TITLE
chore(cloudstatus): bump version to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -485,7 +485,7 @@
     {
       "name": "f5xc-cloudstatus",
       "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/plugins/f5xc-cloudstatus/.claude-plugin/plugin.json
+++ b/plugins/f5xc-cloudstatus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-cloudstatus",
   "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings. Generic Statuspage.io engine with F5 XC domain knowledge layered via reference files.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"


### PR DESCRIPTION
## Summary

- Bump f5xc-cloudstatus plugin version from 1.0.0 to 1.1.0 in `plugin.json` and `marketplace.json`
- Version 1.1.0 reflects the performance optimization shipped in PR #384 (inlined templates, eliminated 4 agent turns, 57% token reduction)
- Marketplace consumers need the version increment to pull the optimized plugin

Closes #385

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Version strings are consistent across both files