### PR TITLE
feat(salesforce): add cross-platform setup wizard with CLI install and auth flow

### DIFF
--- a/plugins/salesforce/hooks/hooks.json
+++ b/plugins/salesforce/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v sf > /dev/null 2>&1 || echo 'WARNING: Salesforce CLI (sf) is not installed. Run: brew install sf'",
+            "command": "command -v sf > /dev/null 2>&1 || echo 'WARNING: Salesforce CLI (sf) is not installed. Run /salesforce:setup to install and configure.'",
             "timeout": 5
           }
         ]

--- a/plugins/salesforce/scripts/tests/test_structure.sh
+++ b/plugins/salesforce/scripts/tests/test_structure.sh
@@ -276,3 +276,20 @@ test_T1_15_salesforce_context_exists() {
     return 1
   fi
 }
+
+# T1.16 — hooks.json references /salesforce:setup, not brew
+test_T1_16_hook_references_setup_command() {
+  local hook="$PLUGIN_ROOT/hooks/hooks.json"
+  if [[ ! -f "$hook" ]]; then
+    echo "FAIL: hooks.json missing"
+    return 1
+  fi
+  if ! grep -q "salesforce:setup" "$hook"; then
+    echo "FAIL: hooks.json should reference /salesforce:setup"
+    return 1
+  fi
+  if grep -q "brew install" "$hook"; then
+    echo "FAIL: hooks.json should not hardcode brew (cross-platform)"
+    return 1
+  fi
+}

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -3,85 +3,101 @@ import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('Salesforce');
 
+  // Always register setup command (even without sf CLI)
+  if (typeof pi.registerCommand === 'function') {
+    pi.registerCommand('salesforce:setup', {
+      description: 'Install and configure Salesforce CLI',
+      async handler(_args, ctx) {
+        const { runSetupWizard } = await import('./wizard');
+        await runSetupWizard(pi, ctx);
+      },
+    });
+  }
+
   // Check if sf CLI is available
+  let sfAvailable = false;
   try {
-    const result = Bun.spawnSync(['which', 'sf']);
-    if (result.exitCode !== 0) {
-      pi.logger.debug('Salesforce CLI (sf) not found — skipping tool registration');
-      return;
-    }
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    sfAvailable = Bun.spawnSync([checker, 'sf']).exitCode === 0;
   } catch {
-    pi.logger.debug('Salesforce CLI (sf) not found — skipping tool registration');
-    return;
+    // sf not available
   }
 
-  // Inject loadProfile dependency from xcsh's internal API
-  const { setLoadProfile } = await import('./context/salesforce-context');
-  if (pi.pi?.loadProfile) {
-    setLoadProfile(pi.pi.loadProfile);
+  // Only register tools when sf CLI is present
+  if (sfAvailable) {
+    // Inject loadProfile dependency
+    const { setLoadProfile } = await import('./context/salesforce-context');
+    if (pi.pi?.loadProfile) {
+      setLoadProfile(pi.pi.loadProfile);
+    }
+
+    // Register tools
+    const { createSfSetupTool } = await import('./tools/sf-setup');
+    const { createSfQueryTool } = await import('./tools/sf-query');
+    const { createSfOrgDisplayTool } = await import('./tools/sf-org-display');
+    const { createSfPipelineReportTool } = await import('./tools/sf-pipeline-report');
+
+    pi.registerTool(createSfSetupTool(pi));
+    pi.registerTool(createSfQueryTool(pi));
+    pi.registerTool(createSfOrgDisplayTool(pi));
+    pi.registerTool(createSfPipelineReportTool(pi));
+
+    // Context injection (only when sf available)
+    pi.on('before_agent_start', async () => {
+      const { loadSalesforceContext, buildSalesforceHint } = await import('./context/salesforce-context');
+      const sfContext = await loadSalesforceContext();
+      if (!sfContext) return;
+      const hint = buildSalesforceHint(sfContext);
+      if (!hint) return;
+      const lines = [
+        `Pipeline: ${hint.pipelineTotal} (${hint.dealCount} deals, ${hint.accountCount} accounts)`,
+        hint.territories ? `Territories: ${hint.territories}` : '',
+        hint.forecastBreakdown ? `Forecast: ${hint.forecastBreakdown}` : '',
+        hint.partnerName ? `Partner: ${hint.partnerName} (${hint.partnerRole ?? 'Partner'})` : '',
+        hint.orgAlias ? `Org: ${hint.orgAlias}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n');
+      return {
+        message: { customType: 'salesforce_hint', content: lines, display: false },
+      };
+    });
   }
 
-  // Register tools
-  const { createSfSetupTool } = await import('./tools/sf-setup');
-  const { createSfQueryTool } = await import('./tools/sf-query');
-  const { createSfOrgDisplayTool } = await import('./tools/sf-org-display');
-  const { createSfPipelineReportTool } = await import('./tools/sf-pipeline-report');
-
-  pi.registerTool(createSfSetupTool(pi));
-  pi.registerTool(createSfQueryTool(pi));
-  pi.registerTool(createSfOrgDisplayTool(pi));
-  pi.registerTool(createSfPipelineReportTool(pi));
-
-  // Register welcome screen service status
+  // Always register service status (shows unavailable when CLI missing)
   if (typeof pi.registerServiceStatus === 'function') {
     pi.registerServiceStatus({
       name: 'Salesforce',
       async check() {
         try {
+          const whichChecker = process.platform === 'win32' ? 'where' : 'which';
+          const whichResult = Bun.spawnSync([whichChecker, 'sf']);
+          if (whichResult.exitCode !== 0) {
+            return { state: 'unavailable', hint: 'run: /salesforce:setup' };
+          }
           const { execSfJson } = await import('./sf/exec');
           const { collectAllOrgs, makeExecApi } = await import('./tools/shared');
           const api = makeExecApi(process.cwd());
           const orgResult = await execSfJson(api, ['org', 'list']);
           const allOrgs = collectAllOrgs(orgResult.result as Record<string, unknown[]>);
-          if (allOrgs.length === 0) return { state: 'unauthenticated', hint: 'run: sf org login web' };
+          if (allOrgs.length === 0) return { state: 'unauthenticated', hint: 'run: /salesforce:setup' };
           const defaultOrg = allOrgs.find((o) => o.isDefault);
-          if (!defaultOrg) return { state: 'unauthenticated', hint: 'run: sf_setup action set_default' };
+          if (!defaultOrg) return { state: 'unauthenticated', hint: 'run: /salesforce:setup' };
           if (defaultOrg.connectedStatus === 'Connected') return { state: 'connected' };
-          return { state: 'unauthenticated', hint: 'session expired, run: sf org login web' };
+          return { state: 'unauthenticated', hint: 'session expired, run: /salesforce:setup' };
         } catch {
           return { state: 'unavailable', hint: 'sf CLI check failed' };
         }
       },
-      fix: {
-        prompt: 'Salesforce not authenticated',
-        command: ['sf', 'org', 'login', 'web', '--set-default'],
-      },
     });
   }
 
-  // Context injection — inject Salesforce pipeline hint before each agent turn
-  pi.on('before_agent_start', async () => {
-    const { loadSalesforceContext, buildSalesforceHint } = await import('./context/salesforce-context');
-    const sfContext = await loadSalesforceContext();
-    if (!sfContext) return;
-    const hint = buildSalesforceHint(sfContext);
-    if (!hint) return;
-    const lines = [
-      `Pipeline: ${hint.pipelineTotal} (${hint.dealCount} deals, ${hint.accountCount} accounts)`,
-      hint.territories ? `Territories: ${hint.territories}` : '',
-      hint.forecastBreakdown ? `Forecast: ${hint.forecastBreakdown}` : '',
-      hint.partnerName ? `Partner: ${hint.partnerName} (${hint.partnerRole ?? 'Partner'})` : '',
-      hint.orgAlias ? `Org: ${hint.orgAlias}` : '',
-    ]
-      .filter(Boolean)
-      .join('\n');
-    return {
-      message: { customType: 'salesforce_hint', content: lines, display: false },
-    };
-  });
-
-  // Welcome check — verify org connectivity at session start (non-fatal)
+  // Session start: notify if CLI missing, check org connectivity if available
   pi.on('session_start', async (_event: unknown, ctx: { cwd: string }) => {
+    if (!sfAvailable) {
+      pi.logger.debug('Salesforce: sf CLI not found');
+      return;
+    }
     try {
       const { execSfJson } = await import('./sf/exec');
       const { collectAllOrgs, makeExecApi } = await import('./tools/shared');

--- a/plugins/salesforce/src/platform.ts
+++ b/plugins/salesforce/src/platform.ts
@@ -1,0 +1,155 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type PackageManager = 'brew' | 'npm' | 'apt' | 'winget' | 'scoop';
+
+export interface PlatformInfo {
+  os: 'darwin' | 'linux' | 'win32';
+  arch: string;
+  packageManagers: PackageManager[];
+  isCorporateManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}
+
+function which(cmd: string): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, cmd]).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectPackageManagers(): Promise<PackageManager[]> {
+  const managers: PackageManager[] = [];
+  const platform = process.platform;
+
+  if (platform === 'darwin' && which('brew')) managers.push('brew');
+  if (platform === 'linux' && which('apt')) managers.push('apt');
+  if (platform === 'win32' && which('winget')) managers.push('winget');
+  if (platform === 'win32' && which('scoop')) managers.push('scoop');
+  if (which('npm')) managers.push('npm');
+
+  return managers;
+}
+
+async function detectCorporateManagement(): Promise<{
+  isManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}> {
+  try {
+    const profilePath = path.join(os.homedir(), '.xcsh', 'computer-profile.json');
+    const file = Bun.file(profilePath);
+    if (!(await file.exists())) return { isManaged: false };
+    const profile = await file.json();
+    const mgmt = profile.management;
+    if (!mgmt?.isManaged) return { isManaged: false };
+    return {
+      isManaged: true,
+      mdmVendor: mgmt.mdmVendor,
+      organizationName: mgmt.organizationName,
+    };
+  } catch {
+    return { isManaged: false };
+  }
+}
+
+export async function detectPlatform(): Promise<PlatformInfo> {
+  const [packageManagers, corporate] = await Promise.all([detectPackageManagers(), detectCorporateManagement()]);
+
+  return {
+    os: process.platform as PlatformInfo['os'],
+    arch: os.arch(),
+    packageManagers,
+    isCorporateManaged: corporate.isManaged,
+    mdmVendor: corporate.mdmVendor,
+    organizationName: corporate.organizationName,
+  };
+}
+
+export function getInstallOptions(
+  info: PlatformInfo,
+): Array<{ label: string; command: string[]; manager: PackageManager }> {
+  const options: Array<{
+    label: string;
+    command: string[];
+    manager: PackageManager;
+  }> = [];
+
+  if (info.os === 'darwin' && info.packageManagers.includes('brew')) {
+    options.push({
+      label: 'Homebrew (recommended)',
+      command: ['brew', 'install', '@salesforce/cli'],
+      manager: 'brew',
+    });
+  }
+  if (info.os === 'win32' && info.packageManagers.includes('winget')) {
+    options.push({
+      label: 'winget (recommended)',
+      command: ['winget', 'install', 'Salesforce.SalesforceCLI'],
+      manager: 'winget',
+    });
+  }
+  if (info.os === 'win32' && info.packageManagers.includes('scoop')) {
+    options.push({
+      label: 'Scoop',
+      command: ['scoop', 'install', 'sf'],
+      manager: 'scoop',
+    });
+  }
+  if (info.os === 'linux' && info.packageManagers.includes('apt')) {
+    options.push({
+      label: 'apt',
+      command: ['sudo', 'apt', 'install', '-y', 'sf'],
+      manager: 'apt',
+    });
+  }
+  if (info.packageManagers.includes('npm')) {
+    options.push({
+      label: 'npm (universal fallback)',
+      command: ['npm', 'install', '-g', '@salesforce/cli'],
+      manager: 'npm',
+    });
+  }
+
+  return options;
+}
+
+export function getAuthOptions(): Array<{
+  label: string;
+  key: string;
+  available: boolean;
+}> {
+  const options: Array<{ label: string; key: string; available: boolean }> = [];
+
+  options.push({
+    label: 'Web browser (recommended for workstations)',
+    key: 'web',
+    available: true,
+  });
+
+  const hasSfdxUrl = !!process.env.SFDX_AUTH_URL;
+  options.push({
+    label: `SFDX Auth URL${hasSfdxUrl ? ' (detected)' : ''}`,
+    key: 'sfdx_url',
+    available: hasSfdxUrl,
+  });
+
+  const hasAccessToken = !!process.env.SF_ACCESS_TOKEN && !!process.env.SF_ORG_INSTANCE_URL;
+  options.push({
+    label: `Access Token${hasAccessToken ? ' (detected)' : ''}`,
+    key: 'access_token',
+    available: hasAccessToken,
+  });
+
+  const hasJwt = !!process.env.SF_JWT_KEY_FILE && !!process.env.SF_CLIENT_ID && !!process.env.SF_USERNAME;
+  options.push({
+    label: `JWT Bearer Flow${hasJwt ? ' (detected)' : ''}`,
+    key: 'jwt',
+    available: hasJwt,
+  });
+
+  return options;
+}

--- a/plugins/salesforce/src/wizard.ts
+++ b/plugins/salesforce/src/wizard.ts
@@ -1,0 +1,191 @@
+import { detectPlatform, getAuthOptions, getInstallOptions, type PlatformInfo } from './platform';
+
+export function buildInstallStep(platform: PlatformInfo) {
+  return getInstallOptions(platform);
+}
+
+export function buildAuthStep() {
+  return getAuthOptions();
+}
+
+export function buildVerifyCommand(alias: string): string[] {
+  return ['sf', 'org', 'display', '--target-org', alias, '--json'];
+}
+
+function sfIsInstalled(): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, 'sf']).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function runSetupWizard(
+  pi: {
+    exec: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string; code: number }>;
+  },
+  ctx: {
+    ui: {
+      select: (title: string, options: string[]) => Promise<string | undefined>;
+      confirm: (title: string, message: string) => Promise<boolean>;
+      notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
+    };
+    cwd: string;
+    reload?: () => Promise<void>;
+  },
+): Promise<void> {
+  ctx.ui.notify('Salesforce Setup Wizard starting...', 'info');
+
+  // Step 1: Platform detection
+  const platform = await detectPlatform();
+  const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
+  ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
+
+  if (platform.isCorporateManaged) {
+    ctx.ui.notify(
+      `Corporate-managed device detected${platform.mdmVendor ? ` (${platform.mdmVendor})` : ''}. Automatic installation may be restricted.`,
+      'warning',
+    );
+  }
+
+  // Step 2: CLI install (if needed)
+  if (!sfIsInstalled()) {
+    const installOptions = buildInstallStep(platform);
+    if (installOptions.length === 0) {
+      ctx.ui.notify(
+        'No package manager found. Install Salesforce CLI manually: https://developer.salesforce.com/tools/salesforcecli',
+        'error',
+      );
+      return;
+    }
+
+    const labels = installOptions.map((o) => o.label);
+    labels.push('Skip installation');
+
+    const choice = await ctx.ui.select('Install Salesforce CLI', labels);
+    if (!choice || choice === 'Skip installation') {
+      ctx.ui.notify('Setup cancelled. Run /salesforce:setup when ready.', 'info');
+      return;
+    }
+
+    const selected = installOptions.find((o) => o.label === choice);
+    if (!selected) return;
+
+    const proceed = await ctx.ui.confirm('Install Salesforce CLI', `Run: ${selected.command.join(' ')}`);
+    if (!proceed) return;
+
+    ctx.ui.notify(`Installing via ${selected.manager}...`, 'info');
+    const result = await pi.exec(selected.command[0], selected.command.slice(1));
+    if (result.code !== 0) {
+      ctx.ui.notify(`Installation failed (exit ${result.code}). ${result.stderr || 'Check output above.'}`, 'error');
+      if (platform.isCorporateManaged) {
+        ctx.ui.notify('This may be due to corporate restrictions. Try npm install or contact IT.', 'warning');
+      }
+      return;
+    }
+
+    // Verify install
+    if (!sfIsInstalled()) {
+      ctx.ui.notify('sf CLI not found after install. You may need to restart your terminal.', 'error');
+      return;
+    }
+    const versionResult = await pi.exec('sf', ['--version']);
+    ctx.ui.notify(`Salesforce CLI installed: ${versionResult.stdout.trim()}`, 'info');
+    // Reload extensions so tools get registered
+    if (ctx.reload) {
+      await ctx.reload();
+    }
+  } else {
+    const versionResult = await pi.exec('sf', ['--version']);
+    ctx.ui.notify(`Salesforce CLI already installed: ${versionResult.stdout.trim()}`, 'info');
+  }
+
+  // Step 3: Authentication
+  const authOptions = buildAuthStep();
+  const availableLabels = authOptions.filter((o) => o.available || o.key === 'web').map((o) => o.label);
+  availableLabels.push('Skip authentication');
+
+  const authChoice = await ctx.ui.select('Authenticate to Salesforce', availableLabels);
+  if (!authChoice || authChoice === 'Skip authentication') {
+    ctx.ui.notify('CLI installed. Run /salesforce:setup again to authenticate.', 'info');
+    return;
+  }
+
+  const selectedAuth = authOptions.find((o) => o.label === authChoice);
+  if (!selectedAuth) return;
+
+  // Step 4: Execute authentication
+  const alias = 'SFDC';
+  let authCmd: string[];
+
+  switch (selectedAuth.key) {
+    case 'web':
+      authCmd = ['sf', 'org', 'login', 'web', '--set-default', '--alias', alias];
+      break;
+    case 'sfdx_url': {
+      const sfdxUrl = process.env.SFDX_AUTH_URL || '';
+      const tmpFile = `${require('node:os').tmpdir()}/xcsh-sfdx-auth-${Date.now()}.txt`;
+      await Bun.write(tmpFile, sfdxUrl);
+      authCmd = ['sf', 'org', 'login', 'sfdx-url', '--sfdx-url-file', tmpFile, '--set-default', '--alias', alias];
+      break;
+    }
+    case 'access_token':
+      authCmd = [
+        'sf',
+        'org',
+        'login',
+        'access-token',
+        '--instance-url',
+        process.env.SF_ORG_INSTANCE_URL || '',
+        '--set-default',
+        '--alias',
+        alias,
+      ];
+      break;
+    case 'jwt':
+      authCmd = [
+        'sf',
+        'org',
+        'login',
+        'jwt',
+        '--client-id',
+        process.env.SF_CLIENT_ID || '',
+        '--jwt-key-file',
+        process.env.SF_JWT_KEY_FILE || '',
+        '--username',
+        process.env.SF_USERNAME || '',
+        '--set-default',
+        '--alias',
+        alias,
+      ];
+      break;
+    default:
+      return;
+  }
+
+  ctx.ui.notify('Authenticating...', 'info');
+  const authResult = await pi.exec(authCmd[0], authCmd.slice(1));
+  if (authResult.code !== 0) {
+    ctx.ui.notify(`Authentication failed: ${authResult.stderr || authResult.stdout}`, 'error');
+    return;
+  }
+
+  // Step 5: Verify
+  const verifyCmd = buildVerifyCommand(alias);
+  const verifyResult = await pi.exec(verifyCmd[0], verifyCmd.slice(1));
+  if (verifyResult.code === 0) {
+    try {
+      const data = JSON.parse(verifyResult.stdout);
+      const org = data.result || {};
+      ctx.ui.notify(
+        `Salesforce ready! Connected as ${org.username || 'unknown'} to ${org.instanceUrl || 'unknown'}`,
+        'info',
+      );
+    } catch {
+      ctx.ui.notify('Salesforce authenticated. Run /salesforce:setup to confirm.', 'info');
+    }
+  } else {
+    ctx.ui.notify('Authentication may have succeeded. Run /salesforce:setup to verify.', 'warning');
+  }
+}

--- a/plugins/salesforce/test/integration/extension-load.test.ts
+++ b/plugins/salesforce/test/integration/extension-load.test.ts
@@ -210,4 +210,20 @@ describe('ExtensionFactory integration', () => {
 
     await expect(handler({}, { cwd: '/tmp' })).resolves.toBeUndefined();
   });
+
+  it('registers salesforce:setup command', async () => {
+    const commands: { name: string; description?: string }[] = [];
+    const { pi } = await buildMockPi();
+
+    // Add registerCommand to the mock
+    (pi as Record<string, unknown>).registerCommand = (name: string, opts: { description?: string }) => {
+      commands.push({ name, description: opts.description });
+    };
+
+    await factory(pi);
+
+    const setup = commands.find((c) => c.name === 'salesforce:setup');
+    expect(setup).toBeDefined();
+    expect(setup?.description).toContain('Install');
+  });
 });

--- a/plugins/salesforce/test/platform.test.ts
+++ b/plugins/salesforce/test/platform.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  detectPackageManagers,
+  detectPlatform,
+  getAuthOptions,
+  getInstallOptions,
+  type PlatformInfo,
+} from '../src/platform';
+
+describe('detectPlatform', () => {
+  it('returns a valid os field', async () => {
+    const info = await detectPlatform();
+    expect(['darwin', 'linux', 'win32']).toContain(info.os);
+  });
+
+  it('returns a non-empty arch', async () => {
+    const info = await detectPlatform();
+    expect(info.arch.length).toBeGreaterThan(0);
+  });
+
+  it('returns packageManagers as an array', async () => {
+    const info = await detectPlatform();
+    expect(Array.isArray(info.packageManagers)).toBe(true);
+  });
+
+  it('isCorporateManaged is a boolean', async () => {
+    const info = await detectPlatform();
+    expect(typeof info.isCorporateManaged).toBe('boolean');
+  });
+});
+
+describe('detectPackageManagers', () => {
+  it('returns an array of detected managers', async () => {
+    const managers = await detectPackageManagers();
+    expect(Array.isArray(managers)).toBe(true);
+    for (const m of managers) {
+      expect(['brew', 'npm', 'apt', 'winget', 'scoop']).toContain(m);
+    }
+  });
+
+  it('npm is detected when available', async () => {
+    const managers = await detectPackageManagers();
+    // npm/bun should be available in test environment
+    expect(managers).toContain('npm');
+  });
+});
+
+describe('getInstallOptions', () => {
+  it('returns brew option for macOS with brew', () => {
+    const platform: PlatformInfo = {
+      os: 'darwin',
+      arch: 'arm64',
+      packageManagers: ['brew', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = getInstallOptions(platform);
+    expect(options.length).toBeGreaterThanOrEqual(2);
+    expect(options[0].label).toContain('Homebrew');
+    expect(options[0].command[0]).toBe('brew');
+  });
+
+  it('returns npm fallback for linux without apt', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['npm'],
+      isCorporateManaged: false,
+    };
+    const options = getInstallOptions(platform);
+    expect(options).toHaveLength(1);
+    expect(options[0].manager).toBe('npm');
+  });
+
+  it('returns winget for windows', () => {
+    const platform: PlatformInfo = {
+      os: 'win32',
+      arch: 'x64',
+      packageManagers: ['winget', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = getInstallOptions(platform);
+    expect(options[0].label).toContain('winget');
+  });
+
+  it('returns empty for no package managers', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: [],
+      isCorporateManaged: false,
+    };
+    const options = getInstallOptions(platform);
+    expect(options).toHaveLength(0);
+  });
+});
+
+describe('getAuthOptions', () => {
+  it('always includes web browser option first', () => {
+    const options = getAuthOptions();
+    expect(options[0].key).toBe('web');
+    expect(options[0].available).toBe(true);
+  });
+
+  it('includes sfdx_url option', () => {
+    const options = getAuthOptions();
+    const sfdx = options.find((o) => o.key === 'sfdx_url');
+    expect(sfdx).toBeDefined();
+  });
+
+  it('includes access_token option', () => {
+    const options = getAuthOptions();
+    const at = options.find((o) => o.key === 'access_token');
+    expect(at).toBeDefined();
+  });
+
+  it('includes jwt option', () => {
+    const options = getAuthOptions();
+    const jwt = options.find((o) => o.key === 'jwt');
+    expect(jwt).toBeDefined();
+  });
+});

--- a/plugins/salesforce/test/wizard.test.ts
+++ b/plugins/salesforce/test/wizard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test';
+import type { PlatformInfo } from '../src/platform';
+import { buildAuthStep, buildInstallStep, buildVerifyCommand } from '../src/wizard';
+
+describe('buildInstallStep', () => {
+  it('returns install options for macOS with brew', () => {
+    const platform: PlatformInfo = {
+      os: 'darwin',
+      arch: 'arm64',
+      packageManagers: ['brew', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    expect(options.length).toBeGreaterThanOrEqual(2);
+    expect(options[0].label).toContain('Homebrew');
+    expect(options[0].command[0]).toBe('brew');
+  });
+
+  it('returns npm fallback for linux without apt', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['npm'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    expect(options).toHaveLength(1);
+    expect(options[0].manager).toBe('npm');
+  });
+
+  it('returns winget for windows', () => {
+    const platform: PlatformInfo = {
+      os: 'win32',
+      arch: 'x64',
+      packageManagers: ['winget', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    expect(options[0].label).toContain('winget');
+  });
+});
+
+describe('buildAuthStep', () => {
+  it('always includes web browser option first', () => {
+    const options = buildAuthStep();
+    expect(options[0].key).toBe('web');
+    expect(options[0].available).toBe(true);
+  });
+});
+
+describe('buildVerifyCommand', () => {
+  it('returns the sf org display command with alias', () => {
+    const cmd = buildVerifyCommand('SFDC');
+    expect(cmd).toEqual(['sf', 'org', 'display', '--target-org', 'SFDC', '--json']);
+  });
+
+  it('uses provided alias', () => {
+    const cmd = buildVerifyCommand('my-org');
+    expect(cmd).toContain('my-org');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `/salesforce:setup` command — multi-step wizard for CLI installation and authentication
- Cross-platform: detects OS (macOS/Linux/Windows), available package managers (brew/apt/winget/scoop/npm), corporate MDM status
- CLI install: selects appropriate package manager, confirms with user, executes, verifies, reloads extensions
- Authentication: offers web browser, SFDX URL (via temp file, cross-platform), access token, JWT bearer flow
- Auto-prompt: welcome screen shows "run: /salesforce:setup" when CLI missing
- Command registered unconditionally (works before sf CLI is installed)
- Service status updated: shows unavailable/unauthenticated with setup hint
- Reviewed by Codex: all P1/P2 issues fixed (exitCode→code, ctx.reload, Windows where/which, POSIX sh removal)

## New files
- `src/platform.ts` — platform detection (OS, arch, package managers, MDM)
- `src/wizard.ts` — setup wizard using Extension API (select, confirm, notify, exec)
- `test/platform.test.ts` — 14 tests
- `test/wizard.test.ts` — 6 tests

## Modified files
- `src/index.ts` — register command unconditionally, restructured flow
- `hooks/hooks.json` — cross-platform CLI check (no brew hardcode)
- `test/integration/extension-load.test.ts` — wizard command registration test
- `scripts/tests/test_structure.sh` — cross-platform hook test

Closes #504

## Test plan
- [x] 138 bun tests pass (0 failures)
- [x] Shell validation tests pass
- [x] Marketplace validation passes
- [x] Codex review: 0 remaining P1/P2