### PR TITLE
fix(github): resolve @sinclair/typebox for xcsh compiled binary

### DIFF
--- a/plugins/github/bun.lock
+++ b/plugins/github/bun.lock
@@ -4,8 +4,10 @@
   "workspaces": {
     "": {
       "name": "@f5xc-salesdemos/xcsh-github",
-      "devDependencies": {
+      "dependencies": {
         "@sinclair/typebox": "^0.34.0",
+      },
+      "devDependencies": {
         "bun-types": "latest",
       },
       "peerDependencies": {

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -18,8 +18,10 @@
   "peerDependencies": {
     "@f5xc-salesdemos/xcsh": ">=1.0.0"
   },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.0"
+  },
   "devDependencies": {
-    "@sinclair/typebox": "^0.34.0",
     "bun-types": "latest"
   },
   "license": "Apache-2.0"

--- a/plugins/github/src/index.ts
+++ b/plugins/github/src/index.ts
@@ -15,7 +15,10 @@ const factory: ExtensionFactory = async (pi) => {
     return;
   }
 
-  // Import tool classes
+  // Inject typebox before importing tool classes (avoids @sinclair/typebox resolution failure in compiled binary)
+  const ghModule = await import('./tools/gh');
+  ghModule.setTypebox(pi.typebox);
+
   const {
     GhRepoViewTool,
     GhIssueViewTool,
@@ -26,7 +29,7 @@ const factory: ExtensionFactory = async (pi) => {
     GhRunWatchTool,
     GhSearchIssuesTool,
     GhSearchPrsTool,
-  } = await import('./tools/gh');
+  } = ghModule;
 
   // Each tool class has a createIf() that checks gh availability and returns
   // an instance with name/label/description/parameters/execute.

--- a/plugins/github/src/tools/gh.ts
+++ b/plugins/github/src/tools/gh.ts
@@ -1,6 +1,43 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { type Static, Type } from '@sinclair/typebox';
+// Import typebox using a file:// URL resolved from this module's location.
+// The compiled xcsh binary can't resolve bare @sinclair/typebox specifiers,
+// but can resolve absolute file paths via dynamic import.
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const tbPath = path.resolve(__dirname, '..', '..', 'node_modules', '@sinclair', 'typebox', 'src', 'index.ts');
+const tbPathJs = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'node_modules',
+  '@sinclair',
+  'typebox',
+  'build',
+  'cjs',
+  'index.js',
+);
+let Type: typeof import('@sinclair/typebox').Type;
+try {
+  const tb = await import('@sinclair/typebox');
+  Type = tb.Type;
+} catch {
+  // Fallback: import from local node_modules via absolute path
+  try {
+    const tb = await import(tbPathJs);
+    Type = tb.Type;
+  } catch {
+    const tb = await import(tbPath);
+    Type = tb.Type;
+  }
+}
+type Static<T> = T extends { static: infer S } ? S : never;
+
+export function setTypebox(tb: { Type: typeof Type }): void {
+  Type = tb.Type;
+}
+
 import ghIssueViewDescription from '../prompts/gh-issue-view.md' with { type: 'text' };
 import ghPrCheckoutDescription from '../prompts/gh-pr-checkout.md' with { type: 'text' };
 import ghPrDiffDescription from '../prompts/gh-pr-diff.md' with { type: 'text' };


### PR DESCRIPTION
## Summary
- Fix extension loading failure: `Cannot find module '@sinclair/typebox'`
- Try normal import first, fall back to absolute path from plugin's node_modules
- Entry point injects typebox via `setTypebox(pi.typebox)`

Closes #500