### PR TITLE
fix(security): replace Cloudflare IP and domain with RFC 5737 and example.com in OSINT docs

### DIFF
--- a/docs/plugins/osint-framework.mdx
+++ b/docs/plugins/osint-framework.mdx
@@ -32,8 +32,8 @@ person name) and routes to the correct category skills.
 
 ```
 /osint-investigate j.smith@example.com
-/osint-investigate cloudflare.com
-/osint-investigate 1.1.1.1
+/osint-investigate example.com
+/osint-investigate 198.51.100.1
 /osint-investigate example-user
 ```
 

--- a/plugins/osint-framework/scripts/test-batch-companies.sh
+++ b/plugins/osint-framework/scripts/test-batch-companies.sh
@@ -20,7 +20,7 @@ COMPANIES=(
   "HSBC|hsbc.com|Banking|UK|HSBC"
   "Deutsche Bank|db.com|Banking|Germany|DB"
   # Tech
-  "Cloudflare|cloudflare.com|Tech/CDN|US|NET"
+  "ExampleCorp|example.com|Tech/CDN|US|EXC"
   "Shopify|shopify.com|Tech/E-commerce|Canada|SHOP"
   "SAP|sap.com|Tech/Enterprise|Germany|SAP"
   "Atlassian|atlassian.com|Tech/SaaS|Australia|TEAM"


### PR DESCRIPTION
## Summary

- Replace Cloudflare's `1.1.1.1` DNS IP with RFC 5737 TEST-NET-2 address `198.51.100.1` and `cloudflare.com` with `example.com` in OSINT framework documentation usage example
- Replace Cloudflare test company references with ExampleCorp/example.com in OSINT batch test script
- Completes remaining cleanup missed in the initial PII sweep (#397)

Closes #399

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify `docs/plugins/osint-framework.mdx` no longer contains `1.1.1.1` or `cloudflare.com`
- [ ] Verify `plugins/osint-framework/scripts/test-batch-companies.sh` no longer references Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)