### PR TITLE
feat: add azure-status, aws-status, gcloud-status welcome screen plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -531,6 +531,45 @@
       ],
       "tags": ["status", "monitoring", "ops", "f5xc"],
       "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "azure-status",
+      "description": "Azure CLI welcome screen status — checks az account authentication and offers auto-fix",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/azure-status",
+      "category": "development",
+      "keywords": ["azure", "az", "cloud"],
+      "tags": ["azure", "cloud", "xcsh-extension"],
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/azure-status",
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "aws-status",
+      "description": "AWS CLI welcome screen status — checks AWS STS authentication with SSO expiry detection and auto-fix",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/aws-status",
+      "category": "development",
+      "keywords": ["aws", "amazon", "cloud"],
+      "tags": ["aws", "cloud", "xcsh-extension"],
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/aws-status",
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "gcloud-status",
+      "description": "Google Cloud CLI welcome screen status — checks gcloud authentication with token expiry detection and auto-fix",
+      "version": "1.0.0",
+      "author": { "name": "f5xc-salesdemos" },
+      "source": "./plugins/gcloud-status",
+      "category": "development",
+      "keywords": ["gcloud", "google", "cloud"],
+      "tags": ["gcloud", "google", "cloud", "xcsh-extension"],
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/gcloud-status",
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
     }
   ]
 }

--- a/plugins/aws-status/.claude-plugin/plugin.json
+++ b/plugins/aws-status/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "aws-status",
+  "description": "AWS CLI welcome screen status — checks AWS STS authentication with SSO expiry detection and offers auto-fix",
+  "version": "1.0.0",
+  "author": { "name": "f5xc-salesdemos", "url": "https://github.com/f5xc-salesdemos" },
+  "keywords": ["aws", "amazon", "cloud", "xcsh-extension"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/aws-status/package.json
+++ b/plugins/aws-status/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@f5xc-salesdemos/xcsh-aws-status",
+  "version": "1.0.0",
+  "description": "AWS CLI status for xcsh welcome screen",
+  "main": "src/index.ts",
+  "xcsh": {
+    "name": "AWS Status",
+    "version": "1.0.0",
+    "extensions": [
+      "src/index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@f5xc-salesdemos/xcsh": ">=1.0.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/aws-status/skills/aws-status/SKILL.md
+++ b/plugins/aws-status/skills/aws-status/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: aws-status
+description: >-
+  Internal skill for aws-status xcsh extension. Provides welcome screen service
+  status via registerServiceStatus API. Not user-invocable.
+user-invocable: false
+---
+
+This skill is a placeholder for the aws-status xcsh extension plugin.
+The actual functionality is provided by the extension entry point at src/index.ts
+which registers a service status check for the xcsh welcome screen.

--- a/plugins/aws-status/src/index.ts
+++ b/plugins/aws-status/src/index.ts
@@ -1,0 +1,46 @@
+import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
+
+const factory: ExtensionFactory = async (pi) => {
+  pi.setLabel('AWS Status');
+
+  try {
+    const which = Bun.spawnSync(['which', 'aws']);
+    if (which.exitCode !== 0) return;
+  } catch {
+    return;
+  }
+
+  if (typeof pi.registerServiceStatus === 'function') {
+    pi.registerServiceStatus({
+      name: 'AWS',
+      async check() {
+        try {
+          const result = Bun.spawnSync(['aws', 'sts', 'get-caller-identity', '--output', 'json']);
+          if (result.exitCode === 0) return { state: 'connected' };
+          const stderr = new TextDecoder().decode(result.stderr).toLowerCase();
+          if (stderr.includes('sso token') || stderr.includes('expired'))
+            return {
+              state: 'unauthenticated',
+              hint: 'SSO expired, run: aws sso login',
+            };
+          if (stderr.includes('could not find profile') || stderr.includes('profile'))
+            return {
+              state: 'unauthenticated',
+              hint: 'profile not found, run: aws configure',
+            };
+          if (stderr.includes('could not connect') || stderr.includes('network'))
+            return { state: 'unavailable', hint: 'network error' };
+          return { state: 'unauthenticated', hint: 'run: aws configure' };
+        } catch {
+          return { state: 'unavailable', hint: 'aws CLI check failed' };
+        }
+      },
+      fix: {
+        prompt: 'AWS SSO session expired',
+        command: ['aws', 'sso', 'login'],
+      },
+    });
+  }
+};
+
+export default factory;

--- a/plugins/aws-status/test/extension.test.ts
+++ b/plugins/aws-status/test/extension.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+describe('AWS Status extension', () => {
+  let factory: (pi: unknown) => Promise<void>;
+
+  beforeAll(async () => {
+    const mod = await import('../src/index');
+    factory = mod.default as typeof factory;
+  });
+
+  it('exports a default factory function', () => {
+    expect(typeof factory).toBe('function');
+  });
+
+  it('registers service status when aws is available', async () => {
+    const registered: { name: string }[] = [];
+    const mockPi = {
+      setLabel() {},
+      logger: { debug() {} },
+      registerServiceStatus(c: { name: string }) {
+        registered.push(c);
+      },
+    };
+    await factory(mockPi);
+
+    // If aws CLI is installed, should register; if not, should skip gracefully
+    if (registered.length > 0) {
+      expect(registered[0].name).toBe('AWS');
+    }
+  });
+
+  it('service check returns valid state', async () => {
+    let checkFn: (() => Promise<{ state: string }>) | undefined;
+    const mockPi = {
+      setLabel() {},
+      logger: { debug() {} },
+      registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
+        checkFn = c.check;
+      },
+    };
+    await factory(mockPi);
+
+    if (checkFn) {
+      const result = await checkFn();
+      expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+    }
+  });
+});

--- a/plugins/azure-status/.claude-plugin/plugin.json
+++ b/plugins/azure-status/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "azure-status",
+  "description": "Azure CLI welcome screen status — checks az account authentication and offers auto-fix",
+  "version": "1.0.0",
+  "author": { "name": "f5xc-salesdemos", "url": "https://github.com/f5xc-salesdemos" },
+  "keywords": ["azure", "az", "cloud", "xcsh-extension"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/azure-status/package.json
+++ b/plugins/azure-status/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@f5xc-salesdemos/xcsh-azure-status",
+  "version": "1.0.0",
+  "description": "Azure CLI status for xcsh welcome screen",
+  "main": "src/index.ts",
+  "xcsh": {
+    "name": "Azure Status",
+    "version": "1.0.0",
+    "extensions": [
+      "src/index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@f5xc-salesdemos/xcsh": ">=1.0.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/azure-status/skills/azure-status/SKILL.md
+++ b/plugins/azure-status/skills/azure-status/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: azure-status
+description: >-
+  Internal skill for azure-status xcsh extension. Provides welcome screen service
+  status via registerServiceStatus API. Not user-invocable.
+user-invocable: false
+---
+
+This skill is a placeholder for the azure-status xcsh extension plugin.
+The actual functionality is provided by the extension entry point at src/index.ts
+which registers a service status check for the xcsh welcome screen.

--- a/plugins/azure-status/src/index.ts
+++ b/plugins/azure-status/src/index.ts
@@ -1,0 +1,33 @@
+import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
+
+const factory: ExtensionFactory = async (pi) => {
+  pi.setLabel('Azure Status');
+
+  try {
+    const which = Bun.spawnSync(['which', 'az']);
+    if (which.exitCode !== 0) return;
+  } catch {
+    return;
+  }
+
+  if (typeof pi.registerServiceStatus === 'function') {
+    pi.registerServiceStatus({
+      name: 'Azure',
+      async check() {
+        try {
+          const result = Bun.spawnSync(['az', 'account', 'show', '--output', 'json']);
+          if (result.exitCode === 0) return { state: 'connected' };
+          return { state: 'unauthenticated', hint: 'run: az login' };
+        } catch {
+          return { state: 'unavailable', hint: 'az CLI check failed' };
+        }
+      },
+      fix: {
+        prompt: 'Azure session expired',
+        command: ['az', 'login', '--use-device-code'],
+      },
+    });
+  }
+};
+
+export default factory;

--- a/plugins/azure-status/test/extension.test.ts
+++ b/plugins/azure-status/test/extension.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+describe('Azure Status extension', () => {
+  let factory: (pi: unknown) => Promise<void>;
+
+  beforeAll(async () => {
+    const mod = await import('../src/index');
+    factory = mod.default as typeof factory;
+  });
+
+  it('exports a default factory function', () => {
+    expect(typeof factory).toBe('function');
+  });
+
+  it('registers service status when az is available', async () => {
+    const registered: { name: string }[] = [];
+    const mockPi = {
+      setLabel() {},
+      logger: { debug() {} },
+      registerServiceStatus(c: { name: string }) {
+        registered.push(c);
+      },
+    };
+    await factory(mockPi);
+
+    // If az CLI is installed, should register; if not, should skip gracefully
+    if (registered.length > 0) {
+      expect(registered[0].name).toBe('Azure');
+    }
+  });
+
+  it('service check returns valid state', async () => {
+    let checkFn: (() => Promise<{ state: string }>) | undefined;
+    const mockPi = {
+      setLabel() {},
+      logger: { debug() {} },
+      registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
+        checkFn = c.check;
+      },
+    };
+    await factory(mockPi);
+
+    if (checkFn) {
+      const result = await checkFn();
+      expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+    }
+  });
+});

--- a/plugins/gcloud-status/.claude-plugin/plugin.json
+++ b/plugins/gcloud-status/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "gcloud-status",
+  "description": "Google Cloud CLI welcome screen status — checks gcloud authentication with token expiry detection and offers auto-fix",
+  "version": "1.0.0",
+  "author": { "name": "f5xc-salesdemos", "url": "https://github.com/f5xc-salesdemos" },
+  "keywords": ["gcloud", "google", "cloud", "xcsh-extension"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/gcloud-status/package.json
+++ b/plugins/gcloud-status/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@f5xc-salesdemos/xcsh-gcloud-status",
+  "version": "1.0.0",
+  "description": "Google Cloud CLI status for xcsh welcome screen",
+  "main": "src/index.ts",
+  "xcsh": {
+    "name": "GCloud Status",
+    "version": "1.0.0",
+    "extensions": [
+      "src/index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@f5xc-salesdemos/xcsh": ">=1.0.0"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/gcloud-status/skills/gcloud-status/SKILL.md
+++ b/plugins/gcloud-status/skills/gcloud-status/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: gcloud-status
+description: >-
+  Internal skill for gcloud-status xcsh extension. Provides welcome screen service
+  status via registerServiceStatus API. Not user-invocable.
+user-invocable: false
+---
+
+This skill is a placeholder for the gcloud-status xcsh extension plugin.
+The actual functionality is provided by the extension entry point at src/index.ts
+which registers a service status check for the xcsh welcome screen.

--- a/plugins/gcloud-status/src/index.ts
+++ b/plugins/gcloud-status/src/index.ts
@@ -1,0 +1,42 @@
+import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
+
+const factory: ExtensionFactory = async (pi) => {
+  pi.setLabel('GCloud Status');
+
+  try {
+    const which = Bun.spawnSync(['which', 'gcloud']);
+    if (which.exitCode !== 0) return;
+  } catch {
+    return;
+  }
+
+  if (typeof pi.registerServiceStatus === 'function') {
+    pi.registerServiceStatus({
+      name: 'GCloud',
+      async check() {
+        try {
+          const result = Bun.spawnSync(['gcloud', 'auth', 'print-access-token', '--quiet']);
+          if (result.exitCode === 0) return { state: 'connected' };
+          const stderr = new TextDecoder().decode(result.stderr).toLowerCase();
+          if (stderr.includes('expired') || stderr.includes('token'))
+            return {
+              state: 'unauthenticated',
+              hint: 'token expired, run: gcloud auth login',
+            };
+          return {
+            state: 'unauthenticated',
+            hint: 'run: gcloud auth login',
+          };
+        } catch {
+          return { state: 'unavailable', hint: 'gcloud CLI check failed' };
+        }
+      },
+      fix: {
+        prompt: 'Google Cloud token expired',
+        command: ['gcloud', 'auth', 'login'],
+      },
+    });
+  }
+};
+
+export default factory;

--- a/plugins/gcloud-status/test/extension.test.ts
+++ b/plugins/gcloud-status/test/extension.test.ts
@@ -1,0 +1,48 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+describe('GCloud Status extension', () => {
+  let factory: (pi: unknown) => Promise<void>;
+
+  beforeAll(async () => {
+    const mod = await import('../src/index');
+    factory = mod.default as typeof factory;
+  });
+
+  it('exports a default factory function', () => {
+    expect(typeof factory).toBe('function');
+  });
+
+  it('registers service status when gcloud is available', async () => {
+    const registered: { name: string }[] = [];
+    const mockPi = {
+      setLabel() {},
+      logger: { debug() {} },
+      registerServiceStatus(c: { name: string }) {
+        registered.push(c);
+      },
+    };
+    await factory(mockPi);
+
+    // If gcloud CLI is installed, should register; if not, should skip gracefully
+    if (registered.length > 0) {
+      expect(registered[0].name).toBe('GCloud');
+    }
+  });
+
+  it('service check returns valid state', async () => {
+    let checkFn: (() => Promise<{ state: string }>) | undefined;
+    const mockPi = {
+      setLabel() {},
+      logger: { debug() {} },
+      registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
+        checkFn = c.check;
+      },
+    };
+    await factory(mockPi);
+
+    if (checkFn) {
+      const result = await checkFn();
+      expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add 3 new xcsh extension plugins for cloud CLI welcome screen status
- `azure-status`: checks `az account show`, offers `az login --use-device-code` fix
- `aws-status`: checks `aws sts get-caller-identity`, classifies SSO expiry/profile errors, offers `aws sso login` fix
- `gcloud-status`: checks `gcloud auth print-access-token`, detects token expiry, offers `gcloud auth login` fix
- Each uses `registerServiceStatus()` Extension API (xcsh >= 18.89.0)
- Part of the cloud connector plugin extraction pattern established with Salesforce

Closes #496

## Test plan
- [x] 9/9 bun tests pass (3 per plugin)
- [x] Marketplace validate-plugins.sh passes