### PR TITLE
fix(osint): restore Cloudflare entry in test-batch-companies.sh

### DIFF
--- a/plugins/osint-framework/scripts/test-batch-companies.sh
+++ b/plugins/osint-framework/scripts/test-batch-companies.sh
@@ -20,7 +20,7 @@ COMPANIES=(
   "HSBC|hsbc.com|Banking|UK|HSBC"
   "Deutsche Bank|db.com|Banking|Germany|DB"
   # Tech
-  "ExampleCorp|example.com|Tech/CDN|US|EXC"
+  "Cloudflare|cloudflare.com|Tech/CDN|US|NET"
   "Shopify|shopify.com|Tech/E-commerce|Canada|SHOP"
   "SAP|sap.com|Tech/Enterprise|Germany|SAP"
   "Atlassian|atlassian.com|Tech/SaaS|Australia|TEAM"


### PR DESCRIPTION
## Summary

- Restores the original Cloudflare entry in the test company dataset that was incorrectly replaced with ExampleCorp in PR #400
- Policy clarification: competitor names are acceptable in test data arrays; the restriction applies only to example commands that instruct users to target competitors

Closes #401

## Test plan

- [ ] CI checks pass
- [ ] Verify the test-batch-companies.sh script contains `Cloudflare|cloudflare.com|Tech/CDN|US|NET`
- [ ] Confirm no other test data entries were affected