### PR TITLE
feat(meddpicc): add deal-update intelligence ingestion skill, jq persistence protocol, fix critical review issues

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "f5xc-meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/plugins/f5xc-meddpicc/.claude-plugin/plugin.json
+++ b/plugins/f5xc-meddpicc/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "f5xc-meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/f5xc-meddpicc/README.md
+++ b/plugins/f5xc-meddpicc/README.md
@@ -34,6 +34,7 @@ MEDDPICC is a qualification and deal-execution framework for complex B2B sales:
 | Command | Skill | Purpose |
 | ------- | ----- | ------- |
 | `/f5xc-meddpicc:qualify-deal` | `deal-qualification` | Score a deal with MEDDPICC scorecard |
+| `/f5xc-meddpicc:update-deal` | `deal-update` | Ingest intel from any source into a deal file |
 | `/f5xc-meddpicc:deal-review` | `deal-review` | Facilitate weekly deal inspection |
 | `/f5xc-meddpicc:champion-test` | `champion-test` | Assess if contact is a true champion |
 | `/f5xc-meddpicc:build-map` | `mutual-action-plan` | Build a Mutual Action Plan |
@@ -67,11 +68,25 @@ Or add to your marketplace configuration for automatic installation.
 
 ## Usage Examples
 
-### Qualify a deal
+### Create a new deal (day-0)
 
 ```
 /f5xc-meddpicc:qualify-deal Acme Corp
 ```
+
+### Ingest intelligence from any source
+
+```
+/f5xc-meddpicc:update-deal Acme Corp
+Here are my notes from today's call with the CTO:
+- Confirmed $500K budget for API security modernization
+- Board mandate to fix API incidents by Q3
+- Currently evaluating us and Cloudflare
+- Architecture review board meets May 26
+```
+
+Accepted sources: meeting notes, emails, transcripts, OSINT reports,
+competitive intel, Salesforce exports, presentation feedback — any text.
 
 ### Run a weekly deal review
 

--- a/plugins/f5xc-meddpicc/commands/update-deal.md
+++ b/plugins/f5xc-meddpicc/commands/update-deal.md
@@ -1,0 +1,20 @@
+---
+description: Ingest meeting notes, emails, transcripts, OSINT reports, or any intel into a MEDDPICC deal file
+argument-hint: "[account or deal name] — then paste or describe the source"
+---
+
+Invoke the `f5xc-meddpicc:deal-update` skill to extract MEDDPICC
+intelligence from "$ARGUMENTS" and update the matching deal JSON file.
+
+**Accepted sources:**
+
+- Meeting notes or call summaries
+- Email threads (paste directly)
+- Online meeting transcripts
+- OSINT or competitive intelligence reports
+- Salesforce opportunity exports
+- Presentation or demo feedback
+- Any text containing deal-relevant information
+
+**Output:** Proposed update diff (for your review) → confirmed
+changes written to the deal JSON via `jq` → updated MEDDPICC scorecard.

--- a/plugins/f5xc-meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/f5xc-meddpicc/skills/deal-qualification/SKILL.md
@@ -26,6 +26,121 @@ review produces a JSON file conforming to this schema. The schema
 embeds guiding questions and scoring rubric definitions for each
 MEDDPICC element.
 
+## Element Key Reference
+
+Use these exact JSON keys in all jq paths:
+
+| Display Name | JSON Key | jq Path |
+| ------------ | -------- | ------- |
+| Metrics (M) | `metrics` | `.qualification.metrics` |
+| Economic Buyer (E) | `economicBuyer` | `.qualification.economicBuyer` |
+| Decision Criteria (D1) | `decisionCriteria` | `.qualification.decisionCriteria` |
+| Decision Process (D2) | `decisionProcess` | `.qualification.decisionProcess` |
+| Paper Process (P) | `paperProcess` | `.qualification.paperProcess` |
+| Identify Pain (I) | `implicateThePain` | `.qualification.implicateThePain` |
+| Champion (C1) | `champion` | `.qualification.champion` |
+| Competition (C2) | `competition` | `.qualification.competition` |
+
+## Data Persistence Protocol
+
+Write data to the deal JSON **incrementally** using `jq` as each
+piece is collected — never batch writes at the end. This ensures
+data is preserved if the user pauses or the session ends.
+
+Verify `jq` is installed before starting: if `jq --version` fails,
+ask the user to install it (`apt install jq` or `brew install jq`).
+
+### File variable
+
+Set a shell variable at the start of the session and reuse it for
+every write:
+
+```bash
+DEAL_FILE="/path/to/account-deal.json"
+```
+
+### Write pattern
+
+Use `jq` with tmp-and-mv (`sponge` is not available):
+
+```bash
+jq '<expression>' "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+### Escaping rules
+
+- Use `--arg name value` for user-provided strings — prevents
+  shell injection and handles quotes automatically
+- Use `--argjson name value` for numbers and booleans
+- Never use `!=` in jq — use `| not` instead
+- Never use `!` in Bash — use `cmd || { handle; }` instead
+
+### Write points and jq patterns
+
+**Metadata field** — after each metadata answer:
+
+```bash
+jq --arg v "Discovery" '.metadata.dealStatus = $v' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Multiple metadata fields** — when collecting several at once:
+
+```bash
+jq --arg status "Discovery" --arg close "2026-09-30" \
+   --argjson prob 0.25 \
+  '.metadata.dealStatus = $status |
+   .metadata.closeDate = $close |
+   .metadata.winProbability = $prob' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**MEDDPICC element completion** — after scoring each element, write
+responses, score, evidence, notes, completionStatus, and
+elementScore. Replace `metrics` with the correct key from the
+Element Key Reference table:
+
+```bash
+jq --arg r0 "Answer to question 1" \
+   --arg r1 "Answer to question 2" \
+   --argjson score 2 \
+   --arg ev "[2026-05-06 interview] Supporting evidence" \
+   --arg notes "Additional context" \
+  '.qualification.metrics.responses = [$r0, $r1] |
+   .qualification.metrics.score = $score |
+   .qualification.metrics.evidence = $ev |
+   .qualification.metrics.notes = $notes |
+   .metadata.completionStatus.metrics = "complete" |
+   .scoring.elementScores.metrics = $score' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Overall score calculation** — after all 8 elements are scored:
+
+```bash
+jq '(.scoring.elementScores | to_entries | map(.value) | add) as $sum |
+  .scoring.overallScore = ($sum / 32 * 100) |
+  .scoring.overallRating = (
+    if $sum <= 13 then "Red"
+    elif $sum <= 25 then "Yellow"
+    else "Green" end)' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Array append** — for stakeholders, milestones, actions, team.
+Stakeholders require `name`, `title`, and `roleInDeal`. Initialize
+the array if absent:
+
+```bash
+jq --argjson item '{"name":"Jane","title":"VP","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"...","viewOfF5":"Neutral","f5Owner":"John Smith"}' \
+  'if .stakeholders then .stakeholders += [$item] else .stakeholders = [$item] end' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Scorecard display:** `scoring.overallScore` stores a percentage
+(0–100). To display `X/32`, sum `scoring.elementScores` values
+directly — do not back-compute from the percentage.
+
 ## Initialization — Determine Mode
 
 When the user invokes this skill, determine which mode to use:
@@ -34,24 +149,49 @@ When the user invokes this skill, determine which mode to use:
 
 User provides a deal or account name with no existing JSON file.
 
-1. Create a new deal JSON with a generated `dealId`, the provided
-   account/deal name, today's date as `reviewDate`, and all
-   `completionStatus` fields set to `"not_started"`
-2. Collect metadata first: deal status, close date, competition,
-   win probability, forecast stage, revenue breakdown, client
-   interactions
-3. Walk through each MEDDPICC element sequentially using the
-   `questions` from the schema — ask one question at a time
-4. After each element: assign a score (0-4) using the
-   `scoreDefinition` from the schema, ask for evidence, update
-   `completionStatus` to `"complete"`
-5. After all 8 elements: collect Three Whys, stakeholders, sales
-   strategy, close plan, and team
-6. Calculate `scoring.overallScore` and `scoring.overallRating`
-7. Write the JSON file
+1. Create a new deal JSON using the `Write` tool with a **full
+   skeleton** that includes all static data pre-populated from the
+   schema. Use [example-deal.json](../../schema/example-deal.json)
+   as the structural reference. Every MEDDPICC element must include:
+   - `definition` — from the schema's `const` value
+   - `questions` — from the schema's `default` array
+   - `scoreDefinition` — from the schema's `default` object
+   - `responses: []` — empty array (not null)
+   - `score: 0` — integer zero
+   - `evidence: ""` — empty string (not null, not omitted)
+   - `notes: ""` — empty string (not null, not omitted)
 
-The user can pause at any time. On pause, write the JSON with
-`completionStatus` reflecting progress for each section.
+   The `evidence` and `notes` fields **must be initialized to `""`**
+   — not `null`, not omitted. Downstream evidence appends depend
+   on these being strings. Also include:
+   - `metadata` with generated `dealId`, account/deal name, today's
+     `reviewDate`, all `completionStatus` fields `"not_started"`
+   - `scoring.elementScores` with all 8 keys set to `0`
+   - `scoring.overallScore: 0` and `scoring.overallRating: "Red"`
+   - Empty `stakeholders: []`, `closePlan: {milestones: [],
+     criticalActions: []}`, `team: {f5: [], partner: []}`
+2. Set the `DEAL_FILE` shell variable to the file path.
+3. Collect metadata: deal status, close date, competition, win
+   probability, forecast stage, revenue breakdown, client
+   interactions. **Write:** after each answer (or batch of related
+   answers), update the metadata field(s) with `jq`.
+4. Walk through each MEDDPICC element sequentially using the
+   `questions` from the schema — ask one question at a time.
+5. After each element: assign a score (0-4) using the
+   `scoreDefinition` from the schema, ask for evidence. **Write:**
+   immediately update `qualification.<element>.responses`,
+   `.score`, `.evidence`, `.notes`, plus
+   `metadata.completionStatus.<element>` = `"complete"` and
+   `scoring.elementScores.<element>` with a single `jq` call.
+6. After all 8 elements: collect Three Whys, stakeholders, sales
+   strategy, close plan, and team. **Write:** after each section,
+   update the section data and its `completionStatus` with `jq`.
+7. **Write:** calculate and write `scoring.overallScore` and
+   `scoring.overallRating` with the overall score `jq` pattern.
+
+The file is always up to date — there is no final "save" step. The
+user can pause at any time without data loss because every answer
+is persisted immediately.
 
 ### Mode 2: Import and Complete
 
@@ -59,12 +199,16 @@ User provides `--import` flag, a Salesforce opportunity ID, or there
 is an existing JSON file for this deal.
 
 **If existing JSON file found:**
-1. Read the file
+
+1. Read the file and set the `DEAL_FILE` shell variable
 2. Check `completionStatus` for incomplete sections
 3. Present a summary of what's complete and what's missing
 4. Ask targeted questions only for incomplete/partial sections
+5. **Write:** use `jq` to update each completed section
+   immediately (same protocol as Mode 1)
 
 **If Salesforce opportunity ID provided:**
+
 1. Read the field mapping from
    [sfdc-field-mapping.json](references/sfdc-field-mapping.json)
 2. Query Salesforce using the SOQL template (requires Salesforce
@@ -80,14 +224,17 @@ Mode 1.
 
 User invokes with an existing complete deal.
 
-1. Read the existing JSON file
+1. Read the existing JSON file and set the `DEAL_FILE` shell variable
 2. Present current scores and gaps
-3. Allow the user to update any section
-4. Recalculate scores after changes
+3. Allow the user to update any section — **Write:** use `jq` to
+   persist each change immediately
+4. **Write:** recalculate `scoring.overallScore` and
+   `scoring.overallRating` with the overall score `jq` pattern
 
 ## File Location
 
 Deal JSON files are stored at a configurable path:
+
 1. If the user specifies a path, use it
 2. Otherwise, use the current working directory
 3. File naming: `{accountName}-{dealName}.json` (slugified —
@@ -127,8 +274,10 @@ detailed scoring criteria.
 
 ### Primary output: JSON file
 
-Write the deal data to a JSON file conforming to the schema. This
-is the source of truth.
+The deal JSON file is written incrementally throughout the session
+via `jq` (see Data Persistence Protocol). By the time the
+interview completes, the file is already up to date and conforms
+to the schema. This file is the source of truth.
 
 ### Secondary output: Markdown scorecard
 

--- a/plugins/f5xc-meddpicc/skills/deal-review/SKILL.md
+++ b/plugins/f5xc-meddpicc/skills/deal-review/SKILL.md
@@ -22,16 +22,128 @@ The deal data model is defined in
 [meddpicc-schema.json](../../schema/meddpicc-schema.json). Reviews
 read and update deal JSON files conforming to this schema.
 
+## Data Persistence Protocol
+
+Update the deal JSON **incrementally** using `jq` as each piece of
+the review is collected — never batch writes at the end. This
+ensures data is preserved if the user pauses or the session ends.
+
+### File variable
+
+Set a shell variable when the deal file is loaded:
+
+```bash
+DEAL_FILE="/path/to/account-deal.json"
+```
+
+### Write pattern
+
+Use `jq` with tmp-and-mv (`sponge` is not available):
+
+```bash
+jq '<expression>' "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+### Escaping rules
+
+- Use `--arg name value` for user-provided strings
+- Use `--argjson name value` for numbers and booleans
+- Never use `!=` in jq — use `| not` instead
+- Never use `!` in Bash — use `cmd || { handle; }` instead
+
+## Element Key Reference
+
+Use these exact JSON keys in all jq paths (display name ≠ key):
+
+| Display Name | JSON Key | jq Path |
+| ------------ | -------- | ------- |
+| Metrics (M) | `metrics` | `.qualification.metrics` |
+| Economic Buyer (E) | `economicBuyer` | `.qualification.economicBuyer` |
+| Decision Criteria (D1) | `decisionCriteria` | `.qualification.decisionCriteria` |
+| Decision Process (D2) | `decisionProcess` | `.qualification.decisionProcess` |
+| Paper Process (P) | `paperProcess` | `.qualification.paperProcess` |
+| Identify Pain (I) | `implicateThePain` | `.qualification.implicateThePain` |
+| Champion (C1) | `champion` | `.qualification.champion` |
+| Competition (C2) | `competition` | `.qualification.competition` |
+
+### Key jq patterns for reviews
+
+**Evidence append** — append new evidence; never replace history.
+Handle both `null` and `""` as empty with `// ""`:
+
+```bash
+jq --arg new "[2026-05-20 weekly-review] Fred confirmed ARB slot June 2" \
+  '.qualification.metrics.evidence = (
+    ((.qualification.metrics.evidence // "") | if . == "" then $new else . + "\n" + $new end)
+  )' "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Score + completionStatus update** — update element score after
+evidence review. Replace `metrics` with the correct key above:
+
+```bash
+jq --argjson score 3 \
+  '.qualification.metrics.score = $score |
+   .metadata.completionStatus.metrics = "complete" |
+   .scoring.elementScores.metrics = $score' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Responses update** — replace responses only when new information
+is materially more specific than existing:
+
+```bash
+jq --arg r0 "Updated response to Q1" --arg r1 "Updated response to Q2" \
+  '.qualification.metrics.responses = [$r0, $r1]' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Append to critical actions**:
+
+```bash
+jq --argjson action '{"action":"Next step","owner":"AE","dueDate":"2026-05-15","status":"pending"}' \
+  'if .closePlan then .closePlan.criticalActions += [$action] else .closePlan = {milestones:[], criticalActions:[$action]} end' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Snapshot previous scores** — take this snapshot at Step 1 (load),
+before any element scores are changed, so the delta table is accurate:
+
+```bash
+jq '.scoring.previousElementScores = .scoring.elementScores' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Recalculate overall score** — run after all element updates:
+
+```bash
+jq '(.scoring.elementScores | to_entries | map(.value) | add) as $sum |
+  .scoring.overallScore = ($sum / 32 * 100) |
+  .scoring.overallRating = (
+    if $sum <= 13 then "Red"
+    elif $sum <= 25 then "Yellow"
+    else "Green" end)' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+**Scorecard display:** `scoring.overallScore` stores a percentage.
+To display `X/32`, sum `scoring.elementScores` values directly.
+
 ## Review Protocol
 
 ### Step 1 — Load deal data
 
 Check for an existing deal JSON file:
+
 - Look for `{accountName}-{dealName}.json` at the configured path
   or current working directory
-- If found: load it and present current scores as the starting point
-- If not found: ask for deal context (same as deal-qualification
-  Mode 1) and create a new file
+- If found: load it, set the `DEAL_FILE` shell variable, and
+  **immediately snapshot** `previousElementScores` using the
+  snapshot jq pattern above — this must happen before any element
+  scores are changed in Steps 3–4
+- If not found: inform the user to create a deal first with
+  `/f5xc-meddpicc:qualify-deal` — a review requires an existing
+  deal file with baseline scores to produce meaningful deltas
 
 ### Step 2 — Establish context
 
@@ -65,8 +177,10 @@ Focus the review on what changed since the last review:
 - "What competitive threat increased or decreased?"
 - "What is the riskiest assumption remaining?"
 
-Update the JSON `responses`, `scores`, `evidence`, and `notes`
-fields based on new information from the review.
+**Write:** after each element discussion, immediately update
+`responses`, `score`, `evidence`, and `notes` in the JSON with
+`jq` (see Data Persistence Protocol). Also update
+`completionStatus` and `scoring.elementScores` for the element.
 
 ### Step 5 — Action items
 
@@ -77,7 +191,8 @@ For each gap identified, produce:
 - **Due date:** Concrete date, not "ASAP"
 - **Success criteria:** How we'll know this is done
 
-Add actions to `closePlan.criticalActions` in the JSON file.
+**Write:** append each action to `closePlan.criticalActions` with
+`jq` using the array append pattern (see Data Persistence Protocol).
 
 ### Step 6 — Forecast assessment
 
@@ -90,13 +205,29 @@ Based on the review, recommend one of:
 - **At Risk** — Deal has stalled or has fundamental gaps
 - **Qualify Out** — Evidence suggests this deal should not be pursued
 
-### Step 7 — Save and report
+### Step 7 — Finalize and report
 
-1. Update `metadata.reviewDate` to today's date
-2. Recalculate `scoring.overallScore` and `scoring.overallRating`
-3. Update `completionStatus` for any sections that changed
-4. Write the updated JSON file
-5. Present the review output
+The file has been updated incrementally throughout the review.
+The `previousElementScores` snapshot was taken at Step 1 (load).
+For the final writes:
+
+1. **Write:** update `metadata.reviewDate` to today's date, update
+   `metadata.reviewer` to the person conducting the review, and
+   update `metadata.lastClientInteraction` with the most recent
+   interaction discussed:
+
+   ```bash
+   jq --arg date "2026-05-20" --arg reviewer "John Smith" \
+      --arg lastDate "2026-05-20" --arg lastOutcome "Weekly review" \
+     '.metadata.reviewDate = $date |
+      .metadata.reviewer = $reviewer |
+      .metadata.lastClientInteraction = {date: $lastDate, outcome: $lastOutcome}' \
+     "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+   ```
+
+2. **Write:** recalculate overall score and rating using the
+   recalculate jq pattern (see Data Persistence Protocol)
+3. Present the review output
 
 ## Output Format
 

--- a/plugins/f5xc-meddpicc/skills/deal-update/SKILL.md
+++ b/plugins/f5xc-meddpicc/skills/deal-update/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: deal-update
+description: >-
+  Ingest unstructured intelligence into a MEDDPICC deal file. Accepts
+  any source — meeting notes, email threads, call transcripts, OSINT
+  reports, Salesforce updates, competitive intel briefs, presentation
+  feedback, or any text containing deal-relevant information. Extracts
+  MEDDPICC elements, proposes updates with a structured diff, and writes
+  confirmed changes to the deal JSON. Use when the user says "here are
+  my meeting notes", "update the deal with this", "I got an email from",
+  "paste these transcript notes", "ran an OSINT scan", "got competitive
+  intel", or provides any raw text to add to a deal.
+user-invocable: true
+---
+
+# MEDDPICC Deal Update
+
+Ingest unstructured intelligence from any source and update a live
+MEDDPICC deal file. This is the **primary ongoing interaction** for
+keeping a deal's qualification data current as new information
+arrives throughout the deal cycle.
+
+## Supported Input Types
+
+- Meeting notes and call summaries
+- Email threads (forwarded or pasted)
+- Online meeting transcripts (Zoom, Teams, Google Meet)
+- OSINT research reports
+- Competitive intelligence briefs
+- Salesforce opportunity exports or field summaries
+- Presentation or demo feedback
+- Internal Slack/Teams conversations
+- Customer-facing documents (RFPs, SOWs, evaluation matrices)
+- Prospect website or public filings analysis
+- News articles about the account or competitors
+
+## Element Key Reference
+
+The JSON schema uses these exact keys. Always use these paths in
+`jq` — never use display names or abbreviations:
+
+| Display Name | JSON Key | jq Path |
+| ------------ | -------- | ------- |
+| Metrics (M) | `metrics` | `.qualification.metrics` |
+| Economic Buyer (E) | `economicBuyer` | `.qualification.economicBuyer` |
+| Decision Criteria (D1) | `decisionCriteria` | `.qualification.decisionCriteria` |
+| Decision Process (D2) | `decisionProcess` | `.qualification.decisionProcess` |
+| Paper Process (P) | `paperProcess` | `.qualification.paperProcess` |
+| Identify Pain (I) | `implicateThePain` | `.qualification.implicateThePain` |
+| Champion (C1) | `champion` | `.qualification.champion` |
+| Competition (C2) | `competition` | `.qualification.competition` |
+
+The corresponding `completionStatus` and `elementScores` keys use
+the same names: `.metadata.completionStatus.implicateThePain`,
+`.scoring.elementScores.implicateThePain`, etc.
+
+## Data Persistence Protocol
+
+All writes use `jq` with tmp-and-mv (`sponge` is not available).
+Verify `jq` is installed before starting: if `jq --version` fails,
+ask the user to install it (`apt install jq` or `brew install jq`).
+
+Set `DEAL_FILE` at the start and reuse it for every write:
+
+```bash
+DEAL_FILE="/path/to/account-deal.json"
+jq '<expression>' "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+Use `--arg name value` for strings, `--argjson name value` for
+numbers/booleans. Never use `!=` — use `| not` instead.
+
+### Evidence append pattern
+
+Append new evidence to existing; never replace. Prefix with
+`[YYYY-MM-DD source-type]` for traceability. Handle both `null`
+and `""` as empty — use `// ""` to coalesce null to empty string:
+
+```bash
+jq --arg new "[2026-05-06 meeting-notes] VP Ops confirmed 99.99% uptime target" \
+  '.qualification.metrics.evidence = (
+    ((.qualification.metrics.evidence // "") | if . == "" then $new else . + "\n" + $new end)
+  )' "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+### Notes append pattern
+
+Same null-safe append pattern, on the `.notes` field:
+
+```bash
+jq --arg new "[2026-05-06 meeting-notes] Board-level visibility on these metrics" \
+  '.qualification.metrics.notes = (
+    ((.qualification.metrics.notes // "") | if . == "" then $new else . + "\n" + $new end)
+  )' "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+### Score update pattern
+
+After updating an element, write the score and recalculate overall.
+Replace `metrics` with the correct key from the Element Key
+Reference table above:
+
+```bash
+jq --argjson score 3 \
+  '.qualification.metrics.score = $score |
+   .scoring.elementScores.metrics = $score' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+
+jq '(.scoring.elementScores | to_entries | map(.value) | add) as $sum |
+  .scoring.overallScore = ($sum / 32 * 100) |
+  .scoring.overallRating = (
+    if $sum <= 13 then "Red"
+    elif $sum <= 25 then "Yellow"
+    else "Green" end)' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+### Stakeholder add pattern
+
+Stakeholders require `name`, `title`, and `roleInDeal` (schema
+required fields). Initialize the array if absent:
+
+```bash
+jq --argjson s '{"name":"Jane Doe","title":"CISO","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"Meets compliance","viewOfF5":"Neutral","f5Owner":"John Smith"}' \
+  'if .stakeholders then .stakeholders += [$s] else .stakeholders = [$s] end' \
+  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
+```
+
+### Scorecard display
+
+`scoring.overallScore` stores a percentage (0–100). To display
+`X/32`, sum `scoring.elementScores` values directly — do not
+back-compute from the percentage.
+
+## Ingestion Protocol
+
+### Step 1 — Locate deal file
+
+1. If the user specifies an account or deal name, search for
+   `{accountName}-{dealName}.json` in the current working directory
+   or configured path
+2. If the user provides a file path directly, use it
+3. If ambiguous (multiple matching files), list them and ask which
+   deal this intel belongs to
+4. Set the `DEAL_FILE` shell variable
+5. If no deal file exists, inform the user to run
+   `/f5xc-meddpicc:qualify-deal` first to create one
+
+### Step 2 — Classify the input
+
+Identify the source type (meeting notes, email, transcript, etc.)
+and extract the date if available. This becomes the source prefix
+for all evidence entries: `[YYYY-MM-DD source-type]`.
+
+If no date is explicit, use today's date.
+
+### Step 3 — Extract MEDDPICC intelligence
+
+Read the input and systematically scan for signals relevant to
+each MEDDPICC element. Use the **Element Key Reference** table
+above for the correct JSON key when writing updates.
+
+If no signal is found for an element in the input, **leave it
+unchanged** — do not propose setting it to score 1 or adding
+empty evidence. Only propose updates for elements where the
+input contains relevant information.
+
+For each element, use these extraction patterns:
+
+#### Metrics (M)
+
+Look for: numbers, percentages, targets, baselines, KPIs,
+measurement systems, financial impacts, improvement claims.
+
+Signals: "we're at X today", "target of Y", "tracked via Z",
+"1% improvement = $N", "success looks like", "OKR", "KPI",
+"SLA", "uptime", "MTTR", "cost per", "revenue impact".
+
+Score signals: Unquantified goal = 1, KPI confirmed = 2,
+baseline + target documented = 3, committed in writing = 4.
+
+#### Economic Buyer (E)
+
+Look for: budget ownership statements, approval authority,
+funding source, executive names + titles + decisions.
+
+Signals: "owns the budget", "needs to approve", "VP of",
+"SVP of", "CFO", "CTO", "CIO", "has authority", "sign-off",
+"reallocate budget", "funded from".
+
+Score signals: Role known but name unknown = 1, named but
+not engaged = 2, met directly + priorities known = 3,
+actively sponsoring procurement = 4.
+
+#### Decision Criteria (D1)
+
+Look for: requirement lists, evaluation matrices, must-haves,
+disqualifiers, weighting statements, vendor scoring.
+
+Signals: "top requirements", "must have", "non-negotiable",
+"disqualify", "evaluation criteria", "scored on", "ranked
+by", "RFP requirement", "we need it to".
+
+Score signals: General requirements = 1, partially documented
+= 2, written + ranked + competitive position mapped = 3,
+criteria influenced toward our strengths = 4.
+
+#### Decision Process (D2)
+
+Look for: workflow steps, gate mentions, committee names,
+named approvers, timelines, event-driven milestones.
+
+Signals: "from yes to signed", "approval process", "review
+board", "steering committee", "architecture review", "next
+step is", "then it goes to", "before we can".
+
+Score signals: High-level only = 1, major steps known = 2,
+step-by-step with names + dates = 3, all gates mapped
+including legal/security = 4.
+
+#### Paper Process (P)
+
+Look for: procurement steps, security artifact requirements,
+legal review mentions, vendor portal, PO process, contract
+terms, insurance, compliance requirements.
+
+Signals: "procurement", "legal review", "security
+questionnaire", "SOC2", "pen test", "DPIA", "vendor portal",
+"purchase order", "master agreement", "DPA", "standard
+contract terms".
+
+Score signals: Aware it exists = 1, some steps known = 2,
+documented with owners + artifacts submitted = 3, all steps
+done + PO format confirmed = 4.
+
+#### Identify Pain (I)
+
+Look for: problem statements, urgency markers, consequences
+of inaction, triggering events, quantified business impact,
+stakeholder pain confirmation.
+
+Signals: "if this doesn't change", "cost us", "SLA penalty",
+"incident", "downtime", "audit", "regulatory", "board
+mandate", "compliance deadline", "what triggered this".
+
+Score signals: Pain implied = 1, acknowledged by customer
+= 2, quantified with business impact = 3, multiple
+stakeholders confirm + triggering event + deadline = 4.
+
+#### Champion (C1)
+
+Look for: internal advocate actions — introductions made,
+intel shared, presentations given, internal advocacy,
+personal stake language.
+
+Signals: "introduced us to", "shared the pricing",
+"presented our case", "went to bat for", "told me internally",
+"my career depends on", "I'll make this happen", "they came
+back to me with".
+
+Score signals: Named friendly contact = 1, willing to help
+but passive = 2, influence + personal win documented = 3,
+actively coaching + taking concrete actions weekly = 4.
+
+#### Competition (C2)
+
+Look for: competitor names, comparison statements, customer
+perception language, build-vs-buy signals, do-nothing risk.
+
+Signals: vendor names (Cloudflare, Akamai, Zscaler, etc.),
+"also evaluating", "we like them because", "concerned about",
+"they're cheaper", "we could build this", "why not just use
+[existing vendor]".
+
+Score signals: Named only = 1, intelligence gathered but
+perception unclear = 2, customer perception documented +
+differentiation strategy = 3, competitive proof delivered
+and do-nothing assessed = 4.
+
+#### Also extract
+
+- **Stakeholder mentions:** new names, titles, roles, sentiments
+  toward F5
+- **Timeline/milestone changes:** dates, deadlines, events
+- **Action items:** next steps mentioned by customer or rep
+- **Three Whys signals:** urgency, differentiation, timing
+  statements
+
+### Step 4 — Load current deal state
+
+Read the deal JSON and load current scores and evidence for all
+8 elements. This is the baseline for the diff.
+
+### Step 5 — Present proposed updates
+
+Before writing anything, display a structured summary of all
+proposed changes:
+
+```
+## Proposed Updates: [Account Name]
+### Source: [source-type] — [date]
+
+| # | Element | Update Type | Current Value (truncated) | Proposed Change |
+|---|---------|-------------|--------------------------|-----------------|
+| 1 | Pain | evidence append | "" | "[2026-05-06 meeting] 3 incidents in Q1..." |
+| 2 | Champion | evidence append | "Barney..." | "[2026-05-06 meeting] Barney presented to steering..." |
+| 3 | Economic Buyer | response update | "Fred Flinstone" | "Fred confirmed $500K budget in today's meeting" |
+
+### Score Recommendations
+
+| Element | Current | Proposed | Reasoning |
+|---------|---------|----------|-----------|
+| Pain | 2/4 | 3/4 | Multiple stakeholders confirmed pain; financial impact documented |
+| Champion | 2/4 | 3/4 | Champion took concrete verifiable action (presentation) |
+
+### Score Impact
+Current overall: X/32 (Y%) [Rating] → Proposed: X/32 (Y%) [Rating]
+
+### Flags
+- [CONFLICT] Competition: Input says Cloudflare is "not in the running" — contradicts existing note that customer is actively evaluating Cloudflare. Clarify before updating.
+- [NEW STAKEHOLDER] Lisa Wang (CISO) mentioned — add to stakeholder list?
+```
+
+**Rules:**
+
+- Always **append** to `evidence` and `notes` — never replace
+  (history is valuable)
+- **Replace** `responses[]` only when new information is
+  materially more specific or accurate than existing
+- **Recommend** score changes with reasoning — require user
+  confirmation before writing score changes
+- **Flag conflicts** when new info contradicts existing data
+  and ask user to reconcile
+- **Flag new stakeholders** and ask whether to add to the
+  stakeholder array
+
+### Step 6 — User confirmation
+
+Ask the user:
+
+- **"Apply all"** — write every proposed update
+- **"Apply selected [numbers]"** — write only listed items,
+  e.g. "apply 1, 2 but not 3"
+- **"Apply without score changes"** — write evidence/notes
+  but hold on score updates
+- **"Reject all"** — discard everything
+
+### Step 7 — Write confirmed updates with jq
+
+For each confirmed update, run the appropriate `jq` write
+immediately. Do not batch — write each item as it is confirmed.
+
+Write types:
+
+- **Evidence append:** Use the evidence append pattern above
+- **Notes append:** Same pattern but on `.notes` field
+- **Response replace:** Use `--arg` for string values
+- **Score update:** Update element score + recalculate overall
+- **Stakeholder add:** Use array append pattern
+- **Action item add:** Append to `closePlan.criticalActions`
+- **Milestone add:** Append to `closePlan.milestones`
+
+After all writes, run the overall score recalculation jq.
+
+### Step 8 — Updated scorecard
+
+Display the full MEDDPICC scorecard in the deal-qualification
+output format, highlighting which elements changed and by how
+much since this ingestion session.
+
+```
+## MEDDPICC Scorecard: [Account Name] (Updated)
+### Source ingested: [source-type] — [date]
+### Elements updated: [list]
+### Overall: X/32 (Y%) — [Rating] (was Z/32 before this update)
+```
+
+## Coaching Notes
+
+After the scorecard, briefly flag:
+
+- The single highest-priority gap to close next
+- Any antipatterns detected in the new intelligence
+- Whether the ingest suggests the deal has advanced, stalled,
+  or has new risks

--- a/plugins/f5xc-meddpicc/skills/deal-update/SKILL.md
+++ b/plugins/f5xc-meddpicc/skills/deal-update/SKILL.md
@@ -31,7 +31,7 @@ arrives throughout the deal cycle.
 - Presentation or demo feedback
 - Internal Slack/Teams conversations
 - Customer-facing documents (RFPs, SOWs, evaluation matrices)
-- Prospect website or public filings analysis
+- Prospect site or public filings analysis
 - News articles about the account or competitors
 
 ## Element Key Reference
@@ -194,7 +194,7 @@ actively sponsoring procurement = 4.
 
 #### Decision Criteria (D1)
 
-Look for: requirement lists, evaluation matrices, must-haves,
+Look for: requirement lists, evaluation matrices, must haves,
 disqualifiers, weighting statements, vendor scoring.
 
 Signals: "top requirements", "must have", "non-negotiable",


### PR DESCRIPTION
## Summary

- Adds new `/update-deal` skill for ongoing intelligence ingestion (meeting notes, emails, transcripts, OSINT)
- Adds jq-based incremental write protocol to all skills for atomic JSON state persistence
- Fixes 4 critical + 5 high issues found during automated testing:
  - Null-safe evidence appends
  - Element key mapping corrections
  - previousElementScores snapshot timing
  - Evidence history preservation

Closes #393

## Test plan

- [ ] CI checks pass
- [ ] `/update-deal` command registers correctly
- [ ] jq persistence protocol validates with edge cases
- [ ] Existing `/qualify-deal` and `/review-deal` skills function with new protocol