### PR TITLE
fix(salesforce): correct homebrew formula name from @salesforce/cli to sf

### DIFF
--- a/plugins/salesforce/src/platform.ts
+++ b/plugins/salesforce/src/platform.ts
@@ -81,7 +81,7 @@ export function getInstallOptions(
   if (info.os === 'darwin' && info.packageManagers.includes('brew')) {
     options.push({
       label: 'Homebrew (recommended)',
-      command: ['brew', 'install', '@salesforce/cli'],
+      command: ['brew', 'install', 'sf'],
       manager: 'brew',
     });
   }


### PR DESCRIPTION
## Summary
- Fix: `brew install @salesforce/cli` to `brew install sf`
- The correct homebrew formula name is `sf`, not the npm package name
- Found during UAT: wizard install step failed with "No available formula with the name cli"

Closes #510

## Test plan
- [x] 147 bun tests pass
- [ ] CI checks pass
- [ ] Verify `brew install sf` resolves correctly