### PR TITLE
feat: add github and gitlab native tool plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "f5xc-sales-engineer",
-      "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
+      "description": "Sales Engineer persona framework for F5 XC demo repositories \u2014 demo execution, environment operations, presentation, Q&A, post-session debrief",
       "version": "1.0.6",
       "author": {
         "name": "f5xc-salesdemos"
@@ -42,7 +42,7 @@
     },
     {
       "name": "f5xc-github-ops",
-      "description": "GitHub operations automation — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
+      "description": "GitHub operations automation \u2014 issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
       "version": "2.3.1",
       "author": {
         "name": "f5xc-salesdemos"
@@ -57,7 +57,7 @@
     },
     {
       "name": "f5xc-docs-pipeline",
-      "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
+      "description": "Documentation pipeline architecture \u2014 config ownership, release dispatch chain, content authoring, managed files, local preview",
       "version": "1.0.2",
       "author": {
         "name": "f5xc-salesdemos"
@@ -72,7 +72,7 @@
     },
     {
       "name": "f5xc-brand",
-      "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
+      "description": "F5 corporate branding enforcement \u2014 colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
       "version": "1.0.2",
       "author": {
         "name": "f5xc-salesdemos"
@@ -87,7 +87,7 @@
     },
     {
       "name": "f5xc-meddpicc",
-      "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
+      "description": "MEDDPICC sales qualification and deal-execution framework \u2014 evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
       "version": "2.1.0",
       "author": {
         "name": "f5xc-salesdemos"
@@ -112,7 +112,7 @@
     },
     {
       "name": "f5xc-devcontainer",
-      "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
+      "description": "Container awareness \u2014 tool catalog, self-identity, self-diagnosis, and maintenance for the f5xc-salesdemos devcontainer",
       "version": "1.1.6",
       "author": {
         "name": "f5xc-salesdemos"
@@ -127,7 +127,7 @@
     },
     {
       "name": "f5xc-platform",
-      "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
+      "description": "F5 Distributed Cloud platform automation \u2014 web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
       "version": "3.1.1",
       "author": {
         "name": "f5xc-salesdemos"
@@ -156,7 +156,7 @@
     },
     {
       "name": "osint-framework",
-      "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
+      "description": "OSINT Framework tool catalog and investigation skills \u2014 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
       "version": "1.0.1",
       "author": {
         "name": "f5xc-salesdemos"
@@ -171,7 +171,7 @@
     },
     {
       "name": "f5xc-firecrawl",
-      "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
+      "description": "Local self-hosted firecrawl web scraping \u2014 scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
       "version": "1.1.0",
       "author": {
         "name": "f5xc-salesdemos"
@@ -484,9 +484,11 @@
     },
     {
       "name": "salesforce",
-      "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
+      "description": "Salesforce pipeline intelligence \u2014 native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/salesforce",
       "category": "development",
       "keywords": [
@@ -510,7 +512,7 @@
     },
     {
       "name": "f5xc-cloudstatus",
-      "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
+      "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API \u2014 status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
       "version": "1.3.0",
       "author": {
         "name": "f5xc-salesdemos"
@@ -534,9 +536,11 @@
     },
     {
       "name": "azure-status",
-      "description": "Azure CLI welcome screen status — checks az account authentication and offers auto-fix",
+      "description": "Azure CLI welcome screen status \u2014 checks az account authentication and offers auto-fix",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/azure-status",
       "category": "development",
       "keywords": ["azure", "az", "cloud"],
@@ -547,9 +551,11 @@
     },
     {
       "name": "aws-status",
-      "description": "AWS CLI welcome screen status — checks AWS STS authentication with SSO expiry detection and auto-fix",
+      "description": "AWS CLI welcome screen status \u2014 checks AWS STS authentication with SSO expiry detection and auto-fix",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/aws-status",
       "category": "development",
       "keywords": ["aws", "amazon", "cloud"],
@@ -560,15 +566,47 @@
     },
     {
       "name": "gcloud-status",
-      "description": "Google Cloud CLI welcome screen status — checks gcloud authentication with token expiry detection and auto-fix",
+      "description": "Google Cloud CLI welcome screen status \u2014 checks gcloud authentication with token expiry detection and auto-fix",
       "version": "1.0.0",
-      "author": { "name": "f5xc-salesdemos" },
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
       "source": "./plugins/gcloud-status",
       "category": "development",
       "keywords": ["gcloud", "google", "cloud"],
       "tags": ["gcloud", "google", "cloud", "xcsh-extension"],
       "license": "Apache-2.0",
       "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/gcloud-status",
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "gitlab",
+      "description": "GitLab CLI integration \u2014 native xcsh tools (glab_setup, glab_issue_list, glab_issue_view, glab_search), welcome screen status, and issue management via glab CLI",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/gitlab",
+      "category": "development",
+      "keywords": ["gitlab", "glab", "issues", "git"],
+      "tags": ["gitlab", "development", "cli", "xcsh-extension"],
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/gitlab",
+      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+    },
+    {
+      "name": "github",
+      "description": "GitHub CLI tools \u2014 repo view, issue/PR management, CI run watching, search, and welcome screen status via xcsh Extension API",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5xc-salesdemos"
+      },
+      "source": "./plugins/github",
+      "category": "development",
+      "keywords": ["github", "gh", "git", "pr", "issues", "ci"],
+      "tags": ["github", "development", "cli", "xcsh-extension"],
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/github",
       "repository": "https://github.com/f5xc-salesdemos/marketplace"
     }
   ]

--- a/plugins/github/.claude-plugin/plugin.json
+++ b/plugins/github/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "github",
+  "description": "GitHub CLI integration — native xcsh tools (gh_repo_view, gh_issue_view, gh_pr_view, gh_pr_diff, gh_pr_checkout, gh_pr_push, gh_run_watch, gh_search_issues, gh_search_prs), profile collection, and service status",
+  "version": "1.0.0",
+  "author": {
+    "name": "f5xc-salesdemos",
+    "url": "https://github.com/f5xc-salesdemos"
+  },
+  "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/github",
+  "keywords": ["github", "gh", "git", "pull-request", "issues", "actions", "xcsh-extension"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/github/bun.lock
+++ b/plugins/github/bun.lock
@@ -1,0 +1,713 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@f5xc-salesdemos/xcsh-github",
+      "devDependencies": {
+        "@sinclair/typebox": "^0.34.0",
+        "bun-types": "latest",
+      },
+      "peerDependencies": {
+        "@f5xc-salesdemos/xcsh": ">=1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1057.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-node": "^3.972.47", "@aws-sdk/eventstream-handler-node": "^3.972.18", "@aws-sdk/middleware-eventstream": "^3.972.14", "@aws-sdk/middleware-websocket": "^3.972.23", "@aws-sdk/token-providers": "3.1057.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-TqnYAhAEk45+w3JmS5uHc05AAxfQ7NDyfuARzBv/Y5WuDftRPJMm6FBHCEH7dqcDCcAHmI+XyCYaBI7g7EgweQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.46", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-env": "^3.972.41", "@aws-sdk/credential-provider-http": "^3.972.43", "@aws-sdk/credential-provider-login": "^3.972.45", "@aws-sdk/credential-provider-process": "^3.972.41", "@aws-sdk/credential-provider-sso": "^3.972.45", "@aws-sdk/credential-provider-web-identity": "^3.972.45", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/credential-provider-imds": "^4.3.6", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.47", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.41", "@aws-sdk/credential-provider-http": "^3.972.43", "@aws-sdk/credential-provider-ini": "^3.972.46", "@aws-sdk/credential-provider-process": "^3.972.41", "@aws-sdk/credential-provider-sso": "^3.972.45", "@aws-sdk/credential-provider-web-identity": "^3.972.45", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/credential-provider-imds": "^4.3.6", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/token-providers": "3.1056.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.18", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QPQhwY/fstR8fMZFWrsJRNoTP6D1RjRPHGRX7u9/VkF3opCsvD0oXPz6qzkX94SchzvuS5vyFZbJbPcMEs2Jeg=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-DoZ4djVj/74XQ6M/IwxuKh543tTvLCL7u1Dx+VDHMgW9yGNrFSJJ1l0LrUQRaekic5CB12wUiiOoHL0VI6H0gg=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.23", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-F0d4A9pJFiwljyKgSwU1Z5n+CXSv8bp+V5SthbS2rftB8wBN9z1K2Yyv3xbeK0AM2T0g4q6Ptf0shFF+oQZyiA=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.13", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/signature-v4-multi-region": "^3.996.30", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.30", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1057.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-nIypx3Pvn9l7XoCi1a1ruY/FdUyfQW0LXk/2BdazRzs7rOAZeoSdZx9E1A6bmXIDedrG+09hFb8QlxhEk40jfA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.26", "", { "dependencies": { "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
+
+    "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
+
+    "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
+
+    "@f5xc-salesdemos/pi-agent-core": ["@f5xc-salesdemos/pi-agent-core@18.89.0", "", { "dependencies": { "@f5xc-salesdemos/pi-ai": "18.89.0", "@f5xc-salesdemos/pi-utils": "18.89.0" } }, "sha512-En73yuHovD+5jtIParD4mq1tznmoIcvWw+gg76QxWd04aNFALavzmEYdnU/SonUeY19XFVTjczwxz4hqMiSsbg=="],
+
+    "@f5xc-salesdemos/pi-ai": ["@f5xc-salesdemos/pi-ai@18.89.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.78", "@aws-sdk/client-bedrock-runtime": "^3", "@bufbuild/protobuf": "^2.11", "@f5xc-salesdemos/pi-utils": "18.89.0", "@google/genai": "^1.43", "@sinclair/typebox": "^0.34", "@smithy/node-http-handler": "^4.4", "ajv": "~8.18.0", "ajv-formats": "^3.0", "openai": "^6.25", "partial-json": "^0.1", "zod": "^4.3" }, "bin": { "pi-ai": "src/cli.ts" } }, "sha512-hi4Fek4pO2/peAxmDQTMt4WaVLhbwiQDt40xPTikIHcOBfF8X2xGdQzjWHr+ZeM9GIUlmBx5bKd/oaRg76kzwg=="],
+
+    "@f5xc-salesdemos/pi-natives": ["@f5xc-salesdemos/pi-natives@18.89.0", "", { "optionalDependencies": { "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.89.0", "@f5xc-salesdemos/pi-natives-darwin-x64": "18.89.0", "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.89.0", "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.89.0", "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.89.0" } }, "sha512-PFcjrIUzQi3ohq9eTjI64SUF/tLgY/+SWm01kEeZH/FeuOfm/N9MN76URlV7GE1eNtyUHnZLDpFlT8OD2EbpTA=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-arm64": ["@f5xc-salesdemos/pi-natives-darwin-arm64@18.89.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yQ2fnVxwKazipPW9nbe2ByhBVdg3xDtSzQtELjTTWhzbs1V7RxJVn/pLdq64L51/r9v4MsYGtruGWizFeYgB/g=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-x64": ["@f5xc-salesdemos/pi-natives-darwin-x64@18.89.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ybkkwceDkgOQgjbowWgplM+rs2cBrOLPD7ZixXyVJbRN9VW8fy9DK0ASLVmKH/iy5EbLkHgG+X9+srxBbqT+8A=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": ["@f5xc-salesdemos/pi-natives-linux-arm64-gnu@18.89.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-OpTHa5KfIiKonXOFCM1sXMI2cyNidBnVmSW4XAgECtmZHt8B7DjcKnvmb3IVTclMiSuOUJyIPM6U7WfGmSG7tg=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-x64-gnu": ["@f5xc-salesdemos/pi-natives-linux-x64-gnu@18.89.0", "", { "os": "linux", "cpu": "x64" }, "sha512-seDJbHFaIOdK1ay8nvtWcTTB6KVp2M4zrhByV8k2Bilppw2ccMRH2Wnae5rLZuf9Zg97IVTm5br+2HAocuh60A=="],
+
+    "@f5xc-salesdemos/pi-natives-win32-x64-msvc": ["@f5xc-salesdemos/pi-natives-win32-x64-msvc@18.89.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fdS/BM+iv2XUzLZINr/G3Oy7iZN+GnoY8xWl7k5fCNoBkAfHsPU5pJcGQ1R8ewJvr7Xtk1uDvhEmDS6bl5lTJQ=="],
+
+    "@f5xc-salesdemos/pi-tui": ["@f5xc-salesdemos/pi-tui@18.89.0", "", { "dependencies": { "@f5xc-salesdemos/pi-natives": "18.89.0", "@f5xc-salesdemos/pi-utils": "18.89.0", "marked": "^17.0" } }, "sha512-/W19zaU9FWSMG5iOBWotk0Ti1CPXM0Vp7awpQSf6WrlTWZ54rP7z/n3dEvfV4upWgAzyjItI/LUUSZACQbuuCQ=="],
+
+    "@f5xc-salesdemos/pi-utils": ["@f5xc-salesdemos/pi-utils@18.89.0", "", { "dependencies": { "beautiful-mermaid": "^1.1", "handlebars": "^4.7.9", "winston": "^3.19", "winston-daily-rotate-file": "^5.0" } }, "sha512-rYDFetxYHa2gheoRkWnk1EA7sjCnGBNrRQqYB7+wyVwzXyHJXpJPUdWNF36aw+eu0wZva8GK+64rdPfT5EjUJQ=="],
+
+    "@f5xc-salesdemos/xcsh": ["@f5xc-salesdemos/xcsh@18.89.0", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@f5xc-salesdemos/pi-agent-core": "18.89.0", "@f5xc-salesdemos/pi-ai": "18.89.0", "@f5xc-salesdemos/pi-natives": "18.89.0", "@f5xc-salesdemos/pi-tui": "18.89.0", "@f5xc-salesdemos/pi-utils": "18.89.0", "@f5xc-salesdemos/xcsh-stats": "18.89.0", "@mozilla/readability": "^0.6", "@sinclair/typebox": "^0.34", "@xterm/headless": "^6.0", "ajv": "^8.18", "chalk": "^5.6", "diff": "^8.0", "fflate": "0.8.2", "handlebars": "^4.7", "linkedom": "^0.18", "lru-cache": "11.3.1", "markit-ai": "0.5.0", "puppeteer": "^24.37", "zod": "4.3.6" }, "bin": { "xcsh": "src/cli.ts" } }, "sha512-eYoFb017Bnihx5JIDhZpzE0QyHY/ZX6eNMptZHcTqJTi+A9GAaHDAZ0K1m0JeiY9PfXJtZuF4jCtMCaYGikQCw=="],
+
+    "@f5xc-salesdemos/xcsh-stats": ["@f5xc-salesdemos/xcsh-stats@18.89.0", "", { "dependencies": { "@f5xc-salesdemos/pi-ai": "18.89.0", "@f5xc-salesdemos/pi-utils": "18.89.0", "@tailwindcss/node": "^4.2", "chart.js": "^4.5", "date-fns": "~4.1.0", "lucide-react": "^0.576", "react": "^19.2", "react-chartjs-2": "^5.3", "react-dom": "^19.2" }, "bin": { "xcsh-stats": "src/index.ts" } }, "sha512-NhJ69P13mG7kWyulJwv/rSplQD6YJcBFsrQyjKdeEaV8Curp+g2IkpF6nk4VRLPv+KpOh0AvdaE5OEoX2Psq+w=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
+
+    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
+    "@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.6", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA=="],
+
+    "@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
+    "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
+    "bare-events": ["bare-events@2.8.3", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw=="],
+
+    "bare-fs": ["bare-fs@4.7.1", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw=="],
+
+    "bare-os": ["bare-os@3.9.1", "", {}, "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ=="],
+
+    "bare-path": ["bare-path@3.0.0", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw=="],
+
+    "bare-stream": ["bare-stream@2.13.1", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow=="],
+
+    "bare-url": ["bare-url@2.4.3", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
+    "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
+
+    "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
+
+    "color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
+
+    "color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
+
+    "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "exifr": ["exifr@7.1.3", "", {}, "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.8.0", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.2.0", "path-expression-matcher": "^1.5.0", "strnum": "^2.3.0", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "fecha": ["fecha@4.2.3", "", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "file-stream-rotator": ["file-stream-rotator@0.6.1", "", { "dependencies": { "moment": "^2.29.1" } }, "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
+    "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
+
+    "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
+
+    "lru-cache": ["lru-cache@11.3.1", "", {}, "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w=="],
+
+    "lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
+
+    "markit-ai": ["markit-ai@0.5.0", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.3", "exifr": "^7.1.3", "fast-xml-parser": "^5.5.9", "jszip": "^3.10.1", "mammoth": "^1.9.0", "mupdf": "^1.27.0", "music-metadata": "^11.12.3", "rss-parser": "^3.13.0", "turndown": "^7.2.0", "turndown-plugin-gfm": "^1.0.2" }, "bin": { "markit": "dist/main.js" } }, "sha512-ob3VxICBZe2Ge3Wg0vFOv6jkk/7OaYisQbtMYR7lUh00MkhAJ/sdVFy0GlqjPkXQ+mGygLdioGB+PfBLUJ5B2w=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mupdf": ["mupdf@1.27.0", "", {}, "sha512-vEPUYwZeu5NgiFLz4e20R7Vp2pNY7szirGEvTxHyQQpQs6ab4DeGdonwT6sH1JZG5EhyHSrojZrZn2/0ee6qZQ=="],
+
+    "music-metadata": ["music-metadata@11.12.3", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.4.3", "file-type": "^21.3.1", "media-typer": "^1.1.0", "strtok3": "^10.3.4", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
+
+    "openai": ["openai@6.39.1", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A=="],
+
+    "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "puppeteer": ["puppeteer@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "cosmiconfig": "^9.0.0", "devtools-protocol": "0.0.1608973", "puppeteer-core": "24.43.1", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/cjs/puppeteer/node/cli.js" } }, "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw=="],
+
+    "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.20.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
+
+    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
+    "react-chartjs-2": ["react-chartjs-2@5.3.1", "", { "peerDependencies": { "chart.js": "^4.1.1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A=="],
+
+    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "rss-parser": ["rss-parser@3.13.0", "", { "dependencies": { "entities": "^2.0.3", "xml2js": "^0.5.0" } }, "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
+    "streamx": ["streamx@2.26.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
+
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
+
+    "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "triple-beam": ["triple-beam@1.4.1", "", {}, "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "turndown-plugin-gfm": ["turndown-plugin-gfm@1.0.2", "", {}, "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="],
+
+    "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
+
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
+
+    "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
+
+    "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
+
+    "winston-daily-rotate-file": ["winston-daily-rotate-file@5.0.0", "", { "dependencies": { "file-stream-rotator": "^0.6.1", "object-hash": "^3.0.0", "triple-beam": "^1.4.1", "winston-transport": "^4.7.0" }, "peerDependencies": { "winston": "^3" } }, "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw=="],
+
+    "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@10.1.1", "", {}, "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1056.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA=="],
+
+    "@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
+    "@f5xc-salesdemos/pi-ai/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "jwa/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "rss-parser/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+  }
+}

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@f5xc-salesdemos/xcsh-github",
+  "version": "1.0.0",
+  "description": "GitHub CLI integration for xcsh — native tools for repos, issues, PRs, diffs, Actions, and search",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "bun test",
+    "test:watch": "bun test --watch"
+  },
+  "xcsh": {
+    "name": "GitHub",
+    "version": "1.0.0",
+    "description": "GitHub CLI integration",
+    "extensions": [
+      "src/index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@f5xc-salesdemos/xcsh": ">=1.0.0"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.0",
+    "bun-types": "latest"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/github/skills/github-status/SKILL.md
+++ b/plugins/github/skills/github-status/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: github-status
+description: Check GitHub CLI authentication status and connectivity
+triggers:
+  - github status
+  - gh status
+  - github auth
+  - check github
+---
+
+Internal skill for verifying GitHub CLI availability and authentication state.
+Not user-invocable — used by the service status check on the welcome screen.

--- a/plugins/github/src/index.ts
+++ b/plugins/github/src/index.ts
@@ -1,0 +1,114 @@
+import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
+
+const factory: ExtensionFactory = async (pi) => {
+  pi.setLabel('GitHub');
+
+  // Gate on gh CLI availability
+  try {
+    const result = Bun.spawnSync(['which', 'gh']);
+    if (result.exitCode !== 0) {
+      pi.logger.debug('GitHub CLI (gh) not found — skipping tool registration');
+      return;
+    }
+  } catch {
+    pi.logger.debug('GitHub CLI (gh) not found — skipping tool registration');
+    return;
+  }
+
+  // Import tool classes
+  const {
+    GhRepoViewTool,
+    GhIssueViewTool,
+    GhPrViewTool,
+    GhPrDiffTool,
+    GhPrCheckoutTool,
+    GhPrPushTool,
+    GhRunWatchTool,
+    GhSearchIssuesTool,
+    GhSearchPrsTool,
+  } = await import('./tools/gh');
+
+  // Each tool class has a createIf() that checks gh availability and returns
+  // an instance with name/label/description/parameters/execute.
+  // In the plugin we use a minimal session that gets cwd from the tool context.
+  const sessionProxy = { cwd: process.cwd() };
+
+  const toolClasses = [
+    GhRepoViewTool,
+    GhIssueViewTool,
+    GhPrViewTool,
+    GhPrDiffTool,
+    GhPrCheckoutTool,
+    GhPrPushTool,
+    GhRunWatchTool,
+    GhSearchIssuesTool,
+    GhSearchPrsTool,
+  ] as const;
+
+  for (const ToolClass of toolClasses) {
+    const instance = ToolClass.createIf(sessionProxy);
+    if (!instance) continue;
+
+    // Wrap the execute to inject cwd from the context argument
+    const originalExecute = instance.execute.bind(instance);
+
+    pi.registerTool({
+      name: instance.name,
+      label: instance.label,
+      description: instance.description,
+      parameters: instance.parameters,
+      async execute(
+        toolCallId: string,
+        params: Record<string, unknown>,
+        signal: AbortSignal | undefined,
+        onUpdate: unknown,
+        ctx: { cwd: string },
+      ) {
+        // Update session cwd from context
+        sessionProxy.cwd = ctx?.cwd ?? process.cwd();
+        // biome-ignore lint/suspicious/noExplicitAny: bridging xcsh internal types
+        return originalExecute(toolCallId, params, signal, onUpdate as any, ctx as any); // eslint-disable-line
+      },
+    });
+  }
+
+  // Register welcome screen service status
+  if (typeof pi.registerServiceStatus === 'function') {
+    pi.registerServiceStatus({
+      name: 'GitHub',
+      async check() {
+        try {
+          const whichResult = Bun.spawnSync(['which', 'gh']);
+          if (whichResult.exitCode !== 0) {
+            return { state: 'unavailable', hint: 'gh CLI not installed — https://cli.github.com/' };
+          }
+          const authResult = Bun.spawnSync(['gh', 'auth', 'status']);
+          if (authResult.exitCode !== 0) {
+            return { state: 'unauthenticated', hint: 'run: gh auth login' };
+          }
+          return { state: 'connected' };
+        } catch {
+          return { state: 'unavailable', hint: 'gh CLI check failed' };
+        }
+      },
+      fix: {
+        prompt: 'GitHub CLI not authenticated',
+        command: ['gh', 'auth', 'login'],
+      },
+    });
+  }
+
+  // Session start — verify gh auth at session start (non-fatal)
+  pi.on('session_start', async (_event: unknown, _ctx: { cwd: string }) => {
+    try {
+      const authResult = Bun.spawnSync(['gh', 'auth', 'status']);
+      if (authResult.exitCode !== 0) {
+        pi.logger.debug('GitHub: not authenticated (non-fatal)');
+      }
+    } catch {
+      pi.logger.debug('GitHub: welcome check failed (non-fatal)');
+    }
+  });
+};
+
+export default factory;

--- a/plugins/github/src/prompts/gh-issue-view.md
+++ b/plugins/github/src/prompts/gh-issue-view.md
@@ -1,0 +1,11 @@
+Reads a GitHub issue through the local GitHub CLI.
+
+<instruction>
+- Accepts an issue number or full GitHub issue URL
+- Use `repo` when you have a number but no active GitHub repository context
+- Keep `comments` enabled when discussion context matters; disable it for a lighter summary
+</instruction>
+
+<output>
+Returns issue metadata, body text, and optionally visible comments in a readable format.
+</output>

--- a/plugins/github/src/prompts/gh-pr-checkout.md
+++ b/plugins/github/src/prompts/gh-pr-checkout.md
@@ -1,0 +1,12 @@
+Checks out a GitHub pull request into a dedicated git worktree through the local GitHub CLI.
+
+<instruction>
+- Accepts a pull request number, URL, or branch name
+- Omitting `pr` targets the pull request associated with the current branch
+- Creates or reuses a local `pr-<number>` branch by default, fetches the contributor head branch, and creates a dedicated worktree for it
+- Configures the local branch to push back to the pull request head branch instead of accidentally publishing to the base repository
+</instruction>
+
+<output>
+Returns the worktree path, local branch name, remote name, and remote branch configured for future pushes.
+</output>

--- a/plugins/github/src/prompts/gh-pr-diff.md
+++ b/plugins/github/src/prompts/gh-pr-diff.md
@@ -1,0 +1,12 @@
+Reads a GitHub pull request diff through the local GitHub CLI.
+
+<instruction>
+- Accepts a pull request number, URL, or branch name
+- Omitting `pr` targets the pull request associated with the current branch
+- Use `nameOnly: true` when you only need changed file names
+- Use `exclude` to drop generated or irrelevant paths from the diff
+</instruction>
+
+<output>
+Returns a unified diff or changed-file list for the selected pull request.
+</output>

--- a/plugins/github/src/prompts/gh-pr-push.md
+++ b/plugins/github/src/prompts/gh-pr-push.md
@@ -1,0 +1,11 @@
+Pushes a checked-out pull request branch back to its source branch through local git.
+
+<instruction>
+- Defaults to the current checked-out git branch
+- Uses branch metadata recorded by `gh_pr_checkout` to push back to the contributor fork and PR head branch
+- Use `forceWithLease` only when rewriting the branch intentionally
+</instruction>
+
+<output>
+Returns the local branch, remote, remote branch, and push target that were used.
+</output>

--- a/plugins/github/src/prompts/gh-pr-view.md
+++ b/plugins/github/src/prompts/gh-pr-view.md
@@ -1,0 +1,11 @@
+Reads a GitHub pull request through the local GitHub CLI.
+
+<instruction>
+- Accepts a pull request number, URL, or branch name
+- Omitting `pr` targets the pull request associated with the current branch
+- Use this for PR metadata, body, changed-file summaries, review discussion, inline review comments, and issue-comment context
+</instruction>
+
+<output>
+Returns pull request metadata, body text, changed files, and optionally visible reviews, inline review comments, and issue comments in a readable format.
+</output>

--- a/plugins/github/src/prompts/gh-repo-view.md
+++ b/plugins/github/src/prompts/gh-repo-view.md
@@ -1,0 +1,11 @@
+Reads GitHub repository metadata using the local GitHub CLI.
+
+<instruction>
+- Prefer this when you need authenticated repository context or GitHub CLI default-repo resolution
+- Use `repo` to target an explicit `OWNER/REPO`; otherwise the current checkout or `gh` default repo is used
+- This tool is read-only and returns repository metadata, not raw file contents
+</instruction>
+
+<output>
+Returns a concise repository summary including description, branch, visibility, stars, forks, and related metadata.
+</output>

--- a/plugins/github/src/prompts/gh-run-watch.md
+++ b/plugins/github/src/prompts/gh-run-watch.md
@@ -1,0 +1,12 @@
+Watches a GitHub Actions workflow run through the local GitHub CLI.
+
+<instruction>
+- Accepts a run ID or full Actions run URL
+- Omitting `run` watches the workflow runs for the current HEAD commit in the current GitHub repository context
+- Omitting `branch` falls back to the current checked-out git branch
+- Fast-fails after the first detected job failure, waits briefly to collect concurrent failures, and then fetches tailed logs for the failed jobs
+</instruction>
+
+<output>
+Streams live run snapshots while polling, then returns the final run status, job list, and tailed logs for failed jobs when available. When failed-job logs are fetched, the full failed-job logs are also saved as a session artifact for on-demand reads. When `run` is omitted, the snapshots cover all workflow runs created for the current HEAD commit.
+</output>

--- a/plugins/github/src/prompts/gh-search-issues.md
+++ b/plugins/github/src/prompts/gh-search-issues.md
@@ -1,0 +1,11 @@
+Searches GitHub issues through the local GitHub CLI.
+
+<instruction>
+- `query` supports normal GitHub issue search syntax
+- Use `repo` to scope results to a single repository when relevant
+- Prefer small limits and refine the query instead of pulling large result sets
+</instruction>
+
+<output>
+Returns a concise list of matching issues with repository, state, labels, timestamps, and URLs.
+</output>

--- a/plugins/github/src/prompts/gh-search-prs.md
+++ b/plugins/github/src/prompts/gh-search-prs.md
@@ -1,0 +1,11 @@
+Searches GitHub pull requests through the local GitHub CLI.
+
+<instruction>
+- `query` supports normal GitHub pull request search syntax
+- Use `repo` to scope results to a single repository when relevant
+- Prefer small limits and refine the query instead of pulling large result sets
+</instruction>
+
+<output>
+Returns a concise list of matching pull requests with repository, state, labels, timestamps, and URLs.
+</output>

--- a/plugins/github/src/tools/gh.ts
+++ b/plugins/github/src/tools/gh.ts
@@ -1,0 +1,2661 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { type Static, Type } from '@sinclair/typebox';
+import ghIssueViewDescription from '../prompts/gh-issue-view.md' with { type: 'text' };
+import ghPrCheckoutDescription from '../prompts/gh-pr-checkout.md' with { type: 'text' };
+import ghPrDiffDescription from '../prompts/gh-pr-diff.md' with { type: 'text' };
+import ghPrPushDescription from '../prompts/gh-pr-push.md' with { type: 'text' };
+import ghPrViewDescription from '../prompts/gh-pr-view.md' with { type: 'text' };
+import ghRepoViewDescription from '../prompts/gh-repo-view.md' with { type: 'text' };
+import ghRunWatchDescription from '../prompts/gh-run-watch.md' with { type: 'text' };
+import ghSearchIssuesDescription from '../prompts/gh-search-issues.md' with { type: 'text' };
+import ghSearchPrsDescription from '../prompts/gh-search-prs.md' with { type: 'text' };
+import * as git from '../utils/git';
+import { ToolError, throwIfAborted } from '../utils/tool-errors';
+
+// ---------------------------------------------------------------------------
+// Shims for xcsh internals removed during extraction
+// ---------------------------------------------------------------------------
+
+/** Minimal session context — replaces ToolSession from xcsh core. */
+export interface ToolSession {
+  cwd: string;
+  allocateOutputArtifact?: (toolType: string) => Promise<{ id?: string; path?: string }>;
+}
+
+/** Minimal prompt shim — returns md text as-is (no Handlebars rendering needed for these tools). */
+const prompt = { render: (text: string) => text };
+
+/** Sleep that respects AbortSignal. */
+function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+}
+
+/** Run fn, converting abort into ToolAbortError. */
+async function untilAborted<T>(signal: AbortSignal | undefined, fn: () => Promise<T>): Promise<T> {
+  throwIfAborted(signal);
+  return fn();
+}
+
+/** Check if error is ENOENT. */
+function isEnoent(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+/** Placeholder for OutputMeta — not used in plugin context. */
+type OutputMeta = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Simplified tool result builder
+// ---------------------------------------------------------------------------
+
+interface ToolResultContent {
+  type: 'text';
+  text: string;
+}
+
+interface AgentToolResult<TDetails = unknown> {
+  content: ToolResultContent[];
+  details?: TDetails;
+  isWarning?: boolean;
+  isError?: boolean;
+}
+
+type AgentToolUpdateCallback<TDetails = unknown> = (update: {
+  content: ToolResultContent[];
+  details?: TDetails;
+}) => void;
+
+interface AgentToolContext {
+  cwd: string;
+}
+
+/** Minimal AgentTool interface matching xcsh's pi-agent-core contract. */
+interface AgentTool<TSchema = unknown, TDetails = unknown> {
+  readonly name: string;
+  readonly label: string;
+  readonly description: string;
+  readonly parameters: TSchema;
+  readonly strict?: boolean;
+  execute(
+    toolCallId: string,
+    params: unknown,
+    signal?: AbortSignal,
+    onUpdate?: AgentToolUpdateCallback<TDetails>,
+    context?: AgentToolContext,
+  ): Promise<AgentToolResult<TDetails>>;
+}
+
+class ToolResultBuilder<TDetails extends { meta?: OutputMeta }> {
+  #details: TDetails;
+  #content: ToolResultContent[] = [];
+
+  constructor(details?: TDetails) {
+    this.#details = details ?? ({} as TDetails);
+  }
+
+  text(text: string): this {
+    this.#content = [{ type: 'text', text }];
+    return this;
+  }
+
+  sourceUrl(_value: string): this {
+    return this;
+  }
+
+  done(): AgentToolResult<TDetails> {
+    const hasDetails = Object.entries(this.#details).some(([, value]) => value !== undefined);
+    return {
+      content: this.#content,
+      details: hasDetails ? this.#details : undefined,
+    };
+  }
+}
+
+function toolResult<TDetails extends { meta?: OutputMeta }>(details?: TDetails): ToolResultBuilder<TDetails> {
+  return new ToolResultBuilder(details);
+}
+
+const GH_REPO_FIELDS = [
+  'nameWithOwner',
+  'description',
+  'url',
+  'defaultBranchRef',
+  'homepageUrl',
+  'forkCount',
+  'isArchived',
+  'isFork',
+  'primaryLanguage',
+  'repositoryTopics',
+  'stargazerCount',
+  'updatedAt',
+  'viewerPermission',
+  'visibility',
+];
+const GH_ISSUE_FIELDS = [
+  'author',
+  'body',
+  'comments',
+  'createdAt',
+  'labels',
+  'number',
+  'state',
+  'stateReason',
+  'title',
+  'updatedAt',
+  'url',
+];
+const GH_ISSUE_FIELDS_NO_COMMENTS = [
+  'author',
+  'body',
+  'createdAt',
+  'labels',
+  'number',
+  'state',
+  'stateReason',
+  'title',
+  'updatedAt',
+  'url',
+];
+const GH_PR_FIELDS = [
+  'author',
+  'baseRefName',
+  'body',
+  'comments',
+  'createdAt',
+  'files',
+  'headRefName',
+  'isDraft',
+  'labels',
+  'mergeStateStatus',
+  'number',
+  'reviewDecision',
+  'state',
+  'title',
+  'updatedAt',
+  'url',
+];
+const GH_PR_FIELDS_NO_COMMENTS = [
+  'author',
+  'baseRefName',
+  'body',
+  'createdAt',
+  'files',
+  'headRefName',
+  'isDraft',
+  'labels',
+  'mergeStateStatus',
+  'number',
+  'reviews',
+  'reviewDecision',
+  'state',
+  'title',
+  'updatedAt',
+  'url',
+];
+const GH_REPO_CLONE_FIELDS = ['nameWithOwner', 'sshUrl', 'url'];
+const GH_PR_CHECKOUT_FIELDS = [
+  'baseRefName',
+  'headRefName',
+  'headRefOid',
+  'headRepository',
+  'headRepositoryOwner',
+  'isCrossRepository',
+  'maintainerCanModify',
+  'number',
+  'title',
+  'url',
+];
+const GH_SEARCH_FIELDS = [
+  'author',
+  'createdAt',
+  'labels',
+  'number',
+  'repository',
+  'state',
+  'title',
+  'updatedAt',
+  'url',
+];
+const SEARCH_LIMIT_DEFAULT = 10;
+const SEARCH_LIMIT_MAX = 50;
+const FILE_PREVIEW_LIMIT = 50;
+const RUN_WATCH_INTERVAL_DEFAULT = 3;
+const RUN_WATCH_GRACE_DEFAULT = 5;
+const RUN_WATCH_TAIL_DEFAULT = 15;
+const RUN_WATCH_TAIL_MAX = 200;
+const REVIEW_COMMENTS_PAGE_SIZE = 100;
+const RUN_JOBS_PAGE_SIZE = 100;
+const PR_URL_PATTERN = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)(?:\/.*)?$/;
+const RUN_URL_PATTERN = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/actions\/runs\/(\d+)(?:\/.*)?$/;
+const RUN_SUCCESS_CONCLUSIONS = new Set(['success', 'neutral', 'skipped']);
+const RUN_FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'action_required', 'startup_failure']);
+const JOB_FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'action_required']);
+
+const ghRepoViewSchema = Type.Object({
+  repo: Type.Optional(
+    Type.String({
+      description: 'Repository in OWNER/REPO format. Defaults to the current GitHub repository context.',
+    }),
+  ),
+  branch: Type.Optional(Type.String({ description: 'Branch name to inspect instead of the default branch.' })),
+});
+
+const ghIssueViewSchema = Type.Object({
+  issue: Type.String({ description: 'Issue number or full GitHub issue URL.' }),
+  repo: Type.Optional(
+    Type.String({ description: 'Repository in OWNER/REPO format. Omit when passing a full issue URL.' }),
+  ),
+  comments: Type.Optional(Type.Boolean({ description: 'Include issue comments (default: true).' })),
+});
+
+const ghPrViewSchema = Type.Object({
+  pr: Type.Optional(
+    Type.String({
+      description:
+        'Pull request number, full GitHub pull request URL, or branch name. Defaults to the current branch PR.',
+    }),
+  ),
+  repo: Type.Optional(
+    Type.String({ description: 'Repository in OWNER/REPO format. Omit when passing a full pull request URL.' }),
+  ),
+  comments: Type.Optional(Type.Boolean({ description: 'Include pull request comments (default: true).' })),
+});
+
+const ghPrDiffSchema = Type.Object({
+  pr: Type.Optional(
+    Type.String({
+      description:
+        'Pull request number, full GitHub pull request URL, or branch name. Defaults to the current branch PR.',
+    }),
+  ),
+  repo: Type.Optional(
+    Type.String({ description: 'Repository in OWNER/REPO format. Omit when passing a full pull request URL.' }),
+  ),
+  nameOnly: Type.Optional(
+    Type.Boolean({ description: 'Return only changed file names instead of unified diff output.' }),
+  ),
+  exclude: Type.Optional(
+    Type.Array(Type.String({ description: 'Glob pattern for files to exclude from the diff.' }), {
+      description: 'File globs to exclude from the diff output.',
+    }),
+  ),
+});
+
+const ghPrCheckoutSchema = Type.Object({
+  pr: Type.Optional(
+    Type.String({
+      description:
+        'Pull request number, full GitHub pull request URL, or branch name. Defaults to the current branch PR.',
+    }),
+  ),
+  repo: Type.Optional(
+    Type.String({ description: 'Repository in OWNER/REPO format. Omit when passing a full pull request URL.' }),
+  ),
+  branch: Type.Optional(Type.String({ description: 'Local branch name to create or reuse (default: pr-<number>).' })),
+  worktree: Type.Optional(
+    Type.String({ description: 'Worktree path to create. Defaults to <repo>/.worktrees/<branch>.' }),
+  ),
+  force: Type.Optional(
+    Type.Boolean({
+      description: 'Reset an existing local branch to the PR head when it is not already checked out elsewhere.',
+    }),
+  ),
+});
+
+const ghPrPushSchema = Type.Object({
+  branch: Type.Optional(
+    Type.String({
+      description: 'Local branch name to push. Defaults to the current checked-out git branch.',
+    }),
+  ),
+  forceWithLease: Type.Optional(Type.Boolean({ description: 'Use --force-with-lease when pushing the PR branch.' })),
+});
+
+const ghSearchIssuesSchema = Type.Object({
+  query: Type.String({ description: 'GitHub issue search query. Supports GitHub search syntax.' }),
+  repo: Type.Optional(Type.String({ description: 'Repository in OWNER/REPO format to scope the search.' })),
+  limit: Type.Optional(Type.Number({ description: 'Maximum results to return (default: 10, max: 50).' })),
+});
+
+const ghSearchPrsSchema = Type.Object({
+  query: Type.String({ description: 'GitHub pull request search query. Supports GitHub search syntax.' }),
+  repo: Type.Optional(Type.String({ description: 'Repository in OWNER/REPO format to scope the search.' })),
+  limit: Type.Optional(Type.Number({ description: 'Maximum results to return (default: 10, max: 50).' })),
+});
+
+const ghRunWatchSchema = Type.Object({
+  run: Type.Optional(
+    Type.String({
+      description:
+        'GitHub Actions run ID or full run URL. Omitting this watches the workflow runs for the current HEAD commit on the selected branch.',
+    }),
+  ),
+  branch: Type.Optional(
+    Type.String({
+      description: 'Branch to inspect when omitting `run`. Defaults to the current checked-out git branch.',
+    }),
+  ),
+  tail: Type.Optional(
+    Type.Number({ description: 'Number of log lines to include per failed job (default: 15, max: 200).' }),
+  ),
+});
+
+type GhRepoViewInput = Static<typeof ghRepoViewSchema>;
+type GhIssueViewInput = Static<typeof ghIssueViewSchema>;
+type GhPrViewInput = Static<typeof ghPrViewSchema>;
+type GhPrDiffInput = Static<typeof ghPrDiffSchema>;
+type GhPrCheckoutInput = Static<typeof ghPrCheckoutSchema>;
+type GhPrPushInput = Static<typeof ghPrPushSchema>;
+type GhSearchIssuesInput = Static<typeof ghSearchIssuesSchema>;
+type GhSearchPrsInput = Static<typeof ghSearchPrsSchema>;
+type GhRunWatchInput = Static<typeof ghRunWatchSchema>;
+
+export interface GhToolDetails {
+  tool?: string;
+  meta?: OutputMeta;
+  artifactId?: string;
+  repo?: string;
+  branch?: string;
+  worktreePath?: string;
+  remote?: string;
+  remoteBranch?: string;
+  headSha?: string;
+  runId?: number;
+  runIds?: number[];
+  status?: string;
+  conclusion?: string;
+  failedJobs?: string[];
+  watch?: GhRunWatchViewDetails;
+}
+
+export interface GhRunWatchJobDetails {
+  id: number;
+  name: string;
+  status?: string;
+  conclusion?: string;
+  durationSeconds?: number;
+  url?: string;
+}
+
+export interface GhRunWatchRunDetails {
+  id: number;
+  workflowName?: string;
+  displayTitle?: string;
+  status?: string;
+  conclusion?: string;
+  branch?: string;
+  headSha?: string;
+  url?: string;
+  jobs: GhRunWatchJobDetails[];
+}
+
+export interface GhRunWatchFailedLogDetails {
+  runId: number;
+  workflowName?: string;
+  jobName: string;
+  conclusion?: string;
+  tail?: string;
+  available: boolean;
+}
+
+export interface GhRunWatchViewDetails {
+  mode: 'run' | 'commit';
+  state: 'watching' | 'completed';
+  repo: string;
+  branch?: string;
+  headSha?: string;
+  pollCount?: number;
+  note?: string;
+  run?: GhRunWatchRunDetails;
+  runs?: GhRunWatchRunDetails[];
+  failedLogs?: GhRunWatchFailedLogDetails[];
+}
+
+interface GhUser {
+  login?: string;
+  name?: string | null;
+}
+
+interface GhLabel {
+  name?: string;
+}
+
+interface GhComment {
+  author?: GhUser | null;
+  body?: string;
+  createdAt?: string;
+  url?: string;
+  isMinimized?: boolean;
+  minimizedReason?: string | null;
+}
+
+interface GhRepoTopic {
+  name?: string;
+  topic?: { name?: string };
+}
+
+interface GhRepoLanguage {
+  name?: string;
+}
+
+interface GhRepoBranch {
+  name?: string;
+}
+
+interface GhRepoViewData {
+  nameWithOwner?: string;
+  description?: string | null;
+  url?: string;
+  sshUrl?: string;
+  defaultBranchRef?: GhRepoBranch | null;
+  homepageUrl?: string | null;
+  forkCount?: number;
+  isArchived?: boolean;
+  isFork?: boolean;
+  primaryLanguage?: GhRepoLanguage | null;
+  repositoryTopics?: GhRepoTopic[];
+  stargazerCount?: number;
+  updatedAt?: string;
+  viewerPermission?: string | null;
+  visibility?: string | null;
+}
+
+interface GhIssueViewData {
+  author?: GhUser | null;
+  body?: string | null;
+  comments?: GhComment[];
+  createdAt?: string;
+  labels?: GhLabel[];
+  number?: number;
+  state?: string;
+  stateReason?: string | null;
+  title?: string;
+  updatedAt?: string;
+  url?: string;
+}
+
+interface GhPrFile {
+  path?: string;
+  additions?: number;
+  deletions?: number;
+  changeType?: string;
+}
+
+interface GhPrViewData extends GhIssueViewData {
+  baseRefName?: string;
+  files?: GhPrFile[];
+  headRefName?: string;
+  headRefOid?: string;
+  headRepository?: GhRepoViewData | null;
+  headRepositoryOwner?: GhUser | null;
+  isCrossRepository?: boolean;
+  isDraft?: boolean;
+  maintainerCanModify?: boolean;
+  mergeStateStatus?: string;
+  reviewComments?: GhPrReviewComment[];
+  reviews?: GhPrReview[];
+  reviewDecision?: string;
+}
+
+interface GhPrReviewCommit {
+  oid?: string | null;
+}
+
+interface GhPrReview {
+  author?: GhUser | null;
+  body?: string | null;
+  commit?: GhPrReviewCommit | null;
+  state?: string | null;
+  submittedAt?: string | null;
+}
+
+interface GhPrReviewCommentApi {
+  body?: string | null;
+  created_at?: string | null;
+  html_url?: string | null;
+  id?: number;
+  in_reply_to_id?: number | null;
+  line?: number | null;
+  original_line?: number | null;
+  path?: string | null;
+  side?: string | null;
+  user?: GhUser | null;
+}
+
+interface GhPrReviewComment {
+  author?: GhUser | null;
+  body?: string | null;
+  createdAt?: string;
+  id: number;
+  inReplyToId?: number;
+  line?: number;
+  originalLine?: number;
+  path?: string;
+  side?: string;
+  url?: string;
+}
+
+interface GhBranchApiResponse {
+  commit?: {
+    sha?: string | null;
+  } | null;
+}
+
+interface GhSearchRepository {
+  nameWithOwner?: string;
+}
+
+interface GhSearchResult {
+  author?: GhUser | null;
+  createdAt?: string;
+  labels?: GhLabel[];
+  number?: number;
+  repository?: GhSearchRepository | null;
+  state?: string;
+  title?: string;
+  updatedAt?: string;
+  url?: string;
+}
+
+interface GhRunReference {
+  repo?: string;
+  runId?: number;
+}
+
+interface GhActionsRunListResponse {
+  workflow_runs?: GhActionsRunApi[];
+}
+
+interface GhActionsRunApi {
+  id?: number;
+  name?: string | null;
+  display_title?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  head_branch?: string | null;
+  head_sha?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  html_url?: string | null;
+}
+
+interface GhActionsJobsResponse {
+  total_count?: number;
+  jobs?: GhActionsJobApi[];
+}
+
+interface GhActionsJobApi {
+  id?: number;
+  name?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  html_url?: string | null;
+}
+
+interface GhRunJobSnapshot {
+  id: number;
+  name: string;
+  status?: string;
+  conclusion?: string;
+  startedAt?: string;
+  completedAt?: string;
+  url?: string;
+}
+
+interface GhRunSnapshot {
+  id: number;
+  workflowName?: string;
+  displayTitle?: string;
+  status?: string;
+  conclusion?: string;
+  branch?: string;
+  headSha?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  url?: string;
+  jobs: GhRunJobSnapshot[];
+}
+
+interface GhFailedJobLog {
+  run: GhRunSnapshot;
+  job: GhRunJobSnapshot;
+  full?: string;
+  tail?: string;
+  available: boolean;
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? '').replaceAll('\r\n', '\n').replaceAll('\r', '\n').replaceAll('\t', '    ').trim();
+}
+
+function normalizeBlock(value: string | null | undefined): string {
+  return (value ?? '').replaceAll('\r\n', '\n').replaceAll('\r', '\n').replaceAll('\t', '    ').trimEnd();
+}
+
+function looksLikeGitHubUrl(value: string | undefined): boolean {
+  return value?.startsWith('https://github.com/') ?? false;
+}
+
+function normalizeOptionalString(value: string | null | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function formatShortSha(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.slice(0, 12);
+}
+
+function requireNonEmpty(value: string | null | undefined, label: string): string {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    throw new ToolError(`${label} must not be empty`);
+  }
+  return normalized;
+}
+
+function resolveSearchLimit(value: number | undefined): number {
+  if (value === undefined) {
+    return SEARCH_LIMIT_DEFAULT;
+  }
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new ToolError('limit must be a positive number');
+  }
+
+  return Math.min(Math.floor(value), SEARCH_LIMIT_MAX);
+}
+
+function resolveTailLimit(value: number | undefined): number {
+  if (value === undefined) {
+    return RUN_WATCH_TAIL_DEFAULT;
+  }
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new ToolError('tail must be a positive number');
+  }
+
+  return Math.min(Math.floor(value), RUN_WATCH_TAIL_MAX);
+}
+
+function appendRepoFlag(args: string[], repo: string | undefined, identifier?: string): void {
+  if (!repo || looksLikeGitHubUrl(identifier)) {
+    return;
+  }
+
+  args.push('--repo', repo);
+}
+
+function buildGhSearchArgs(
+  command: 'issues' | 'prs',
+  query: string,
+  limit: number,
+  repo: string | undefined,
+): string[] {
+  const args = ['search', command, '--limit', String(limit), '--json', GH_SEARCH_FIELDS.join(',')];
+  appendRepoFlag(args, repo);
+  args.push('--', query);
+  return args;
+}
+
+function sanitizeRemoteName(value: string): string {
+  const sanitized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+/g, '')
+    .replace(/-+$/g, '');
+  return sanitized.length > 0 ? `fork-${sanitized}` : 'fork';
+}
+
+function toLocalBranchRef(value: string): string {
+  return `refs/heads/${value}`;
+}
+
+function stripHeadsRef(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.startsWith('refs/heads/') ? value.slice('refs/heads/'.length) : value;
+}
+
+async function requireGitRepoRoot(cwd: string, signal?: AbortSignal): Promise<string> {
+  const repoRoot = await git.repo.root(cwd, signal);
+  if (!repoRoot) {
+    throw new ToolError('Current git repository is unavailable.');
+  }
+
+  return repoRoot;
+}
+
+async function requirePrimaryGitRepoRoot(cwd: string, signal?: AbortSignal): Promise<string> {
+  const primaryRepoRoot = await git.repo.primaryRoot(cwd, signal);
+  if (!primaryRepoRoot) {
+    throw new ToolError('Current git repository is unavailable.');
+  }
+
+  return primaryRepoRoot;
+}
+
+async function requireCurrentGitBranch(cwd: string, signal?: AbortSignal): Promise<string> {
+  const branch = await git.branch.current(cwd, signal);
+  if (!branch) {
+    throw new ToolError('Current git branch is unavailable. Pass `branch` or `run` explicitly.');
+  }
+
+  return branch;
+}
+
+async function requireCurrentGitHead(cwd: string, signal?: AbortSignal): Promise<string> {
+  const headSha = await git.head.sha(cwd, signal);
+  if (!headSha) {
+    throw new ToolError('Current git HEAD is unavailable. Pass `run` explicitly.');
+  }
+
+  return headSha;
+}
+
+async function ensureGitWorktreePathAvailable(
+  worktreePath: string,
+  existingWorktrees: git.GitWorktreeEntry[],
+): Promise<void> {
+  const normalizedTarget = path.resolve(worktreePath);
+  const conflictingWorktree = existingWorktrees.find((entry) => path.resolve(entry.path) === normalizedTarget);
+  if (conflictingWorktree) {
+    throw new ToolError(`worktree path is already registered: ${conflictingWorktree.path}`);
+  }
+
+  try {
+    await fs.stat(normalizedTarget);
+    throw new ToolError(`worktree path already exists: ${normalizedTarget}`);
+  } catch (error) {
+    if (isEnoent(error)) {
+      return;
+    }
+    throw error;
+  }
+}
+
+function selectPrCloneUrl(originUrl: string | undefined, repo: Pick<GhRepoViewData, 'url' | 'sshUrl'>): string {
+  if (originUrl?.startsWith('http://') || originUrl?.startsWith('https://')) {
+    return normalizeOptionalString(repo.url) ?? normalizeOptionalString(repo.sshUrl) ?? '';
+  }
+
+  return normalizeOptionalString(repo.sshUrl) ?? normalizeOptionalString(repo.url) ?? '';
+}
+
+async function getRemoteUrls(repoRoot: string, signal?: AbortSignal): Promise<Map<string, string>> {
+  const remotes = await git.remote.list(repoRoot, signal);
+  const urls = new Map<string, string>();
+  for (const remoteName of remotes) {
+    const remoteUrl = await git.remote.url(repoRoot, remoteName, signal);
+    if (remoteUrl) {
+      urls.set(remoteName, remoteUrl);
+    }
+  }
+  return urls;
+}
+
+async function ensurePrRemote(
+  repoRoot: string,
+  data: GhPrViewData,
+  signal?: AbortSignal,
+): Promise<{ name: string; url: string }> {
+  if (!data.isCrossRepository) {
+    const originUrl = await git.remote.url(repoRoot, 'origin', signal);
+    if (!originUrl) {
+      throw new ToolError('origin remote is unavailable for this repository.');
+    }
+
+    return {
+      name: 'origin',
+      url: originUrl,
+    };
+  }
+
+  const headRepository = requireNonEmpty(data.headRepository?.nameWithOwner, 'head repository');
+  const repoSummary = await git.github.json<GhRepoViewData>(
+    repoRoot,
+    ['repo', 'view', headRepository, '--json', GH_REPO_CLONE_FIELDS.join(',')],
+    signal,
+    { repoProvided: true },
+  );
+  const originUrl = await git.remote.url(repoRoot, 'origin', signal);
+  const remoteUrl = selectPrCloneUrl(originUrl, repoSummary);
+  if (!remoteUrl) {
+    throw new ToolError(`Could not determine a clone URL for ${headRepository}.`);
+  }
+
+  const remotes = await getRemoteUrls(repoRoot, signal);
+  for (const [remoteName, url] of remotes) {
+    if (url === remoteUrl) {
+      return { name: remoteName, url };
+    }
+  }
+
+  const preferredRemoteName = sanitizeRemoteName(
+    data.headRepositoryOwner?.login ?? headRepository.split('/')[0] ?? 'fork',
+  );
+  let remoteName = preferredRemoteName;
+  let suffix = 2;
+  while (remotes.has(remoteName)) {
+    remoteName = `${preferredRemoteName}-${suffix}`;
+    suffix += 1;
+  }
+
+  await git.remote.add(repoRoot, remoteName, remoteUrl, signal);
+
+  return {
+    name: remoteName,
+    url: remoteUrl,
+  };
+}
+
+async function resolvePrBranchPushTarget(
+  repoRoot: string,
+  localBranch: string,
+  signal?: AbortSignal,
+): Promise<{
+  remoteName: string;
+  remoteBranch: string;
+  remoteUrl?: string;
+  prUrl?: string;
+  maintainerCanModify?: boolean;
+  isCrossRepository: boolean;
+}> {
+  const pushRemote = await git.config.getBranch(repoRoot, localBranch, 'pushRemote', signal);
+  const remote = await git.config.getBranch(repoRoot, localBranch, 'remote', signal);
+  const mergeRef = await git.config.getBranch(repoRoot, localBranch, 'merge', signal);
+  const headRef = await git.config.getBranch(repoRoot, localBranch, 'ompPrHeadRef', signal);
+  const prUrl = await git.config.getBranch(repoRoot, localBranch, 'ompPrUrl', signal);
+  const maintainerCanModifyValue = await git.config.getBranch(
+    repoRoot,
+    localBranch,
+    'ompPrMaintainerCanModify',
+    signal,
+  );
+  const isCrossRepositoryValue = await git.config.getBranch(repoRoot, localBranch, 'ompPrIsCrossRepository', signal);
+
+  const remoteName = pushRemote ?? remote;
+  if (!remoteName) {
+    throw new ToolError(`branch ${localBranch} has no configured push remote`);
+  }
+
+  const remoteBranch = headRef ?? stripHeadsRef(mergeRef);
+  if (!remoteBranch) {
+    throw new ToolError(`branch ${localBranch} has no tracked PR head ref`);
+  }
+
+  return {
+    remoteName,
+    remoteBranch,
+    remoteUrl: await git.remote.url(repoRoot, remoteName, signal),
+    prUrl,
+    maintainerCanModify:
+      maintainerCanModifyValue === undefined
+        ? undefined
+        : ['1', 'true', 'yes', 'on'].includes(maintainerCanModifyValue.toLowerCase()),
+    isCrossRepository: ['1', 'true', 'yes', 'on'].includes((isCrossRepositoryValue ?? '').toLowerCase()),
+  };
+}
+
+function formatAuthor(author: GhUser | null | undefined): string | undefined {
+  if (!author) return undefined;
+  if (author.login) return `@${author.login}`;
+  if (author.name) return author.name;
+  return undefined;
+}
+
+function formatLabels(labels: GhLabel[] | undefined): string | undefined {
+  const names = labels?.map((label) => label.name).filter((value): value is string => Boolean(value)) ?? [];
+  if (names.length === 0) return undefined;
+  return names.join(', ');
+}
+
+function pushLine(lines: string[], label: string, value: string | number | boolean | undefined): void {
+  if (value === undefined || value === '') return;
+  lines.push(`${label}: ${value}`);
+}
+
+function parseRunReference(value: string | undefined): GhRunReference {
+  const run = normalizeOptionalString(value);
+  if (!run) {
+    return {};
+  }
+
+  if (/^\d+$/.test(run)) {
+    return { runId: Number(run) };
+  }
+
+  const match = run.match(RUN_URL_PATTERN);
+  if (!match) {
+    throw new ToolError('run must be a numeric workflow run ID or a full GitHub Actions run URL');
+  }
+
+  return {
+    repo: match[1],
+    runId: Number(match[2]),
+  };
+}
+
+function parsePullRequestUrl(value: string | undefined): { repo?: string; prNumber?: number } {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return {};
+  }
+
+  const match = normalized.match(PR_URL_PATTERN);
+  if (!match) {
+    return {};
+  }
+
+  return {
+    repo: match[1],
+    prNumber: Number(match[2]),
+  };
+}
+
+function normalizePrReviewComment(comment: GhPrReviewCommentApi): GhPrReviewComment | null {
+  if (typeof comment.id !== 'number') {
+    return null;
+  }
+
+  return {
+    author: comment.user ?? null,
+    body: comment.body,
+    createdAt: normalizeOptionalString(comment.created_at),
+    id: comment.id,
+    inReplyToId: typeof comment.in_reply_to_id === 'number' ? comment.in_reply_to_id : undefined,
+    line: typeof comment.line === 'number' ? comment.line : undefined,
+    originalLine: typeof comment.original_line === 'number' ? comment.original_line : undefined,
+    path: normalizeOptionalString(comment.path),
+    side: normalizeOptionalString(comment.side),
+    url: normalizeOptionalString(comment.html_url),
+  };
+}
+
+function normalizeRunJob(job: GhActionsJobApi): GhRunJobSnapshot | null {
+  if (typeof job.id !== 'number') {
+    return null;
+  }
+
+  return {
+    id: job.id,
+    name: normalizeOptionalString(job.name) ?? `job-${job.id}`,
+    status: normalizeOptionalString(job.status),
+    conclusion: normalizeOptionalString(job.conclusion),
+    startedAt: normalizeOptionalString(job.started_at),
+    completedAt: normalizeOptionalString(job.completed_at),
+    url: normalizeOptionalString(job.html_url),
+  };
+}
+
+function normalizeRunSnapshot(run: GhActionsRunApi, jobs: GhRunJobSnapshot[]): GhRunSnapshot {
+  if (typeof run.id !== 'number') {
+    throw new ToolError('GitHub Actions run response did not include a run ID.');
+  }
+
+  return {
+    id: run.id,
+    workflowName: normalizeOptionalString(run.name),
+    displayTitle: normalizeOptionalString(run.display_title),
+    status: normalizeOptionalString(run.status),
+    conclusion: normalizeOptionalString(run.conclusion),
+    branch: normalizeOptionalString(run.head_branch),
+    headSha: normalizeOptionalString(run.head_sha),
+    createdAt: normalizeOptionalString(run.created_at),
+    updatedAt: normalizeOptionalString(run.updated_at),
+    url: normalizeOptionalString(run.html_url),
+    jobs,
+  };
+}
+
+function getRunOutcome(value: string | undefined): 'success' | 'failure' | 'pending' {
+  if (!value) {
+    return 'pending';
+  }
+
+  if (RUN_SUCCESS_CONCLUSIONS.has(value)) {
+    return 'success';
+  }
+
+  if (RUN_FAILURE_CONCLUSIONS.has(value)) {
+    return 'failure';
+  }
+
+  return 'pending';
+}
+
+function getRunSnapshotOutcome(run: GhRunSnapshot): 'success' | 'failure' | 'pending' {
+  if (run.status !== 'completed') {
+    return 'pending';
+  }
+
+  return getRunOutcome(run.conclusion);
+}
+
+function getRunCollectionOutcome(runs: GhRunSnapshot[]): 'success' | 'failure' | 'pending' {
+  if (runs.length === 0) {
+    return 'pending';
+  }
+
+  let pending = false;
+  for (const run of runs) {
+    if (run.jobs.some(isFailedJob)) {
+      return 'failure';
+    }
+
+    const outcome = getRunSnapshotOutcome(run);
+    if (outcome === 'failure') {
+      return 'failure';
+    }
+    if (outcome === 'pending') {
+      pending = true;
+    }
+  }
+
+  return pending ? 'pending' : 'success';
+}
+
+function getRunCollectionSignature(runs: GhRunSnapshot[]): string {
+  return runs
+    .map((run) => run.id)
+    .sort((left, right) => left - right)
+    .join(',');
+}
+
+function isFailedJob(job: GhRunJobSnapshot): boolean {
+  return job.conclusion !== undefined && JOB_FAILURE_CONCLUSIONS.has(job.conclusion);
+}
+
+function formatJobState(job: GhRunJobSnapshot): string {
+  return job.conclusion ?? job.status ?? 'unknown';
+}
+
+function parseTimestampMs(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
+function getJobDurationSeconds(job: GhRunJobSnapshot, observedAtMs: number): number | undefined {
+  const startedAtMs = parseTimestampMs(job.startedAt);
+  if (startedAtMs === undefined) {
+    return undefined;
+  }
+
+  const completedAtMs = parseTimestampMs(job.completedAt) ?? observedAtMs;
+  return Math.max(0, Math.floor((completedAtMs - startedAtMs) / 1000));
+}
+
+function buildRunWatchJobDetails(job: GhRunJobSnapshot, observedAtMs: number): GhRunWatchJobDetails {
+  return {
+    id: job.id,
+    name: job.name,
+    status: job.status,
+    conclusion: job.conclusion,
+    durationSeconds: getJobDurationSeconds(job, observedAtMs),
+    url: job.url,
+  };
+}
+
+function buildRunWatchRunDetails(run: GhRunSnapshot, observedAtMs: number): GhRunWatchRunDetails {
+  return {
+    id: run.id,
+    workflowName: run.workflowName,
+    displayTitle: run.displayTitle,
+    status: run.status,
+    conclusion: run.conclusion,
+    branch: run.branch,
+    headSha: run.headSha,
+    url: run.url,
+    jobs: run.jobs.map((job) => buildRunWatchJobDetails(job, observedAtMs)),
+  };
+}
+
+function buildFailedLogDetails(failedJobLogs: GhFailedJobLog[]): GhRunWatchFailedLogDetails[] {
+  return failedJobLogs.map((entry) => ({
+    runId: entry.run.id,
+    workflowName: entry.run.workflowName,
+    jobName: entry.job.name,
+    conclusion: entry.job.conclusion,
+    tail: entry.tail,
+    available: entry.available,
+  }));
+}
+
+function renderJobsSection(jobs: GhRunJobSnapshot[]): string[] {
+  if (jobs.length === 0) {
+    return ['## Jobs', '', 'No jobs reported yet.'];
+  }
+
+  const lines: string[] = [`## Jobs (${jobs.length})`, ''];
+  for (const job of jobs) {
+    lines.push(`- [${formatJobState(job)}] ${job.name}`);
+    if (job.startedAt) {
+      pushLine(lines, '  Started', job.startedAt);
+    }
+    if (job.completedAt) {
+      pushLine(lines, '  Completed', job.completedAt);
+    }
+    if (job.url) {
+      pushLine(lines, '  URL', job.url);
+    }
+  }
+
+  return lines;
+}
+
+function renderFailedJobLogs(
+  failedJobLogs: GhFailedJobLog[],
+  options: { mode: 'tail'; tail: number } | { mode: 'full' },
+): string[] {
+  if (failedJobLogs.length === 0) {
+    return [];
+  }
+
+  const lines: string[] = ['## Failed Jobs', ''];
+  for (const entry of failedJobLogs) {
+    lines.push(`### ${entry.job.name} [${entry.job.conclusion ?? 'failed'}]`);
+    pushLine(lines, 'Run', `#${entry.run.id}`);
+    pushLine(lines, 'Workflow', entry.run.workflowName ?? undefined);
+    if (entry.job.startedAt) {
+      pushLine(lines, 'Started', entry.job.startedAt);
+    }
+    if (entry.job.completedAt) {
+      pushLine(lines, 'Completed', entry.job.completedAt);
+    }
+    if (entry.job.url) {
+      pushLine(lines, 'URL', entry.job.url);
+    }
+    lines.push('');
+    const logText = options.mode === 'full' ? entry.full : entry.tail;
+    if (entry.available && logText) {
+      lines.push(options.mode === 'full' ? 'Full log:' : `Last ${options.tail} log lines:`);
+      lines.push('```text');
+      lines.push(logText);
+      lines.push('```');
+    } else {
+      lines.push(options.mode === 'full' ? 'Full log unavailable.' : 'Log tail unavailable.');
+    }
+    lines.push('');
+  }
+
+  return lines;
+}
+
+function renderRunSection(run: GhRunSnapshot): string[] {
+  const label = run.workflowName ? `### Run #${run.id} - ${run.workflowName}` : `### Run #${run.id}`;
+  const lines: string[] = [label, ''];
+  pushLine(lines, 'Title', run.displayTitle ?? undefined);
+  pushLine(lines, 'Branch', run.branch ?? undefined);
+  pushLine(lines, 'Commit', formatShortSha(run.headSha));
+  pushLine(lines, 'Status', run.status);
+  pushLine(lines, 'Conclusion', run.conclusion ?? undefined);
+  pushLine(lines, 'Created', run.createdAt);
+  pushLine(lines, 'Updated', run.updatedAt);
+  pushLine(lines, 'URL', run.url);
+  lines.push('');
+  lines.push(...renderJobsSection(run.jobs));
+  return lines;
+}
+
+function formatRunWatchSnapshot(
+  repo: string,
+  run: GhRunSnapshot,
+  pollCount: number,
+  note?: string,
+  includeOutcome: boolean = false,
+): string {
+  const failedJobs = run.jobs.filter(isFailedJob);
+  const lines: string[] = [`# Watching GitHub Actions Run #${run.id}`, ''];
+  pushLine(lines, 'Repository', repo);
+  pushLine(lines, 'Workflow', run.workflowName ?? undefined);
+  pushLine(lines, 'Title', run.displayTitle ?? undefined);
+  pushLine(lines, 'Branch', run.branch ?? undefined);
+  pushLine(lines, 'Status', run.status);
+  pushLine(lines, 'Conclusion', run.conclusion ?? undefined);
+  pushLine(lines, 'Created', run.createdAt);
+  pushLine(lines, 'Updated', run.updatedAt);
+  pushLine(lines, 'URL', run.url);
+  pushLine(lines, 'Poll', pollCount);
+  pushLine(lines, 'Failed jobs', failedJobs.length || undefined);
+
+  if (note) {
+    lines.push('');
+    lines.push(`Note: ${note}`);
+  }
+
+  lines.push('');
+  lines.push(...renderJobsSection(run.jobs));
+
+  if (includeOutcome) {
+    lines.push('');
+    lines.push(failedJobs.length > 0 ? 'Failures detected.' : 'All jobs passed.');
+  }
+
+  return lines.join('\n').trim();
+}
+
+function formatRunWatchResult(
+  repo: string,
+  run: GhRunSnapshot,
+  failedJobLogs: GhFailedJobLog[],
+  tail: number,
+  options?: { mode?: 'tail' | 'full' },
+): string {
+  const failedJobs = run.jobs.filter(isFailedJob);
+  const lines: string[] = [`# GitHub Actions Run #${run.id}`, ''];
+  pushLine(lines, 'Repository', repo);
+  pushLine(lines, 'Workflow', run.workflowName ?? undefined);
+  pushLine(lines, 'Title', run.displayTitle ?? undefined);
+  pushLine(lines, 'Branch', run.branch ?? undefined);
+  pushLine(lines, 'Status', run.status);
+  pushLine(lines, 'Conclusion', run.conclusion ?? undefined);
+  pushLine(lines, 'Created', run.createdAt);
+  pushLine(lines, 'Updated', run.updatedAt);
+  pushLine(lines, 'URL', run.url);
+  lines.push('');
+  lines.push(...renderJobsSection(run.jobs));
+
+  if (failedJobs.length > 0) {
+    lines.push('');
+    lines.push(
+      ...renderFailedJobLogs(failedJobLogs, options?.mode === 'full' ? { mode: 'full' } : { mode: 'tail', tail }),
+    );
+    lines.push('Run failed.');
+  } else if (getRunOutcome(run.conclusion) === 'success') {
+    lines.push('');
+    lines.push('All jobs passed.');
+  } else {
+    lines.push('');
+    lines.push('Run completed without successful jobs, but no failed job logs were available.');
+  }
+
+  return lines.join('\n').trim();
+}
+
+function formatCommitRunWatchSnapshot(
+  repo: string,
+  headSha: string,
+  branch: string | undefined,
+  runs: GhRunSnapshot[],
+  pollCount: number,
+  note?: string,
+): string {
+  const failedJobs = runs.flatMap((run) => run.jobs.filter(isFailedJob));
+  const completedRuns = runs.filter((run) => run.status === 'completed').length;
+  const lines: string[] = [`# Watching GitHub Actions for ${formatShortSha(headSha) ?? headSha}`, ''];
+  pushLine(lines, 'Repository', repo);
+  pushLine(lines, 'Branch', branch);
+  pushLine(lines, 'Commit', headSha);
+  pushLine(lines, 'Poll', pollCount);
+  pushLine(lines, 'Runs', runs.length);
+  pushLine(lines, 'Completed runs', `${completedRuns}/${runs.length}`);
+  pushLine(lines, 'Failed jobs', failedJobs.length || undefined);
+
+  if (note) {
+    lines.push('');
+    lines.push(`Note: ${note}`);
+  }
+
+  if (runs.length === 0) {
+    lines.push('');
+    lines.push('Waiting for workflow runs for this commit.');
+    return lines.join('\n').trim();
+  }
+
+  for (const run of runs) {
+    lines.push('');
+    lines.push(...renderRunSection(run));
+  }
+
+  return lines.join('\n').trim();
+}
+
+function formatCommitRunWatchResult(
+  repo: string,
+  headSha: string,
+  branch: string | undefined,
+  runs: GhRunSnapshot[],
+  failedJobLogs: GhFailedJobLog[],
+  tail: number,
+  options?: { mode?: 'tail' | 'full' },
+): string {
+  const outcome = getRunCollectionOutcome(runs);
+  const lines: string[] = [`# GitHub Actions for ${formatShortSha(headSha) ?? headSha}`, ''];
+  pushLine(lines, 'Repository', repo);
+  pushLine(lines, 'Branch', branch);
+  pushLine(lines, 'Commit', headSha);
+  pushLine(lines, 'Runs', runs.length);
+
+  for (const run of runs) {
+    lines.push('');
+    lines.push(...renderRunSection(run));
+  }
+
+  if (failedJobLogs.length > 0) {
+    lines.push('');
+    lines.push(
+      ...renderFailedJobLogs(failedJobLogs, options?.mode === 'full' ? { mode: 'full' } : { mode: 'tail', tail }),
+    );
+    lines.push('Workflow runs for this commit failed.');
+  } else if (outcome === 'success') {
+    lines.push('');
+    lines.push('All workflow runs for this commit passed.');
+  } else {
+    lines.push('');
+    lines.push('Workflow runs for this commit did not complete successfully.');
+  }
+
+  return lines.join('\n').trim();
+}
+
+function buildGhDetails(repo: string, run: GhRunSnapshot): GhToolDetails {
+  return {
+    repo,
+    branch: run.branch,
+    headSha: run.headSha,
+    runId: run.id,
+    runIds: [run.id],
+    status: run.status,
+    conclusion: run.conclusion,
+    failedJobs: run.jobs.filter(isFailedJob).map((job) => job.name),
+  };
+}
+
+function buildRunWatchDetails(
+  repo: string,
+  run: GhRunSnapshot,
+  options?: {
+    state?: GhRunWatchViewDetails['state'];
+    pollCount?: number;
+    note?: string;
+    failedJobLogs?: GhFailedJobLog[];
+  },
+): GhToolDetails {
+  const observedAtMs = Date.now();
+  return {
+    ...buildGhDetails(repo, run),
+    watch: {
+      mode: 'run',
+      state: options?.state ?? 'completed',
+      repo,
+      branch: run.branch,
+      headSha: run.headSha,
+      pollCount: options?.pollCount,
+      note: options?.note,
+      run: buildRunWatchRunDetails(run, observedAtMs),
+      failedLogs: buildFailedLogDetails(options?.failedJobLogs ?? []),
+    },
+  };
+}
+
+function buildGhRunCollectionDetails(
+  repo: string,
+  headSha: string,
+  branch: string | undefined,
+  runs: GhRunSnapshot[],
+): GhToolDetails {
+  const outcome = getRunCollectionOutcome(runs);
+  return {
+    repo,
+    branch,
+    headSha,
+    runIds: runs.map((run) => run.id),
+    status: runs.length > 0 && runs.every((run) => run.status === 'completed') ? 'completed' : 'in_progress',
+    conclusion: outcome,
+    failedJobs: runs.flatMap((run) =>
+      run.jobs.filter(isFailedJob).map((job) => `${run.workflowName ?? `run ${run.id}`}: ${job.name}`),
+    ),
+  };
+}
+
+function buildCommitRunWatchDetails(
+  repo: string,
+  headSha: string,
+  branch: string | undefined,
+  runs: GhRunSnapshot[],
+  options?: {
+    state?: GhRunWatchViewDetails['state'];
+    pollCount?: number;
+    note?: string;
+    failedJobLogs?: GhFailedJobLog[];
+  },
+): GhToolDetails {
+  const observedAtMs = Date.now();
+  return {
+    ...buildGhRunCollectionDetails(repo, headSha, branch, runs),
+    watch: {
+      mode: 'commit',
+      state: options?.state ?? 'completed',
+      repo,
+      branch,
+      headSha,
+      pollCount: options?.pollCount,
+      note: options?.note,
+      runs: runs.map((run) => buildRunWatchRunDetails(run, observedAtMs)),
+      failedLogs: buildFailedLogDetails(options?.failedJobLogs ?? []),
+    },
+  };
+}
+
+async function resolveGitHubRepo(
+  cwd: string,
+  repo: string | undefined,
+  runRepo: string | undefined,
+  signal?: AbortSignal,
+): Promise<string> {
+  if (repo && runRepo && repo !== runRepo) {
+    throw new ToolError('run URL repository does not match the provided repo');
+  }
+
+  if (repo) {
+    return repo;
+  }
+
+  if (runRepo) {
+    return runRepo;
+  }
+
+  const resolved = await git.github.text(
+    cwd,
+    ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
+    signal,
+  );
+  return requireNonEmpty(resolved, 'repo');
+}
+
+async function resolveGitHubBranchHead(
+  cwd: string,
+  repo: string,
+  branch: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const response = await git.github.json<GhBranchApiResponse>(
+    cwd,
+    ['api', '--method', 'GET', `/repos/${repo}/branches/${encodeURIComponent(branch)}`],
+    signal,
+    { repoProvided: true },
+  );
+  return requireNonEmpty(response.commit?.sha, `head SHA for branch ${branch}`);
+}
+
+async function fetchRunsForCommit(
+  cwd: string,
+  repo: string,
+  headSha: string,
+  branch: string | undefined,
+  signal?: AbortSignal,
+): Promise<GhRunSnapshot[]> {
+  const response = await git.github.json<GhActionsRunListResponse>(
+    cwd,
+    [
+      'api',
+      '--method',
+      'GET',
+      `/repos/${repo}/actions/runs`,
+      '-F',
+      `head_sha=${headSha}`,
+      '-F',
+      `per_page=${RUN_JOBS_PAGE_SIZE}`,
+      ...(branch ? ['-F', `branch=${branch}`] : []),
+    ],
+    signal,
+    { repoProvided: true },
+  );
+
+  return Promise.all(
+    (response.workflow_runs ?? [])
+      .filter((run): run is GhActionsRunApi & { id: number } => typeof run.id === 'number')
+      .map(async (run) => {
+        const jobs = await fetchRunJobs(cwd, repo, run.id, signal);
+        return normalizeRunSnapshot(run, jobs);
+      }),
+  );
+}
+
+async function fetchRunJobs(
+  cwd: string,
+  repo: string,
+  runId: number,
+  signal?: AbortSignal,
+): Promise<GhRunJobSnapshot[]> {
+  const jobs: GhRunJobSnapshot[] = [];
+  let page = 1;
+
+  while (true) {
+    const response = await git.github.json<GhActionsJobsResponse>(
+      cwd,
+      [
+        'api',
+        '--method',
+        'GET',
+        `/repos/${repo}/actions/runs/${runId}/jobs`,
+        '-F',
+        `per_page=${RUN_JOBS_PAGE_SIZE}`,
+        '-F',
+        `page=${page}`,
+      ],
+      signal,
+      { repoProvided: true },
+    );
+    const pageJobs = (response.jobs ?? [])
+      .map((job) => normalizeRunJob(job))
+      .filter((job): job is GhRunJobSnapshot => job !== null);
+    jobs.push(...pageJobs);
+
+    if (pageJobs.length < RUN_JOBS_PAGE_SIZE) {
+      break;
+    }
+
+    if ((response.total_count ?? 0) <= jobs.length) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return jobs;
+}
+
+async function fetchPrReviewComments(
+  cwd: string,
+  repo: string,
+  prNumber: number,
+  signal?: AbortSignal,
+): Promise<GhPrReviewComment[]> {
+  const reviewComments: GhPrReviewComment[] = [];
+  let page = 1;
+
+  while (true) {
+    const response = await git.github.json<GhPrReviewCommentApi[]>(
+      cwd,
+      [
+        'api',
+        '--method',
+        'GET',
+        `/repos/${repo}/pulls/${prNumber}/comments`,
+        '-F',
+        `per_page=${REVIEW_COMMENTS_PAGE_SIZE}`,
+        '-F',
+        `page=${page}`,
+      ],
+      signal,
+      { repoProvided: true },
+    );
+
+    const pageComments = response
+      .map((comment) => normalizePrReviewComment(comment))
+      .filter((comment): comment is GhPrReviewComment => comment !== null);
+    reviewComments.push(...pageComments);
+
+    if (pageComments.length < REVIEW_COMMENTS_PAGE_SIZE) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return reviewComments;
+}
+
+async function fetchRunSnapshot(
+  cwd: string,
+  repo: string,
+  runId: number,
+  signal?: AbortSignal,
+): Promise<GhRunSnapshot> {
+  const [run, jobs] = await Promise.all([
+    git.github.json<GhActionsRunApi>(cwd, ['api', '--method', 'GET', `/repos/${repo}/actions/runs/${runId}`], signal, {
+      repoProvided: true,
+    }),
+    fetchRunJobs(cwd, repo, runId, signal),
+  ]);
+
+  return normalizeRunSnapshot(run, jobs);
+}
+
+function tailLogLines(log: string, tail: number): string | undefined {
+  const normalized = normalizeBlock(log);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const lines = normalized.split('\n');
+  return lines.slice(-tail).join('\n').trimEnd();
+}
+
+async function fetchFailedJobLogs(
+  cwd: string,
+  repo: string,
+  failedJobs: Array<{ run: GhRunSnapshot; job: GhRunJobSnapshot }>,
+  tail: number,
+  signal?: AbortSignal,
+): Promise<GhFailedJobLog[]> {
+  return Promise.all(
+    failedJobs.map(async (entry) => {
+      const result = await git.github.run(cwd, ['api', `/repos/${repo}/actions/jobs/${entry.job.id}/logs`], signal);
+      const fullLog = result.exitCode === 0 ? normalizeBlock(result.stdout) : undefined;
+      const logTail = fullLog ? tailLogLines(fullLog, tail) : undefined;
+      return {
+        run: entry.run,
+        job: entry.job,
+        full: fullLog,
+        tail: logTail,
+        available: Boolean(fullLog),
+      };
+    }),
+  );
+}
+
+function formatCommentsSection(comments: GhComment[] | undefined): string[] {
+  if (!comments || comments.length === 0) {
+    return [];
+  }
+
+  const visible = comments.filter((comment) => !comment.isMinimized);
+  const hiddenCount = comments.length - visible.length;
+  const lines: string[] = ['## Comments', ''];
+
+  if (visible.length === 0) {
+    lines.push(`No visible comments. Minimized comments omitted: ${hiddenCount}.`);
+    return lines;
+  }
+
+  lines[0] = `## Comments (${visible.length})`;
+
+  for (const comment of visible) {
+    const author = formatAuthor(comment.author) ?? 'unknown';
+    const createdAt = comment.createdAt ? ` · ${comment.createdAt}` : '';
+    lines.push(`### ${author}${createdAt}`);
+    lines.push('');
+    lines.push(normalizeText(comment.body) || 'No comment body.');
+    if (comment.url) {
+      lines.push('');
+      lines.push(`URL: ${comment.url}`);
+    }
+    lines.push('');
+  }
+
+  if (hiddenCount > 0) {
+    lines.push(`Minimized comments omitted: ${hiddenCount}.`);
+  }
+
+  return lines;
+}
+
+function formatReviewsSection(reviews: GhPrReview[] | undefined): string[] {
+  if (!reviews || reviews.length === 0) {
+    return [];
+  }
+
+  const lines: string[] = [`## Reviews (${reviews.length})`, ''];
+  for (const review of reviews) {
+    const author = formatAuthor(review.author) ?? 'unknown';
+    const submittedAt = review.submittedAt ? ` - ${review.submittedAt}` : '';
+    const state = review.state ? ` [${review.state}]` : '';
+    lines.push(`### ${author}${submittedAt}${state}`);
+    if (review.commit?.oid) {
+      lines.push('');
+      lines.push(`Commit: ${formatShortSha(review.commit.oid)}`);
+    }
+    lines.push('');
+    lines.push(normalizeText(review.body) || 'No review body.');
+    lines.push('');
+  }
+
+  return lines;
+}
+
+function formatReviewCommentLocation(comment: GhPrReviewComment): string | undefined {
+  if (!comment.path) {
+    return undefined;
+  }
+
+  const line = comment.line ?? comment.originalLine;
+  return line === undefined ? comment.path : `${comment.path}:${line}`;
+}
+
+function formatReviewCommentsSection(comments: GhPrReviewComment[] | undefined): string[] {
+  if (!comments || comments.length === 0) {
+    return [];
+  }
+
+  const lines: string[] = [`## Review Comments (${comments.length})`, ''];
+  for (const comment of comments) {
+    const author = formatAuthor(comment.author) ?? 'unknown';
+    const createdAt = comment.createdAt ? ` · ${comment.createdAt}` : '';
+    lines.push(`### ${author}${createdAt}`);
+    lines.push('');
+    pushLine(lines, 'Location', formatReviewCommentLocation(comment));
+    pushLine(lines, 'Side', comment.side);
+    pushLine(lines, 'Reply to', comment.inReplyToId);
+    pushLine(lines, 'URL', comment.url);
+    lines.push('');
+    lines.push(normalizeText(comment.body) || 'No review comment body.');
+    lines.push('');
+  }
+
+  return lines;
+}
+
+function formatRepoView(data: GhRepoViewData, input: GhRepoViewInput): string {
+  const lines: string[] = [];
+  const name = data.nameWithOwner ?? input.repo ?? 'GitHub Repository';
+  lines.push(`# ${name}`);
+  lines.push('');
+  lines.push(normalizeText(data.description) || 'No description provided.');
+  lines.push('');
+  pushLine(lines, 'URL', data.url);
+  pushLine(lines, 'Default branch', data.defaultBranchRef?.name);
+  pushLine(lines, 'Branch', normalizeOptionalString(input.branch));
+  pushLine(lines, 'Visibility', data.visibility ?? undefined);
+  pushLine(lines, 'Viewer permission', data.viewerPermission ?? undefined);
+  pushLine(lines, 'Primary language', data.primaryLanguage?.name);
+  pushLine(lines, 'Stars', data.stargazerCount);
+  pushLine(lines, 'Forks', data.forkCount);
+  pushLine(lines, 'Archived', data.isArchived);
+  pushLine(lines, 'Fork', data.isFork);
+  pushLine(lines, 'Updated', data.updatedAt);
+  pushLine(lines, 'Homepage', data.homepageUrl ?? undefined);
+  const topics = data.repositoryTopics
+    ?.map((topic) => topic.name ?? topic.topic?.name)
+    .filter((value): value is string => Boolean(value))
+    .join(', ');
+  pushLine(lines, 'Topics', topics || undefined);
+  return lines.join('\n').trim();
+}
+
+function formatIssueView(data: GhIssueViewData, input: GhIssueViewInput): string {
+  const lines: string[] = [];
+  const issueNumber = data.number ?? input.issue;
+  lines.push(`# Issue #${issueNumber}: ${data.title ?? 'Untitled'}`);
+  lines.push('');
+  pushLine(lines, 'State', data.state);
+  pushLine(lines, 'State reason', data.stateReason ?? undefined);
+  pushLine(lines, 'Author', formatAuthor(data.author));
+  pushLine(lines, 'Created', data.createdAt);
+  pushLine(lines, 'Updated', data.updatedAt);
+  pushLine(lines, 'Labels', formatLabels(data.labels));
+  pushLine(lines, 'URL', data.url);
+  lines.push('');
+  lines.push('## Body');
+  lines.push('');
+  lines.push(normalizeText(data.body) || 'No description provided.');
+
+  if ((input.comments ?? true) && data.comments) {
+    const commentSection = formatCommentsSection(data.comments);
+    if (commentSection.length > 0) {
+      lines.push('');
+      lines.push(...commentSection);
+    }
+  }
+
+  return lines.join('\n').trim();
+}
+
+function formatPrFiles(files: GhPrFile[] | undefined): string[] {
+  if (!files || files.length === 0) return [];
+
+  const lines: string[] = [`## Files (${files.length})`, ''];
+  for (const file of files.slice(0, FILE_PREVIEW_LIMIT)) {
+    const changeType = file.changeType ?? 'CHANGED';
+    const additions = file.additions ?? 0;
+    const deletions = file.deletions ?? 0;
+    lines.push(`- ${file.path ?? '(unknown file)'} [${changeType}] (+${additions} -${deletions})`);
+  }
+
+  if (files.length > FILE_PREVIEW_LIMIT) {
+    lines.push(`- ... ${files.length - FILE_PREVIEW_LIMIT} more files`);
+  }
+
+  return lines;
+}
+
+function formatPrView(data: GhPrViewData, input: GhPrViewInput): string {
+  const lines: string[] = [];
+  const prIdentifier = data.number ?? input.pr ?? 'current';
+  lines.push(`# Pull Request #${prIdentifier}: ${data.title ?? 'Untitled'}`);
+  lines.push('');
+  pushLine(lines, 'State', data.state);
+  pushLine(lines, 'Draft', data.isDraft);
+  pushLine(lines, 'Author', formatAuthor(data.author));
+  pushLine(lines, 'Base', data.baseRefName);
+  pushLine(lines, 'Head', data.headRefName);
+  pushLine(lines, 'Review decision', data.reviewDecision ?? undefined);
+  pushLine(lines, 'Merge state', data.mergeStateStatus);
+  pushLine(lines, 'Created', data.createdAt);
+  pushLine(lines, 'Updated', data.updatedAt);
+  pushLine(lines, 'Labels', formatLabels(data.labels));
+  pushLine(lines, 'URL', data.url);
+  lines.push('');
+  lines.push('## Body');
+  lines.push('');
+  lines.push(normalizeText(data.body) || 'No description provided.');
+
+  const fileSection = formatPrFiles(data.files);
+  if (fileSection.length > 0) {
+    lines.push('');
+    lines.push(...fileSection);
+  }
+
+  if ((input.comments ?? true) && data.reviews) {
+    const reviewSection = formatReviewsSection(data.reviews);
+    if (reviewSection.length > 0) {
+      lines.push('');
+      lines.push(...reviewSection);
+    }
+  }
+
+  if ((input.comments ?? true) && data.reviewComments) {
+    const reviewCommentsSection = formatReviewCommentsSection(data.reviewComments);
+    if (reviewCommentsSection.length > 0) {
+      lines.push('');
+      lines.push(...reviewCommentsSection);
+    }
+  }
+
+  if ((input.comments ?? true) && data.comments) {
+    const commentSection = formatCommentsSection(data.comments);
+    if (commentSection.length > 0) {
+      lines.push('');
+      lines.push(...commentSection);
+    }
+  }
+
+  return lines.join('\n').trim();
+}
+
+function formatPrCheckoutResult(options: {
+  data: GhPrViewData;
+  localBranch: string;
+  worktreePath: string;
+  remoteName: string;
+  remoteUrl: string;
+  reused: boolean;
+}): string {
+  const { data, localBranch, worktreePath, remoteName, remoteUrl, reused } = options;
+  const lines: string[] = [
+    reused ? `# Pull Request #${data.number ?? '?'} Worktree` : `# Checked Out Pull Request #${data.number ?? '?'}`,
+    '',
+  ];
+  pushLine(lines, 'Title', data.title ?? undefined);
+  pushLine(lines, 'URL', data.url);
+  pushLine(lines, 'Base', data.baseRefName);
+  pushLine(lines, 'Head', data.headRefName);
+  pushLine(lines, 'Local branch', localBranch);
+  pushLine(lines, 'Worktree', worktreePath);
+  pushLine(lines, 'Remote', remoteName);
+  pushLine(lines, 'Remote URL', remoteUrl);
+  pushLine(lines, 'Cross repository', data.isCrossRepository);
+  pushLine(lines, 'Maintainer can modify', data.maintainerCanModify);
+  lines.push('');
+  lines.push(
+    reused
+      ? 'Reused the existing PR worktree.'
+      : 'Created a dedicated worktree for this PR and configured the local branch to push back to the PR head branch.',
+  );
+  return lines.join('\n').trim();
+}
+
+function formatPrPushResult(options: {
+  localBranch: string;
+  remoteName: string;
+  remoteBranch: string;
+  remoteUrl?: string;
+  prUrl?: string;
+  forceWithLease: boolean;
+}): string {
+  const lines: string[] = ['# Pushed Pull Request Branch', ''];
+  pushLine(lines, 'Local branch', options.localBranch);
+  pushLine(lines, 'Remote', options.remoteName);
+  pushLine(lines, 'Remote branch', options.remoteBranch);
+  pushLine(lines, 'Remote URL', options.remoteUrl);
+  pushLine(lines, 'PR', options.prUrl);
+  pushLine(lines, 'Force with lease', options.forceWithLease);
+  lines.push('');
+  lines.push(`Pushed ${options.localBranch} to ${options.remoteName}:${options.remoteBranch}.`);
+  return lines.join('\n').trim();
+}
+
+function formatSearchResults(
+  kind: 'issues' | 'pull requests',
+  query: string,
+  repo: string | undefined,
+  items: GhSearchResult[],
+): string {
+  const lines: string[] = [`# GitHub ${kind} search`, '', `Query: ${query}`];
+  pushLine(lines, 'Repository', repo);
+  pushLine(lines, 'Results', items.length);
+
+  if (items.length === 0) {
+    lines.push('');
+    lines.push(`No ${kind} found.`);
+    return lines.join('\n').trim();
+  }
+
+  for (const item of items) {
+    lines.push('');
+    lines.push(`- #${item.number ?? '?'} ${item.title ?? 'Untitled'}`);
+    pushLine(lines, '  Repo', item.repository?.nameWithOwner);
+    pushLine(lines, '  State', item.state);
+    pushLine(lines, '  Author', formatAuthor(item.author));
+    pushLine(lines, '  Labels', formatLabels(item.labels));
+    pushLine(lines, '  Created', item.createdAt);
+    pushLine(lines, '  Updated', item.updatedAt);
+    pushLine(lines, '  URL', item.url);
+  }
+
+  return lines.join('\n').trim();
+}
+
+async function saveArtifactText(session: ToolSession, toolType: string, text: string): Promise<string | undefined> {
+  const { path: artifactPath, id: artifactId } = (await session.allocateOutputArtifact?.(toolType)) ?? {};
+  if (!artifactPath || !artifactId) {
+    return undefined;
+  }
+
+  await Bun.write(artifactPath, text);
+  return artifactId;
+}
+
+function appendArtifactReference(text: string, artifactId: string | undefined, label: string): string {
+  if (!artifactId) {
+    return text;
+  }
+
+  return `${text}\n\n${label}: artifact://${artifactId}`;
+}
+
+function buildTextResult(
+  text: string,
+  sourceUrl?: string,
+  details?: GhToolDetails,
+  options?: { artifactId?: string; artifactLabel?: string },
+): AgentToolResult<GhToolDetails> {
+  const builder = toolResult<GhToolDetails>(details).text(
+    appendArtifactReference(text, options?.artifactId, options?.artifactLabel ?? 'Saved artifact'),
+  );
+  if (sourceUrl) {
+    builder.sourceUrl(sourceUrl);
+  }
+  return builder.done();
+}
+
+export class GhRepoViewTool implements AgentTool<typeof ghRepoViewSchema, GhToolDetails> {
+  readonly name = 'gh_repo_view';
+  readonly label = 'GitHub Repo';
+  readonly description = prompt.render(ghRepoViewDescription);
+  readonly parameters = ghRepoViewSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhRepoViewTool | null {
+    if (!git.github.available()) return null;
+    return new GhRepoViewTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhRepoViewInput,
+    signal?: AbortSignal,
+    _onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const repo = normalizeOptionalString(params.repo);
+      const branch = normalizeOptionalString(params.branch);
+      const args = ['repo', 'view'];
+      if (repo) {
+        args.push(repo);
+      }
+      if (branch) {
+        args.push('--branch', branch);
+      }
+      args.push('--json', GH_REPO_FIELDS.join(','));
+
+      const data = await git.github.json<GhRepoViewData>(this.session.cwd, args, signal, {
+        repoProvided: Boolean(repo),
+      });
+      return buildTextResult(formatRepoView(data, { repo, branch }), data.url, {
+        tool: 'gh_repo_view',
+        repo: repo ?? data.nameWithOwner,
+      });
+    });
+  }
+}
+
+export class GhIssueViewTool implements AgentTool<typeof ghIssueViewSchema, GhToolDetails> {
+  readonly name = 'gh_issue_view';
+  readonly label = 'GitHub Issue';
+  readonly description = prompt.render(ghIssueViewDescription);
+  readonly parameters = ghIssueViewSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhIssueViewTool | null {
+    if (!git.github.available()) return null;
+    return new GhIssueViewTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhIssueViewInput,
+    signal?: AbortSignal,
+    _onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const issue = requireNonEmpty(params.issue, 'issue');
+      const repo = normalizeOptionalString(params.repo);
+      const includeComments = params.comments ?? true;
+      const args = ['issue', 'view', issue];
+      appendRepoFlag(args, repo, issue);
+      args.push('--json', (includeComments ? GH_ISSUE_FIELDS : GH_ISSUE_FIELDS_NO_COMMENTS).join(','));
+
+      const data = await git.github.json<GhIssueViewData>(this.session.cwd, args, signal, {
+        repoProvided: Boolean(repo),
+      });
+      return buildTextResult(formatIssueView(data, { issue, repo, comments: includeComments }), data.url, {
+        tool: 'gh_issue_view',
+      });
+    });
+  }
+}
+
+export class GhPrViewTool implements AgentTool<typeof ghPrViewSchema, GhToolDetails> {
+  readonly name = 'gh_pr_view';
+  readonly label = 'GitHub PR';
+  readonly description = prompt.render(ghPrViewDescription);
+  readonly parameters = ghPrViewSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhPrViewTool | null {
+    if (!git.github.available()) return null;
+    return new GhPrViewTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhPrViewInput,
+    signal?: AbortSignal,
+    _onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const pr = normalizeOptionalString(params.pr);
+      const repo = normalizeOptionalString(params.repo);
+      const includeComments = params.comments ?? true;
+      const args = ['pr', 'view'];
+      if (pr) {
+        args.push(pr);
+      }
+      appendRepoFlag(args, repo, pr);
+      args.push('--json', (includeComments ? GH_PR_FIELDS : GH_PR_FIELDS_NO_COMMENTS).join(','));
+
+      const data = await git.github.json<GhPrViewData>(this.session.cwd, args, signal, {
+        repoProvided: Boolean(repo),
+      });
+      const resolvedRepo = repo ?? parsePullRequestUrl(data.url).repo;
+      if (includeComments && resolvedRepo && typeof data.number === 'number') {
+        data.reviewComments = await fetchPrReviewComments(this.session.cwd, resolvedRepo, data.number, signal);
+      }
+      return buildTextResult(formatPrView(data, { pr, repo, comments: includeComments }), data.url, {
+        tool: 'gh_pr_view',
+      });
+    });
+  }
+}
+
+export class GhPrDiffTool implements AgentTool<typeof ghPrDiffSchema, GhToolDetails> {
+  readonly name = 'gh_pr_diff';
+  readonly label = 'GitHub PR Diff';
+  readonly description = prompt.render(ghPrDiffDescription);
+  readonly parameters = ghPrDiffSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhPrDiffTool | null {
+    if (!git.github.available()) return null;
+    return new GhPrDiffTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhPrDiffInput,
+    signal?: AbortSignal,
+    _onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const pr = normalizeOptionalString(params.pr);
+      const repo = normalizeOptionalString(params.repo);
+      const args = ['pr', 'diff'];
+      if (pr) {
+        args.push(pr);
+      }
+      appendRepoFlag(args, repo, pr);
+      args.push('--color', 'never');
+      if (params.nameOnly) {
+        args.push('--name-only');
+      }
+      for (const pattern of params.exclude ?? []) {
+        const normalizedPattern = requireNonEmpty(pattern, 'exclude pattern');
+        args.push('--exclude', normalizedPattern);
+      }
+
+      const output = await git.github.text(this.session.cwd, args, signal, {
+        repoProvided: Boolean(repo),
+        trimOutput: false,
+      });
+      const title = params.nameOnly ? '# Pull Request Files' : '# Pull Request Diff';
+      const body = output.length > 0 ? output : params.nameOnly ? 'No changed files.' : 'No diff output.';
+      return buildTextResult(`${title}\n\n${body}`, undefined, { tool: 'gh_pr_diff' });
+    });
+  }
+}
+
+export class GhPrCheckoutTool implements AgentTool<typeof ghPrCheckoutSchema, GhToolDetails> {
+  readonly name = 'gh_pr_checkout';
+  readonly label = 'GitHub PR Checkout';
+  readonly description = prompt.render(ghPrCheckoutDescription);
+  readonly parameters = ghPrCheckoutSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhPrCheckoutTool | null {
+    if (!git.github.available()) return null;
+    return new GhPrCheckoutTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhPrCheckoutInput,
+    signal?: AbortSignal,
+    _onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const pr = normalizeOptionalString(params.pr);
+      const repo = normalizeOptionalString(params.repo);
+      const requestedBranch = normalizeOptionalString(params.branch);
+      const requestedWorktree = normalizeOptionalString(params.worktree);
+      const force = params.force ?? false;
+      const args = ['pr', 'view'];
+      if (pr) {
+        args.push(pr);
+      }
+      appendRepoFlag(args, repo, pr);
+      args.push('--json', GH_PR_CHECKOUT_FIELDS.join(','));
+
+      const data = await git.github.json<GhPrViewData>(this.session.cwd, args, signal, {
+        repoProvided: Boolean(repo),
+      });
+      const prNumber = data.number;
+      if (typeof prNumber !== 'number') {
+        throw new ToolError('GitHub CLI did not return a pull request number.');
+      }
+
+      const headRefName = requireNonEmpty(data.headRefName, 'head branch');
+      const headRefOid = requireNonEmpty(data.headRefOid, 'head commit');
+      const repoRoot = await requireGitRepoRoot(this.session.cwd, signal);
+      const primaryRepoRoot = await requirePrimaryGitRepoRoot(repoRoot, signal);
+      const localBranch = requestedBranch ?? `pr-${prNumber}`;
+      const worktreePath = requestedWorktree
+        ? path.resolve(this.session.cwd, requestedWorktree)
+        : path.join(primaryRepoRoot, '.worktrees', localBranch);
+      const existingWorktrees = await git.worktree.list(repoRoot, signal);
+      const existingWorktree = existingWorktrees.find((entry) => entry.branch === toLocalBranchRef(localBranch));
+
+      const remote = await ensurePrRemote(repoRoot, data, signal);
+      await git.fetch(
+        repoRoot,
+        remote.name,
+        `refs/heads/${headRefName}`,
+        `refs/remotes/${remote.name}/${headRefName}`,
+        signal,
+      );
+
+      if (!existingWorktree) {
+        const localBranchRef = toLocalBranchRef(localBranch);
+        const localBranchExists = await git.ref.exists(repoRoot, localBranchRef, signal);
+        if (localBranchExists) {
+          const existingOid = await git.ref.resolve(repoRoot, localBranchRef, signal);
+          if (existingOid !== headRefOid) {
+            if (!force) {
+              throw new ToolError(
+                `local branch ${localBranch} already exists at ${formatShortSha(existingOid ?? undefined) ?? existingOid ?? 'unknown commit'}; pass force=true to reset it`,
+              );
+            }
+
+            await git.branch.force(repoRoot, localBranch, `refs/remotes/${remote.name}/${headRefName}`, signal);
+          }
+        } else {
+          await git.branch.create(repoRoot, localBranch, `refs/remotes/${remote.name}/${headRefName}`, signal);
+        }
+      }
+
+      await git.config.setBranch(repoRoot, localBranch, 'remote', remote.name, signal);
+      await git.config.setBranch(repoRoot, localBranch, 'merge', `refs/heads/${headRefName}`, signal);
+      await git.config.setBranch(repoRoot, localBranch, 'pushRemote', remote.name, signal);
+      await git.config.setBranch(repoRoot, localBranch, 'ompPrHeadRef', headRefName, signal);
+      await git.config.setBranch(repoRoot, localBranch, 'ompPrUrl', data.url ?? '', signal);
+      await git.config.setBranch(
+        repoRoot,
+        localBranch,
+        'ompPrIsCrossRepository',
+        String(Boolean(data.isCrossRepository)),
+        signal,
+      );
+      await git.config.setBranch(
+        repoRoot,
+        localBranch,
+        'ompPrMaintainerCanModify',
+        String(Boolean(data.maintainerCanModify)),
+        signal,
+      );
+
+      const finalWorktreePath = existingWorktree?.path ?? worktreePath;
+      if (!existingWorktree) {
+        await ensureGitWorktreePathAvailable(finalWorktreePath, existingWorktrees);
+        await fs.mkdir(path.dirname(finalWorktreePath), { recursive: true });
+        await git.worktree.add(repoRoot, finalWorktreePath, localBranch, { signal });
+      }
+      const resolvedWorktreePath = await fs.realpath(finalWorktreePath);
+
+      return buildTextResult(
+        formatPrCheckoutResult({
+          data,
+          localBranch,
+          worktreePath: resolvedWorktreePath,
+          remoteName: remote.name,
+          remoteUrl: remote.url,
+          reused: Boolean(existingWorktree),
+        }),
+        data.url,
+        {
+          tool: 'gh_pr_checkout',
+          repo: repo ?? data.headRepository?.nameWithOwner,
+          branch: localBranch,
+          worktreePath: resolvedWorktreePath,
+          remote: remote.name,
+          remoteBranch: headRefName,
+        },
+      );
+    });
+  }
+}
+
+export class GhPrPushTool implements AgentTool<typeof ghPrPushSchema, GhToolDetails> {
+  readonly name = 'gh_pr_push';
+  readonly label = 'GitHub PR Push';
+  readonly description = prompt.render(ghPrPushDescription);
+  readonly parameters = ghPrPushSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhPrPushTool | null {
+    if (!git.github.available()) return null;
+    return new GhPrPushTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhPrPushInput,
+    signal?: AbortSignal,
+    _onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const repoRoot = await requireGitRepoRoot(this.session.cwd, signal);
+      const localBranch = normalizeOptionalString(params.branch) ?? (await requireCurrentGitBranch(repoRoot, signal));
+      const refExists = await git.ref.exists(repoRoot, toLocalBranchRef(localBranch), signal);
+      if (!refExists) {
+        throw new ToolError(`local branch ${localBranch} does not exist`);
+      }
+
+      const target = await resolvePrBranchPushTarget(repoRoot, localBranch, signal);
+      const currentBranch = await git.branch.current(repoRoot, signal);
+      const sourceRef = currentBranch === localBranch ? 'HEAD' : toLocalBranchRef(localBranch);
+      const refspec = `${sourceRef}:refs/heads/${target.remoteBranch}`;
+      await git.push(repoRoot, {
+        forceWithLease: params.forceWithLease,
+        refspec,
+        remote: target.remoteName,
+        signal,
+      });
+
+      return buildTextResult(
+        formatPrPushResult({
+          localBranch,
+          remoteName: target.remoteName,
+          remoteBranch: target.remoteBranch,
+          remoteUrl: target.remoteUrl,
+          prUrl: target.prUrl,
+          forceWithLease: params.forceWithLease ?? false,
+        }),
+        target.prUrl,
+        {
+          tool: 'gh_pr_push',
+          branch: localBranch,
+          remote: target.remoteName,
+          remoteBranch: target.remoteBranch,
+        },
+      );
+    });
+  }
+}
+
+export class GhSearchIssuesTool implements AgentTool<typeof ghSearchIssuesSchema, GhToolDetails> {
+  readonly name = 'gh_search_issues';
+  readonly label = 'GitHub Issue Search';
+  readonly description = prompt.render(ghSearchIssuesDescription);
+  readonly parameters = ghSearchIssuesSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhSearchIssuesTool | null {
+    if (!git.github.available()) return null;
+    return new GhSearchIssuesTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhSearchIssuesInput,
+    signal?: AbortSignal,
+    _onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const query = requireNonEmpty(params.query, 'query');
+      const repo = normalizeOptionalString(params.repo);
+      const limit = resolveSearchLimit(params.limit);
+      const args = buildGhSearchArgs('issues', query, limit, repo);
+
+      const items = await git.github.json<GhSearchResult[]>(this.session.cwd, args, signal, {
+        repoProvided: Boolean(repo),
+      });
+      return buildTextResult(formatSearchResults('issues', query, repo, items), undefined, {
+        tool: 'gh_search_issues',
+      });
+    });
+  }
+}
+
+export class GhSearchPrsTool implements AgentTool<typeof ghSearchPrsSchema, GhToolDetails> {
+  readonly name = 'gh_search_prs';
+  readonly label = 'GitHub PR Search';
+  readonly description = prompt.render(ghSearchPrsDescription);
+  readonly parameters = ghSearchPrsSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhSearchPrsTool | null {
+    if (!git.github.available()) return null;
+    return new GhSearchPrsTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhSearchPrsInput,
+    signal?: AbortSignal,
+    _onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const query = requireNonEmpty(params.query, 'query');
+      const repo = normalizeOptionalString(params.repo);
+      const limit = resolveSearchLimit(params.limit);
+      const args = buildGhSearchArgs('prs', query, limit, repo);
+
+      const items = await git.github.json<GhSearchResult[]>(this.session.cwd, args, signal, {
+        repoProvided: Boolean(repo),
+      });
+      return buildTextResult(formatSearchResults('pull requests', query, repo, items), undefined, {
+        tool: 'gh_search_prs',
+      });
+    });
+  }
+}
+
+export class GhRunWatchTool implements AgentTool<typeof ghRunWatchSchema, GhToolDetails> {
+  readonly name = 'gh_run_watch';
+  readonly label = 'GitHub Run Watch';
+  readonly description = prompt.render(ghRunWatchDescription);
+  readonly parameters = ghRunWatchSchema;
+  readonly strict = true;
+
+  constructor(private readonly session: ToolSession) {}
+
+  static createIf(session: ToolSession): GhRunWatchTool | null {
+    if (!git.github.available()) return null;
+    return new GhRunWatchTool(session);
+  }
+
+  async execute(
+    _toolCallId: string,
+    params: GhRunWatchInput,
+    signal?: AbortSignal,
+    onUpdate?: AgentToolUpdateCallback<GhToolDetails>,
+    _context?: AgentToolContext,
+  ): Promise<AgentToolResult<GhToolDetails>> {
+    return untilAborted(signal, async () => {
+      const branchInput = normalizeOptionalString(params.branch);
+      const runReference = parseRunReference(params.run);
+      const repo = await resolveGitHubRepo(this.session.cwd, undefined, runReference.repo, signal);
+      const intervalSeconds = RUN_WATCH_INTERVAL_DEFAULT;
+      const graceSeconds = RUN_WATCH_GRACE_DEFAULT;
+      const tail = resolveTailLimit(params.tail);
+      if (runReference.runId !== undefined) {
+        const runId = runReference.runId;
+        let pollCount = 0;
+
+        while (true) {
+          throwIfAborted(signal);
+          pollCount += 1;
+
+          let run = await fetchRunSnapshot(this.session.cwd, repo, runId, signal);
+          const details = buildRunWatchDetails(repo, run, {
+            state: 'watching',
+            pollCount,
+          });
+          onUpdate?.({
+            content: [{ type: 'text', text: formatRunWatchSnapshot(repo, run, pollCount) }],
+            details,
+          });
+
+          const failedJobs = run.jobs.filter(isFailedJob);
+          const runCompleted = run.status === 'completed';
+
+          if (failedJobs.length > 0) {
+            if (!runCompleted && graceSeconds > 0) {
+              const note = `Failure detected. Waiting ${graceSeconds}s to capture concurrent failures before fetching logs.`;
+              onUpdate?.({
+                content: [
+                  {
+                    type: 'text',
+                    text: formatRunWatchSnapshot(repo, run, pollCount, note),
+                  },
+                ],
+                details: buildRunWatchDetails(repo, run, {
+                  state: 'watching',
+                  pollCount,
+                  note,
+                }),
+              });
+              await abortableSleep(graceSeconds * 1000, signal);
+              run = await fetchRunSnapshot(this.session.cwd, repo, runId, signal);
+            }
+
+            const failedJobLogs = await fetchFailedJobLogs(
+              this.session.cwd,
+              repo,
+              run.jobs.filter(isFailedJob).map((job) => ({ run, job })),
+              tail,
+              signal,
+            );
+            const finalDetails = buildRunWatchDetails(repo, run, {
+              state: 'completed',
+              failedJobLogs,
+            });
+            const artifactId = await saveArtifactText(
+              this.session,
+              this.name,
+              formatRunWatchResult(repo, run, failedJobLogs, tail, { mode: 'full' }),
+            );
+            return buildTextResult(
+              formatRunWatchResult(repo, run, failedJobLogs, tail),
+              run.url,
+              { ...finalDetails, artifactId },
+              { artifactId, artifactLabel: 'Full failed-job logs' },
+            );
+          }
+
+          if (runCompleted) {
+            const finalDetails = buildRunWatchDetails(repo, run, {
+              state: 'completed',
+            });
+            return buildTextResult(formatRunWatchResult(repo, run, [], tail), run.url, finalDetails);
+          }
+
+          await abortableSleep(intervalSeconds * 1000, signal);
+        }
+      }
+
+      const branch = branchInput ?? (await requireCurrentGitBranch(this.session.cwd, signal));
+      const headSha = branchInput
+        ? await resolveGitHubBranchHead(this.session.cwd, repo, branch, signal)
+        : await requireCurrentGitHead(this.session.cwd, signal);
+      let pollCount = 0;
+      let settledSuccessSignature: string | undefined;
+
+      while (true) {
+        throwIfAborted(signal);
+        pollCount += 1;
+
+        let runs = await fetchRunsForCommit(this.session.cwd, repo, headSha, branch, signal);
+        const details = buildCommitRunWatchDetails(repo, headSha, branch, runs, {
+          state: 'watching',
+          pollCount,
+        });
+        onUpdate?.({
+          content: [{ type: 'text', text: formatCommitRunWatchSnapshot(repo, headSha, branch, runs, pollCount) }],
+          details,
+        });
+
+        const outcome = getRunCollectionOutcome(runs);
+        if (outcome === 'failure') {
+          if (graceSeconds > 0) {
+            const note = `Failure detected. Waiting ${graceSeconds}s to capture concurrent failures before fetching logs.`;
+            onUpdate?.({
+              content: [
+                {
+                  type: 'text',
+                  text: formatCommitRunWatchSnapshot(repo, headSha, branch, runs, pollCount, note),
+                },
+              ],
+              details: buildCommitRunWatchDetails(repo, headSha, branch, runs, {
+                state: 'watching',
+                pollCount,
+                note,
+              }),
+            });
+            await abortableSleep(graceSeconds * 1000, signal);
+            runs = await fetchRunsForCommit(this.session.cwd, repo, headSha, branch, signal);
+          }
+
+          const failedJobLogs = await fetchFailedJobLogs(
+            this.session.cwd,
+            repo,
+            runs.flatMap((run) => run.jobs.filter(isFailedJob).map((job) => ({ run, job }))),
+            tail,
+            signal,
+          );
+          const finalDetails = buildCommitRunWatchDetails(repo, headSha, branch, runs, {
+            state: 'completed',
+            failedJobLogs,
+          });
+          const artifactId = await saveArtifactText(
+            this.session,
+            this.name,
+            formatCommitRunWatchResult(repo, headSha, branch, runs, failedJobLogs, tail, { mode: 'full' }),
+          );
+          return buildTextResult(
+            formatCommitRunWatchResult(repo, headSha, branch, runs, failedJobLogs, tail),
+            undefined,
+            { ...finalDetails, artifactId },
+            { artifactId, artifactLabel: 'Full failed-job logs' },
+          );
+        }
+
+        if (outcome === 'success') {
+          const signature = getRunCollectionSignature(runs);
+          if (signature === settledSuccessSignature) {
+            const finalDetails = buildCommitRunWatchDetails(repo, headSha, branch, runs, {
+              state: 'completed',
+            });
+            return buildTextResult(
+              formatCommitRunWatchResult(repo, headSha, branch, runs, [], tail),
+              undefined,
+              finalDetails,
+            );
+          }
+
+          settledSuccessSignature = signature;
+          const note = `All known workflow runs completed successfully. Waiting ${intervalSeconds}s to ensure no additional runs appear for this commit.`;
+          onUpdate?.({
+            content: [
+              {
+                type: 'text',
+                text: formatCommitRunWatchSnapshot(repo, headSha, branch, runs, pollCount, note),
+              },
+            ],
+            details: buildCommitRunWatchDetails(repo, headSha, branch, runs, {
+              state: 'watching',
+              pollCount,
+              note,
+            }),
+          });
+          await abortableSleep(intervalSeconds * 1000, signal);
+          continue;
+        }
+
+        settledSuccessSignature = undefined;
+        await abortableSleep(intervalSeconds * 1000, signal);
+      }
+    });
+  }
+}

--- a/plugins/github/src/utils/git.ts
+++ b/plugins/github/src/utils/git.ts
@@ -1,0 +1,368 @@
+/**
+ * Minimal git utility shim for the GitHub plugin.
+ *
+ * Re-implements only the subset of xcsh's utils/git that gh.ts needs.
+ * All implementations are thin wrappers around Bun.spawn.
+ */
+import { ToolAbortError, ToolError, throwIfAborted } from './tool-errors';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface GitCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function which(binary: string): boolean {
+  try {
+    const result = Bun.spawnSync(['which', binary]);
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+async function runCommand(cwd: string, args: readonly string[], signal?: AbortSignal): Promise<GitCommandResult> {
+  throwIfAborted(signal);
+  const child = Bun.spawn(['git', '--no-optional-locks', ...args], {
+    cwd,
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    windowsHide: true,
+    signal,
+  });
+
+  if (!child.stdout || !child.stderr) {
+    throw new Error('Failed to capture git command output.');
+  }
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+
+  return { exitCode: exitCode ?? 0, stdout, stderr };
+}
+
+async function runEffect(cwd: string, args: readonly string[], signal?: AbortSignal): Promise<void> {
+  const result = await runCommand(cwd, args, signal);
+  if (result.exitCode !== 0) {
+    throw new ToolError(`git ${args.join(' ')} failed: ${(result.stderr || result.stdout).trim()}`);
+  }
+}
+
+async function runText(cwd: string, args: readonly string[], signal?: AbortSignal): Promise<string> {
+  const result = await runCommand(cwd, args, signal);
+  if (result.exitCode !== 0) {
+    throw new ToolError(`git ${args.join(' ')} failed: ${(result.stderr || result.stdout).trim()}`);
+  }
+  return result.stdout;
+}
+
+async function tryText(cwd: string, args: readonly string[], signal?: AbortSignal): Promise<string | undefined> {
+  const result = await runCommand(cwd, args, signal);
+  if (result.exitCode !== 0) return undefined;
+  return result.stdout;
+}
+
+function splitLines(text: string): string[] {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function trimScalar(text: string | undefined): string | undefined {
+  const trimmed = text?.trim();
+  return trimmed || undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: repo
+// ---------------------------------------------------------------------------
+
+export const repo = {
+  async root(cwd: string, signal?: AbortSignal): Promise<string | null> {
+    const result = await runCommand(cwd, ['rev-parse', '--show-toplevel'], signal);
+    if (result.exitCode !== 0) return null;
+    return result.stdout.trim() || null;
+  },
+
+  async primaryRoot(cwd: string, signal?: AbortSignal): Promise<string | null> {
+    const repoRoot = await repo.root(cwd, signal);
+    if (!repoRoot) return null;
+    const commonDir = await runText(repoRoot, ['rev-parse', '--path-format=absolute', '--git-common-dir'], signal);
+    const { basename, dirname } = await import('node:path');
+    if (basename(commonDir.trim()) === '.git') return dirname(commonDir.trim());
+    return repoRoot;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API: branch
+// ---------------------------------------------------------------------------
+
+export const branch = {
+  async current(cwd: string, signal?: AbortSignal): Promise<string | null> {
+    const result = await runCommand(cwd, ['symbolic-ref', '--short', 'HEAD'], signal);
+    if (result.exitCode !== 0) return null;
+    return result.stdout.trim() || null;
+  },
+
+  async create(cwd: string, name: string, startPoint = 'HEAD', signal?: AbortSignal): Promise<void> {
+    await runEffect(cwd, ['branch', name, startPoint], signal);
+  },
+
+  async force(cwd: string, name: string, startPoint: string, signal?: AbortSignal): Promise<void> {
+    await runEffect(cwd, ['branch', '--force', name, startPoint], signal);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API: remote
+// ---------------------------------------------------------------------------
+
+export const remote = {
+  async list(cwd: string, signal?: AbortSignal): Promise<string[]> {
+    return splitLines(await runText(cwd, ['remote'], signal));
+  },
+
+  async url(cwd: string, name: string, signal?: AbortSignal): Promise<string | undefined> {
+    return trimScalar(await tryText(cwd, ['remote', 'get-url', name], signal));
+  },
+
+  async add(cwd: string, name: string, url: string, signal?: AbortSignal): Promise<void> {
+    await runEffect(cwd, ['remote', 'add', name, url], signal);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API: ref
+// ---------------------------------------------------------------------------
+
+export const ref = {
+  async exists(cwd: string, refName: string, signal?: AbortSignal): Promise<boolean> {
+    if (refName === 'HEAD') return (await head.sha(cwd, signal)) !== null;
+    const result = await runCommand(cwd, ['show-ref', '--verify', '--quiet', refName], signal);
+    return result.exitCode === 0;
+  },
+
+  async resolve(cwd: string, refName: string, signal?: AbortSignal): Promise<string | null> {
+    if (refName === 'HEAD') return head.sha(cwd, signal);
+    const result = await runCommand(cwd, ['rev-parse', refName], signal);
+    if (result.exitCode !== 0) return null;
+    return result.stdout.trim() || null;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API: config
+// ---------------------------------------------------------------------------
+
+export const config = {
+  async get(cwd: string, key: string, signal?: AbortSignal): Promise<string | undefined> {
+    return trimScalar(await tryText(cwd, ['config', '--get', key], signal));
+  },
+
+  async set(cwd: string, key: string, value: string, signal?: AbortSignal): Promise<void> {
+    await runEffect(cwd, ['config', key, value], signal);
+  },
+
+  async getBranch(cwd: string, branchName: string, key: string, signal?: AbortSignal): Promise<string | undefined> {
+    return config.get(cwd, `branch.${branchName}.${key}`, signal);
+  },
+
+  async setBranch(cwd: string, branchName: string, key: string, value: string, signal?: AbortSignal): Promise<void> {
+    return config.set(cwd, `branch.${branchName}.${key}`, value, signal);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API: worktree
+// ---------------------------------------------------------------------------
+
+export interface GitWorktreeEntry {
+  branch?: string;
+  detached: boolean;
+  head?: string;
+  path: string;
+}
+
+function parseWorktreeList(text: string): GitWorktreeEntry[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  return trimmed
+    .split(/\n\s*\n/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => {
+      const entry: GitWorktreeEntry = { detached: false, path: '' };
+      for (const line of block.split('\n')) {
+        if (line.startsWith('worktree ')) entry.path = line.slice('worktree '.length);
+        else if (line.startsWith('HEAD ')) entry.head = line.slice('HEAD '.length);
+        else if (line.startsWith('branch ')) entry.branch = line.slice('branch '.length);
+        else if (line === 'detached') entry.detached = true;
+      }
+      return entry;
+    });
+}
+
+export const worktree = {
+  async add(
+    cwd: string,
+    worktreePath: string,
+    refName: string,
+    options: { detach?: boolean; signal?: AbortSignal } = {},
+  ): Promise<void> {
+    const args = ['worktree', 'add'];
+    if (options.detach) args.push('--detach');
+    args.push(worktreePath, refName);
+    await runEffect(cwd, args, options.signal);
+  },
+
+  async list(cwd: string, signal?: AbortSignal): Promise<GitWorktreeEntry[]> {
+    return parseWorktreeList(await runText(cwd, ['worktree', 'list', '--porcelain'], signal));
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API: head
+// ---------------------------------------------------------------------------
+
+export const head = {
+  async sha(cwd: string, signal?: AbortSignal): Promise<string | null> {
+    const result = await runCommand(cwd, ['rev-parse', 'HEAD'], signal);
+    if (result.exitCode !== 0) return null;
+    return result.stdout.trim() || null;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API: push / fetch
+// ---------------------------------------------------------------------------
+
+export interface PushOptions {
+  readonly forceWithLease?: boolean;
+  readonly refspec?: string;
+  readonly remote?: string;
+  readonly signal?: AbortSignal;
+}
+
+export async function push(cwd: string, options: PushOptions = {}): Promise<void> {
+  const args = ['push'];
+  if (options.forceWithLease) args.push('--force-with-lease');
+  if (options.remote) args.push(options.remote);
+  if (options.refspec) args.push(options.refspec);
+  await runEffect(cwd, args, options.signal);
+}
+
+export async function fetch(
+  cwd: string,
+  remoteName: string,
+  source: string,
+  target: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await runEffect(cwd, ['fetch', remoteName, `+${source}:${target}`], signal);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: github (gh CLI)
+// ---------------------------------------------------------------------------
+
+export interface GhCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface GhCommandOptions {
+  repoProvided?: boolean;
+  trimOutput?: boolean;
+}
+
+function formatGhFailure(args: readonly string[], stdout: string, stderr: string, options?: GhCommandOptions): string {
+  const message = (stderr || stdout).trim();
+  if (message.includes('gh auth login') || message.includes('not logged into any GitHub hosts')) {
+    return 'GitHub CLI is not authenticated. Run `gh auth login`.';
+  }
+  if (
+    !options?.repoProvided &&
+    (message.includes('not a git repository') ||
+      message.includes('no git remotes found') ||
+      message.includes('unable to determine current repository'))
+  ) {
+    return 'GitHub repository context is unavailable. Pass `repo` explicitly or run the tool inside a GitHub checkout.';
+  }
+  if (message.length > 0) return message;
+  return `GitHub CLI command failed: gh ${args.join(' ')}`;
+}
+
+export const github = {
+  available(): boolean {
+    return which('gh');
+  },
+
+  async run(cwd: string, args: string[], signal?: AbortSignal, options?: GhCommandOptions): Promise<GhCommandResult> {
+    throwIfAborted(signal);
+    if (!which('gh')) {
+      throw new ToolError('GitHub CLI (gh) is not installed. Install it from https://cli.github.com/.');
+    }
+    try {
+      const child = Bun.spawn(['gh', ...args], {
+        cwd,
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        windowsHide: true,
+        signal,
+      });
+      if (!child.stdout || !child.stderr) {
+        throw new ToolError('Failed to capture GitHub CLI output.');
+      }
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      throwIfAborted(signal);
+      const trim = options?.trimOutput !== false;
+      return {
+        exitCode: exitCode ?? 0,
+        stdout: trim ? stdout.trim() : stdout,
+        stderr: trim ? stderr.trim() : stderr,
+      };
+    } catch (error) {
+      if (signal?.aborted) throw new ToolAbortError();
+      throw error;
+    }
+  },
+
+  async json<T>(cwd: string, args: string[], signal?: AbortSignal, options?: GhCommandOptions): Promise<T> {
+    const result = await github.run(cwd, args, signal, options);
+    if (result.exitCode !== 0) {
+      throw new ToolError(formatGhFailure(args, result.stdout, result.stderr, options));
+    }
+    if (!result.stdout) {
+      throw new ToolError('GitHub CLI returned empty output.');
+    }
+    try {
+      return JSON.parse(result.stdout) as T;
+    } catch {
+      throw new ToolError('GitHub CLI returned invalid JSON output.');
+    }
+  },
+
+  async text(cwd: string, args: string[], signal?: AbortSignal, options?: GhCommandOptions): Promise<string> {
+    const result = await github.run(cwd, args, signal, options);
+    if (result.exitCode !== 0) {
+      throw new ToolError(formatGhFailure(args, result.stdout, result.stderr, options));
+    }
+    return result.stdout;
+  },
+};

--- a/plugins/github/src/utils/tool-errors.ts
+++ b/plugins/github/src/utils/tool-errors.ts
@@ -1,0 +1,44 @@
+/**
+ * Standardized error types for tool execution.
+ * Simplified shim extracted from xcsh core.
+ */
+
+export class ToolError extends Error {
+  constructor(
+    message: string,
+    readonly context?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'ToolError';
+  }
+
+  render(): string {
+    return this.message;
+  }
+}
+
+export class ToolAbortError extends Error {
+  static readonly MESSAGE = 'Operation aborted';
+
+  constructor(message: string = ToolAbortError.MESSAGE) {
+    super(message);
+    this.name = 'ToolAbortError';
+  }
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    const reason = signal.reason instanceof Error ? signal.reason : undefined;
+    throw reason instanceof ToolAbortError ? reason : new ToolAbortError();
+  }
+}
+
+export function renderError(e: unknown): string {
+  if (e instanceof ToolError) {
+    return e.render();
+  }
+  if (e instanceof Error) {
+    return e.message;
+  }
+  return String(e);
+}

--- a/plugins/github/test/extension.test.ts
+++ b/plugins/github/test/extension.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+
+interface ToolDef {
+  name: string;
+  label: string;
+  description: string;
+  parameters: unknown;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+    signal: undefined,
+    update: undefined,
+    ctx: { cwd: string },
+  ) => Promise<{ content: { type: string; text: string }[]; isError?: boolean; details?: unknown }>;
+}
+
+interface ServiceStatusDef {
+  name: string;
+  check: () => Promise<{ state: string; hint?: string }>;
+  fix?: { prompt: string; command: string[] };
+}
+
+interface MockPi {
+  setLabel: (label: string) => void;
+  logger: { debug: (...args: unknown[]) => void };
+  typebox: typeof import('@sinclair/typebox');
+  pi: Record<string, unknown>;
+  registerTool: (tool: ToolDef) => void;
+  registerServiceStatus: (status: ServiceStatusDef) => void;
+  on: (event: string, handler: (...args: unknown[]) => Promise<unknown>) => void;
+}
+
+type FactoryFn = (pi: MockPi) => Promise<void>;
+
+async function buildMockPi(): Promise<{
+  pi: MockPi;
+  tools: ToolDef[];
+  serviceStatuses: ServiceStatusDef[];
+  events: Record<string, Array<(...args: unknown[]) => Promise<unknown>>>;
+}> {
+  const tools: ToolDef[] = [];
+  const serviceStatuses: ServiceStatusDef[] = [];
+  const events: Record<string, Array<(...args: unknown[]) => Promise<unknown>>> = {};
+  const pi: MockPi = {
+    setLabel() {},
+    logger: { debug() {} },
+    typebox: await import('@sinclair/typebox'),
+    pi: {},
+    registerTool(tool: ToolDef) {
+      tools.push(tool);
+    },
+    registerServiceStatus(status: ServiceStatusDef) {
+      serviceStatuses.push(status);
+    },
+    on(event: string, handler: (...args: unknown[]) => Promise<unknown>) {
+      if (!events[event]) events[event] = [];
+      events[event].push(handler);
+    },
+  };
+  return { pi, tools, serviceStatuses, events };
+}
+
+describe('GitHub ExtensionFactory integration', () => {
+  let factory: FactoryFn;
+
+  beforeAll(async () => {
+    const mod = await import('../src/index');
+    factory = mod.default as FactoryFn;
+  });
+
+  it('exports a default function (ExtensionFactory)', () => {
+    expect(typeof factory).toBe('function');
+  });
+
+  it('factory executes without throwing when gh is available', async () => {
+    const { pi, tools, serviceStatuses, events } = await buildMockPi();
+
+    await factory(pi);
+
+    // gh CLI should be available in dev environment
+    const whichResult = Bun.spawnSync(['which', 'gh']);
+    if (whichResult.exitCode !== 0) {
+      // gh not installed — factory should skip tool registration
+      expect(tools).toHaveLength(0);
+      return;
+    }
+
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      'gh_issue_view',
+      'gh_pr_checkout',
+      'gh_pr_diff',
+      'gh_pr_push',
+      'gh_pr_view',
+      'gh_repo_view',
+      'gh_run_watch',
+      'gh_search_issues',
+      'gh_search_prs',
+    ]);
+
+    const labels = tools.map((t) => t.label).sort();
+    expect(labels).toEqual([
+      'GitHub Issue',
+      'GitHub Issue Search',
+      'GitHub PR',
+      'GitHub PR Checkout',
+      'GitHub PR Diff',
+      'GitHub PR Push',
+      'GitHub PR Search',
+      'GitHub Repo',
+      'GitHub Run Watch',
+    ]);
+
+    // Service status registered
+    expect(serviceStatuses).toHaveLength(1);
+    expect(serviceStatuses[0].name).toBe('GitHub');
+
+    // session_start event registered
+    expect(events.session_start).toHaveLength(1);
+  });
+
+  it('each registered tool has required ToolDefinition fields', async () => {
+    const { pi, tools } = await buildMockPi();
+    await factory(pi);
+
+    for (const tool of tools) {
+      expect(typeof tool.name).toBe('string');
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(typeof tool.label).toBe('string');
+      expect(typeof tool.description).toBe('string');
+      expect(tool.description.length).toBeGreaterThan(0);
+      expect(tool.parameters).toBeTruthy();
+      expect(typeof tool.execute).toBe('function');
+    }
+  });
+
+  it('service status check returns valid state', async () => {
+    const { pi, serviceStatuses } = await buildMockPi();
+    await factory(pi);
+
+    if (serviceStatuses.length === 0) return; // gh not installed
+
+    const status = await serviceStatuses[0].check();
+    expect(['connected', 'unauthenticated', 'unavailable']).toContain(status.state);
+  });
+
+  it('session_start hook runs without throwing', async () => {
+    const { pi, events } = await buildMockPi();
+    await factory(pi);
+
+    const handler = events.session_start?.[0];
+    if (!handler) return; // gh not installed
+
+    await expect(handler({}, { cwd: '/tmp' })).resolves.toBeUndefined();
+  });
+});

--- a/plugins/gitlab/.claude-plugin/plugin.json
+++ b/plugins/gitlab/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "gitlab",
+  "description": "GitLab CLI integration — native xcsh tools (glab_setup, glab_issue_list, glab_issue_view, glab_search), welcome screen status, and issue management via glab CLI",
+  "version": "1.0.0",
+  "author": { "name": "f5xc-salesdemos", "url": "https://github.com/f5xc-salesdemos" },
+  "keywords": ["gitlab", "glab", "issues", "git", "xcsh-extension"],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/f5xc-salesdemos/marketplace"
+}

--- a/plugins/gitlab/bun.lock
+++ b/plugins/gitlab/bun.lock
@@ -1,0 +1,707 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@f5xc-salesdemos/xcsh-gitlab",
+      "devDependencies": {
+        "@sinclair/typebox": "^0.34.0",
+        "bun-types": "latest",
+      },
+      "peerDependencies": {
+        "@f5xc-salesdemos/xcsh": ">=1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1057.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-node": "^3.972.47", "@aws-sdk/eventstream-handler-node": "^3.972.18", "@aws-sdk/middleware-eventstream": "^3.972.14", "@aws-sdk/middleware-websocket": "^3.972.23", "@aws-sdk/token-providers": "3.1057.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-TqnYAhAEk45+w3JmS5uHc05AAxfQ7NDyfuARzBv/Y5WuDftRPJMm6FBHCEH7dqcDCcAHmI+XyCYaBI7g7EgweQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.46", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-env": "^3.972.41", "@aws-sdk/credential-provider-http": "^3.972.43", "@aws-sdk/credential-provider-login": "^3.972.45", "@aws-sdk/credential-provider-process": "^3.972.41", "@aws-sdk/credential-provider-sso": "^3.972.45", "@aws-sdk/credential-provider-web-identity": "^3.972.45", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/credential-provider-imds": "^4.3.6", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.47", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.41", "@aws-sdk/credential-provider-http": "^3.972.43", "@aws-sdk/credential-provider-ini": "^3.972.46", "@aws-sdk/credential-provider-process": "^3.972.41", "@aws-sdk/credential-provider-sso": "^3.972.45", "@aws-sdk/credential-provider-web-identity": "^3.972.45", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/credential-provider-imds": "^4.3.6", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/token-providers": "3.1056.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.18", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QPQhwY/fstR8fMZFWrsJRNoTP6D1RjRPHGRX7u9/VkF3opCsvD0oXPz6qzkX94SchzvuS5vyFZbJbPcMEs2Jeg=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-DoZ4djVj/74XQ6M/IwxuKh543tTvLCL7u1Dx+VDHMgW9yGNrFSJJ1l0LrUQRaekic5CB12wUiiOoHL0VI6H0gg=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.23", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-F0d4A9pJFiwljyKgSwU1Z5n+CXSv8bp+V5SthbS2rftB8wBN9z1K2Yyv3xbeK0AM2T0g4q6Ptf0shFF+oQZyiA=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.13", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/signature-v4-multi-region": "^3.996.30", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.30", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1057.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-nIypx3Pvn9l7XoCi1a1ruY/FdUyfQW0LXk/2BdazRzs7rOAZeoSdZx9E1A6bmXIDedrG+09hFb8QlxhEk40jfA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.26", "", { "dependencies": { "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
+
+    "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
+
+    "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
+
+    "@f5xc-salesdemos/pi-agent-core": ["@f5xc-salesdemos/pi-agent-core@18.89.0", "", { "dependencies": { "@f5xc-salesdemos/pi-ai": "18.89.0", "@f5xc-salesdemos/pi-utils": "18.89.0" } }, "sha512-En73yuHovD+5jtIParD4mq1tznmoIcvWw+gg76QxWd04aNFALavzmEYdnU/SonUeY19XFVTjczwxz4hqMiSsbg=="],
+
+    "@f5xc-salesdemos/pi-ai": ["@f5xc-salesdemos/pi-ai@18.89.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.78", "@aws-sdk/client-bedrock-runtime": "^3", "@bufbuild/protobuf": "^2.11", "@f5xc-salesdemos/pi-utils": "18.89.0", "@google/genai": "^1.43", "@sinclair/typebox": "^0.34", "@smithy/node-http-handler": "^4.4", "ajv": "~8.18.0", "ajv-formats": "^3.0", "openai": "^6.25", "partial-json": "^0.1", "zod": "^4.3" }, "bin": { "pi-ai": "src/cli.ts" } }, "sha512-hi4Fek4pO2/peAxmDQTMt4WaVLhbwiQDt40xPTikIHcOBfF8X2xGdQzjWHr+ZeM9GIUlmBx5bKd/oaRg76kzwg=="],
+
+    "@f5xc-salesdemos/pi-natives": ["@f5xc-salesdemos/pi-natives@18.89.0", "", { "optionalDependencies": { "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.89.0", "@f5xc-salesdemos/pi-natives-darwin-x64": "18.89.0", "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.89.0", "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.89.0", "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.89.0" } }, "sha512-PFcjrIUzQi3ohq9eTjI64SUF/tLgY/+SWm01kEeZH/FeuOfm/N9MN76URlV7GE1eNtyUHnZLDpFlT8OD2EbpTA=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-arm64": ["@f5xc-salesdemos/pi-natives-darwin-arm64@18.89.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yQ2fnVxwKazipPW9nbe2ByhBVdg3xDtSzQtELjTTWhzbs1V7RxJVn/pLdq64L51/r9v4MsYGtruGWizFeYgB/g=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-x64": ["@f5xc-salesdemos/pi-natives-darwin-x64@18.89.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ybkkwceDkgOQgjbowWgplM+rs2cBrOLPD7ZixXyVJbRN9VW8fy9DK0ASLVmKH/iy5EbLkHgG+X9+srxBbqT+8A=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": ["@f5xc-salesdemos/pi-natives-linux-arm64-gnu@18.89.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-OpTHa5KfIiKonXOFCM1sXMI2cyNidBnVmSW4XAgECtmZHt8B7DjcKnvmb3IVTclMiSuOUJyIPM6U7WfGmSG7tg=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-x64-gnu": ["@f5xc-salesdemos/pi-natives-linux-x64-gnu@18.89.0", "", { "os": "linux", "cpu": "x64" }, "sha512-seDJbHFaIOdK1ay8nvtWcTTB6KVp2M4zrhByV8k2Bilppw2ccMRH2Wnae5rLZuf9Zg97IVTm5br+2HAocuh60A=="],
+
+    "@f5xc-salesdemos/pi-natives-win32-x64-msvc": ["@f5xc-salesdemos/pi-natives-win32-x64-msvc@18.89.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fdS/BM+iv2XUzLZINr/G3Oy7iZN+GnoY8xWl7k5fCNoBkAfHsPU5pJcGQ1R8ewJvr7Xtk1uDvhEmDS6bl5lTJQ=="],
+
+    "@f5xc-salesdemos/pi-tui": ["@f5xc-salesdemos/pi-tui@18.89.0", "", { "dependencies": { "@f5xc-salesdemos/pi-natives": "18.89.0", "@f5xc-salesdemos/pi-utils": "18.89.0", "marked": "^17.0" } }, "sha512-/W19zaU9FWSMG5iOBWotk0Ti1CPXM0Vp7awpQSf6WrlTWZ54rP7z/n3dEvfV4upWgAzyjItI/LUUSZACQbuuCQ=="],
+
+    "@f5xc-salesdemos/pi-utils": ["@f5xc-salesdemos/pi-utils@18.89.0", "", { "dependencies": { "beautiful-mermaid": "^1.1", "handlebars": "^4.7.9", "winston": "^3.19", "winston-daily-rotate-file": "^5.0" } }, "sha512-rYDFetxYHa2gheoRkWnk1EA7sjCnGBNrRQqYB7+wyVwzXyHJXpJPUdWNF36aw+eu0wZva8GK+64rdPfT5EjUJQ=="],
+
+    "@f5xc-salesdemos/xcsh": ["@f5xc-salesdemos/xcsh@18.89.0", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@f5xc-salesdemos/pi-agent-core": "18.89.0", "@f5xc-salesdemos/pi-ai": "18.89.0", "@f5xc-salesdemos/pi-natives": "18.89.0", "@f5xc-salesdemos/pi-tui": "18.89.0", "@f5xc-salesdemos/pi-utils": "18.89.0", "@f5xc-salesdemos/xcsh-stats": "18.89.0", "@mozilla/readability": "^0.6", "@sinclair/typebox": "^0.34", "@xterm/headless": "^6.0", "ajv": "^8.18", "chalk": "^5.6", "diff": "^8.0", "fflate": "0.8.2", "handlebars": "^4.7", "linkedom": "^0.18", "lru-cache": "11.3.1", "markit-ai": "0.5.0", "puppeteer": "^24.37", "zod": "4.3.6" }, "bin": { "xcsh": "src/cli.ts" } }, "sha512-eYoFb017Bnihx5JIDhZpzE0QyHY/ZX6eNMptZHcTqJTi+A9GAaHDAZ0K1m0JeiY9PfXJtZuF4jCtMCaYGikQCw=="],
+
+    "@f5xc-salesdemos/xcsh-stats": ["@f5xc-salesdemos/xcsh-stats@18.89.0", "", { "dependencies": { "@f5xc-salesdemos/pi-ai": "18.89.0", "@f5xc-salesdemos/pi-utils": "18.89.0", "@tailwindcss/node": "^4.2", "chart.js": "^4.5", "date-fns": "~4.1.0", "lucide-react": "^0.576", "react": "^19.2", "react-chartjs-2": "^5.3", "react-dom": "^19.2" }, "bin": { "xcsh-stats": "src/index.ts" } }, "sha512-NhJ69P13mG7kWyulJwv/rSplQD6YJcBFsrQyjKdeEaV8Curp+g2IkpF6nk4VRLPv+KpOh0AvdaE5OEoX2Psq+w=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
+
+    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
+    "@smithy/core": ["@smithy/core@3.24.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.6", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.5", "", { "dependencies": { "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA=="],
+
+    "@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
+    "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
+    "bare-events": ["bare-events@2.8.3", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw=="],
+
+    "bare-fs": ["bare-fs@4.7.1", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw=="],
+
+    "bare-os": ["bare-os@3.9.1", "", {}, "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ=="],
+
+    "bare-path": ["bare-path@3.0.0", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw=="],
+
+    "bare-stream": ["bare-stream@2.13.1", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow=="],
+
+    "bare-url": ["bare-url@2.4.3", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
+    "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
+
+    "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
+
+    "color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
+
+    "color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
+
+    "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "exifr": ["exifr@7.1.3", "", {}, "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.8.0", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.2.0", "path-expression-matcher": "^1.5.0", "strnum": "^2.3.0", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "fecha": ["fecha@4.2.3", "", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "file-stream-rotator": ["file-stream-rotator@0.6.1", "", { "dependencies": { "moment": "^2.29.1" } }, "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
+    "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
+
+    "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
+
+    "lru-cache": ["lru-cache@11.3.1", "", {}, "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w=="],
+
+    "lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
+
+    "markit-ai": ["markit-ai@0.5.0", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.3", "exifr": "^7.1.3", "fast-xml-parser": "^5.5.9", "jszip": "^3.10.1", "mammoth": "^1.9.0", "mupdf": "^1.27.0", "music-metadata": "^11.12.3", "rss-parser": "^3.13.0", "turndown": "^7.2.0", "turndown-plugin-gfm": "^1.0.2" }, "bin": { "markit": "dist/main.js" } }, "sha512-ob3VxICBZe2Ge3Wg0vFOv6jkk/7OaYisQbtMYR7lUh00MkhAJ/sdVFy0GlqjPkXQ+mGygLdioGB+PfBLUJ5B2w=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mupdf": ["mupdf@1.27.0", "", {}, "sha512-vEPUYwZeu5NgiFLz4e20R7Vp2pNY7szirGEvTxHyQQpQs6ab4DeGdonwT6sH1JZG5EhyHSrojZrZn2/0ee6qZQ=="],
+
+    "music-metadata": ["music-metadata@11.12.3", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.4.3", "file-type": "^21.3.1", "media-typer": "^1.1.0", "strtok3": "^10.3.4", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
+
+    "openai": ["openai@6.39.1", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A=="],
+
+    "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "puppeteer": ["puppeteer@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "cosmiconfig": "^9.0.0", "devtools-protocol": "0.0.1608973", "puppeteer-core": "24.43.1", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/cjs/puppeteer/node/cli.js" } }, "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw=="],
+
+    "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.20.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
+
+    "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
+
+    "react-chartjs-2": ["react-chartjs-2@5.3.1", "", { "peerDependencies": { "chart.js": "^4.1.1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A=="],
+
+    "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "rss-parser": ["rss-parser@3.13.0", "", { "dependencies": { "entities": "^2.0.3", "xml2js": "^0.5.0" } }, "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
+    "streamx": ["streamx@2.26.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
+
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
+
+    "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "triple-beam": ["triple-beam@1.4.1", "", {}, "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "turndown-plugin-gfm": ["turndown-plugin-gfm@1.0.2", "", {}, "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="],
+
+    "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
+
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
+
+    "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
+
+    "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
+
+    "winston-daily-rotate-file": ["winston-daily-rotate-file@5.0.0", "", { "dependencies": { "file-stream-rotator": "^0.6.1", "object-hash": "^3.0.0", "triple-beam": "^1.4.1", "winston-transport": "^4.7.0" }, "peerDependencies": { "winston": "^3" } }, "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw=="],
+
+    "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@10.1.1", "", {}, "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1056.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA=="],
+
+    "@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
+    "@f5xc-salesdemos/pi-ai/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "rss-parser/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
+    "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+  }
+}

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@f5xc-salesdemos/xcsh-gitlab",
+  "version": "1.0.0",
+  "description": "GitLab CLI integration for xcsh — native tools, welcome screen status, issue management",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "bun test",
+    "test:watch": "bun test --watch"
+  },
+  "xcsh": {
+    "name": "GitLab",
+    "version": "1.0.0",
+    "description": "GitLab CLI integration",
+    "extensions": [
+      "src/index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@f5xc-salesdemos/xcsh": ">=1.0.0"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.0",
+    "bun-types": "latest"
+  },
+  "license": "Apache-2.0"
+}

--- a/plugins/gitlab/skills/gitlab-status/SKILL.md
+++ b/plugins/gitlab/skills/gitlab-status/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: gitlab-status
+description: >-
+  Internal skill for gitlab xcsh extension. Provides welcome screen service
+  status via registerServiceStatus API. Not user-invocable.
+user-invocable: false
+---
+
+This skill is a placeholder for the gitlab xcsh extension plugin.
+The actual functionality is provided by the extension entry point at src/index.ts
+which registers 4 native tools (glab_setup, glab_issue_list, glab_issue_view,
+glab_search) and a service status check for the xcsh welcome screen.

--- a/plugins/gitlab/skills/gitlab-status/SKILL.md
+++ b/plugins/gitlab/skills/gitlab-status/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: gitlab-status
+name: GitLab-status
 description: >-
-  Internal skill for gitlab xcsh extension. Provides welcome screen service
+  Internal skill for GitLab xcsh extension. Provides welcome screen service
   status via registerServiceStatus API. Not user-invocable.
 user-invocable: false
 ---
 
-This skill is a placeholder for the gitlab xcsh extension plugin.
+This skill is a placeholder for the GitLab xcsh extension plugin.
 The actual functionality is provided by the extension entry point at src/index.ts
 which registers 4 native tools (glab_setup, glab_issue_list, glab_issue_view,
 glab_search) and a service status check for the xcsh welcome screen.

--- a/plugins/gitlab/src/glab/config.ts
+++ b/plugins/gitlab/src/glab/config.ts
@@ -1,0 +1,106 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { GlabConfig } from './types';
+
+const CONFIG_FILENAME = 'glab-config.json';
+const XCSH_DIR = '.xcsh';
+
+function homeDir(): string {
+  return process.env.HOME || os.homedir();
+}
+
+export async function loadConfig(cwd: string): Promise<GlabConfig | null> {
+  const projectConfig = path.join(cwd, XCSH_DIR, CONFIG_FILENAME);
+  try {
+    const raw = await fs.readFile(projectConfig, 'utf8');
+    return JSON.parse(raw) as GlabConfig;
+  } catch {
+    // try user-level fallback
+  }
+
+  const userConfig = path.join(homeDir(), '.xcsh', 'agent', CONFIG_FILENAME);
+  try {
+    const raw = await fs.readFile(userConfig, 'utf8');
+    return JSON.parse(raw) as GlabConfig;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveConfig(cwd: string, config: GlabConfig): Promise<void> {
+  const json = JSON.stringify(config, null, 2);
+  const projectDir = path.join(cwd, XCSH_DIR);
+  await fs.mkdir(projectDir, { recursive: true });
+  await fs.writeFile(path.join(projectDir, CONFIG_FILENAME), json, 'utf8');
+  const userDir = path.join(homeDir(), '.xcsh', 'agent');
+  await fs.mkdir(userDir, { recursive: true });
+  await fs.writeFile(path.join(userDir, CONFIG_FILENAME), json, 'utf8');
+}
+
+export async function resolveProject(
+  paramProject: string | undefined,
+  cwd: string,
+  exec?: (cmd: string, args: string[]) => Promise<{ stdout: string; code: number }>,
+): Promise<string | null> {
+  if (paramProject) return paramProject;
+  const config = await loadConfig(cwd);
+  if (config?.project) return config.project;
+  // Auto-detect: check if cwd has a gitlab remote
+  if (exec) {
+    try {
+      const result = await exec('glab', ['repo', 'view', '--output', 'json']);
+      if (result.code === 0 && result.stdout) {
+        const repo = JSON.parse(result.stdout);
+        if (repo.path_with_namespace) return repo.path_with_namespace;
+      }
+    } catch {
+      // Not a GitLab repo or glab not available — fall through
+    }
+  }
+  return null;
+}
+
+const CONFIG_DEFAULTS = {
+  hostname: 'gitlab.com',
+  defaultState: 'opened' as const,
+  perPage: 100,
+};
+
+/**
+ * Parse glab auth status output to extract hostname and username.
+ * Expected format: "Logged in to gitlab.com as username (...)"
+ */
+export function parseAuthStatus(output: string): { hostname?: string; user?: string } {
+  const match = output.match(/Logged in to ([\w.-]+) as (\S+)/);
+  if (match) return { hostname: match[1], user: match[2] };
+  const firstLine = output.split('\n').find((l) => l.trim() && !l.startsWith(' '));
+  return { hostname: firstLine?.trim() };
+}
+
+/**
+ * Ensures xcsh glab config exists with sensible defaults.
+ * Merges existing config with detected values (hostname from auth, project from git remote).
+ * Only writes to disk if the config is new or values were updated.
+ */
+export async function ensureGlabConfig(
+  cwd: string,
+  detected?: { hostname?: string; project?: string },
+): Promise<GlabConfig> {
+  const existing = await loadConfig(cwd);
+  const config: GlabConfig = {
+    hostname: existing?.hostname ?? detected?.hostname ?? CONFIG_DEFAULTS.hostname,
+    defaultState: existing?.defaultState ?? CONFIG_DEFAULTS.defaultState,
+    perPage: existing?.perPage ?? CONFIG_DEFAULTS.perPage,
+  };
+  const project = existing?.project ?? detected?.project;
+  if (project) config.project = project;
+
+  const changed =
+    !existing ||
+    existing.hostname !== config.hostname ||
+    existing.project !== config.project ||
+    existing.defaultState !== config.defaultState;
+  if (changed) await saveConfig(cwd, config);
+  return config;
+}

--- a/plugins/gitlab/src/glab/exec.ts
+++ b/plugins/gitlab/src/glab/exec.ts
@@ -1,0 +1,68 @@
+export interface GlabExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+  killed: boolean;
+}
+
+export interface GlabExecApi {
+  cwd: string;
+  exec(command: string, args: string[], options?: { signal?: AbortSignal; cwd?: string }): Promise<GlabExecResult>;
+}
+
+export class GlabAuthError extends Error {
+  constructor(message: string) {
+    super(`GitLab auth error: ${message}. Run glab_setup with action "login".`);
+    this.name = 'GlabAuthError';
+  }
+}
+
+export class GlabNotFoundError extends Error {
+  constructor(message: string) {
+    super(`GitLab resource not found (404/403): ${message}`);
+    this.name = 'GlabNotFoundError';
+  }
+}
+
+export class GlabExecError extends Error {
+  constructor(
+    message: string,
+    public readonly code: number,
+  ) {
+    super(`glab command failed (exit ${code}): ${message}`);
+    this.name = 'GlabExecError';
+  }
+}
+
+export async function checkInstalled(pi: GlabExecApi): Promise<boolean> {
+  const result = await pi.exec('which', ['glab'], { cwd: pi.cwd });
+  return result.code === 0;
+}
+
+export async function checkAuth(pi: GlabExecApi): Promise<boolean> {
+  const result = await pi.exec('glab', ['auth', 'status'], { cwd: pi.cwd });
+  return result.code === 0;
+}
+
+export async function execGlab(pi: GlabExecApi, args: string[], signal?: AbortSignal): Promise<GlabExecResult> {
+  const result = await pi.exec('glab', args, { signal, cwd: pi.cwd });
+  // Bun.spawn sets killed=true even on successful exits — only treat as
+  // cancelled when killed AND no stdout was captured (actual signal kill).
+  if (result.killed && !result.stdout && result.code !== 0) throw new Error('Command was cancelled');
+  if (result.code !== 0) {
+    const stderr = result.stderr.toLowerCase();
+    if (stderr.includes('auth') || stderr.includes('not logged in') || stderr.includes('token')) {
+      throw new GlabAuthError(result.stderr);
+    }
+    if (stderr.includes('404') || stderr.includes('403') || stderr.includes('not found')) {
+      throw new GlabNotFoundError(result.stderr);
+    }
+    throw new GlabExecError(result.stderr, result.code);
+  }
+  return result;
+}
+
+export async function execGlabJson<T = unknown>(pi: GlabExecApi, args: string[], signal?: AbortSignal): Promise<T> {
+  const result = await execGlab(pi, args, signal);
+  return JSON.parse(result.stdout) as T;
+}

--- a/plugins/gitlab/src/glab/formatters.ts
+++ b/plugins/gitlab/src/glab/formatters.ts
@@ -1,0 +1,73 @@
+import type { GlabIssue } from './types';
+
+function formatDate(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+function truncateLabels(labels: string[], maxLen = 30): string {
+  if (!labels.length) return '(none)';
+  const joined = labels.join(', ');
+  if (joined.length <= maxLen) return joined;
+  const truncated = labels.slice(0, 3).join(', ');
+  const remaining = labels.length - 3;
+  return remaining > 0 ? `${truncated}, +${remaining}` : truncated;
+}
+
+export function formatIssueTable(issues: GlabIssue[]): string {
+  if (issues.length === 0) {
+    return 'No issues found matching the criteria.';
+  }
+
+  const header = '| IID | Title | State | Labels | Assignee | Updated |';
+  const divider = '|-----|-------|-------|--------|----------|---------|';
+
+  const rows = issues.map((issue) => {
+    const title = issue.title.length > 50 ? `${issue.title.slice(0, 47)}...` : issue.title;
+    const labels = truncateLabels(issue.labels);
+    const assignee = issue.assignees.length > 0 ? `@${issue.assignees[0].username}` : 'unassigned';
+    const updated = formatDate(issue.updated_at);
+    return `| ${issue.iid} | ${title} | ${issue.state} | ${labels} | ${assignee} | ${updated} |`;
+  });
+
+  return [header, divider, ...rows].join('\n');
+}
+
+export function formatIssueDetail(issue: GlabIssue): string {
+  const lines: string[] = [];
+
+  lines.push(`# Issue #${issue.iid}: ${issue.title}`);
+  lines.push('');
+  lines.push(
+    `State: ${issue.state} | Author: @${issue.author.username} | Created: ${formatDate(issue.created_at)} | Updated: ${formatDate(issue.updated_at)}`,
+  );
+
+  if (issue.labels.length > 0) {
+    lines.push(`Labels: ${issue.labels.join(', ')}`);
+  }
+
+  const assigneeStr =
+    issue.assignees.length > 0 ? issue.assignees.map((a) => `@${a.username}`).join(', ') : 'unassigned';
+  lines.push(`Assignee: ${assigneeStr}${issue.milestone ? ` | Milestone: ${issue.milestone.title}` : ''}`);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  lines.push(issue.description || '(no description)');
+
+  const humanNotes = (issue.notes ?? []).filter((n) => !n.system);
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+
+  if (humanNotes.length === 0) {
+    lines.push('No comments.');
+  } else {
+    lines.push(`## Comments (${humanNotes.length})`);
+    for (const note of humanNotes) {
+      lines.push('');
+      lines.push(`**@${note.author.username}** (${formatDate(note.created_at)}):`);
+      lines.push(`> ${note.body.split('\n').join('\n> ')}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/plugins/gitlab/src/glab/graphql.ts
+++ b/plugins/gitlab/src/glab/graphql.ts
@@ -1,0 +1,55 @@
+import type { GlabExecApi } from './exec';
+import { execGlab } from './exec';
+import type { GraphQLIssueNode, GraphQLSearchResponse } from './types';
+
+export function buildSearchQuery(includeState: boolean): string {
+  const stateVar = includeState ? ', $state: IssuableState' : '';
+  const stateArg = includeState ? ', state: $state' : '';
+  return `
+query SearchIssues($projectPath: ID!, $search: String!, $first: Int!${stateVar}) {
+  project(fullPath: $projectPath) {
+    issues(search: $search, first: $first${stateArg}) {
+      nodes {
+        iid
+        title
+        state
+        labels { nodes { title } }
+        assignees { nodes { username } }
+        updatedAt
+        notes(first: 20) {
+          nodes {
+            body
+            author { username }
+            createdAt
+          }
+        }
+      }
+    }
+  }
+}`.trim();
+}
+
+export async function executeGraphQL(
+  pi: GlabExecApi,
+  projectPath: string,
+  searchText: string,
+  limit: number,
+  signal?: AbortSignal,
+  state?: string,
+): Promise<GraphQLIssueNode[]> {
+  const includeState = !!state && state !== 'all';
+  const query = buildSearchQuery(includeState);
+  const vars: Record<string, unknown> = { projectPath, search: searchText, first: limit };
+  if (includeState) vars.state = state === 'closed' ? 'closed' : 'opened';
+  const variables = JSON.stringify(vars);
+
+  const result = await execGlab(pi, ['api', 'graphql', '-f', `query=${query}`, '-f', `variables=${variables}`], signal);
+
+  const response = JSON.parse(result.stdout) as GraphQLSearchResponse;
+
+  if (response.errors && response.errors.length > 0) {
+    throw new Error(response.errors.map((e) => e.message).join('; '));
+  }
+
+  return response.data?.project?.issues?.nodes ?? [];
+}

--- a/plugins/gitlab/src/glab/types.ts
+++ b/plugins/gitlab/src/glab/types.ts
@@ -1,0 +1,84 @@
+export interface GlabLabel {
+  name: string;
+  color: string;
+}
+
+export interface GlabUser {
+  username: string;
+  name: string;
+}
+
+export interface GlabMilestone {
+  title: string;
+  iid: number;
+}
+
+export interface GlabNote {
+  id: number;
+  body: string;
+  author: GlabUser;
+  created_at: string;
+  updated_at: string;
+  system: boolean;
+}
+
+export interface GlabIssue {
+  id: number;
+  iid: number;
+  title: string;
+  description: string;
+  state: 'opened' | 'closed';
+  labels: string[];
+  assignees: GlabUser[];
+  author: GlabUser;
+  milestone: GlabMilestone | null;
+  created_at: string;
+  updated_at: string;
+  web_url: string;
+  references: { full: string };
+  issue_type: string;
+  notes?: GlabNote[];
+}
+
+export interface GlabProject {
+  id: number;
+  name: string;
+  name_with_namespace: string;
+  path_with_namespace: string;
+  web_url: string;
+  description: string | null;
+}
+
+export interface GlabConfig {
+  project?: string;
+  hostname: string;
+  defaultState: 'opened' | 'closed' | 'all';
+  perPage: number;
+}
+
+export interface GraphQLIssueNode {
+  iid: string;
+  title: string;
+  state: string;
+  labels: { nodes: Array<{ title: string }> };
+  assignees: { nodes: Array<{ username: string }> };
+  updatedAt: string;
+  notes: {
+    nodes: Array<{
+      body: string;
+      author: { username: string };
+      createdAt: string;
+    }>;
+  };
+}
+
+export interface GraphQLSearchResponse {
+  data?: {
+    project?: {
+      issues?: {
+        nodes: GraphQLIssueNode[];
+      };
+    };
+  };
+  errors?: Array<{ message: string }>;
+}

--- a/plugins/gitlab/src/index.ts
+++ b/plugins/gitlab/src/index.ts
@@ -1,0 +1,88 @@
+import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
+
+const factory: ExtensionFactory = async (pi) => {
+  pi.setLabel('GitLab');
+
+  // Check if glab CLI is available
+  try {
+    const result = Bun.spawnSync(['which', 'glab']);
+    if (result.exitCode !== 0) {
+      pi.logger.debug('GitLab CLI (glab) not found — skipping tool registration');
+      return;
+    }
+  } catch {
+    pi.logger.debug('GitLab CLI (glab) not found — skipping tool registration');
+    return;
+  }
+
+  // Register tools
+  const { createGlabSetupTool } = await import('./tools/glab-setup');
+  const { createGlabIssueListTool } = await import('./tools/glab-issue-list');
+  const { createGlabIssueViewTool } = await import('./tools/glab-issue-view');
+  const { createGlabSearchTool } = await import('./tools/glab-search');
+
+  pi.registerTool(createGlabSetupTool(pi));
+  pi.registerTool(createGlabIssueListTool(pi));
+  pi.registerTool(createGlabIssueViewTool(pi));
+  pi.registerTool(createGlabSearchTool(pi));
+
+  // Register welcome screen service status
+  // Replicates the multi-step GitLab check from xcsh welcome-checks:
+  //   1. glab auth status (authentication)
+  //   2. glab repo view (project access)
+  if (typeof pi.registerServiceStatus === 'function') {
+    pi.registerServiceStatus({
+      name: 'GitLab',
+      async check() {
+        try {
+          // Step 1: Check authentication
+          const authResult = Bun.spawnSync(['glab', 'auth', 'status']);
+          if (authResult.exitCode !== 0) {
+            return { state: 'unauthenticated', hint: 'run: glab auth login' };
+          }
+
+          // Step 2: Parse auth output for user info
+          const authOutput = authResult.stderr.toString();
+          const match = authOutput.match(/Logged in to ([\w.-]+) as (\S+)/);
+          const user = match?.[2];
+
+          // Step 3: Suppress glab update nag (idempotent)
+          Bun.spawnSync(['glab', 'config', 'set', 'check_update', 'false']);
+
+          // Step 4: Try to detect project from git remote
+          const repoResult = Bun.spawnSync(['glab', 'repo', 'view', '--output', 'json']);
+          if (repoResult.exitCode === 0) {
+            try {
+              const repo = JSON.parse(repoResult.stdout.toString());
+              if (repo.path_with_namespace) {
+                // Step 5: Verify project access
+                const encoded = encodeURIComponent(repo.path_with_namespace);
+                const accessResult = Bun.spawnSync(['glab', 'api', `projects/${encoded}`]);
+                if (accessResult.exitCode === 0) {
+                  return { state: 'connected' };
+                }
+                return {
+                  state: 'unauthenticated',
+                  hint: `project ${repo.path_with_namespace} inaccessible${user ? ` for @${user}` : ''}`,
+                };
+              }
+            } catch {
+              // JSON parse failed — fall through
+            }
+          }
+
+          // Authenticated but no project detected — still connected
+          return { state: 'connected' };
+        } catch {
+          return { state: 'unavailable', hint: 'glab CLI check failed' };
+        }
+      },
+      fix: {
+        prompt: 'GitLab not authenticated',
+        command: ['glab', 'auth', 'login', '--hostname', 'gitlab.com', '--git-protocol', 'https', '--web'],
+      },
+    });
+  }
+};
+
+export default factory;

--- a/plugins/gitlab/src/prompts/glab-issue-list.md
+++ b/plugins/gitlab/src/prompts/glab-issue-list.md
@@ -1,0 +1,7 @@
+List GitLab issues with structured filters via glab CLI. Returns a markdown summary table.
+
+<instruction>
+Use for "show open bugs", "list issues assigned to X", "show high priority issues".
+Supports: state (opened/closed/all), labels, assignee, search text, milestone, sort field, order direction, limit.
+Defaults to the configured project. Pass project explicitly to override.
+</instruction>

--- a/plugins/gitlab/src/prompts/glab-issue-view.md
+++ b/plugins/gitlab/src/prompts/glab-issue-view.md
@@ -1,0 +1,7 @@
+View a single GitLab issue with full details, description, and comments via glab CLI.
+
+<instruction>
+Use when the user asks to "show issue #N" or "view details of issue X".
+Returns structured markdown with title, state, author, labels, assignee, milestone, description, and comments thread.
+System notes (automated messages) are filtered out.
+</instruction>

--- a/plugins/gitlab/src/prompts/glab-search.md
+++ b/plugins/gitlab/src/prompts/glab-search.md
@@ -1,0 +1,7 @@
+Full-text search across GitLab issue titles, descriptions, labels, and comments via glab CLI.
+
+<instruction>
+Use for "find issues about Tempus", "search for login timeout bugs", "bugs mentioning Safari".
+Three-tier search: REST API (fast, titles+descriptions), GraphQL (includes comments), client-side dedup.
+Supports state filtering and label filtering alongside text search.
+</instruction>

--- a/plugins/gitlab/src/prompts/glab-setup.md
+++ b/plugins/gitlab/src/prompts/glab-setup.md
@@ -1,0 +1,6 @@
+GitLab onboarding wizard via glab CLI. Check installation, authenticate, discover projects, and persist configuration.
+
+<instruction>
+Actions: "check" (verify glab installed), "status" (auth + config), "login" (browser OAuth), "select_project" (list available projects), "save_project" (persist selected project path).
+Run this sequence when the user first asks about GitLab issues and no project is configured.
+</instruction>

--- a/plugins/gitlab/src/renderers/glab-renderer.ts
+++ b/plugins/gitlab/src/renderers/glab-renderer.ts
@@ -1,0 +1,62 @@
+/**
+ * GitLab tool renderer — placeholder for TUI rendering.
+ *
+ * The full TUI renderer from xcsh core depends on @f5xc-salesdemos/pi-tui
+ * (Theme, Component, CachedOutputBlock, etc.) which is not available as a
+ * plugin peer dependency. This file preserves the rendering data shapes so
+ * xcsh can wire up the TUI renderer when loading the plugin, and provides
+ * a plain-text fallback for non-TUI contexts.
+ */
+
+import type { GlabIssue } from '../glab/types';
+
+// Re-export the details type for renderer consumers
+export interface GlabToolDetails {
+  tool?: 'glab_setup' | 'glab_issue_list' | 'glab_issue_view' | 'glab_search';
+  items?: GlabIssue[];
+  issue?: GlabIssue;
+  total?: number;
+  project?: string;
+  query?: string;
+}
+
+export type GlabRenderArgs = {
+  action?: string;
+  project?: string;
+  issue?: number;
+  query?: string;
+  state?: string;
+  labels?: string[];
+  limit?: number;
+  search?: string;
+};
+
+/**
+ * Plain-text summary for non-TUI contexts.
+ * When xcsh loads this plugin with TUI support, it can replace this
+ * with the full themed renderer.
+ */
+export function renderPlainSummary(
+  result: { content: Array<{ type: string; text?: string }>; details?: GlabToolDetails },
+  args?: GlabRenderArgs,
+): string {
+  const details = result.details;
+  const text = result.content?.find((c) => c.type === 'text')?.text ?? '';
+
+  if (!details?.tool) return text;
+
+  const parts: string[] = [];
+
+  if (details.tool === 'glab_issue_list' || details.tool === 'glab_search') {
+    const count = details.total ?? details.items?.length ?? 0;
+    parts.push(`GitLab: ${count} issue${count !== 1 ? 's' : ''}`);
+    if (details.project) parts.push(`(${details.project})`);
+    if (details.query) parts.push(`search: "${details.query}"`);
+  } else if (details.tool === 'glab_issue_view' && details.issue) {
+    parts.push(`GitLab: #${details.issue.iid} ${details.issue.title}`);
+  } else if (details.tool === 'glab_setup') {
+    parts.push(`GitLab Setup: ${args?.action ?? 'complete'}`);
+  }
+
+  return parts.length > 0 ? `${parts.join(' ')}\n\n${text}` : text;
+}

--- a/plugins/gitlab/src/tools/glab-issue-list.ts
+++ b/plugins/gitlab/src/tools/glab-issue-list.ts
@@ -1,0 +1,87 @@
+import { resolveProject } from '../glab/config';
+import { execGlabJson, GlabAuthError } from '../glab/exec';
+import { formatIssueTable } from '../glab/formatters';
+import type { GlabIssue } from '../glab/types';
+import glabIssueListDescription from '../prompts/glab-issue-list.md' with { type: 'text' };
+import { makeExecApi, textResult } from './shared';
+
+export function createGlabIssueListTool(pi: any) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    project: Type.Optional(
+      Type.String({ description: 'GitLab project path (e.g. group/repo). Defaults to configured project.' }),
+    ),
+    state: Type.Optional(
+      Type.Union([Type.Literal('opened'), Type.Literal('closed'), Type.Literal('all')], {
+        description: 'Filter by issue state',
+      }),
+    ),
+    labels: Type.Optional(Type.Array(Type.String(), { description: 'Filter by labels' })),
+    assignee: Type.Optional(Type.String({ description: 'Filter by assignee username' })),
+    search: Type.Optional(Type.String({ description: 'Search text in title and description' })),
+    milestone: Type.Optional(Type.String()),
+    sort: Type.Optional(
+      Type.Union(
+        [Type.Literal('created_at'), Type.Literal('updated_at'), Type.Literal('priority'), Type.Literal('due_date')],
+        { description: 'Sort field' },
+      ),
+    ),
+    order: Type.Optional(Type.Union([Type.Literal('asc'), Type.Literal('desc')], { description: 'Sort direction' })),
+    limit: Type.Optional(Type.Number({ default: 30, maximum: 100, description: 'Max results' })),
+  });
+
+  return {
+    name: 'glab_issue_list',
+    label: 'GitLab Issues',
+    description: glabIssueListDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: {
+        project?: string;
+        state?: string;
+        labels?: string[];
+        assignee?: string;
+        search?: string;
+        milestone?: string;
+        sort?: string;
+        order?: string;
+        limit?: number;
+      },
+      signal: any,
+      _onUpdate: any,
+      ctx: { cwd: string },
+    ) {
+      const api = makeExecApi(ctx.cwd);
+      const project = await resolveProject(params.project, ctx.cwd, (cmd, args) => api.exec(cmd, args));
+      if (!project) {
+        return textResult('No GitLab project configured. Run glab_setup to set one up.');
+      }
+
+      const args = ['issue', 'list', '--output', 'json', '--repo', project];
+      if (params.state === 'closed') args.push('--closed');
+      else if (params.state === 'all') args.push('--all');
+      if (params.labels?.length) args.push('--label', params.labels.join(','));
+      if (params.assignee) args.push('--assignee', params.assignee);
+      if (params.search) args.push('--search', params.search);
+      if (params.milestone) args.push('--milestone', params.milestone);
+      if (params.sort) args.push('--order', params.sort);
+      if (params.order) args.push('--sort', params.order);
+      args.push('--per-page', String(Math.min(params.limit ?? 30, 100)));
+
+      try {
+        const issues = await execGlabJson<GlabIssue[]>(api, args, signal);
+        return textResult(formatIssueTable(issues), {
+          tool: 'glab_issue_list',
+          items: issues,
+          total: issues.length,
+          project,
+        });
+      } catch (err) {
+        if (err instanceof GlabAuthError) return textResult((err as Error).message);
+        throw err;
+      }
+    },
+  };
+}

--- a/plugins/gitlab/src/tools/glab-issue-view.ts
+++ b/plugins/gitlab/src/tools/glab-issue-view.ts
@@ -1,0 +1,48 @@
+import { resolveProject } from '../glab/config';
+import { execGlabJson, GlabAuthError } from '../glab/exec';
+import { formatIssueDetail } from '../glab/formatters';
+import type { GlabIssue } from '../glab/types';
+import glabIssueViewDescription from '../prompts/glab-issue-view.md' with { type: 'text' };
+import { makeExecApi, textResult } from './shared';
+
+export function createGlabIssueViewTool(pi: any) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    issue: Type.Union([Type.Number(), Type.String()], { description: 'Issue IID number or full URL' }),
+    project: Type.Optional(Type.String()),
+    comments: Type.Optional(Type.Boolean({ default: true })),
+  });
+
+  return {
+    name: 'glab_issue_view',
+    label: 'GitLab Issue',
+    description: glabIssueViewDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { issue: number | string; project?: string; comments?: boolean },
+      signal: any,
+      _onUpdate: any,
+      ctx: { cwd: string },
+    ) {
+      const api = makeExecApi(ctx.cwd);
+      const project = await resolveProject(params.project, ctx.cwd, (cmd, args) => api.exec(cmd, args));
+      if (!project) {
+        return textResult('No GitLab project configured. Run glab_setup to set one up.');
+      }
+
+      const issueId = String(params.issue);
+      const args = ['issue', 'view', issueId, '--output', 'json', '--repo', project];
+      if (params.comments !== false) args.push('--comments');
+
+      try {
+        const issue = await execGlabJson<GlabIssue>(api, args, signal);
+        return textResult(formatIssueDetail(issue), { tool: 'glab_issue_view', issue, project });
+      } catch (err) {
+        if (err instanceof GlabAuthError) return textResult((err as Error).message);
+        throw err;
+      }
+    },
+  };
+}

--- a/plugins/gitlab/src/tools/glab-search.ts
+++ b/plugins/gitlab/src/tools/glab-search.ts
@@ -1,0 +1,113 @@
+import { resolveProject } from '../glab/config';
+import { execGlabJson, GlabAuthError } from '../glab/exec';
+import { formatIssueTable } from '../glab/formatters';
+import { executeGraphQL } from '../glab/graphql';
+import type { GlabIssue, GraphQLIssueNode } from '../glab/types';
+import glabSearchDescription from '../prompts/glab-search.md' with { type: 'text' };
+import { makeExecApi, textResult } from './shared';
+
+export function createGlabSearchTool(pi: any) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    query: Type.String({ description: 'Search text to find across issue titles, descriptions, labels, and comments' }),
+    project: Type.Optional(Type.String()),
+    state: Type.Optional(
+      Type.Union([Type.Literal('opened'), Type.Literal('closed'), Type.Literal('all')], {
+        description: 'Filter by issue state',
+      }),
+    ),
+    labels: Type.Optional(Type.Array(Type.String())),
+    limit: Type.Optional(Type.Number({ default: 20, maximum: 100 })),
+  });
+
+  return {
+    name: 'glab_search',
+    label: 'GitLab Search',
+    description: glabSearchDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { query: string; project?: string; state?: string; labels?: string[]; limit?: number },
+      signal: any,
+      _onUpdate: any,
+      ctx: { cwd: string },
+    ) {
+      const api = makeExecApi(ctx.cwd);
+      const project = await resolveProject(params.project, ctx.cwd, (cmd, args) => api.exec(cmd, args));
+      if (!project) {
+        return textResult('No GitLab project configured. Run glab_setup to set one up.');
+      }
+
+      const limit = Math.min(params.limit ?? 20, 100);
+      let issues: GlabIssue[] = [];
+
+      const restArgs = [
+        'issue',
+        'list',
+        '--output',
+        'json',
+        '--repo',
+        project,
+        '--search',
+        params.query,
+        '--per-page',
+        String(limit),
+      ];
+      if (params.state === 'closed') restArgs.push('--closed');
+      else if (params.state === 'all') restArgs.push('--all');
+      if (params.labels?.length) restArgs.push('--label', params.labels.join(','));
+
+      try {
+        issues = await execGlabJson<GlabIssue[]>(api, restArgs, signal);
+      } catch (err) {
+        if (err instanceof GlabAuthError) return textResult((err as Error).message);
+      }
+
+      let graphqlNodes: GraphQLIssueNode[] = [];
+      try {
+        graphqlNodes = await executeGraphQL(api, project, params.query, limit, signal, params.state);
+      } catch {
+        // GraphQL unavailable — use REST results only
+      }
+
+      if (graphqlNodes.length > 0) {
+        const seenIids = new Set(issues.map((i) => i.iid));
+        for (const node of graphqlNodes) {
+          const iid = parseInt(node.iid, 10);
+          if (seenIids.has(iid)) continue;
+          seenIids.add(iid);
+          const lowerQuery = params.query.toLowerCase();
+          const inTitle = node.title.toLowerCase().includes(lowerQuery);
+          const inComments = node.notes.nodes.some((n) => n.body.toLowerCase().includes(lowerQuery));
+          if (inTitle || inComments) {
+            issues.push({
+              id: iid,
+              iid,
+              title: node.title,
+              description: '',
+              state: node.state === 'OPEN' ? 'opened' : 'closed',
+              labels: node.labels.nodes.map((l) => l.title),
+              assignees: node.assignees.nodes.map((a) => ({ username: a.username, name: a.username })),
+              author: { username: '', name: '' },
+              milestone: null,
+              created_at: node.updatedAt,
+              updated_at: node.updatedAt,
+              web_url: `https://gitlab.com/${project}/-/issues/${iid}`,
+              references: { full: `${project}#${iid}` },
+              issue_type: 'issue',
+            });
+          }
+        }
+      }
+
+      return textResult(formatIssueTable(issues), {
+        tool: 'glab_search',
+        items: issues,
+        total: issues.length,
+        project,
+        query: params.query,
+      });
+    },
+  };
+}

--- a/plugins/gitlab/src/tools/glab-setup.ts
+++ b/plugins/gitlab/src/tools/glab-setup.ts
@@ -1,0 +1,106 @@
+import { loadConfig, saveConfig } from '../glab/config';
+import { checkAuth, checkInstalled, execGlabJson } from '../glab/exec';
+import type { GlabProject } from '../glab/types';
+import glabSetupDescription from '../prompts/glab-setup.md' with { type: 'text' };
+import { makeExecApi, textResult } from './shared';
+
+export function createGlabSetupTool(pi: any) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    action: Type.Union(
+      [
+        Type.Literal('check'),
+        Type.Literal('login'),
+        Type.Literal('select_project'),
+        Type.Literal('save_project'),
+        Type.Literal('status'),
+      ],
+      { description: 'Onboarding action to perform' },
+    ),
+    project: Type.Optional(Type.String({ description: 'Project path to persist (used with save_project)' })),
+  });
+
+  return {
+    name: 'glab_setup',
+    label: 'GitLab Setup',
+    description: glabSetupDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { action: string; project?: string },
+      signal: any,
+      _onUpdate: any,
+      ctx: { cwd: string },
+    ) {
+      const api = makeExecApi(ctx.cwd);
+
+      switch (params.action) {
+        case 'check': {
+          const installed = await checkInstalled(api);
+          if (!installed) {
+            return textResult(
+              'glab is not installed.\n\nInstall it with:\n- **macOS**: `brew install glab`\n- **Linux**: Download from https://gitlab.com/gitlab-org/cli/-/releases\n- **Windows**: `winget install gitlab.glab`\n\nAfter installing, call glab_setup with action "login" to authenticate.',
+            );
+          }
+          const ver = await api.exec('glab', ['--version'], { signal });
+          return textResult(`glab is installed: ${ver.stdout.trim()}`);
+        }
+
+        case 'status': {
+          const authResult = await api.exec('glab', ['auth', 'status'], { signal });
+          const config = await loadConfig(ctx.cwd);
+          const projectInfo = config?.project
+            ? `\nConfigured project: ${config.project}`
+            : '\nNo project configured. Run select_project to choose one.';
+          const authStatus = authResult.code === 0 ? authResult.stdout : `Not authenticated: ${authResult.stderr}`;
+          return textResult(authStatus + projectInfo);
+        }
+
+        case 'login':
+          return textResult(
+            'Starting GitLab authentication...\n\nRunning: `glab auth login --hostname gitlab.com --git-protocol https --web`\n\nYour browser will open for you to authorize access. Return here after authorizing.',
+          );
+
+        case 'select_project': {
+          const authenticated = await checkAuth(api);
+          if (!authenticated) {
+            return textResult('Not authenticated. Run glab_setup with action "login" first.');
+          }
+          const projects = await execGlabJson<GlabProject[]>(
+            api,
+            ['repo', 'list', '--member', '--output', 'json', '--per-page', '50'],
+            signal,
+          );
+          if (!projects.length) {
+            return textResult('No projects found for your account.');
+          }
+          const list = projects
+            .map((p, i) => `${i + 1}. **${p.name_with_namespace}** — \`${p.path_with_namespace}\``)
+            .join('\n');
+          return textResult(
+            `Found ${projects.length} projects:\n\n${list}\n\nWhich project do you want to use for GitLab issue tracking? Reply with the number or full path.`,
+            { tool: 'glab_setup', projects },
+          );
+        }
+
+        case 'save_project': {
+          if (!params.project) {
+            return textResult('Error: project parameter is required for save_project action.');
+          }
+          const existing = (await loadConfig(ctx.cwd)) ?? {
+            project: '',
+            hostname: 'gitlab.com',
+            defaultState: 'opened' as const,
+            perPage: 30,
+          };
+          await saveConfig(ctx.cwd, { ...existing, project: params.project });
+          return textResult(`Configuration saved. Default project set to: **${params.project}**`);
+        }
+
+        default:
+          return textResult(`Unknown action: ${params.action}`);
+      }
+    },
+  };
+}

--- a/plugins/gitlab/src/tools/shared.ts
+++ b/plugins/gitlab/src/tools/shared.ts
@@ -1,0 +1,73 @@
+import type { GlabExecApi } from '../glab/exec';
+import { GlabAuthError } from '../glab/exec';
+import type { GlabIssue, GlabProject } from '../glab/types';
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export type GlabErrorType = 'auth_required' | 'not_found' | 'exec_error';
+
+export interface GlabToolDetails {
+  tool?: 'glab_setup' | 'glab_issue_list' | 'glab_issue_view' | 'glab_search';
+  items?: GlabIssue[];
+  issue?: GlabIssue;
+  projects?: GlabProject[];
+  total?: number;
+  project?: string;
+  query?: string;
+  errorType?: GlabErrorType;
+}
+
+// ---------------------------------------------------------------------------
+// Result helpers
+// ---------------------------------------------------------------------------
+
+export function textResult(text: string, details?: GlabToolDetails) {
+  return { content: [{ type: 'text' as const, text }], details };
+}
+
+export function errorResult(text: string, details?: GlabToolDetails) {
+  return { content: [{ type: 'text' as const, text }], isError: true, details };
+}
+
+export function detectErrorType(err: unknown): GlabErrorType {
+  if (err instanceof GlabAuthError) return 'auth_required';
+  return 'exec_error';
+}
+
+// ---------------------------------------------------------------------------
+// Exec API factory
+// ---------------------------------------------------------------------------
+
+export function makeExecApi(cwd: string): GlabExecApi {
+  return {
+    cwd,
+    async exec(command: string, args: string[], options?: { signal?: AbortSignal; cwd?: string }) {
+      // Never pass signal to Bun.spawn and never pre-check signal.aborted.
+      // glab commands finish in 1-3s. Passing the signal or pre-checking causes
+      // false cancellations when xcsh's AbortSignal fires between multi-turn
+      // tool calls (the signal is stale from a prior turn).
+      const child = Bun.spawn([command, ...args], {
+        cwd: options?.cwd ?? cwd,
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      if (!child.stdout || !child.stderr) {
+        return { stdout: '', stderr: 'Failed to capture output', code: 1, killed: false };
+      }
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      return {
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        code: exitCode ?? 0,
+        killed: child.killed,
+      };
+    },
+  };
+}

--- a/plugins/gitlab/test/extension.test.ts
+++ b/plugins/gitlab/test/extension.test.ts
@@ -1,0 +1,117 @@
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+
+const mockPi = {
+  typebox: { Type },
+  logger: { debug() {} },
+  setLabel() {},
+  registerTool(t: { name: string }) {
+    (mockPi as any)._tools.push(t);
+  },
+  registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
+    (mockPi as any)._serviceStatus.push(c);
+  },
+  _tools: [] as { name: string }[],
+  _serviceStatus: [] as { name: string; check: () => Promise<{ state: string }> }[],
+};
+
+describe('GitLab extension', () => {
+  let factory: (pi: unknown) => Promise<void>;
+
+  beforeAll(async () => {
+    // Reset mock state
+    mockPi._tools = [];
+    mockPi._serviceStatus = [];
+    const mod = await import('../src/index');
+    factory = mod.default as typeof factory;
+  });
+
+  it('exports a default factory function', () => {
+    expect(typeof factory).toBe('function');
+  });
+
+  it('registers tools and service status when glab is available', async () => {
+    // Reset
+    mockPi._tools = [];
+    mockPi._serviceStatus = [];
+
+    await factory(mockPi);
+
+    // If glab CLI is installed, should register 4 tools; if not, should skip gracefully
+    if (mockPi._tools.length > 0) {
+      expect(mockPi._tools.length).toBe(4);
+      const names = mockPi._tools.map((t) => t.name).sort();
+      expect(names).toEqual(['glab_issue_list', 'glab_issue_view', 'glab_search', 'glab_setup']);
+    }
+  });
+
+  it('registers service status with name GitLab', async () => {
+    // Reset
+    mockPi._tools = [];
+    mockPi._serviceStatus = [];
+
+    await factory(mockPi);
+
+    if (mockPi._serviceStatus.length > 0) {
+      expect(mockPi._serviceStatus[0].name).toBe('GitLab');
+    }
+  });
+
+  it('service check returns valid state', async () => {
+    // Reset
+    mockPi._tools = [];
+    mockPi._serviceStatus = [];
+
+    await factory(mockPi);
+
+    if (mockPi._serviceStatus.length > 0) {
+      const result = await mockPi._serviceStatus[0].check();
+      expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+    }
+  });
+});
+
+describe('Tool factories', () => {
+  it('createGlabSetupTool returns correct name and label', async () => {
+    const { createGlabSetupTool } = await import('../src/tools/glab-setup');
+    const tool = createGlabSetupTool(mockPi);
+    expect(tool.name).toBe('glab_setup');
+    expect(tool.label).toBe('GitLab Setup');
+    expect(tool.description).toBeTruthy();
+    expect(tool.parameters).toBeTruthy();
+  });
+
+  it('createGlabIssueListTool returns correct name and label', async () => {
+    const { createGlabIssueListTool } = await import('../src/tools/glab-issue-list');
+    const tool = createGlabIssueListTool(mockPi);
+    expect(tool.name).toBe('glab_issue_list');
+    expect(tool.label).toBe('GitLab Issues');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('createGlabIssueViewTool returns correct name and label', async () => {
+    const { createGlabIssueViewTool } = await import('../src/tools/glab-issue-view');
+    const tool = createGlabIssueViewTool(mockPi);
+    expect(tool.name).toBe('glab_issue_view');
+    expect(tool.label).toBe('GitLab Issue');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('createGlabSearchTool returns correct name and label', async () => {
+    const { createGlabSearchTool } = await import('../src/tools/glab-search');
+    const tool = createGlabSearchTool(mockPi);
+    expect(tool.name).toBe('glab_search');
+    expect(tool.label).toBe('GitLab Search');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('glab_setup save_project requires project param', async () => {
+    const { createGlabSetupTool } = await import('../src/tools/glab-setup');
+    const tool = createGlabSetupTool(mockPi);
+    const result = await tool.execute('t1', { action: 'save_project' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.content[0].text).toContain('project parameter is required');
+  });
+});

--- a/plugins/gitlab/tsconfig.json
+++ b/plugins/gitlab/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- **GitHub plugin** (`plugins/github/`): 9 native tools (gh_repo_view, gh_issue_view, gh_pr_view, gh_pr_diff, gh_pr_checkout, gh_pr_push, gh_run_watch, gh_search_issues, gh_search_prs) + welcome screen status via registerServiceStatus
- **GitLab plugin** (`plugins/gitlab/`): 4 native tools (glab_setup, glab_issue_list, glab_issue_view, glab_search) + welcome screen status via registerServiceStatus
- Both follow the Salesforce extraction pattern: ExtensionFactory with registerTool + registerServiceStatus
- GitHub: 5 tests, 71 assertions; GitLab: 9 tests, 22 assertions
- Marketplace validation passes

Closes #498

## Test plan
- [x] GitHub: 5/5 bun tests pass
- [x] GitLab: 9/9 bun tests pass
- [x] validate-plugins.sh passes for all plugins