### PR TITLE
fix(security): remove PII, competitor names, and real IPs

### DIFF
--- a/docs/plugins/osint-framework.mdx
+++ b/docs/plugins/osint-framework.mdx
@@ -31,10 +31,10 @@ detects the target type (email, domain, IP, username, company,
 person name) and routes to the correct category skills.
 
 ```
-/osint-investigate robin.mordasiewicz@f5.com
+/osint-investigate j.smith@example.com
 /osint-investigate cloudflare.com
 /osint-investigate 1.1.1.1
-/osint-investigate robinmordasiewicz
+/osint-investigate example-user
 ```
 
 ### /osint-search
@@ -172,7 +172,7 @@ source plugins/osint-framework/scripts/osint-graph.sh
 osint_graph_init
 
 # Add entities
-P=$(osint_entity_add "person" "Robin Mordasiewicz" --tool github-api)
+P=$(osint_entity_add "person" "J. Smith" --tool github-api)
 C=$(osint_entity_add "company" "F5" --tool github-api)
 
 # Link them

--- a/docs/superpowers/plans/2026-05-05-f5xc-cloudstatus.md
+++ b/docs/superpowers/plans/2026-05-05-f5xc-cloudstatus.md
@@ -1342,7 +1342,7 @@ Beyond raw data retrieval, the plugin provides:
 
 ## Ported From
 
-This plugin replaces the [f5xc-cloudstatus-mcp](https://github.com/robinmordasiewicz/f5xc-cloudstatus-mcp)
+This plugin replaces the [f5xc-cloudstatus-mcp](https://github.com/example-user/f5xc-cloudstatus-mcp)
 MCP server. All 6 MCP tools are ported with full feature parity, plus new
 operational intelligence capabilities. The MCP server's infrastructure
 (Playwright browser, connection pooling, in-memory caching) is replaced by

--- a/plugins/f5xc-cloudstatus/README.md
+++ b/plugins/f5xc-cloudstatus/README.md
@@ -115,7 +115,7 @@ Beyond raw data retrieval, the plugin provides:
 
 ## Ported From
 
-This plugin replaces the [f5xc-cloudstatus-mcp](https://github.com/robinmordasiewicz/f5xc-cloudstatus-mcp)
+This plugin replaces the [f5xc-cloudstatus-mcp](https://github.com/example-user/f5xc-cloudstatus-mcp)
 MCP server. All 6 MCP tools are ported with full feature parity, plus new
 operational intelligence capabilities. The MCP server's infrastructure
 (Playwright browser, connection pooling, in-memory caching) is replaced by

--- a/plugins/f5xc-devcontainer/agents/container-introspector.md
+++ b/plugins/f5xc-devcontainer/agents/container-introspector.md
@@ -84,7 +84,7 @@ arch
 Combine all data into a grounded identity response. Example format:
 
 > I am Claude Code running inside a devcontainer built from commit
-> `abc1234` on 2026-03-24 by Robin Mordasiewicz. My image is
+> `abc1234` on 2026-03-24 by J. Smith. My image is
 > `ghcr.io/f5xc-salesdemos/devcontainer:latest`, built from
 > github.com/f5xc-salesdemos/devcontainer. I run as user `vscode`
 > on Linux arm64. My creators: [list contributors with counts].

--- a/plugins/f5xc-meddpicc/README.md
+++ b/plugins/f5xc-meddpicc/README.md
@@ -193,7 +193,7 @@ Pre-populates the deal JSON from Salesforce fields, then asks targeted questions
 Here are my notes from today's call with the CTO:
 - Confirmed $500K budget for API security modernization
 - Board mandate to fix API incidents by Q3
-- Currently evaluating us and Cloudflare
+- Currently evaluating us and Vendor A
 - Architecture review board meets May 26
 ```
 
@@ -205,7 +205,7 @@ The AI extracts MEDDPICC signals, presents a proposed update diff with score rec
 /f5xc-meddpicc:update-deal Acme Corp
 FW: RE: API Gateway eval - internal update
 Hey John, wanted to give you a heads up. The architecture review
-board approved F5 for the shortlist. Cloudflare pricing came in at
+board approved F5 for the shortlist. Vendor A pricing came in at
 $85K/yr vs your $120K. Legal confirmed their standard review takes
 3 weeks. Talk soon, Barney
 ```

--- a/plugins/f5xc-meddpicc/schema/example-deal.json
+++ b/plugins/f5xc-meddpicc/schema/example-deal.json
@@ -5,7 +5,7 @@
     "dealName": "DC Modernization Phase 2",
     "dealStatus": "Qualified",
     "closeDate": "2026-06-30",
-    "competition": "Cloudflare, Akamai",
+    "competition": "Vendor A, Vendor B",
     "winProbability": 0.5,
     "forecastStage": "Best Case",
     "revenue": {
@@ -180,7 +180,7 @@
         "3": "Validated — Named individual with influence and credibility; personal win documented",
         "4": "Mobilizing — Champion is actively coaching you, sharing intel, and taking concrete actions weekly"
       },
-      "evidence": "Mike scheduled the EB meeting, shared competitor pricing (Cloudflare quote), and presented our POC results at the architecture review board on 2026-04-28.",
+      "evidence": "Mike scheduled the EB meeting, shared competitor pricing (Vendor A quote), and presented our POC results at the architecture review board on 2026-04-28.",
       "notes": "Mike's personal win: his team gets headcount if MTTR target is met with automation"
     },
     "competition": {
@@ -190,8 +190,8 @@
         "What are their strengths and weaknesses?"
       ],
       "responses": [
-        "Cloudflare (primary) — leading on price, positioning as simpler to deploy. Akamai (secondary) — incumbent for CDN, trying to upsell API security.",
-        "Cloudflare: strong brand, lower price point, but lacks F5's depth on API discovery and Kubernetes-native integration. Akamai: existing relationship but their API security product is immature."
+        "Vendor A (primary) — leading on price, positioning as simpler to deploy. Vendor B (secondary) — incumbent for CDN, trying to upsell API security.",
+        "Vendor A: strong brand, lower price point, but lacks F5's depth on API discovery and Kubernetes-native integration. Vendor B: existing relationship but their API security product is immature."
       ],
       "score": 2,
       "scoreDefinition": {
@@ -201,8 +201,8 @@
         "3": "Differentiated — Competitors named and qualified; customer perception documented; differentiation strategy clear",
         "4": "Neutralized — Competitive proof delivered; do-nothing risk assessed; win theme validated with customer"
       },
-      "evidence": "Champion shared Cloudflare quote. CTO mentioned Akamai in initial call. No formal competitive proof test done yet.",
-      "notes": "Need customer's perception of Cloudflare vs F5 on key criteria. Plan competitive demo for week of May 19."
+      "evidence": "Champion shared Vendor A quote. CTO mentioned Vendor B in initial call. No formal competitive proof test done yet.",
+      "notes": "Need customer's perception of Vendor A vs F5 on key criteria. Plan competitive demo for week of May 19."
     }
   },
   "threeWhys": {
@@ -212,10 +212,10 @@
       "whyNow": "Board mandate deadline is Q3 2026; regulatory audit in September; every month of delay is another month of exposure to SLA penalties"
     },
     "partner": {
-      "name": "TechServ Solutions",
+      "name": "PartnerCo",
       "whyAnything": "Acme needs implementation support — their platform team is at capacity with the Kubernetes migration",
-      "whyThisPartner": "TechServ has 3 certified F5 engineers and prior Acme relationship from the load balancer deployment",
-      "whyNow": "TechServ has a team available in June; if we wait, they're committed to another project through Q4"
+      "whyThisPartner": "PartnerCo has 3 certified F5 engineers and prior Acme relationship from the load balancer deployment",
+      "whyNow": "PartnerCo has a team available in June; if we wait, they're committed to another project through Q4"
     }
   },
   "stakeholders": [
@@ -262,7 +262,7 @@
   ],
   "salesStrategy": {
     "differentiatedValueProposition": "F5 is the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Acme's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
-    "winStrategy": "Lead with the pain: $400K SLA penalties and board mandate create urgency. Differentiate on Kubernetes-native integration (Cloudflare can't match this). Use the POC to prove MTTR improvement quantitatively. Get EB alignment on business case before architecture review board. Neutralize Cloudflare's price advantage by quantifying the cost of deploying and managing a separate API discovery tool."
+    "winStrategy": "Lead with the pain: $400K SLA penalties and board mandate create urgency. Differentiate on Kubernetes-native integration (Vendor A can't match this). Use the POC to prove MTTR improvement quantitatively. Get EB alignment on business case before architecture review board. Neutralize Vendor A's price advantage by quantifying the cost of deploying and managing a separate API discovery tool."
   },
   "closePlan": {
     "milestones": [
@@ -294,7 +294,7 @@
     ],
     "criticalActions": [
       {
-        "action": "Schedule competitive differentiation demo vs Cloudflare",
+        "action": "Schedule competitive differentiation demo vs Vendor A",
         "owner": "Bob Johnson (SE)",
         "dueDate": "2026-05-19",
         "status": "pending"

--- a/plugins/f5xc-meddpicc/skills/deal-update/SKILL.md
+++ b/plugins/f5xc-meddpicc/skills/deal-update/SKILL.md
@@ -267,7 +267,7 @@ actively coaching + taking concrete actions weekly = 4.
 Look for: competitor names, comparison statements, customer
 perception language, build-vs-buy signals, do-nothing risk.
 
-Signals: vendor names (Cloudflare, Akamai, Zscaler, etc.),
+Signals: competitor vendor names (Vendor A, Vendor B, CDN providers, etc.),
 "also evaluating", "we like them because", "concerned about",
 "they're cheaper", "we could build this", "why not just use
 [existing vendor]".
@@ -317,7 +317,7 @@ proposed changes:
 Current overall: X/32 (Y%) [Rating] → Proposed: X/32 (Y%) [Rating]
 
 ### Flags
-- [CONFLICT] Competition: Input says Cloudflare is "not in the running" — contradicts existing note that customer is actively evaluating Cloudflare. Clarify before updating.
+- [CONFLICT] Competition: Input says Vendor A is "not in the running" — contradicts existing note that customer is actively evaluating Vendor A. Clarify before updating.
 - [NEW STAKEHOLDER] Lisa Wang (CISO) mentioned — add to stakeholder list?
 ```
 

--- a/plugins/osint-framework/scripts/osint-graph.sh
+++ b/plugins/osint-framework/scripts/osint-graph.sh
@@ -5,7 +5,7 @@
 # Usage: source this file, then call functions:
 #   source plugins/osint-framework/scripts/osint-graph.sh
 #   osint_graph_init
-#   osint_entity_add "person" "Robin Mordasiewicz" name="Robin Mordasiewicz" location="Toronto"
+#   osint_entity_add "person" "J. Smith" name="J. Smith" location="Anytown"
 #   osint_entity_add "company" "F5" domain="f5.com"
 #   osint_rel_add "$ID1" "$ID2" "works_at" --tool github-api --confidence 0.9
 #   osint_graph_query "$ID1" 2

--- a/plugins/osint-framework/scripts/test-correlation.sh
+++ b/plugins/osint-framework/scripts/test-correlation.sh
@@ -71,7 +71,7 @@ osint_graph_reset
 # ── Test 1: Entity Creation ────────────────────────────────
 echo -e "${CYAN}--- Entity CRUD ---${NC}"
 
-P1=$(osint_entity_add "person" "Robin Mordasiewicz" name="Robin Mordasiewicz" location="Toronto" --tool github-api --investigation test-001)
+P1=$(osint_entity_add "person" "J. Smith" name="J. Smith" location="Anytown" --tool github-api --investigation test-001)
 assert_contains "Entity add returns ID" "e-" "$P1"
 
 C1=$(osint_entity_add "company" "F5" domain="f5.com" --tool github-api --investigation test-001)
@@ -80,13 +80,13 @@ assert_contains "Company entity created" "e-" "$C1"
 D1=$(osint_entity_add "domain" "f5.com" registrar="CSC" --tool whois --investigation test-001)
 assert_contains "Domain entity created" "e-" "$D1"
 
-U1=$(osint_entity_add "username" "robinmordasiewicz" platform="github" --tool github-api --investigation test-001)
+U1=$(osint_entity_add "username" "example-user" platform="github" --tool github-api --investigation test-001)
 assert_contains "Username entity created" "e-" "$U1"
 
 IP1=$(osint_entity_add "ip" "159.60.134.0" org="F5 Networks" --tool dig --investigation test-001)
 assert_contains "IP entity created" "e-" "$IP1"
 
-E1=$(osint_entity_add "email" "robin@f5.com" --tool inference --investigation test-001)
+E1=$(osint_entity_add "email" "j.smith@example.com" --tool inference --investigation test-001)
 assert_contains "Email entity created" "e-" "$E1"
 
 entity_count=$(jq 'length' "$OSINT_GRAPH_DIR/entities.json")
@@ -96,7 +96,7 @@ assert_eq "6 entities in graph" "6" "$entity_count"
 echo ""
 echo -e "${CYAN}--- Deduplication ---${NC}"
 
-P1_DUP=$(osint_entity_add "person" "Robin Mordasiewicz" company="F5" --tool linkedin --investigation test-001)
+P1_DUP=$(osint_entity_add "person" "J. Smith" company="F5" --tool linkedin --investigation test-001)
 assert_eq "Dedup: same person returns same ID" "$P1" "$P1_DUP"
 
 entity_count=$(jq 'length' "$OSINT_GRAPH_DIR/entities.json")
@@ -121,7 +121,7 @@ e1_conf=$(osint_entity_get "$E1" | jq -r '.confidence')
 assert_gt "Email confidence from inference < 0.5" "0.0" "$e1_conf"
 
 # Add same email from authoritative source — confidence should rise
-osint_entity_add "email" "robin@f5.com" --tool whois --investigation test-001 >/dev/null
+osint_entity_add "email" "j.smith@example.com" --tool whois --investigation test-001 >/dev/null
 e1_conf_new=$(osint_entity_get "$E1" | jq -r '.confidence')
 assert_gt "Email confidence rises after WHOIS confirms (>0.9)" "0.9" "$e1_conf_new"
 

--- a/plugins/osint-framework/scripts/test-e2e.sh
+++ b/plugins/osint-framework/scripts/test-e2e.sh
@@ -216,15 +216,15 @@ if [ -z "$LAYER_FILTER" ] || { [ "$LAYER_FILTER" = "--layer" ] && [ "${2:-}" = "
 
   # IP tools
   run_test "U08" "ipinfo.io returns IP JSON" \
-    "curl -s 'https://ipinfo.io/93.184.216.34/json' 2>/dev/null" \
+    "curl -s 'https://ipinfo.io/198.51.100.1/json' 2>/dev/null" \
     "\"ip\"" 15
 
   run_test "U09" "whois IP returns NetName" \
-    "whois 93.184.216.34 2>/dev/null" \
+    "whois 198.51.100.1 2>/dev/null" \
     "netname|orgname|org-name|NetName|OrgName" 30
 
   run_test "U10" "dig reverse DNS runs clean" \
-    "dig -x 93.184.216.34 +short 2>/dev/null; echo 'reverse_done'" \
+    "dig -x 198.51.100.1 +short 2>/dev/null; echo 'reverse_done'" \
     "reverse_done" 15
 
   # Active scanning (safe targets only)
@@ -321,7 +321,7 @@ if [ -z "$LAYER_FILTER" ] || { [ "$LAYER_FILTER" = "--layer" ] && [ "${2:-}" = "
     "verified" 5
 
   run_test "T03d" "Passive pipeline: ipinfo country" \
-    "curl -s 'https://ipinfo.io/93.184.216.34/json' 2>/dev/null | jq -r '.country' 2>/dev/null" \
+    "curl -s 'https://ipinfo.io/198.51.100.1/json' 2>/dev/null | jq -r '.country' 2>/dev/null" \
     "US" 15
 
   # T04: Reference File Integrity

--- a/plugins/osint-framework/skills/osint-catalog/references/correlation-engine.md
+++ b/plugins/osint-framework/skills/osint-catalog/references/correlation-engine.md
@@ -20,7 +20,7 @@ creating, querying, and reporting on graph data.
 | `person` | A human individual | `"John Smith"` |
 | `company` | A business or organization | `"Acme Corp"` |
 | `domain` | A DNS domain name | `"example.com"` |
-| `ip` | An IPv4 or IPv6 address | `"93.184.216.34"` |
+| `ip` | An IPv4 or IPv6 address | `"198.51.100.1"` |
 | `email` | An email address | `"john@example.com"` |
 | `username` | An account handle on a platform | `"jsmith"` |
 | `phone` | A phone number | `"+1-555-0100"` |

--- a/plugins/osint-framework/skills/osint-catalog/references/investigation-pipelines.md
+++ b/plugins/osint-framework/skills/osint-catalog/references/investigation-pipelines.md
@@ -683,7 +683,7 @@ DOMAIN="example.com" && echo "--- WHOIS ---" && whois "$DOMAIN" 2>/dev/null | gr
 
 ## 4. IP Address Investigation Pipeline
 
-**Target:** an IP address (e.g., `93.184.216.34`)
+**Target:** an IP address (e.g., `198.51.100.1`)
 **Goal:** geolocation, ownership, open ports, running services, reputation
 **Estimated time:** 3-15 minutes
 
@@ -691,7 +691,7 @@ DOMAIN="example.com" && echo "--- WHOIS ---" && whois "$DOMAIN" 2>/dev/null | gr
 
 ```bash
 set -eo pipefail
-IP="93.184.216.34"
+IP="198.51.100.1"
 OUTDIR="./osint-results/ip-${IP//./-}"
 mkdir -p "${OUTDIR}"
 
@@ -708,7 +708,7 @@ done
 
 ```bash
 set -eo pipefail
-IP="93.184.216.34"
+IP="198.51.100.1"
 OUTDIR="./osint-results/ip-${IP//./-}"
 mkdir -p "${OUTDIR}"
 
@@ -897,7 +897,7 @@ ls -la "${OUTDIR}/"
 
 ```bash
 # Fast IP overview — geolocation + reverse DNS + Shodan + blocklist
-IP="93.184.216.34" \
+IP="198.51.100.1" \
   && echo "--- GeoIP ---" \
   && curl -s "https://ipinfo.io/${IP}/json" | jq '{ip,city,region,country,org}' \
   && echo "--- rDNS ---" \


### PR DESCRIPTION
## Summary

- Remove PII (f5.com corporate emails, real employee names/usernames) from documentation and examples
- Replace competitor names (Cloudflare, Akamai, Zscaler) with generic placeholders (Vendor A/B/C) in MEDDPICC sales examples
- Replace real IP addresses with RFC 5737 test addresses (198.51.100.1, 192.0.2.1)

Closes #397

## Test plan

- [ ] CI checks pass
- [ ] Verify no remaining f5.com emails in changed files
- [ ] Verify no competitor names in MEDDPICC examples
- [ ] Verify all IPs in OSINT docs use RFC 5737 ranges