### PR TITLE
fix(salesforce): remove pi-utils dependency from pipeline-report generator

### DIFF
--- a/plugins/salesforce/src/pipeline-report/generator.ts
+++ b/plugins/salesforce/src/pipeline-report/generator.ts
@@ -1,4 +1,3 @@
-import { logger } from '@f5xc-salesdemos/pi-utils';
 import { $ } from 'bun';
 import type {
   AccountRow,
@@ -32,7 +31,7 @@ async function runSfQuery(soql: string, orgAlias?: string): Promise<Record<strin
     };
     return parsed.result?.records ?? [];
   } catch (err) {
-    logger.debug('Pipeline SOQL query failed', { error: err });
+    // Silently swallow — the caller handles empty results
     return [];
   }
 }


### PR DESCRIPTION
## Summary

- Remove `@f5xc-salesdemos/pi-utils` import from `generator.ts` that caused extension loading failure
- The import was a leftover from xcsh core copy — `logger.debug()` in a catch block replaced with a comment
- Root cause: xcsh's extension loader fails to resolve `@f5xc-salesdemos/pi-utils` when loading plugin modules since it's not installed in the plugin's dependency tree

Closes #490

## Test plan

- [x] 117 bun tests pass
- [x] Zero `@f5xc-salesdemos/` runtime imports remain (only type-only import of ExtensionFactory)
- [ ] CI checks pass