### PR TITLE
fix(salesforce): remove ctx.reload() that hangs after CLI install

### DIFF
--- a/plugins/salesforce/src/wizard.ts
+++ b/plugins/salesforce/src/wizard.ts
@@ -187,7 +187,10 @@ export async function runSetupWizard(
 
     const ver = await pi.exec('sf', ['--version']);
     ctx.ui.notify(`Salesforce CLI installed: ${ver.stdout.trim()}`, 'info');
-    if (ctx.reload) await ctx.reload();
+    ctx.ui.notify(
+      'Restart xcsh to activate Salesforce tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report).',
+      'info',
+    );
   } else {
     const ver = await pi.exec('sf', ['--version']);
     ctx.ui.notify(`Salesforce CLI: ${ver.stdout.trim()}`, 'info');

--- a/plugins/salesforce/test/wizard.test.ts
+++ b/plugins/salesforce/test/wizard.test.ts
@@ -235,7 +235,7 @@ describe('runSetupWizard — sf not installed', () => {
     },
   };
 
-  it('auto-installs via preferred package manager and reloads', async () => {
+  it('auto-installs via preferred package manager and notifies restart', async () => {
     installCount = 0;
     const { pi, calls } = buildMockPi({
       'brew install sf': { stdout: 'installed', stderr: '', code: 0 },
@@ -246,7 +246,7 @@ describe('runSetupWizard — sf not installed', () => {
         code: 0,
       },
     });
-    const { ctx, notifications, wasReloadCalled } = buildMockCtx({
+    const { ctx, notifications } = buildMockCtx({
       selectResponses: ['https://login.salesforce.com (standard)'],
     });
 
@@ -256,7 +256,7 @@ describe('runSetupWizard — sf not installed', () => {
     expect(installCall).toBeDefined();
     expect(installCall?.args).toEqual(['install', 'sf']);
     expect(notifications.find((n) => n.message.includes('installed'))?.message).toContain('2.50.0');
-    expect(wasReloadCalled()).toBe(true);
+    expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
   });
 
   it('install failure shows error', async () => {


### PR DESCRIPTION
## Summary
- Remove `ctx.reload()` call after CLI install — it hangs the session by triggering a full extension reload mid-command
- Replace with a notification: "Restart xcsh to activate Salesforce tools"
- Updated test assertion from `wasReloadCalled()` to checking restart notification

Closes #516

## Test plan
- [x] 148 bun tests pass
- [ ] CI checks pass