### PR TITLE
fix(salesforce): serialize SalesforceHint to string for CustomMessage content

### DIFF
--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -39,8 +39,17 @@ const factory: ExtensionFactory = async (pi) => {
     if (!sfContext) return;
     const hint = buildSalesforceHint(sfContext);
     if (!hint) return;
+    const lines = [
+      `Pipeline: ${hint.pipelineTotal} (${hint.dealCount} deals, ${hint.accountCount} accounts)`,
+      hint.territories ? `Territories: ${hint.territories}` : '',
+      hint.forecastBreakdown ? `Forecast: ${hint.forecastBreakdown}` : '',
+      hint.partnerName ? `Partner: ${hint.partnerName} (${hint.partnerRole ?? 'Partner'})` : '',
+      hint.orgAlias ? `Org: ${hint.orgAlias}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
     return {
-      message: { customType: 'salesforce_hint', content: hint, display: false },
+      message: { customType: 'salesforce_hint', content: lines, display: false },
     };
   });
 


### PR DESCRIPTION
## Summary

- Fix runtime crash: `msg.content.map is not a function`
- Root cause: `buildSalesforceHint()` returns a `SalesforceHint` object, but `CustomMessage.content` requires `string | ContentBlock[]`
- Fix: serialize the hint object fields into a multi-line string before passing as message content

Closes #492

## Test plan

- [x] 117 bun tests pass
- [x] xcsh starts without msg.content.map crash
- [x] Extension loads and registers 4 tools (confirmed via log)