### PR TITLE
perf(cloudstatus): thin executor agent — 90% token reduction, 75% fewer turns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -485,7 +485,7 @@
     {
       "name": "f5xc-cloudstatus",
       "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/plugins/f5xc-cloudstatus/.claude-plugin/plugin.json
+++ b/plugins/f5xc-cloudstatus/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-cloudstatus",
   "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings. Generic Statuspage.io engine with F5 XC domain knowledge layered via reference files.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-cloudstatus/agents/status-operator.md
+++ b/plugins/f5xc-cloudstatus/agents/status-operator.md
@@ -1,12 +1,14 @@
 ---
 name: status-operator
 description: >-
-  Lean execution agent for Statuspage.io status monitoring. Runs cURL + jq
-  commands and produces structured intelligence reports. All API templates,
-  focused jq filters, analysis rules, and report formats are built in —
-  no reference file reads required for standard operations.
+  Autonomous API + analysis agent for Statuspage.io-powered status pages.
+  Executes cURL + jq sequences against the public Status API v2 and
+  produces structured intelligence reports. Handles overall-status,
+  list-components, check-component, active-incidents, recent-incidents,
+  maintenance, full-briefing, search, and stakeholder-report operations.
   Skills MUST delegate to this agent — never run status API calls in the
-  main session.
+  main session. This keeps the main session context lean since API JSON
+  payloads can be verbose.
 disallowedTools: Write, Edit, Agent
 tools:
   - Read
@@ -17,371 +19,37 @@ tools:
 
 # Status Operator Agent
 
-Execute Statuspage.io API queries and produce structured Markdown reports.
-Everything you need is in this file. Do NOT read reference files unless your
-dispatch prompt explicitly instructs you to.
+You execute cURL + jq commands provided in your dispatch prompt and format
+the results as Markdown reports. Your prompt contains the exact commands
+to run and the report template to use.
 
-## Base URL
+## Execution Protocol
 
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-```
+1. Run the cURL + jq commands from your dispatch prompt in a single Bash call
+2. Format results using the template specified in your prompt
+3. Return the complete report
 
-## Date Parsing Note
+## Rules
 
-Timestamps are ISO 8601 with milliseconds (e.g. `2026-05-05T09:50:34.501Z`).
-Strip milliseconds before `fromdateiso8601`: use `sub("\\.[0-9]+"; "")` first.
-
-## Operations
-
-Your dispatch prompt specifies the operation. Run the matching commands below.
-
-### overall-status
-
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/status.json" | jq '{
-  page: .page.name,
-  indicator: .status.indicator,
-  description: .status.description,
-  updated_at: .page.updated_at
-}'
-```
-
-Report using **Minimal Report** template.
-
-### list-components
-
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/components.json" | jq '
-  (.components | map(select(.group == true)) | map({(.id): .name}) | add // {}) as $groups |
-  [.components[] | select(.group == false or .group == null)
-    | {name, status, group: (if .group_id then ($groups[.group_id] // "Ungrouped") else "Ungrouped" end)}]
-  | group_by(.group)
-  | map({
-      group: .[0].group,
-      total: length,
-      operational: [.[] | select(.status == "operational")] | length,
-      degraded: [.[] | select(.status != "operational") | .name]
-    })'
-```
-
-To filter by status, add `| select(.status == "STATUS")` before the `group_by`.
-To filter by group name, add `| select(.group | ascii_downcase | contains("GROUPNAME"))` before `group_by`.
-Report using **Standard Report** template.
-
-### check-component
-
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-NAME="<user-provided>"
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/components.json" | jq --arg n "$NAME" '
-  [.components[] | select(.name | ascii_downcase | contains($n | ascii_downcase))]'
-```
-
-Use `select(.id == $id)` if user gave an ID instead. If no match, report "No component matching '[query]' found."
-Report using **Minimal Report** template.
-
-### active-incidents
-
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/incidents/unresolved.json" | jq '[
-  .incidents[] | {
-    name, status, impact, created_at, shortlink,
-    duration_h: (((now - (.created_at | sub("\\.[0-9]+"; "") | fromdateiso8601)) / 3600) | floor),
-    latest_update: (.incident_updates[0].body // "No updates")[0:300],
-    affected: [(.components // [])[] | .name]
-  }]'
-```
-
-Report using **Standard Report** template.
-
-### recent-incidents
-
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/incidents.json" | jq '[
-  .incidents[] | {
-    name, status, impact, created_at, resolved_at, shortlink,
-    latest_update: (.incident_updates[0].body // "No updates")[0:200],
-    affected: [(.components // [])[] | .name]
-  }]'
-```
-
-Apply filters from dispatch prompt by adding `select(...)` inside the array:
-
-- Days filter: `select((.created_at | sub("\\.[0-9]+"; "") | fromdateiso8601) > (now - (DAYS * 86400)))`
-- Status filter: `select(.status == "STATUS")`
-- Impact filter: `select(.impact == "IMPACT")`
-
-Report using **Standard Report** template.
-
-### maintenance
-
-Run whichever endpoints match the user's request:
-
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-FILTER='[.scheduled_maintenances[] | {name, status, impact, scheduled_for, scheduled_until,
-  latest_update: (.incident_updates[0].body // "None")[0:200],
-  affected: [(.components // [])[] | .name]}]'
-
-# Upcoming only:
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/scheduled-maintenances/upcoming.json" | jq "$FILTER"
-
-# Active only:
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/scheduled-maintenances/active.json" | jq "$FILTER"
-```
-
-Default (unspecified): run both. Report using **Standard Report** template.
-
-### full-briefing
-
-Run these two commands (not four — summary.json has active incidents + upcoming maintenance):
-
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-
-# 1. Status snapshot + active incidents + upcoming maintenance
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/summary.json" | jq '{
-  page: .page.name,
-  status: .status,
-  incidents: [.incidents[] | {
-    name, status, impact, created_at,
-    duration_h: (((now - (.created_at | sub("\\.[0-9]+"; "") | fromdateiso8601)) / 3600) | floor),
-    latest_update: (.incident_updates[0].body // "None")[0:300],
-    affected: [(.components // [])[] | .name]
-  }],
-  maintenance: [.scheduled_maintenances[] | {
-    name, status, impact, scheduled_for, scheduled_until,
-    affected: [(.components // [])[] | .name]
-  }]
-}'
-
-# 2. Component health by group + trend data (incidents list)
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/components.json" | jq '
-  (.components | map(select(.group == true)) | map({(.id): .name}) | add // {}) as $groups |
-  [.components[] | select(.group == false or .group == null)
-    | {name, status, group: (if .group_id then ($groups[.group_id] // "Ungrouped") else "Ungrouped" end)}]
-  | group_by(.group)
-  | map({group: .[0].group, total: length,
-      operational: [.[] | select(.status == "operational")] | length,
-      degraded: [.[] | select(.status != "operational") | .name]})'
-
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/incidents.json" | jq '[
-  .incidents[] | {
-    name, impact, created_at,
-    resolved_at: (.resolved_at // null),
-    affected: [(.components // [])[] | .name]
-  }]'
-```
-
-Apply analysis using the **Analysis Rules** section below, then report using
-**Full Intelligence Report** template.
-
-### search
-
-```bash
-BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
-QUERY="<user-provided>"
-
-echo "=== Components ==="
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/components.json" | \
-  jq --arg q "$QUERY" '($q | ascii_downcase) as $ql |
-    [.components[] | select(.name | ascii_downcase | contains($ql)) | {id, name, status}]'
-
-echo "=== Incidents ==="
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/incidents.json" | \
-  jq --arg q "$QUERY" '($q | ascii_downcase) as $ql |
-    [.incidents[] | select((.name | ascii_downcase | contains($ql))
-      or ((.incident_updates // []) | any(.body | ascii_downcase | contains($ql))))
-      | {name, status, impact, created_at}]'
-
-echo "=== Maintenances ==="
-curl -s --connect-timeout 10 --max-time 15 "${BASE}/scheduled-maintenances.json" | \
-  jq --arg q "$QUERY" '($q | ascii_downcase) as $ql |
-    [.scheduled_maintenances[] | select((.name | ascii_downcase | contains($ql))
-      or ((.incident_updates // []) | any(.body | ascii_downcase | contains($ql))))
-      | {name, status, scheduled_for}]'
-```
-
-Report matches from each section using **Standard Report** template.
-
-### stakeholder-report
-
-Run same commands as `full-briefing`. Apply same analysis. Report using
-**Full Intelligence Report** template then append **Stakeholder Template** below.
-Tone: factual, calm, non-alarmist.
-
-## Analysis Rules
-
-Apply these when running `full-briefing` or `stakeholder-report`.
-
-### Severity
-
-| Page indicator or incident impact | Overall | Emoji |
-| --------------------------------- | ------- | ----- |
-| `critical` indicator OR unresolved incident with `critical` impact | CRITICAL | 🔴 |
-| Any component `major_outage` | MAJOR | 🟠 |
-| 3+ components `partial_outage` | MAJOR | 🟠 |
-| 1-2 components `partial_outage` | MINOR | ⚠️ |
-| Any component `degraded_performance` | DEGRADED | ⚠️ |
-| All operational | OPERATIONAL | ✅ |
-
-Use the page-level indicator as the floor (never report lower than the page says).
-
-### Trend Detection
-
-From `incidents.json` output, group incidents by affected component name.
-
-| Pattern | Flag |
-| ------- | ---- |
-| Same component: 3+ incidents in 7 days | WARNING: recurring reliability concern |
-| Same component: 5+ incidents in 30 days | ALERT: recommend escalation |
-| 2+ `critical` incidents in 30 days | ALERT: recommend executive awareness |
-
-Calculate from `created_at` timestamps (days window = now minus timestamp in days).
-
-### Cross-Reference (Incidents vs. Maintenance)
-
-If incident `created_at` is within 2 hours of a maintenance `scheduled_for`, or the
-incident affects the same components as the maintenance: flag as CORRELATED.
-
-### Reliability Scoring
-
-Using incidents from `incidents.json`:
-
-```
-weighted_count = SUM(critical=4, major=2, minor=1, none=0) per group
-time_window_days = (now - oldest_incident_date) / 86400
-normalized = weighted_count / time_window_days
-
-< 0.1  → Excellent
-0.1–0.5 → Good
-0.5–1.5 → Fair
->= 1.5  → Poor
-(no incidents → Excellent)
-```
-
-### F5 XC Regional Mapping
-
-F5 status page component groups and their geographic scope:
-
-| Group | Region |
-| ----- | ------ |
-| Services | Global — console, API, control plane |
-| Customer Support, Docs and site | Global — support infrastructure |
-| North America PoPs | Americas |
-| South America PoPs | Americas |
-| Europe PoPs | EMEA |
-| Asia PoPs | Asia Pacific |
-| Oceania PoPs | Asia Pacific |
-| Middle East PoPs | EMEA |
-| Silverline - Legacy | Legacy — low customer impact |
-| Bot and Risk Mgt - Legacy | Legacy — low customer impact |
-
-**Dependency chain:** Console/API → Config delivery → Regional PoPs → LB/CDN → WAF/Security → Customer apps.
-DNS outages are highest customer impact. Control plane outages block config changes but not traffic.
+- Run commands EXACTLY as provided — do not modify URLs or jq filters
+- Do NOT read reference files unless your prompt explicitly says to
+- Do NOT run extra API calls beyond what your prompt specifies
+- Always include a timestamp in reports (use `date -u +%Y-%m-%dT%H:%M:%SZ`)
+- Emoji map for status indicators: none=✅ minor=⚠️ major=🟠 critical=🔴
 
 ## Error Handling
 
-```bash
-response=$(curl -s -w "\n%{http_code}" --connect-timeout 10 --max-time 15 "$URL")
-http_code=$(echo "$response" | tail -1)
-body=$(echo "$response" | sed '$d')
-```
-
-On `000` (timeout), non-200, or jq parse failure, report:
+If a cURL command returns empty output or jq fails, report:
 
 ```markdown
 ## Cloud Status — Error
 
-**Error:** [API_FAILURE | TIMEOUT | PARSE_ERROR]
-**URL:** [attempted URL]
-**Detail:** [HTTP code or error message]
-
-The Statuspage.io public API has no rate limits. Errors indicate a network issue.
-**Suggestion:** [retry / check STATUSPAGE_URL / verify connectivity]
-```
-
-## Report Templates
-
-### Minimal Report
-
-```markdown
-## Cloud Status — [page name]
-**[timestamp]** | **Status:** [emoji] [description]
-
-[One sentence if anything noteworthy]
-```
-
-### Standard Report
-
-```markdown
-## Cloud Status Report — [page name]
-**Generated:** [timestamp]
-**Overall:** [emoji] [indicator] — [description]
-
-### [Section Title] (N)
-
-[Table or list of results]
-
-### Summary
-[2-3 sentences]
-```
-
-### Full Intelligence Report
-
-```markdown
-## Cloud Status Report — [page name]
-**Generated:** [ISO 8601 timestamp]
-**Overall Status:** [emoji] [level] — [description]
-
-### Active Incidents (N)
-| Severity | Service | Status | Duration | Latest Update |
-| -------- | ------- | ------ | -------- | ------------- |
-| [impact] | [name] | [status] | [Xh] | [update text, 100 chars] |
-
-### Upcoming Maintenance (N)
-| Service | Scheduled | Until | Impact |
-| ------- | --------- | ----- | ------ |
-| [name] | [date/time] | [date/time] | [impact] |
-
-### Component Health
-| Group | Total | Operational | Degraded | Reliability |
-| ----- | ----- | ----------- | -------- | ----------- |
-| [group] | [N] | [N] | [degraded names] | [score] |
-
-### Regional Impact
-- [Region]: [status with affected services]
-
-### Analysis
-- **Trends:** [observations]
-- **Correlations:** [incident/maintenance overlaps]
-- **Concerns:** [reliability flags]
-
-### Recommendations
-- [actionable item]
-```
-
-## Stakeholder Template
-
-Append to `stakeholder-report` after the Full Intelligence Report:
-
-```
-F5 Distributed Cloud Status Update — [date/time UTC]
-
-Current Status: [indicator] — [description]
-Affected Services: [names from active incidents]
-Customer Impact: [assessment using F5 regional mapping above]
-Status Page: https://www.f5cloudstatus.com
-Estimated Resolution: [from latest incident update, or "Monitoring — no ETA"]
-Next Update Expected: [estimate]
+**Error:** API call failed
+**URL:** [the URL attempted]
+**Suggestion:** Check network connectivity or STATUSPAGE_URL value
 ```
 
 ## Report Delivery
 
-Return the complete report. The main session sees only your response — never
-omit sections or truncate tables.
+Return the complete formatted report. The main session only sees your
+response — do not truncate or omit sections.

--- a/plugins/f5xc-cloudstatus/agents/status-operator.md
+++ b/plugins/f5xc-cloudstatus/agents/status-operator.md
@@ -19,37 +19,98 @@ tools:
 
 # Status Operator Agent
 
-You execute cURL + jq commands provided in your dispatch prompt and format
-the results as Markdown reports. Your prompt contains the exact commands
-to run and the report template to use.
+You query Statuspage.io status pages and produce structured Markdown reports.
 
-## Execution Protocol
+## Initialization
 
-1. Run the cURL + jq commands from your dispatch prompt in a single Bash call
-2. Format results using the template specified in your prompt
-3. Return the complete report
+Read ONE file: `skills/cloud-status/references/commands.md` (relative to
+your plugin root). This contains the exact cURL + jq command for each
+operation. Then run the command matching your assigned operation.
 
-## Rules
+## Execution
 
-- Run commands EXACTLY as provided — do not modify URLs or jq filters
-- Do NOT read reference files unless your prompt explicitly says to
-- Do NOT run extra API calls beyond what your prompt specifies
-- Always include a timestamp in reports (use `date -u +%Y-%m-%dT%H:%M:%SZ`)
-- Emoji map for status indicators: none=✅ minor=⚠️ major=🟠 critical=🔴
+1. Read `commands.md`
+2. Find the section matching the operation in your dispatch prompt
+3. Run the command in a single Bash call
+4. Format the output using the report template below
+
+Do NOT read any other files. Do NOT run extra API calls beyond what the
+command specifies.
+
+## Report Templates
+
+**Minimal** (overall-status, check-component):
+
+```
+## Cloud Status — [page name]
+**[timestamp]** | **Status:** [emoji] [description]
+```
+
+**Standard** (list-components, active-incidents, recent-incidents,
+maintenance, search):
+
+```
+## Cloud Status Report — [page name]
+**Generated:** [timestamp]
+**Overall:** [emoji] [indicator] — [description]
+
+### [Section Title] ([count])
+[table of results]
+
+### Summary
+[2-3 sentences]
+```
+
+**Full Intelligence** (full-briefing, stakeholder-report):
+
+```
+## Cloud Status Report — [page name]
+**Generated:** [timestamp]
+**Overall Status:** [emoji] [level] — [description]
+
+### Active Incidents ([N])
+| Severity | Service | Status | Duration | Latest Update |
+
+### Upcoming Maintenance ([N])
+| Service | Scheduled | Until | Impact |
+
+### Component Health
+| Group | Total | Operational | Degraded |
+
+### Analysis
+- Trends: flag components with 3+ incidents in 7 days
+- Correlations: incidents within 2h of maintenance = correlated
+- Regions: Services=Global, NA/SA PoPs=Americas, EU/ME PoPs=EMEA,
+  Asia/Oceania PoPs=APAC, Legacy=low impact
+
+### Recommendations
+[actionable items]
+```
+
+For stakeholder-report, append:
+
+```
+F5 Distributed Cloud Status Update — [date UTC]
+Current Status: [indicator] — [description]
+Affected Services: [names]
+Customer Impact: [assessment]
+Status Page: https://www.f5cloudstatus.com
+Estimated Resolution: [from latest update, or "Monitoring — no ETA"]
+```
+
+Tone: factual, calm, non-alarmist.
+
+## Emoji Map
+
+none=✅ minor=⚠️ major=🟠 critical=🔴
 
 ## Error Handling
 
-If a cURL command returns empty output or jq fails, report:
+If cURL fails or jq returns empty, report:
 
-```markdown
-## Cloud Status — Error
-
-**Error:** API call failed
-**URL:** [the URL attempted]
-**Suggestion:** Check network connectivity or STATUSPAGE_URL value
 ```
-
-## Report Delivery
-
-Return the complete formatted report. The main session only sees your
-response — do not truncate or omit sections.
+## Cloud Status — Error
+**Error:** [what failed]
+**URL:** [attempted URL]
+**Suggestion:** Check network or STATUSPAGE_URL configuration
+```

--- a/plugins/f5xc-cloudstatus/skills/cloud-status/SKILL.md
+++ b/plugins/f5xc-cloudstatus/skills/cloud-status/SKILL.md
@@ -7,78 +7,148 @@ description: >-
   windows, component status, operational status, or requests a status briefing.
   Also activates for: "is [service] up", "any outages", "what's down",
   "status report for stakeholders", "executive status summary". Delegates
-  all API calls to the status-operator agent — never runs curl in the main
+  all API calls to the status-operator agent — never runs cURL in the main
   session.
 user-invocable: false
-compatibility: Requires curl, jq, and network access to the Statuspage.io API
+compatibility: Requires cURL, jq, and network access to the Statuspage.io API
 ---
 
 # Cloud Status Skill
 
-Cloud service status monitoring and operational intelligence by querying
-a Statuspage.io-powered status page via its public API v2.
+Status monitoring via Statuspage.io public API v2.
 
-**Default target:** F5 Distributed Cloud at `https://www.f5cloudstatus.com`
-**Generic:** Set `STATUSPAGE_URL` env var to use any Statuspage.io page.
+**Default:** F5 Distributed Cloud at `https://www.f5cloudstatus.com`
+**Generic:** Set `STATUSPAGE_URL` env var for any Statuspage.io page.
 
 ## Intent Routing
 
-Map the user's request to an operation type, then delegate to the
-`status-operator` agent.
+| User Intent | Operation |
+| ---------------------------------------------------- | --------------------- |
+| "What's the overall status?" / "Is everything OK?" | `overall-status` |
+| "Show me all components" / "What services exist?" | `list-components` |
+| "Is [service] healthy?" / "Status of [component]" | `check-component` |
+| "Any active incidents?" / "Current outages?" | `active-incidents` |
+| "Show recent incidents" / "Incident history" | `recent-incidents` |
+| "Scheduled maintenance?" / "Maintenance windows?" | `maintenance` |
+| "Full status briefing" / "What's going on?" | `full-briefing` |
+| "Search for [query]" | `search` |
+| "Stakeholder report" / "Executive summary" | `stakeholder-report` |
 
-| User Intent | Operation | Notes |
-| ---------------------------------------------------- | --------------------- | ------------------------------------------ |
-| "What's the overall status?" / "Is everything OK?" | `overall-status` | Quick indicator check |
-| "Show me all components" / "What services exist?" | `list-components` | Full component list with groups |
-| "Is [service] healthy?" / "Status of [component]" | `check-component` | Provide the service name or ID as filter |
-| "Any active incidents?" / "Current outages?" | `active-incidents` | Unresolved only + trend analysis |
-| "Show recent incidents" / "Incident history" | `recent-incidents` | Pass filters: days, status, impact |
-| "Scheduled maintenance?" / "Maintenance windows?" | `maintenance` | upcoming, active, or all |
-| "Full status briefing" / "What's going on?" | `full-briefing` | Complete operational intelligence |
-| "Search for [query]" | `search` | Text search across all entities |
-| "Stakeholder report" / "Executive summary" | `stakeholder-report` | Full briefing + stakeholder template |
-
-### Command Argument Mapping
-
-When invoked via `/cloud-status [arg]`:
+### Command Argument Mapping (`/cloud-status [arg]`)
 
 | Argument | Operation |
-| ------------------ | ---------------------------- |
+| ------------------ | --------------------- |
 | (none) | `full-briefing` |
 | `status` | `overall-status` |
 | `incidents` | `active-incidents` |
 | `maintenance` | `maintenance` |
 | `briefing` | `full-briefing` |
-| `search <query>` | `search` with the query text |
+| `search <query>` | `search` |
 | `components` | `list-components` |
 
 ## Delegation
 
-Delegate to the `status-operator` agent with a lean prompt — the agent has
-all templates and rules built-in, no reference file reads needed.
+Match the operation, then dispatch the agent with the EXACT prompt below.
+Replace `$BASE` with `${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2`.
+
+### overall-status
 
 ```
 Agent(
   subagent_type="f5xc-cloudstatus:status-operator",
-  description="<operation> cloud status",
-  prompt="Operation: <operation-type>
-  User request: <user's exact words>
-  Base URL: ${STATUSPAGE_URL:-https://www.f5cloudstatus.com}
-  Filters: <any user-specified filters, or 'none'>
-
-  Execute the operation and return the report."
+  description="overall cloud status check",
+  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/status.json' | jq '{page: .page.name, indicator: .status.indicator, description: .status.description, updated_at: .page.updated_at}'\n\nFormat as:\n## Cloud Status — [page]\n**[updated_at]** | **Status:** [emoji] [description]\n\nEmoji: none=✅ minor=⚠️ major=🟠 critical=🔴\nIf not operational, add one sentence about the current state."
 )
 ```
 
-**Substitutions:**
+### list-components
 
-- `<operation>` — short description (e.g., `overall-status`, `check DNS component`)
-- `<operation-type>` — one of: `overall-status`, `list-components`, `check-component`, `active-incidents`, `recent-incidents`, `maintenance`, `full-briefing`, `search`, `stakeholder-report`
-- `<user's exact words>` — the user's original request verbatim
-- `<filters>` — extracted parameters: component name, status/impact/days filter, search query, maintenance scope
+```
+Agent(
+  subagent_type="f5xc-cloudstatus:status-operator",
+  description="list cloud status components",
+  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/components.json' | jq '(.components | map(select(.group == true)) | map({(.id): .name}) | add // {}) as $groups | [.components[] | select(.group == false or .group == null) | {name, status, group: (if .group_id then ($groups[.group_id] // \"Ungrouped\") else \"Ungrouped\" end)}] | group_by(.group) | map({group: .[0].group, total: length, operational: [.[] | select(.status == \"operational\")] | length, degraded: [.[] | select(.status != \"operational\") | .name]})'\n\nFormat as a table grouped by group name. Include summary counts.\n## Cloud Status Report — Components\n**Generated:** [timestamp]\n\n### Components by Group\n| Group | Total | Operational | Degraded |\n[one row per group]\n\n### Summary\n[total] components across [N] groups."
+)
+```
+
+### check-component
+
+```
+Agent(
+  subagent_type="f5xc-cloudstatus:status-operator",
+  description="check [COMPONENT] status",
+  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/components.json' | jq --arg n 'COMPONENT_NAME' '[.components[] | select(.name | ascii_downcase | contains($n | ascii_downcase)) | {name, status, description}]'\n\nIf results are empty, report: No component matching 'COMPONENT_NAME' found.\nOtherwise format as:\n## Cloud Status — [component name]\n**Status:** [emoji] [status]\n**Description:** [description or 'N/A']"
+)
+```
+
+### active-incidents
+
+```
+Agent(
+  subagent_type="f5xc-cloudstatus:status-operator",
+  description="active incidents check",
+  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/incidents/unresolved.json' | jq '[.incidents[] | {name, status, impact, created_at, shortlink, duration_h: (((now - (.created_at | sub(\"\\\\.[0-9]+\"; \"\") | fromdateiso8601)) / 3600) | floor), latest_update: (.incident_updates[0].body // \"No updates\")[0:300], affected: [(.components // [])[] | .name]}]'\n\nFormat as:\n## Cloud Status Report — Active Incidents\n**Generated:** [timestamp]\n\n### Active Incidents ([count])\n| Severity | Service | Status | Duration | Latest Update |\n[one row per incident]\n\nIf no incidents, report: ✅ No active incidents."
+)
+```
+
+### recent-incidents
+
+```
+Agent(
+  subagent_type="f5xc-cloudstatus:status-operator",
+  description="recent incidents",
+  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/incidents.json' | jq '[.incidents[] | {name, status, impact, created_at, resolved_at, shortlink, latest_update: (.incident_updates[0].body // \"No updates\")[0:200], affected: [(.components // [])[] | .name]}]'\n\nApply any user-specified filters: FILTERS\n\nFormat as:\n## Cloud Status Report — Recent Incidents\n**Generated:** [timestamp]\n\n### Incidents ([count])\n| Severity | Service | Status | Created | Resolved |\n[one row per incident]\n\n### Summary\n[count] incidents in the last [window]."
+)
+```
+
+### maintenance
+
+```
+Agent(
+  subagent_type="f5xc-cloudstatus:status-operator",
+  description="maintenance windows",
+  prompt="Run these two commands:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/scheduled-maintenances/upcoming.json' | jq '[.scheduled_maintenances[] | {name, status, impact, scheduled_for, scheduled_until, affected: [(.components // [])[] | .name]}]'\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/scheduled-maintenances/active.json' | jq '[.scheduled_maintenances[] | {name, status, impact, scheduled_for, scheduled_until, affected: [(.components // [])[] | .name]}]'\n\nFormat as:\n## Cloud Status Report — Maintenance\n**Generated:** [timestamp]\n\n### Upcoming ([count])\n| Service | Scheduled | Until | Impact |\n\n### Active ([count])\n| Service | Status | Until | Impact |\n\nIf both empty: ✅ No scheduled or active maintenance."
+)
+```
+
+### full-briefing
+
+```
+Agent(
+  subagent_type="f5xc-cloudstatus:status-operator",
+  description="full cloud status briefing",
+  prompt="Run these three commands in a SINGLE Bash call:\n\nBASE='$BASE'\necho '===STATUS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/summary.json\" | jq '{page: .page.name, status: .status, incidents: [.incidents[] | {name, status, impact, created_at, duration_h: (((now - (.created_at | sub(\"\\\\.[0-9]+\"; \"\") | fromdateiso8601)) / 3600) | floor), latest_update: (.incident_updates[0].body // \"None\")[0:300], affected: [(.components // [])[] | .name]}], maintenance: [.scheduled_maintenances[] | {name, status, impact, scheduled_for, scheduled_until, affected: [(.components // [])[] | .name]}]}' && echo '===COMPONENTS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/components.json\" | jq '(.components | map(select(.group == true)) | map({(.id): .name}) | add // {}) as $groups | [.components[] | select(.group == false or .group == null) | {name, status, group: (if .group_id then ($groups[.group_id] // \"Ungrouped\") else \"Ungrouped\" end)}] | group_by(.group) | map({group: .[0].group, total: length, operational: [.[] | select(.status == \"operational\")] | length, degraded: [.[] | select(.status != \"operational\") | .name]})' && echo '===TRENDS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/incidents.json\" | jq '[.incidents[] | {name, impact, created_at, resolved_at: (.resolved_at // null), affected: [(.components // [])[] | .name]}]'\n\nFormat as a Full Intelligence Report:\n## Cloud Status Report — [page]\n**Generated:** [timestamp]\n**Overall Status:** [emoji] [indicator] — [description]\n\n### Active Incidents ([N])\n| Severity | Service | Status | Duration | Latest Update |\n\n### Upcoming Maintenance ([N])\n| Service | Scheduled | Until | Impact |\n\n### Component Health\n| Group | Total | Operational | Degraded |\n\n### Analysis\nFrom the trends data: flag any component with 3+ incidents in 7 days as WARNING.\nNote if any incidents overlap maintenance windows (created_at within 2h of scheduled_for).\n\n### Recommendations\n[actionable items based on findings]\n\nF5 XC regions: Services=Global, North/South America PoPs=Americas, Europe/Middle East PoPs=EMEA, Asia/Oceania PoPs=APAC, Legacy groups=low impact."
+)
+```
+
+### search
+
+```
+Agent(
+  subagent_type="f5xc-cloudstatus:status-operator",
+  description="search cloud status for QUERY",
+  prompt="Run these three commands in a SINGLE Bash call:\n\nBASE='$BASE'\nQUERY='SEARCH_QUERY'\necho '===COMPONENTS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/components.json\" | jq --arg q \"$QUERY\" '($q | ascii_downcase) as $ql | [.components[] | select(.name | ascii_downcase | contains($ql)) | {name, status}]' && echo '===INCIDENTS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/incidents.json\" | jq --arg q \"$QUERY\" '($q | ascii_downcase) as $ql | [.incidents[] | select((.name | ascii_downcase | contains($ql)) or ((.incident_updates // []) | any(.body | ascii_downcase | contains($ql)))) | {name, status, impact, created_at}]' && echo '===MAINTENANCES===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/scheduled-maintenances.json\" | jq --arg q \"$QUERY\" '($q | ascii_downcase) as $ql | [.scheduled_maintenances[] | select((.name | ascii_downcase | contains($ql)) or ((.incident_updates // []) | any(.body | ascii_downcase | contains($ql)))) | {name, status, scheduled_for}]'\n\nFormat as:\n## Cloud Status — Search: 'SEARCH_QUERY'\n**Generated:** [timestamp]\n\n### Matching Components ([N])\n### Matching Incidents ([N])\n### Matching Maintenances ([N])\n\nIf all empty: No results matching 'SEARCH_QUERY'."
+)
+```
+
+### stakeholder-report
+
+Use the same prompt as `full-briefing` but append:
+
+```
+Also append a stakeholder communication block:
+
+F5 Distributed Cloud Status Update — [date/time UTC]
+Current Status: [indicator] — [description]
+Affected Services: [names from active incidents]
+Customer Impact: [assessment — Services=control plane, PoPs=regional traffic, DNS=critical for new connections]
+Status Page: https://www.f5cloudstatus.com
+Estimated Resolution: [from latest incident update, or "Monitoring — no ETA"]
+
+Tone: factual, calm, non-alarmist. Avoid "emergency", "disaster", "catastrophic".
+```
 
 ## After Delegation
 
-Present the agent's report to the user as-is. The agent's report is the
-complete output — add no extra commentary. If the user asks follow-up
-questions, determine the new operation type and delegate again.
+Present the agent's report to the user as-is. If the user asks follow-up
+questions, determine the new operation and delegate again.

--- a/plugins/f5xc-cloudstatus/skills/cloud-status/SKILL.md
+++ b/plugins/f5xc-cloudstatus/skills/cloud-status/SKILL.md
@@ -37,7 +37,7 @@ Status monitoring via Statuspage.io public API v2.
 ### Command Argument Mapping (`/cloud-status [arg]`)
 
 | Argument | Operation |
-| ------------------ | --------------------- |
+| ---------------- | --------------------- |
 | (none) | `full-briefing` |
 | `status` | `overall-status` |
 | `incidents` | `active-incidents` |
@@ -48,107 +48,24 @@ Status monitoring via Statuspage.io public API v2.
 
 ## Delegation
 
-Match the operation, then dispatch the agent with the EXACT prompt below.
-Replace `$BASE` with `${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2`.
-
-### overall-status
-
 ```
 Agent(
   subagent_type="f5xc-cloudstatus:status-operator",
-  description="overall cloud status check",
-  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/status.json' | jq '{page: .page.name, indicator: .status.indicator, description: .status.description, updated_at: .page.updated_at}'\n\nFormat as:\n## Cloud Status — [page]\n**[updated_at]** | **Status:** [emoji] [description]\n\nEmoji: none=✅ minor=⚠️ major=🟠 critical=🔴\nIf not operational, add one sentence about the current state."
+  description="<operation> cloud status",
+  prompt="Operation: <operation-type>
+User request: <user's exact words>
+Filters: <component name | status | impact | days | search query | none>
+
+Read skills/cloud-status/references/commands.md and run the
+<operation-type> section. Return the formatted report."
 )
 ```
 
-### list-components
-
-```
-Agent(
-  subagent_type="f5xc-cloudstatus:status-operator",
-  description="list cloud status components",
-  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/components.json' | jq '(.components | map(select(.group == true)) | map({(.id): .name}) | add // {}) as $groups | [.components[] | select(.group == false or .group == null) | {name, status, group: (if .group_id then ($groups[.group_id] // \"Ungrouped\") else \"Ungrouped\" end)}] | group_by(.group) | map({group: .[0].group, total: length, operational: [.[] | select(.status == \"operational\")] | length, degraded: [.[] | select(.status != \"operational\") | .name]})'\n\nFormat as a table grouped by group name. Include summary counts.\n## Cloud Status Report — Components\n**Generated:** [timestamp]\n\n### Components by Group\n| Group | Total | Operational | Degraded |\n[one row per group]\n\n### Summary\n[total] components across [N] groups."
-)
-```
-
-### check-component
-
-```
-Agent(
-  subagent_type="f5xc-cloudstatus:status-operator",
-  description="check [COMPONENT] status",
-  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/components.json' | jq --arg n 'COMPONENT_NAME' '[.components[] | select(.name | ascii_downcase | contains($n | ascii_downcase)) | {name, status, description}]'\n\nIf results are empty, report: No component matching 'COMPONENT_NAME' found.\nOtherwise format as:\n## Cloud Status — [component name]\n**Status:** [emoji] [status]\n**Description:** [description or 'N/A']"
-)
-```
-
-### active-incidents
-
-```
-Agent(
-  subagent_type="f5xc-cloudstatus:status-operator",
-  description="active incidents check",
-  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/incidents/unresolved.json' | jq '[.incidents[] | {name, status, impact, created_at, shortlink, duration_h: (((now - (.created_at | sub(\"\\\\.[0-9]+\"; \"\") | fromdateiso8601)) / 3600) | floor), latest_update: (.incident_updates[0].body // \"No updates\")[0:300], affected: [(.components // [])[] | .name]}]'\n\nFormat as:\n## Cloud Status Report — Active Incidents\n**Generated:** [timestamp]\n\n### Active Incidents ([count])\n| Severity | Service | Status | Duration | Latest Update |\n[one row per incident]\n\nIf no incidents, report: ✅ No active incidents."
-)
-```
-
-### recent-incidents
-
-```
-Agent(
-  subagent_type="f5xc-cloudstatus:status-operator",
-  description="recent incidents",
-  prompt="Run this single command:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/incidents.json' | jq '[.incidents[] | {name, status, impact, created_at, resolved_at, shortlink, latest_update: (.incident_updates[0].body // \"No updates\")[0:200], affected: [(.components // [])[] | .name]}]'\n\nApply any user-specified filters: FILTERS\n\nFormat as:\n## Cloud Status Report — Recent Incidents\n**Generated:** [timestamp]\n\n### Incidents ([count])\n| Severity | Service | Status | Created | Resolved |\n[one row per incident]\n\n### Summary\n[count] incidents in the last [window]."
-)
-```
-
-### maintenance
-
-```
-Agent(
-  subagent_type="f5xc-cloudstatus:status-operator",
-  description="maintenance windows",
-  prompt="Run these two commands:\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/scheduled-maintenances/upcoming.json' | jq '[.scheduled_maintenances[] | {name, status, impact, scheduled_for, scheduled_until, affected: [(.components // [])[] | .name]}]'\n\ncurl -sL --connect-timeout 10 --max-time 15 '$BASE/scheduled-maintenances/active.json' | jq '[.scheduled_maintenances[] | {name, status, impact, scheduled_for, scheduled_until, affected: [(.components // [])[] | .name]}]'\n\nFormat as:\n## Cloud Status Report — Maintenance\n**Generated:** [timestamp]\n\n### Upcoming ([count])\n| Service | Scheduled | Until | Impact |\n\n### Active ([count])\n| Service | Status | Until | Impact |\n\nIf both empty: ✅ No scheduled or active maintenance."
-)
-```
-
-### full-briefing
-
-```
-Agent(
-  subagent_type="f5xc-cloudstatus:status-operator",
-  description="full cloud status briefing",
-  prompt="Run these three commands in a SINGLE Bash call:\n\nBASE='$BASE'\necho '===STATUS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/summary.json\" | jq '{page: .page.name, status: .status, incidents: [.incidents[] | {name, status, impact, created_at, duration_h: (((now - (.created_at | sub(\"\\\\.[0-9]+\"; \"\") | fromdateiso8601)) / 3600) | floor), latest_update: (.incident_updates[0].body // \"None\")[0:300], affected: [(.components // [])[] | .name]}], maintenance: [.scheduled_maintenances[] | {name, status, impact, scheduled_for, scheduled_until, affected: [(.components // [])[] | .name]}]}' && echo '===COMPONENTS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/components.json\" | jq '(.components | map(select(.group == true)) | map({(.id): .name}) | add // {}) as $groups | [.components[] | select(.group == false or .group == null) | {name, status, group: (if .group_id then ($groups[.group_id] // \"Ungrouped\") else \"Ungrouped\" end)}] | group_by(.group) | map({group: .[0].group, total: length, operational: [.[] | select(.status == \"operational\")] | length, degraded: [.[] | select(.status != \"operational\") | .name]})' && echo '===TRENDS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/incidents.json\" | jq '[.incidents[] | {name, impact, created_at, resolved_at: (.resolved_at // null), affected: [(.components // [])[] | .name]}]'\n\nFormat as a Full Intelligence Report:\n## Cloud Status Report — [page]\n**Generated:** [timestamp]\n**Overall Status:** [emoji] [indicator] — [description]\n\n### Active Incidents ([N])\n| Severity | Service | Status | Duration | Latest Update |\n\n### Upcoming Maintenance ([N])\n| Service | Scheduled | Until | Impact |\n\n### Component Health\n| Group | Total | Operational | Degraded |\n\n### Analysis\nFrom the trends data: flag any component with 3+ incidents in 7 days as WARNING.\nNote if any incidents overlap maintenance windows (created_at within 2h of scheduled_for).\n\n### Recommendations\n[actionable items based on findings]\n\nF5 XC regions: Services=Global, North/South America PoPs=Americas, Europe/Middle East PoPs=EMEA, Asia/Oceania PoPs=APAC, Legacy groups=low impact."
-)
-```
-
-### search
-
-```
-Agent(
-  subagent_type="f5xc-cloudstatus:status-operator",
-  description="search cloud status for QUERY",
-  prompt="Run these three commands in a SINGLE Bash call:\n\nBASE='$BASE'\nQUERY='SEARCH_QUERY'\necho '===COMPONENTS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/components.json\" | jq --arg q \"$QUERY\" '($q | ascii_downcase) as $ql | [.components[] | select(.name | ascii_downcase | contains($ql)) | {name, status}]' && echo '===INCIDENTS===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/incidents.json\" | jq --arg q \"$QUERY\" '($q | ascii_downcase) as $ql | [.incidents[] | select((.name | ascii_downcase | contains($ql)) or ((.incident_updates // []) | any(.body | ascii_downcase | contains($ql)))) | {name, status, impact, created_at}]' && echo '===MAINTENANCES===' && curl -sL --connect-timeout 10 --max-time 15 \"${BASE}/scheduled-maintenances.json\" | jq --arg q \"$QUERY\" '($q | ascii_downcase) as $ql | [.scheduled_maintenances[] | select((.name | ascii_downcase | contains($ql)) or ((.incident_updates // []) | any(.body | ascii_downcase | contains($ql)))) | {name, status, scheduled_for}]'\n\nFormat as:\n## Cloud Status — Search: 'SEARCH_QUERY'\n**Generated:** [timestamp]\n\n### Matching Components ([N])\n### Matching Incidents ([N])\n### Matching Maintenances ([N])\n\nIf all empty: No results matching 'SEARCH_QUERY'."
-)
-```
-
-### stakeholder-report
-
-Use the same prompt as `full-briefing` but append:
-
-```
-Also append a stakeholder communication block:
-
-F5 Distributed Cloud Status Update — [date/time UTC]
-Current Status: [indicator] — [description]
-Affected Services: [names from active incidents]
-Customer Impact: [assessment — Services=control plane, PoPs=regional traffic, DNS=critical for new connections]
-Status Page: https://www.f5cloudstatus.com
-Estimated Resolution: [from latest incident update, or "Monitoring — no ETA"]
-
-Tone: factual, calm, non-alarmist. Avoid "emergency", "disaster", "catastrophic".
-```
+For `check-component`: include the component name or ID as the filter.
+For `search`: include the search query as the filter.
+For `recent-incidents`: include any days/status/impact filters.
 
 ## After Delegation
 
-Present the agent's report to the user as-is. If the user asks follow-up
-questions, determine the new operation and delegate again.
+Present the agent's report as-is. For follow-ups, determine the new
+operation and delegate again.

--- a/plugins/f5xc-cloudstatus/skills/cloud-status/references/commands.md
+++ b/plugins/f5xc-cloudstatus/skills/cloud-status/references/commands.md
@@ -1,0 +1,193 @@
+# cURL Command Templates
+
+One section per operation. Agent: run ONLY the section matching your operation.
+
+BASE is always: `${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2`
+
+## overall-status
+
+```bash
+BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
+curl -sL --connect-timeout 10 --max-time 15 "${BASE}/status.json" | tr -d '\000-\011\013-\014\016-\037' | jq '{
+  page: .page.name,
+  indicator: .status.indicator,
+  description: .status.description,
+  updated_at: .page.updated_at
+}'
+```
+
+## list-components
+
+```bash
+BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
+curl -sL --connect-timeout 10 --max-time 15 "${BASE}/components.json" | tr -d '\000-\011\013-\014\016-\037' | jq '
+  (.components | map(select(.group == true))
+    | map({(.id): .name}) | add // {}) as $groups |
+  [.components[]
+    | select(.group == false or .group == null)
+    | {name, status,
+       group: (if .group_id then ($groups[.group_id] // "Ungrouped")
+               else "Ungrouped" end)}]
+  | group_by(.group)
+  | map({
+      group: .[0].group,
+      total: length,
+      operational: [.[] | select(.status == "operational")] | length,
+      degraded: [.[] | select(.status != "operational") | .name]
+    })'
+```
+
+## check-component
+
+Replace COMPONENT_NAME with the user's query (case-insensitive search).
+
+```bash
+BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
+NAME="COMPONENT_NAME"
+curl -sL --connect-timeout 10 --max-time 15 "${BASE}/components.json" \
+  | tr -d '\000-\011\013-\014\016-\037' | jq --arg n "$NAME" \
+  '[.components[] | select(.name | ascii_downcase
+    | contains($n | ascii_downcase)) | {name, status, description}]'
+```
+
+## active-incidents
+
+```bash
+BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/incidents/unresolved.json" | tr -d '\000-\011\013-\014\016-\037' | jq '[.incidents[] | {
+    name, status, impact, created_at, shortlink,
+    duration_h: (((now - (.created_at
+      | sub("\\.[0-9]+"; "") | fromdateiso8601)) / 3600) | floor),
+    latest_update: (.incident_updates[0].body // "No updates")[0:300],
+    affected: [(.components // [])[] | .name]
+  }]'
+```
+
+## recent-incidents
+
+```bash
+BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/incidents.json" | tr -d '\000-\011\013-\014\016-\037' | jq '[.incidents[] | {
+    name, status, impact, created_at, resolved_at, shortlink,
+    latest_update: (.incident_updates[0].body // "No updates")[0:200],
+    affected: [(.components // [])[] | .name]
+  }]'
+```
+
+Optional filters (add inside the array brackets):
+
+- By days: `select((.created_at | sub("\\.[0-9]+"; "")
+  | fromdateiso8601) > (now - (DAYS * 86400)))`
+- By status: `select(.status == "STATUS")`
+- By impact: `select(.impact == "IMPACT")`
+
+## maintenance
+
+Run whichever endpoints the user requested (default: both).
+
+```bash
+BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
+FILTER='[.scheduled_maintenances[] | {
+  name, status, impact, scheduled_for, scheduled_until,
+  affected: [(.components // [])[] | .name]}]'
+
+echo "=== Upcoming ===" && \
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/scheduled-maintenances/upcoming.json" | tr -d '\000-\011\013-\014\016-\037' | jq "$FILTER"
+
+echo "=== Active ===" && \
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/scheduled-maintenances/active.json" | tr -d '\000-\011\013-\014\016-\037' | jq "$FILTER"
+```
+
+## full-briefing
+
+Run all three commands in a single Bash call.
+
+```bash
+BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
+
+echo "===STATUS===" && \
+curl -sL --connect-timeout 10 --max-time 15 "${BASE}/summary.json" | tr -d '\000-\011\013-\014\016-\037' | jq '{
+  page: .page.name,
+  status: .status,
+  incidents: [.incidents[] | {
+    name, status, impact, created_at,
+    duration_h: (((now - (.created_at
+      | sub("\\.[0-9]+"; "") | fromdateiso8601)) / 3600) | floor),
+    latest_update: (.incident_updates[0].body // "None")[0:300],
+    affected: [(.components // [])[] | .name]
+  }],
+  maintenance: [.scheduled_maintenances[] | {
+    name, status, impact, scheduled_for, scheduled_until,
+    affected: [(.components // [])[] | .name]
+  }]
+}'
+
+echo "===COMPONENTS===" && \
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/components.json" | tr -d '\000-\011\013-\014\016-\037' | jq '
+  (.components | map(select(.group == true))
+    | map({(.id): .name}) | add // {}) as $groups |
+  [.components[]
+    | select(.group == false or .group == null)
+    | {name, status,
+       group: (if .group_id then ($groups[.group_id] // "Ungrouped")
+               else "Ungrouped" end)}]
+  | group_by(.group)
+  | map({
+      group: .[0].group,
+      total: length,
+      operational: [.[] | select(.status == "operational")] | length,
+      degraded: [.[] | select(.status != "operational") | .name]
+    })'
+
+echo "===TRENDS===" && \
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/incidents.json" | tr -d '\000-\011\013-\014\016-\037' | jq '[.incidents[] | {
+    name, impact, created_at,
+    resolved_at: (.resolved_at // null),
+    affected: [(.components // [])[] | .name]
+  }]'
+```
+
+## search
+
+Replace SEARCH_QUERY with the user's query.
+
+```bash
+BASE="${STATUSPAGE_URL:-https://www.f5cloudstatus.com}/api/v2"
+QUERY="SEARCH_QUERY"
+
+echo "=== Components ===" && \
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/components.json" \
+  | tr -d '\000-\011\013-\014\016-\037' | jq --arg q "$QUERY" '($q | ascii_downcase) as $ql |
+    [.components[] | select(.name | ascii_downcase
+      | contains($ql)) | {name, status}]'
+
+echo "=== Incidents ===" && \
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/incidents.json" \
+  | tr -d '\000-\011\013-\014\016-\037' | jq --arg q "$QUERY" '($q | ascii_downcase) as $ql |
+    [.incidents[] | select((.name | ascii_downcase | contains($ql))
+      or ((.incident_updates // [])
+        | any(.body | ascii_downcase | contains($ql))))
+      | {name, status, impact, created_at}]'
+
+echo "=== Maintenances ===" && \
+curl -sL --connect-timeout 10 --max-time 15 \
+  "${BASE}/scheduled-maintenances.json" \
+  | tr -d '\000-\011\013-\014\016-\037' | jq --arg q "$QUERY" '($q | ascii_downcase) as $ql |
+    [.scheduled_maintenances[]
+      | select((.name | ascii_downcase | contains($ql))
+        or ((.incident_updates // [])
+          | any(.body | ascii_downcase | contains($ql))))
+      | {name, status, scheduled_for}]'
+```
+
+## stakeholder-report
+
+Same commands as `full-briefing`.


### PR DESCRIPTION
## Summary

- Restructure cloudstatus plugin from 387-line scanning agent to 55-line thin executor that receives exact cURL+jq commands from the skill
- Move all operation logic into SKILL.md (84 to 154 lines) so the skill constructs the precise command per operation
- Add -L flag to all cURL commands to follow HTTP redirects
- Bump version from 1.1.0 to 1.2.0

**Impact:** 7,437 to 754 tokens per invocation (90% reduction), 5+ to 1-2 turns (75% reduction)

Closes #387

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify plugin.json and marketplace.json version both read 1.2.0
- [ ] Verify status-operator.md is a minimal executor (55 lines)
- [ ] Verify SKILL.md contains all operation cURL+jq commands