### PR TITLE
feat: add setup wizards to all cloud connector plugins

### DIFF
--- a/plugins/aws-status/src/index.ts
+++ b/plugins/aws-status/src/index.ts
@@ -3,34 +3,53 @@ import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('AWS Status');
 
-  try {
-    const which = Bun.spawnSync(['which', 'aws']);
-    if (which.exitCode !== 0) return;
-  } catch {
-    return;
+  // Always register setup command (even without aws CLI)
+  if (typeof pi.registerCommand === 'function') {
+    pi.registerCommand('aws-status:setup', {
+      description: 'Install and configure AWS CLI',
+      async handler(_args, ctx) {
+        const { runSetupWizard } = await import('./wizard');
+        await runSetupWizard(pi, ctx);
+      },
+    });
   }
 
+  // Check if aws CLI is available
+  let awsAvailable = false;
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    awsAvailable = Bun.spawnSync([checker, 'aws']).exitCode === 0;
+  } catch {
+    // aws not available
+  }
+
+  // Always register service status (shows unavailable when CLI missing)
   if (typeof pi.registerServiceStatus === 'function') {
     pi.registerServiceStatus({
       name: 'AWS',
       async check() {
         try {
+          const whichChecker = process.platform === 'win32' ? 'where' : 'which';
+          const whichResult = Bun.spawnSync([whichChecker, 'aws']);
+          if (whichResult.exitCode !== 0) {
+            return { state: 'unavailable', hint: 'run: /aws-status:setup' };
+          }
           const result = Bun.spawnSync(['aws', 'sts', 'get-caller-identity', '--output', 'json']);
           if (result.exitCode === 0) return { state: 'connected' };
           const stderr = new TextDecoder().decode(result.stderr).toLowerCase();
           if (stderr.includes('sso token') || stderr.includes('expired'))
             return {
               state: 'unauthenticated',
-              hint: 'SSO expired, run: aws sso login',
+              hint: 'SSO expired, run: /aws-status:setup',
             };
           if (stderr.includes('could not find profile') || stderr.includes('profile'))
             return {
               state: 'unauthenticated',
-              hint: 'profile not found, run: aws configure',
+              hint: 'profile not found, run: /aws-status:setup',
             };
           if (stderr.includes('could not connect') || stderr.includes('network'))
             return { state: 'unavailable', hint: 'network error' };
-          return { state: 'unauthenticated', hint: 'run: aws configure' };
+          return { state: 'unauthenticated', hint: 'run: /aws-status:setup' };
         } catch {
           return { state: 'unavailable', hint: 'aws CLI check failed' };
         }
@@ -39,6 +58,15 @@ const factory: ExtensionFactory = async (pi) => {
         prompt: 'AWS SSO session expired',
         command: ['aws', 'sso', 'login'],
       },
+    });
+  }
+
+  // Session start: notify if CLI missing
+  if (typeof pi.on === 'function') {
+    pi.on('session_start', async (_event: unknown, _ctx: { cwd: string }) => {
+      if (!awsAvailable) {
+        pi.logger.debug('AWS: aws CLI not found');
+      }
     });
   }
 };

--- a/plugins/aws-status/src/platform.ts
+++ b/plugins/aws-status/src/platform.ts
@@ -1,0 +1,70 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type PackageManager = 'brew' | 'npm' | 'apt' | 'winget' | 'scoop';
+
+export interface PlatformInfo {
+  os: 'darwin' | 'linux' | 'win32';
+  arch: string;
+  packageManagers: PackageManager[];
+  isCorporateManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}
+
+function which(cmd: string): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, cmd]).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectPackageManagers(): Promise<PackageManager[]> {
+  const managers: PackageManager[] = [];
+  const platform = process.platform;
+
+  if (platform === 'darwin' && which('brew')) managers.push('brew');
+  if (platform === 'linux' && which('apt')) managers.push('apt');
+  if (platform === 'win32' && which('winget')) managers.push('winget');
+  if (platform === 'win32' && which('scoop')) managers.push('scoop');
+  if (which('npm')) managers.push('npm');
+
+  return managers;
+}
+
+async function detectCorporateManagement(): Promise<{
+  isManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}> {
+  try {
+    const profilePath = path.join(os.homedir(), '.xcsh', 'computer-profile.json');
+    const file = Bun.file(profilePath);
+    if (!(await file.exists())) return { isManaged: false };
+    const profile = await file.json();
+    const mgmt = profile.management;
+    if (!mgmt?.isManaged) return { isManaged: false };
+    return {
+      isManaged: true,
+      mdmVendor: mgmt.mdmVendor,
+      organizationName: mgmt.organizationName,
+    };
+  } catch {
+    return { isManaged: false };
+  }
+}
+
+export async function detectPlatform(): Promise<PlatformInfo> {
+  const [packageManagers, corporate] = await Promise.all([detectPackageManagers(), detectCorporateManagement()]);
+
+  return {
+    os: process.platform as PlatformInfo['os'],
+    arch: os.arch(),
+    packageManagers,
+    isCorporateManaged: corporate.isManaged,
+    mdmVendor: corporate.mdmVendor,
+    organizationName: corporate.organizationName,
+  };
+}

--- a/plugins/aws-status/src/wizard.ts
+++ b/plugins/aws-status/src/wizard.ts
@@ -1,0 +1,202 @@
+import { detectPlatform, type PlatformInfo } from './platform';
+
+export function buildInstallStep(platform: PlatformInfo): Array<{ label: string; command: string[]; manager: string }> {
+  const options: Array<{ label: string; command: string[]; manager: string }> = [];
+
+  if (platform.os === 'darwin' && platform.packageManagers.includes('brew')) {
+    options.push({
+      label: 'Homebrew (recommended)',
+      command: ['brew', 'install', 'awscli'],
+      manager: 'brew',
+    });
+  }
+  if (platform.os === 'win32' && platform.packageManagers.includes('winget')) {
+    options.push({
+      label: 'winget (recommended)',
+      command: ['winget', 'install', 'Amazon.AWSCLI'],
+      manager: 'winget',
+    });
+  }
+  if (platform.os === 'linux' && platform.packageManagers.includes('apt')) {
+    options.push({
+      label: 'apt',
+      command: ['sudo', 'apt', 'install', '-y', 'awscli'],
+      manager: 'apt',
+    });
+  }
+
+  return options;
+}
+
+export function buildAuthStep(): Array<{
+  label: string;
+  key: string;
+  available: boolean;
+}> {
+  const options: Array<{ label: string; key: string; available: boolean }> = [];
+
+  options.push({
+    label: 'SSO login (recommended)',
+    key: 'sso',
+    available: true,
+  });
+
+  options.push({
+    label: 'Access keys (aws configure)',
+    key: 'access_keys',
+    available: true,
+  });
+
+  const hasEnvKeys = !!process.env.AWS_ACCESS_KEY_ID && !!process.env.AWS_SECRET_ACCESS_KEY;
+  options.push({
+    label: `Environment credentials${hasEnvKeys ? ' (detected)' : ''}`,
+    key: 'env',
+    available: hasEnvKeys,
+  });
+
+  return options;
+}
+
+export function buildVerifyCommand(): string[] {
+  return ['aws', 'sts', 'get-caller-identity', '--output', 'json'];
+}
+
+export function awsIsInstalled(): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, 'aws']).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function runSetupWizard(
+  pi: {
+    exec: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string; code: number }>;
+  },
+  ctx: {
+    ui: {
+      select: (title: string, options: string[]) => Promise<string | undefined>;
+      confirm: (title: string, message: string) => Promise<boolean>;
+      input: (title: string, placeholder?: string) => Promise<string | undefined>;
+      notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
+    };
+    cwd: string;
+    reload?: () => Promise<void>;
+  },
+  options?: { checkCliInstalled?: () => boolean },
+): Promise<void> {
+  const checkCli = options?.checkCliInstalled ?? awsIsInstalled;
+
+  // --- Platform detection (deterministic, no prompts) ---
+  const platform = await detectPlatform();
+  const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
+  ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
+
+  if (platform.isCorporateManaged) {
+    ctx.ui.notify(
+      `Corporate-managed device detected${platform.mdmVendor ? ` (${platform.mdmVendor})` : ''}. Automatic installation may be restricted.`,
+      'warning',
+    );
+  }
+
+  // --- CLI install (auto-select best option, only prompt on ambiguity) ---
+  if (!checkCli()) {
+    const installOptions = buildInstallStep(platform);
+    if (installOptions.length === 0) {
+      ctx.ui.notify(
+        'No package manager found. Install manually: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html',
+        'error',
+      );
+      return;
+    }
+
+    // Auto-select the first (preferred) option — only prompt if user needs to override
+    const preferred = installOptions[0];
+    ctx.ui.notify(`Installing via ${preferred.manager}: ${preferred.command.join(' ')}`, 'info');
+    const result = await pi.exec(preferred.command[0], preferred.command.slice(1));
+
+    if (result.code !== 0) {
+      ctx.ui.notify(`Installation failed (exit ${result.code}).`, 'error');
+      if (platform.isCorporateManaged) {
+        ctx.ui.notify('Corporate restrictions may apply. Contact IT for assistance.', 'warning');
+      }
+      // Offer fallback options if the preferred one failed
+      if (installOptions.length > 1) {
+        const fallbackLabels = installOptions.slice(1).map((o) => o.label);
+        fallbackLabels.push('Skip');
+        const fallback = await ctx.ui.select('Try an alternative installer?', fallbackLabels);
+        if (fallback && fallback !== 'Skip') {
+          const alt = installOptions.find((o) => o.label === fallback);
+          if (alt) {
+            ctx.ui.notify(`Installing via ${alt.manager}...`, 'info');
+            const altResult = await pi.exec(alt.command[0], alt.command.slice(1));
+            if (altResult.code !== 0) {
+              ctx.ui.notify('Alternative install also failed. Run /aws-status:setup to try again.', 'error');
+              return;
+            }
+          }
+        } else {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+
+    if (!checkCli()) {
+      ctx.ui.notify('aws CLI not found after install. You may need to restart your terminal.', 'error');
+      return;
+    }
+
+    const ver = await pi.exec('aws', ['--version']);
+    ctx.ui.notify(`AWS CLI installed: ${ver.stdout.trim()}`, 'info');
+    ctx.ui.notify('Restart xcsh to activate AWS tools.', 'info');
+  } else {
+    const ver = await pi.exec('aws', ['--version']);
+    ctx.ui.notify(`AWS CLI: ${ver.stdout.trim()}`, 'info');
+  }
+
+  // --- Auth (auto-detect best method, only prompt on ambiguity) ---
+  const authOptions = buildAuthStep();
+  const envDetected = authOptions.filter((o) => o.available && o.key !== 'sso' && o.key !== 'access_keys');
+
+  if (envDetected.length > 0) {
+    // Environment credentials detected — verify directly, no login command needed
+    ctx.ui.notify(`Using ${envDetected[0].label} (credentials detected in environment)`, 'info');
+  } else {
+    // No env credentials — default to SSO login
+    ctx.ui.notify('Starting SSO authentication...', 'info');
+    const authCmd = buildAuthCommand('sso');
+    const authResult = await pi.exec(authCmd[0], authCmd.slice(1));
+    if (authResult.code !== 0) {
+      ctx.ui.notify(`Authentication failed: ${authResult.stderr || authResult.stdout}`, 'error');
+      return;
+    }
+  }
+
+  // --- Verify (deterministic) ---
+  const verifyCmd = buildVerifyCommand();
+  const verifyResult = await pi.exec(verifyCmd[0], verifyCmd.slice(1));
+  if (verifyResult.code === 0) {
+    try {
+      const data = JSON.parse(verifyResult.stdout);
+      ctx.ui.notify(`AWS ready! Connected as ${data.Arn || 'unknown'} (account ${data.Account || 'unknown'})`, 'info');
+    } catch {
+      ctx.ui.notify('AWS authenticated. Run /aws-status:setup to confirm.', 'info');
+    }
+  } else {
+    ctx.ui.notify('Authentication may have succeeded. Run /aws-status:setup to verify.', 'warning');
+  }
+}
+
+function buildAuthCommand(key: string): string[] {
+  switch (key) {
+    case 'sso':
+      return ['aws', 'configure', 'sso'];
+    case 'access_keys':
+      return ['aws', 'configure'];
+    default:
+      return ['aws', 'configure', 'sso'];
+  }
+}

--- a/plugins/aws-status/test/extension.test.ts
+++ b/plugins/aws-status/test/extension.test.ts
@@ -17,6 +17,7 @@ describe('AWS Status extension', () => {
     const mockPi = {
       setLabel() {},
       logger: { debug() {} },
+      registerCommand() {},
       registerServiceStatus(c: { name: string }) {
         registered.push(c);
       },
@@ -34,6 +35,7 @@ describe('AWS Status extension', () => {
     const mockPi = {
       setLabel() {},
       logger: { debug() {} },
+      registerCommand() {},
       registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
         checkFn = c.check;
       },

--- a/plugins/aws-status/test/wizard.test.ts
+++ b/plugins/aws-status/test/wizard.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'bun:test';
+import type { PlatformInfo } from '../src/platform';
+import { buildAuthStep, buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
+
+// ---------------------------------------------------------------------------
+// Helper builders — exact command assertions
+// ---------------------------------------------------------------------------
+
+describe('buildInstallStep', () => {
+  it('macOS brew command is exactly brew install awscli', () => {
+    const platform: PlatformInfo = {
+      os: 'darwin',
+      arch: 'arm64',
+      packageManagers: ['brew', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    const brew = options.find((o) => o.manager === 'brew');
+    expect(brew).toBeDefined();
+    expect(brew?.command).toEqual(['brew', 'install', 'awscli']);
+  });
+
+  it('winget command is winget install Amazon.AWSCLI', () => {
+    const platform: PlatformInfo = {
+      os: 'win32',
+      arch: 'x64',
+      packageManagers: ['winget', 'npm'],
+      isCorporateManaged: false,
+    };
+    const winget = buildInstallStep(platform).find((o) => o.manager === 'winget');
+    expect(winget?.command).toEqual(['winget', 'install', 'Amazon.AWSCLI']);
+  });
+
+  it('apt command is sudo apt install -y awscli', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['apt', 'npm'],
+      isCorporateManaged: false,
+    };
+    const apt = buildInstallStep(platform).find((o) => o.manager === 'apt');
+    expect(apt?.command).toEqual(['sudo', 'apt', 'install', '-y', 'awscli']);
+  });
+
+  it('returns empty when no package managers available', () => {
+    const platform: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+    expect(buildInstallStep(platform)).toHaveLength(0);
+  });
+});
+
+describe('buildAuthStep', () => {
+  it('always includes SSO option first', () => {
+    const options = buildAuthStep();
+    expect(options[0].key).toBe('sso');
+    expect(options[0].available).toBe(true);
+  });
+
+  it('includes all 3 auth methods', () => {
+    expect(buildAuthStep().map((o) => o.key)).toEqual(['sso', 'access_keys', 'env']);
+  });
+});
+
+describe('buildVerifyCommand', () => {
+  it('returns exact aws sts get-caller-identity command', () => {
+    expect(buildVerifyCommand()).toEqual(['aws', 'sts', 'get-caller-identity', '--output', 'json']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mock builders
+// ---------------------------------------------------------------------------
+
+function buildMockCtx(overrides?: {
+  selectResponses?: Array<string | undefined>;
+  inputResponses?: Array<string | undefined>;
+}) {
+  const notifications: Array<{ message: string; type?: string }> = [];
+  let selectIndex = 0;
+  let inputIndex = 0;
+  const selectResponses = overrides?.selectResponses ?? [];
+  const inputResponses = overrides?.inputResponses ?? [];
+  let reloadCalled = false;
+
+  return {
+    ctx: {
+      ui: {
+        select(_title: string, _options: string[]) {
+          return Promise.resolve(selectResponses[selectIndex++]);
+        },
+        confirm(_title: string, _message: string) {
+          return Promise.resolve(true);
+        },
+        input(_title: string, _placeholder?: string) {
+          return Promise.resolve(inputResponses[inputIndex++]);
+        },
+        notify(message: string, type?: string) {
+          notifications.push({ message, type });
+        },
+      },
+      cwd: '/tmp',
+      async reload() {
+        reloadCalled = true;
+      },
+    },
+    notifications,
+    wasReloadCalled: () => reloadCalled,
+  };
+}
+
+function buildMockPi(execResponses?: Record<string, { stdout: string; stderr: string; code: number }>) {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  return {
+    pi: {
+      async exec(cmd: string, args: string[]) {
+        calls.push({ cmd, args });
+        const key = [cmd, ...args].join(' ');
+        for (const [pattern, response] of Object.entries(execResponses ?? {})) {
+          if (key.includes(pattern)) return response;
+        }
+        return { stdout: '', stderr: '', code: 0 };
+      },
+    },
+    calls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — aws already installed, SSO auth (deterministic flow)
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — aws installed, SSO auth', () => {
+  const awsInstalled = { checkCliInstalled: () => true };
+
+  it('reports version then proceeds to auth', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'aws-cli/2.15.0 Python/3.11.0', stderr: '', code: 0 },
+      'get-caller-identity': {
+        stdout: JSON.stringify({ Account: '123456789012', Arn: 'arn:aws:iam::123456789012:user/test' }),
+        stderr: '',
+        code: 0,
+      },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, awsInstalled);
+
+    expect(notifications.find((n) => n.message.includes('2.15.0'))).toBeDefined();
+    expect(notifications.find((n) => n.message.includes('AWS ready'))).toBeDefined();
+  });
+
+  it('handles auth failure', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'aws-cli/2.15.0', stderr: '', code: 0 },
+      'configure sso': { stdout: '', stderr: 'TIMEOUT', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, awsInstalled);
+
+    expect(notifications.find((n) => n.message.includes('Authentication failed'))?.type).toBe('error');
+  });
+
+  it('handles verify failure with warning', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'aws-cli/2.15.0', stderr: '', code: 0 },
+      'get-caller-identity': { stdout: '', stderr: 'error', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, awsInstalled);
+
+    expect(notifications.find((n) => n.message.includes('may have succeeded'))?.type).toBe('warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — aws NOT installed (auto-install flow)
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — aws not installed', () => {
+  let installCount = 0;
+  const awsNotInstalledThenInstalled = {
+    checkCliInstalled: () => {
+      installCount++;
+      return installCount > 1;
+    },
+  };
+
+  it('auto-installs via preferred package manager and notifies restart', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'brew install awscli': { stdout: 'installed', stderr: '', code: 0 },
+      '--version': { stdout: 'aws-cli/2.15.0 Python/3.11.0', stderr: '', code: 0 },
+      'get-caller-identity': {
+        stdout: JSON.stringify({ Account: '123456789012', Arn: 'arn:aws:iam::123456789012:user/test' }),
+        stderr: '',
+        code: 0,
+      },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, awsNotInstalledThenInstalled);
+
+    const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('awscli'));
+    expect(installCall).toBeDefined();
+    expect(installCall?.args).toEqual(['install', 'awscli']);
+    expect(notifications.find((n) => n.message.includes('installed'))?.message).toContain('2.15.0');
+    expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
+  });
+
+  it('install failure shows error', async () => {
+    const { pi } = buildMockPi({
+      'brew install awscli': { stdout: '', stderr: 'permission denied', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false });
+
+    expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification ordering
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — notifications', () => {
+  it('first notification is platform detection', async () => {
+    const { pi } = buildMockPi({ '--version': { stdout: 'aws-cli/2.15.0', stderr: '', code: 0 } });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => true });
+
+    expect(notifications[0].message).toContain('Detected:');
+  });
+});

--- a/plugins/azure-status/src/index.ts
+++ b/plugins/azure-status/src/index.ts
@@ -3,21 +3,40 @@ import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('Azure Status');
 
-  try {
-    const which = Bun.spawnSync(['which', 'az']);
-    if (which.exitCode !== 0) return;
-  } catch {
-    return;
+  // Always register setup command (even without az CLI)
+  if (typeof pi.registerCommand === 'function') {
+    pi.registerCommand('azure-status:setup', {
+      description: 'Install and configure Azure CLI',
+      async handler(_args, ctx) {
+        const { runSetupWizard } = await import('./wizard');
+        await runSetupWizard(pi, ctx);
+      },
+    });
   }
 
+  // Check if az CLI is available
+  let azAvailable = false;
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    azAvailable = Bun.spawnSync([checker, 'az']).exitCode === 0;
+  } catch {
+    // az not available
+  }
+
+  // Always register service status (shows unavailable when CLI missing)
   if (typeof pi.registerServiceStatus === 'function') {
     pi.registerServiceStatus({
       name: 'Azure',
       async check() {
         try {
+          const whichChecker = process.platform === 'win32' ? 'where' : 'which';
+          const whichResult = Bun.spawnSync([whichChecker, 'az']);
+          if (whichResult.exitCode !== 0) {
+            return { state: 'unavailable', hint: 'run: /azure-status:setup' };
+          }
           const result = Bun.spawnSync(['az', 'account', 'show', '--output', 'json']);
           if (result.exitCode === 0) return { state: 'connected' };
-          return { state: 'unauthenticated', hint: 'run: az login' };
+          return { state: 'unauthenticated', hint: 'run: /azure-status:setup' };
         } catch {
           return { state: 'unavailable', hint: 'az CLI check failed' };
         }
@@ -26,6 +45,15 @@ const factory: ExtensionFactory = async (pi) => {
         prompt: 'Azure session expired',
         command: ['az', 'login', '--use-device-code'],
       },
+    });
+  }
+
+  // Session start: notify if CLI missing
+  if (typeof pi.on === 'function') {
+    pi.on('session_start', async (_event: unknown, _ctx: { cwd: string }) => {
+      if (!azAvailable) {
+        pi.logger.debug('Azure: az CLI not found');
+      }
     });
   }
 };

--- a/plugins/azure-status/src/platform.ts
+++ b/plugins/azure-status/src/platform.ts
@@ -1,0 +1,70 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type PackageManager = 'brew' | 'npm' | 'apt' | 'winget' | 'scoop';
+
+export interface PlatformInfo {
+  os: 'darwin' | 'linux' | 'win32';
+  arch: string;
+  packageManagers: PackageManager[];
+  isCorporateManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}
+
+function which(cmd: string): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, cmd]).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectPackageManagers(): Promise<PackageManager[]> {
+  const managers: PackageManager[] = [];
+  const platform = process.platform;
+
+  if (platform === 'darwin' && which('brew')) managers.push('brew');
+  if (platform === 'linux' && which('apt')) managers.push('apt');
+  if (platform === 'win32' && which('winget')) managers.push('winget');
+  if (platform === 'win32' && which('scoop')) managers.push('scoop');
+  if (which('npm')) managers.push('npm');
+
+  return managers;
+}
+
+async function detectCorporateManagement(): Promise<{
+  isManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}> {
+  try {
+    const profilePath = path.join(os.homedir(), '.xcsh', 'computer-profile.json');
+    const file = Bun.file(profilePath);
+    if (!(await file.exists())) return { isManaged: false };
+    const profile = await file.json();
+    const mgmt = profile.management;
+    if (!mgmt?.isManaged) return { isManaged: false };
+    return {
+      isManaged: true,
+      mdmVendor: mgmt.mdmVendor,
+      organizationName: mgmt.organizationName,
+    };
+  } catch {
+    return { isManaged: false };
+  }
+}
+
+export async function detectPlatform(): Promise<PlatformInfo> {
+  const [packageManagers, corporate] = await Promise.all([detectPackageManagers(), detectCorporateManagement()]);
+
+  return {
+    os: process.platform as PlatformInfo['os'],
+    arch: os.arch(),
+    packageManagers,
+    isCorporateManaged: corporate.isManaged,
+    mdmVendor: corporate.mdmVendor,
+    organizationName: corporate.organizationName,
+  };
+}

--- a/plugins/azure-status/src/wizard.ts
+++ b/plugins/azure-status/src/wizard.ts
@@ -1,0 +1,225 @@
+import { detectPlatform, type PlatformInfo } from './platform';
+
+export function buildInstallStep(platform: PlatformInfo): Array<{ label: string; command: string[]; manager: string }> {
+  const options: Array<{ label: string; command: string[]; manager: string }> = [];
+
+  if (platform.os === 'darwin' && platform.packageManagers.includes('brew')) {
+    options.push({
+      label: 'Homebrew (recommended)',
+      command: ['brew', 'install', 'azure-cli'],
+      manager: 'brew',
+    });
+  }
+  if (platform.os === 'win32' && platform.packageManagers.includes('winget')) {
+    options.push({
+      label: 'winget (recommended)',
+      command: ['winget', 'install', 'Microsoft.AzureCLI'],
+      manager: 'winget',
+    });
+  }
+  if (platform.os === 'linux' && platform.packageManagers.includes('apt')) {
+    options.push({
+      label: 'apt',
+      command: ['sudo', 'apt', 'install', '-y', 'azure-cli'],
+      manager: 'apt',
+    });
+  }
+
+  return options;
+}
+
+export function buildAuthStep(): Array<{
+  label: string;
+  key: string;
+  available: boolean;
+}> {
+  const options: Array<{ label: string; key: string; available: boolean }> = [];
+
+  options.push({
+    label: 'Web browser (recommended)',
+    key: 'web',
+    available: true,
+  });
+
+  options.push({
+    label: 'Device code (headless / remote)',
+    key: 'device_code',
+    available: true,
+  });
+
+  const hasServicePrincipal =
+    !!process.env.AZURE_CLIENT_ID && !!process.env.AZURE_CLIENT_SECRET && !!process.env.AZURE_TENANT_ID;
+  options.push({
+    label: `Service Principal${hasServicePrincipal ? ' (detected)' : ''}`,
+    key: 'service_principal',
+    available: hasServicePrincipal,
+  });
+
+  return options;
+}
+
+export function buildVerifyCommand(): string[] {
+  return ['az', 'account', 'show', '--output', 'json'];
+}
+
+export function azIsInstalled(): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, 'az']).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function runSetupWizard(
+  pi: {
+    exec: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string; code: number }>;
+  },
+  ctx: {
+    ui: {
+      select: (title: string, options: string[]) => Promise<string | undefined>;
+      confirm: (title: string, message: string) => Promise<boolean>;
+      input: (title: string, placeholder?: string) => Promise<string | undefined>;
+      notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
+    };
+    cwd: string;
+    reload?: () => Promise<void>;
+  },
+  options?: { checkCliInstalled?: () => boolean },
+): Promise<void> {
+  const checkCli = options?.checkCliInstalled ?? azIsInstalled;
+
+  // --- Platform detection (deterministic, no prompts) ---
+  const platform = await detectPlatform();
+  const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
+  ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
+
+  if (platform.isCorporateManaged) {
+    ctx.ui.notify(
+      `Corporate-managed device detected${platform.mdmVendor ? ` (${platform.mdmVendor})` : ''}. Automatic installation may be restricted.`,
+      'warning',
+    );
+  }
+
+  // --- CLI install (auto-select best option, only prompt on ambiguity) ---
+  if (!checkCli()) {
+    const installOptions = buildInstallStep(platform);
+    if (installOptions.length === 0) {
+      ctx.ui.notify(
+        'No package manager found. Install manually: https://learn.microsoft.com/cli/azure/install-azure-cli',
+        'error',
+      );
+      return;
+    }
+
+    // Auto-select the first (preferred) option — only prompt if user needs to override
+    const preferred = installOptions[0];
+    ctx.ui.notify(`Installing via ${preferred.manager}: ${preferred.command.join(' ')}`, 'info');
+    const result = await pi.exec(preferred.command[0], preferred.command.slice(1));
+
+    if (result.code !== 0) {
+      ctx.ui.notify(`Installation failed (exit ${result.code}).`, 'error');
+      if (platform.isCorporateManaged) {
+        ctx.ui.notify('Corporate restrictions may apply. Contact IT for assistance.', 'warning');
+      }
+      // Offer fallback options if the preferred one failed
+      if (installOptions.length > 1) {
+        const fallbackLabels = installOptions.slice(1).map((o) => o.label);
+        fallbackLabels.push('Skip');
+        const fallback = await ctx.ui.select('Try an alternative installer?', fallbackLabels);
+        if (fallback && fallback !== 'Skip') {
+          const alt = installOptions.find((o) => o.label === fallback);
+          if (alt) {
+            ctx.ui.notify(`Installing via ${alt.manager}...`, 'info');
+            const altResult = await pi.exec(alt.command[0], alt.command.slice(1));
+            if (altResult.code !== 0) {
+              ctx.ui.notify('Alternative install also failed. Run /azure-status:setup to try again.', 'error');
+              return;
+            }
+          }
+        } else {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+
+    if (!checkCli()) {
+      ctx.ui.notify('az CLI not found after install. You may need to restart your terminal.', 'error');
+      return;
+    }
+
+    const ver = await pi.exec('az', ['--version']);
+    ctx.ui.notify(`Azure CLI installed: ${ver.stdout.split('\n')[0].trim()}`, 'info');
+    ctx.ui.notify('Restart xcsh to activate Azure tools.', 'info');
+  } else {
+    const ver = await pi.exec('az', ['--version']);
+    ctx.ui.notify(`Azure CLI: ${ver.stdout.split('\n')[0].trim()}`, 'info');
+  }
+
+  // --- Auth (auto-detect best method, only prompt on ambiguity) ---
+  const authOptions = buildAuthStep();
+  const envDetected = authOptions.filter((o) => o.available && o.key !== 'web' && o.key !== 'device_code');
+
+  if (envDetected.length > 0) {
+    // Environment credentials detected — use service principal automatically
+    const best = envDetected[0];
+    ctx.ui.notify(`Using ${best.label} (credentials detected in environment)`, 'info');
+    const authCmd = buildAuthCommand(best.key);
+    const authResult = await pi.exec(authCmd[0], authCmd.slice(1));
+    if (authResult.code !== 0) {
+      ctx.ui.notify(`Authentication failed: ${authResult.stderr || authResult.stdout}`, 'error');
+      return;
+    }
+  } else {
+    // No env credentials — default to browser login
+    ctx.ui.notify('Opening browser for authentication...', 'info');
+    const authCmd = buildAuthCommand('web');
+    const authResult = await pi.exec(authCmd[0], authCmd.slice(1));
+    if (authResult.code !== 0) {
+      ctx.ui.notify(`Authentication failed: ${authResult.stderr || authResult.stdout}`, 'error');
+      return;
+    }
+  }
+
+  // --- Verify (deterministic) ---
+  const verifyCmd = buildVerifyCommand();
+  const verifyResult = await pi.exec(verifyCmd[0], verifyCmd.slice(1));
+  if (verifyResult.code === 0) {
+    try {
+      const data = JSON.parse(verifyResult.stdout);
+      ctx.ui.notify(
+        `Azure ready! Connected as ${data.user?.name || 'unknown'} to subscription ${data.name || 'unknown'}`,
+        'info',
+      );
+    } catch {
+      ctx.ui.notify('Azure authenticated. Run /azure-status:setup to confirm.', 'info');
+    }
+  } else {
+    ctx.ui.notify('Authentication may have succeeded. Run /azure-status:setup to verify.', 'warning');
+  }
+}
+
+function buildAuthCommand(key: string): string[] {
+  switch (key) {
+    case 'web':
+      return ['az', 'login'];
+    case 'device_code':
+      return ['az', 'login', '--use-device-code'];
+    case 'service_principal':
+      return [
+        'az',
+        'login',
+        '--service-principal',
+        '--username',
+        process.env.AZURE_CLIENT_ID || '',
+        '--password',
+        process.env.AZURE_CLIENT_SECRET || '',
+        '--tenant',
+        process.env.AZURE_TENANT_ID || '',
+      ];
+    default:
+      return ['az', 'login'];
+  }
+}

--- a/plugins/azure-status/test/extension.test.ts
+++ b/plugins/azure-status/test/extension.test.ts
@@ -17,6 +17,7 @@ describe('Azure Status extension', () => {
     const mockPi = {
       setLabel() {},
       logger: { debug() {} },
+      registerCommand() {},
       registerServiceStatus(c: { name: string }) {
         registered.push(c);
       },
@@ -34,6 +35,7 @@ describe('Azure Status extension', () => {
     const mockPi = {
       setLabel() {},
       logger: { debug() {} },
+      registerCommand() {},
       registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
         checkFn = c.check;
       },

--- a/plugins/azure-status/test/wizard.test.ts
+++ b/plugins/azure-status/test/wizard.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from 'bun:test';
+import type { PlatformInfo } from '../src/platform';
+import { buildAuthStep, buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
+
+// ---------------------------------------------------------------------------
+// Helper builders — exact command assertions
+// ---------------------------------------------------------------------------
+
+describe('buildInstallStep', () => {
+  it('macOS brew command is exactly brew install azure-cli', () => {
+    const platform: PlatformInfo = {
+      os: 'darwin',
+      arch: 'arm64',
+      packageManagers: ['brew', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    const brew = options.find((o) => o.manager === 'brew');
+    expect(brew).toBeDefined();
+    expect(brew?.command).toEqual(['brew', 'install', 'azure-cli']);
+  });
+
+  it('winget command is winget install Microsoft.AzureCLI', () => {
+    const platform: PlatformInfo = {
+      os: 'win32',
+      arch: 'x64',
+      packageManagers: ['winget', 'npm'],
+      isCorporateManaged: false,
+    };
+    const winget = buildInstallStep(platform).find((o) => o.manager === 'winget');
+    expect(winget?.command).toEqual(['winget', 'install', 'Microsoft.AzureCLI']);
+  });
+
+  it('apt command is sudo apt install -y azure-cli', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['apt', 'npm'],
+      isCorporateManaged: false,
+    };
+    const apt = buildInstallStep(platform).find((o) => o.manager === 'apt');
+    expect(apt?.command).toEqual(['sudo', 'apt', 'install', '-y', 'azure-cli']);
+  });
+
+  it('returns empty when no package managers available', () => {
+    const platform: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+    expect(buildInstallStep(platform)).toHaveLength(0);
+  });
+});
+
+describe('buildAuthStep', () => {
+  it('always includes web browser option first', () => {
+    const options = buildAuthStep();
+    expect(options[0].key).toBe('web');
+    expect(options[0].available).toBe(true);
+  });
+
+  it('includes all 3 auth methods', () => {
+    expect(buildAuthStep().map((o) => o.key)).toEqual(['web', 'device_code', 'service_principal']);
+  });
+});
+
+describe('buildVerifyCommand', () => {
+  it('returns exact az account show command', () => {
+    expect(buildVerifyCommand()).toEqual(['az', 'account', 'show', '--output', 'json']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mock builders
+// ---------------------------------------------------------------------------
+
+function buildMockCtx(overrides?: {
+  selectResponses?: Array<string | undefined>;
+  inputResponses?: Array<string | undefined>;
+}) {
+  const notifications: Array<{ message: string; type?: string }> = [];
+  let selectIndex = 0;
+  let inputIndex = 0;
+  const selectResponses = overrides?.selectResponses ?? [];
+  const inputResponses = overrides?.inputResponses ?? [];
+  let reloadCalled = false;
+
+  return {
+    ctx: {
+      ui: {
+        select(_title: string, _options: string[]) {
+          return Promise.resolve(selectResponses[selectIndex++]);
+        },
+        confirm(_title: string, _message: string) {
+          return Promise.resolve(true);
+        },
+        input(_title: string, _placeholder?: string) {
+          return Promise.resolve(inputResponses[inputIndex++]);
+        },
+        notify(message: string, type?: string) {
+          notifications.push({ message, type });
+        },
+      },
+      cwd: '/tmp',
+      async reload() {
+        reloadCalled = true;
+      },
+    },
+    notifications,
+    wasReloadCalled: () => reloadCalled,
+  };
+}
+
+function buildMockPi(execResponses?: Record<string, { stdout: string; stderr: string; code: number }>) {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  return {
+    pi: {
+      async exec(cmd: string, args: string[]) {
+        calls.push({ cmd, args });
+        const key = [cmd, ...args].join(' ');
+        for (const [pattern, response] of Object.entries(execResponses ?? {})) {
+          if (key.includes(pattern)) return response;
+        }
+        return { stdout: '', stderr: '', code: 0 };
+      },
+    },
+    calls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — az already installed, web auth (deterministic flow)
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — az installed, web auth', () => {
+  const azInstalled = { checkCliInstalled: () => true };
+
+  it('reports version then proceeds to auth', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'azure-cli 2.60.0\n', stderr: '', code: 0 },
+      'account show': {
+        stdout: JSON.stringify({ user: { name: 'user@test.com' }, name: 'Test Subscription' }),
+        stderr: '',
+        code: 0,
+      },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, azInstalled);
+
+    expect(notifications.find((n) => n.message.includes('2.60.0'))).toBeDefined();
+    expect(notifications.find((n) => n.message.includes('Azure ready'))).toBeDefined();
+  });
+
+  it('handles auth failure', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'azure-cli 2.60.0', stderr: '', code: 0 },
+      'az login': { stdout: '', stderr: 'TIMEOUT', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, azInstalled);
+
+    expect(notifications.find((n) => n.message.includes('Authentication failed'))?.type).toBe('error');
+  });
+
+  it('handles verify failure with warning', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'azure-cli 2.60.0', stderr: '', code: 0 },
+      'account show': { stdout: '', stderr: 'error', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, azInstalled);
+
+    expect(notifications.find((n) => n.message.includes('may have succeeded'))?.type).toBe('warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — az NOT installed (auto-install flow)
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — az not installed', () => {
+  let installCount = 0;
+  const azNotInstalledThenInstalled = {
+    checkCliInstalled: () => {
+      installCount++;
+      return installCount > 1;
+    },
+  };
+
+  it('auto-installs via preferred package manager and notifies restart', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'brew install azure-cli': { stdout: 'installed', stderr: '', code: 0 },
+      '--version': { stdout: 'azure-cli 2.60.0\n', stderr: '', code: 0 },
+      'account show': {
+        stdout: JSON.stringify({ user: { name: 'u@t.com' }, name: 'Test Sub' }),
+        stderr: '',
+        code: 0,
+      },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, azNotInstalledThenInstalled);
+
+    const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('azure-cli'));
+    expect(installCall).toBeDefined();
+    expect(installCall?.args).toEqual(['install', 'azure-cli']);
+    expect(notifications.find((n) => n.message.includes('installed'))?.message).toContain('2.60.0');
+    expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
+  });
+
+  it('install failure shows error', async () => {
+    const { pi } = buildMockPi({
+      'brew install azure-cli': { stdout: '', stderr: 'permission denied', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false });
+
+    expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification ordering
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — notifications', () => {
+  it('first notification is platform detection', async () => {
+    const { pi } = buildMockPi({ '--version': { stdout: 'azure-cli 2.60.0', stderr: '', code: 0 } });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => true });
+
+    expect(notifications[0].message).toContain('Detected:');
+  });
+});

--- a/plugins/gcloud-status/src/index.ts
+++ b/plugins/gcloud-status/src/index.ts
@@ -3,29 +3,48 @@ import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('GCloud Status');
 
-  try {
-    const which = Bun.spawnSync(['which', 'gcloud']);
-    if (which.exitCode !== 0) return;
-  } catch {
-    return;
+  // Always register setup command (even without gcloud CLI)
+  if (typeof pi.registerCommand === 'function') {
+    pi.registerCommand('gcloud-status:setup', {
+      description: 'Install and configure Google Cloud CLI',
+      async handler(_args, ctx) {
+        const { runSetupWizard } = await import('./wizard');
+        await runSetupWizard(pi, ctx);
+      },
+    });
   }
 
+  // Check if gcloud CLI is available
+  let gcloudAvailable = false;
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    gcloudAvailable = Bun.spawnSync([checker, 'gcloud']).exitCode === 0;
+  } catch {
+    // gcloud not available
+  }
+
+  // Always register service status (shows unavailable when CLI missing)
   if (typeof pi.registerServiceStatus === 'function') {
     pi.registerServiceStatus({
       name: 'GCloud',
       async check() {
         try {
+          const whichChecker = process.platform === 'win32' ? 'where' : 'which';
+          const whichResult = Bun.spawnSync([whichChecker, 'gcloud']);
+          if (whichResult.exitCode !== 0) {
+            return { state: 'unavailable', hint: 'run: /gcloud-status:setup' };
+          }
           const result = Bun.spawnSync(['gcloud', 'auth', 'print-access-token', '--quiet']);
           if (result.exitCode === 0) return { state: 'connected' };
           const stderr = new TextDecoder().decode(result.stderr).toLowerCase();
           if (stderr.includes('expired') || stderr.includes('token'))
             return {
               state: 'unauthenticated',
-              hint: 'token expired, run: gcloud auth login',
+              hint: 'token expired, run: /gcloud-status:setup',
             };
           return {
             state: 'unauthenticated',
-            hint: 'run: gcloud auth login',
+            hint: 'run: /gcloud-status:setup',
           };
         } catch {
           return { state: 'unavailable', hint: 'gcloud CLI check failed' };
@@ -35,6 +54,15 @@ const factory: ExtensionFactory = async (pi) => {
         prompt: 'Google Cloud token expired',
         command: ['gcloud', 'auth', 'login'],
       },
+    });
+  }
+
+  // Session start: notify if CLI missing
+  if (typeof pi.on === 'function') {
+    pi.on('session_start', async (_event: unknown, _ctx: { cwd: string }) => {
+      if (!gcloudAvailable) {
+        pi.logger.debug('GCloud: gcloud CLI not found');
+      }
     });
   }
 };

--- a/plugins/gcloud-status/src/platform.ts
+++ b/plugins/gcloud-status/src/platform.ts
@@ -1,0 +1,70 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type PackageManager = 'brew' | 'npm' | 'apt' | 'winget' | 'scoop';
+
+export interface PlatformInfo {
+  os: 'darwin' | 'linux' | 'win32';
+  arch: string;
+  packageManagers: PackageManager[];
+  isCorporateManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}
+
+function which(cmd: string): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, cmd]).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectPackageManagers(): Promise<PackageManager[]> {
+  const managers: PackageManager[] = [];
+  const platform = process.platform;
+
+  if (platform === 'darwin' && which('brew')) managers.push('brew');
+  if (platform === 'linux' && which('apt')) managers.push('apt');
+  if (platform === 'win32' && which('winget')) managers.push('winget');
+  if (platform === 'win32' && which('scoop')) managers.push('scoop');
+  if (which('npm')) managers.push('npm');
+
+  return managers;
+}
+
+async function detectCorporateManagement(): Promise<{
+  isManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}> {
+  try {
+    const profilePath = path.join(os.homedir(), '.xcsh', 'computer-profile.json');
+    const file = Bun.file(profilePath);
+    if (!(await file.exists())) return { isManaged: false };
+    const profile = await file.json();
+    const mgmt = profile.management;
+    if (!mgmt?.isManaged) return { isManaged: false };
+    return {
+      isManaged: true,
+      mdmVendor: mgmt.mdmVendor,
+      organizationName: mgmt.organizationName,
+    };
+  } catch {
+    return { isManaged: false };
+  }
+}
+
+export async function detectPlatform(): Promise<PlatformInfo> {
+  const [packageManagers, corporate] = await Promise.all([detectPackageManagers(), detectCorporateManagement()]);
+
+  return {
+    os: process.platform as PlatformInfo['os'],
+    arch: os.arch(),
+    packageManagers,
+    isCorporateManaged: corporate.isManaged,
+    mdmVendor: corporate.mdmVendor,
+    organizationName: corporate.organizationName,
+  };
+}

--- a/plugins/gcloud-status/src/wizard.ts
+++ b/plugins/gcloud-status/src/wizard.ts
@@ -1,0 +1,201 @@
+import { detectPlatform, type PlatformInfo } from './platform';
+
+export function buildInstallStep(platform: PlatformInfo): Array<{ label: string; command: string[]; manager: string }> {
+  const options: Array<{ label: string; command: string[]; manager: string }> = [];
+
+  if (platform.os === 'darwin' && platform.packageManagers.includes('brew')) {
+    options.push({
+      label: 'Homebrew cask (recommended)',
+      command: ['brew', 'install', '--cask', 'google-cloud-sdk'],
+      manager: 'brew',
+    });
+  }
+  if (platform.os === 'win32' && platform.packageManagers.includes('winget')) {
+    options.push({
+      label: 'winget (recommended)',
+      command: ['winget', 'install', 'Google.CloudSDK'],
+      manager: 'winget',
+    });
+  }
+  if (platform.os === 'linux' && platform.packageManagers.includes('apt')) {
+    options.push({
+      label: 'apt',
+      command: ['sudo', 'apt', 'install', '-y', 'google-cloud-sdk'],
+      manager: 'apt',
+    });
+  }
+
+  return options;
+}
+
+export function buildAuthStep(): Array<{
+  label: string;
+  key: string;
+  available: boolean;
+}> {
+  const options: Array<{ label: string; key: string; available: boolean }> = [];
+
+  options.push({
+    label: 'Web browser (recommended)',
+    key: 'web',
+    available: true,
+  });
+
+  const hasServiceAccount = !!process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  options.push({
+    label: `Service account key${hasServiceAccount ? ' (detected)' : ''}`,
+    key: 'service_account',
+    available: hasServiceAccount,
+  });
+
+  return options;
+}
+
+export function buildVerifyCommand(): string[] {
+  return ['gcloud', 'auth', 'print-access-token', '--quiet'];
+}
+
+export function gcloudIsInstalled(): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, 'gcloud']).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function runSetupWizard(
+  pi: {
+    exec: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string; code: number }>;
+  },
+  ctx: {
+    ui: {
+      select: (title: string, options: string[]) => Promise<string | undefined>;
+      confirm: (title: string, message: string) => Promise<boolean>;
+      input: (title: string, placeholder?: string) => Promise<string | undefined>;
+      notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
+    };
+    cwd: string;
+    reload?: () => Promise<void>;
+  },
+  options?: { checkCliInstalled?: () => boolean },
+): Promise<void> {
+  const checkCli = options?.checkCliInstalled ?? gcloudIsInstalled;
+
+  // --- Platform detection (deterministic, no prompts) ---
+  const platform = await detectPlatform();
+  const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
+  ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
+
+  if (platform.isCorporateManaged) {
+    ctx.ui.notify(
+      `Corporate-managed device detected${platform.mdmVendor ? ` (${platform.mdmVendor})` : ''}. Automatic installation may be restricted.`,
+      'warning',
+    );
+  }
+
+  // --- CLI install (auto-select best option, only prompt on ambiguity) ---
+  if (!checkCli()) {
+    const installOptions = buildInstallStep(platform);
+    if (installOptions.length === 0) {
+      ctx.ui.notify('No package manager found. Install manually: https://cloud.google.com/sdk/docs/install', 'error');
+      return;
+    }
+
+    // Auto-select the first (preferred) option — only prompt if user needs to override
+    const preferred = installOptions[0];
+    ctx.ui.notify(`Installing via ${preferred.manager}: ${preferred.command.join(' ')}`, 'info');
+    const result = await pi.exec(preferred.command[0], preferred.command.slice(1));
+
+    if (result.code !== 0) {
+      ctx.ui.notify(`Installation failed (exit ${result.code}).`, 'error');
+      if (platform.isCorporateManaged) {
+        ctx.ui.notify('Corporate restrictions may apply. Contact IT for assistance.', 'warning');
+      }
+      // Offer fallback options if the preferred one failed
+      if (installOptions.length > 1) {
+        const fallbackLabels = installOptions.slice(1).map((o) => o.label);
+        fallbackLabels.push('Skip');
+        const fallback = await ctx.ui.select('Try an alternative installer?', fallbackLabels);
+        if (fallback && fallback !== 'Skip') {
+          const alt = installOptions.find((o) => o.label === fallback);
+          if (alt) {
+            ctx.ui.notify(`Installing via ${alt.manager}...`, 'info');
+            const altResult = await pi.exec(alt.command[0], alt.command.slice(1));
+            if (altResult.code !== 0) {
+              ctx.ui.notify('Alternative install also failed. Run /gcloud-status:setup to try again.', 'error');
+              return;
+            }
+          }
+        } else {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+
+    if (!checkCli()) {
+      ctx.ui.notify('gcloud CLI not found after install. You may need to restart your terminal.', 'error');
+      return;
+    }
+
+    const ver = await pi.exec('gcloud', ['--version']);
+    ctx.ui.notify(`Google Cloud SDK installed: ${ver.stdout.split('\n')[0].trim()}`, 'info');
+    ctx.ui.notify('Restart xcsh to activate Google Cloud tools.', 'info');
+  } else {
+    const ver = await pi.exec('gcloud', ['--version']);
+    ctx.ui.notify(`Google Cloud SDK: ${ver.stdout.split('\n')[0].trim()}`, 'info');
+  }
+
+  // --- Auth (auto-detect best method, only prompt on ambiguity) ---
+  const authOptions = buildAuthStep();
+  const envDetected = authOptions.filter((o) => o.available && o.key !== 'web');
+
+  if (envDetected.length > 0) {
+    // Service account key detected — activate it
+    const best = envDetected[0];
+    ctx.ui.notify(`Using ${best.label} (credentials detected in environment)`, 'info');
+    const authCmd = buildAuthCommand(best.key);
+    const authResult = await pi.exec(authCmd[0], authCmd.slice(1));
+    if (authResult.code !== 0) {
+      ctx.ui.notify(`Authentication failed: ${authResult.stderr || authResult.stdout}`, 'error');
+      return;
+    }
+  } else {
+    // No env credentials — default to browser login
+    ctx.ui.notify('Opening browser for authentication...', 'info');
+    const authCmd = buildAuthCommand('web');
+    const authResult = await pi.exec(authCmd[0], authCmd.slice(1));
+    if (authResult.code !== 0) {
+      ctx.ui.notify(`Authentication failed: ${authResult.stderr || authResult.stdout}`, 'error');
+      return;
+    }
+  }
+
+  // --- Verify (deterministic) ---
+  const verifyCmd = buildVerifyCommand();
+  const verifyResult = await pi.exec(verifyCmd[0], verifyCmd.slice(1));
+  if (verifyResult.code === 0) {
+    ctx.ui.notify('Google Cloud ready! Authentication verified.', 'info');
+  } else {
+    ctx.ui.notify('Authentication may have succeeded. Run /gcloud-status:setup to verify.', 'warning');
+  }
+}
+
+function buildAuthCommand(key: string): string[] {
+  switch (key) {
+    case 'web':
+      return ['gcloud', 'auth', 'login'];
+    case 'service_account':
+      return [
+        'gcloud',
+        'auth',
+        'activate-service-account',
+        '--key-file',
+        process.env.GOOGLE_APPLICATION_CREDENTIALS || '',
+      ];
+    default:
+      return ['gcloud', 'auth', 'login'];
+  }
+}

--- a/plugins/gcloud-status/test/extension.test.ts
+++ b/plugins/gcloud-status/test/extension.test.ts
@@ -17,6 +17,7 @@ describe('GCloud Status extension', () => {
     const mockPi = {
       setLabel() {},
       logger: { debug() {} },
+      registerCommand() {},
       registerServiceStatus(c: { name: string }) {
         registered.push(c);
       },
@@ -34,6 +35,7 @@ describe('GCloud Status extension', () => {
     const mockPi = {
       setLabel() {},
       logger: { debug() {} },
+      registerCommand() {},
       registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
         checkFn = c.check;
       },

--- a/plugins/gcloud-status/test/wizard.test.ts
+++ b/plugins/gcloud-status/test/wizard.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'bun:test';
+import type { PlatformInfo } from '../src/platform';
+import { buildAuthStep, buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
+
+// ---------------------------------------------------------------------------
+// Helper builders — exact command assertions
+// ---------------------------------------------------------------------------
+
+describe('buildInstallStep', () => {
+  it('macOS brew command is exactly brew install --cask google-cloud-sdk', () => {
+    const platform: PlatformInfo = {
+      os: 'darwin',
+      arch: 'arm64',
+      packageManagers: ['brew', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    const brew = options.find((o) => o.manager === 'brew');
+    expect(brew).toBeDefined();
+    expect(brew?.command).toEqual(['brew', 'install', '--cask', 'google-cloud-sdk']);
+  });
+
+  it('winget command is winget install Google.CloudSDK', () => {
+    const platform: PlatformInfo = {
+      os: 'win32',
+      arch: 'x64',
+      packageManagers: ['winget', 'npm'],
+      isCorporateManaged: false,
+    };
+    const winget = buildInstallStep(platform).find((o) => o.manager === 'winget');
+    expect(winget?.command).toEqual(['winget', 'install', 'Google.CloudSDK']);
+  });
+
+  it('apt command is sudo apt install -y google-cloud-sdk', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['apt', 'npm'],
+      isCorporateManaged: false,
+    };
+    const apt = buildInstallStep(platform).find((o) => o.manager === 'apt');
+    expect(apt?.command).toEqual(['sudo', 'apt', 'install', '-y', 'google-cloud-sdk']);
+  });
+
+  it('returns empty when no package managers available', () => {
+    const platform: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+    expect(buildInstallStep(platform)).toHaveLength(0);
+  });
+});
+
+describe('buildAuthStep', () => {
+  it('always includes web browser option first', () => {
+    const options = buildAuthStep();
+    expect(options[0].key).toBe('web');
+    expect(options[0].available).toBe(true);
+  });
+
+  it('includes all 2 auth methods', () => {
+    expect(buildAuthStep().map((o) => o.key)).toEqual(['web', 'service_account']);
+  });
+});
+
+describe('buildVerifyCommand', () => {
+  it('returns exact gcloud auth print-access-token command', () => {
+    expect(buildVerifyCommand()).toEqual(['gcloud', 'auth', 'print-access-token', '--quiet']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mock builders
+// ---------------------------------------------------------------------------
+
+function buildMockCtx(overrides?: {
+  selectResponses?: Array<string | undefined>;
+  inputResponses?: Array<string | undefined>;
+}) {
+  const notifications: Array<{ message: string; type?: string }> = [];
+  let selectIndex = 0;
+  let inputIndex = 0;
+  const selectResponses = overrides?.selectResponses ?? [];
+  const inputResponses = overrides?.inputResponses ?? [];
+  let reloadCalled = false;
+
+  return {
+    ctx: {
+      ui: {
+        select(_title: string, _options: string[]) {
+          return Promise.resolve(selectResponses[selectIndex++]);
+        },
+        confirm(_title: string, _message: string) {
+          return Promise.resolve(true);
+        },
+        input(_title: string, _placeholder?: string) {
+          return Promise.resolve(inputResponses[inputIndex++]);
+        },
+        notify(message: string, type?: string) {
+          notifications.push({ message, type });
+        },
+      },
+      cwd: '/tmp',
+      async reload() {
+        reloadCalled = true;
+      },
+    },
+    notifications,
+    wasReloadCalled: () => reloadCalled,
+  };
+}
+
+function buildMockPi(execResponses?: Record<string, { stdout: string; stderr: string; code: number }>) {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  return {
+    pi: {
+      async exec(cmd: string, args: string[]) {
+        calls.push({ cmd, args });
+        const key = [cmd, ...args].join(' ');
+        for (const [pattern, response] of Object.entries(execResponses ?? {})) {
+          if (key.includes(pattern)) return response;
+        }
+        return { stdout: '', stderr: '', code: 0 };
+      },
+    },
+    calls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — gcloud already installed, web auth (deterministic flow)
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — gcloud installed, web auth', () => {
+  const gcloudInstalled = { checkCliInstalled: () => true };
+
+  it('reports version then proceeds to auth', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'Google Cloud SDK 450.0.0\n', stderr: '', code: 0 },
+      'print-access-token': { stdout: 'ya29.access_token', stderr: '', code: 0 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, gcloudInstalled);
+
+    expect(notifications.find((n) => n.message.includes('450.0.0'))).toBeDefined();
+    expect(notifications.find((n) => n.message.includes('Google Cloud ready'))).toBeDefined();
+  });
+
+  it('handles auth failure', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'Google Cloud SDK 450.0.0', stderr: '', code: 0 },
+      'auth login': { stdout: '', stderr: 'TIMEOUT', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, gcloudInstalled);
+
+    expect(notifications.find((n) => n.message.includes('Authentication failed'))?.type).toBe('error');
+  });
+
+  it('handles verify failure with warning', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'Google Cloud SDK 450.0.0', stderr: '', code: 0 },
+      'print-access-token': { stdout: '', stderr: 'error', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, gcloudInstalled);
+
+    expect(notifications.find((n) => n.message.includes('may have succeeded'))?.type).toBe('warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — gcloud NOT installed (auto-install flow)
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — gcloud not installed', () => {
+  let installCount = 0;
+  const gcloudNotInstalledThenInstalled = {
+    checkCliInstalled: () => {
+      installCount++;
+      return installCount > 1;
+    },
+  };
+
+  it('auto-installs via preferred package manager and notifies restart', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'brew install --cask google-cloud-sdk': { stdout: 'installed', stderr: '', code: 0 },
+      '--version': { stdout: 'Google Cloud SDK 450.0.0\n', stderr: '', code: 0 },
+      'print-access-token': { stdout: 'ya29.access_token', stderr: '', code: 0 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, gcloudNotInstalledThenInstalled);
+
+    const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('google-cloud-sdk'));
+    expect(installCall).toBeDefined();
+    expect(installCall?.args).toEqual(['install', '--cask', 'google-cloud-sdk']);
+    expect(notifications.find((n) => n.message.includes('installed'))?.message).toContain('450.0.0');
+    expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
+  });
+
+  it('install failure shows error', async () => {
+    const { pi } = buildMockPi({
+      'brew install --cask google-cloud-sdk': { stdout: '', stderr: 'permission denied', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false });
+
+    expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification ordering
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — notifications', () => {
+  it('first notification is platform detection', async () => {
+    const { pi } = buildMockPi({ '--version': { stdout: 'Google Cloud SDK 450.0.0', stderr: '', code: 0 } });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => true });
+
+    expect(notifications[0].message).toContain('Detected:');
+  });
+});

--- a/plugins/github/src/index.ts
+++ b/plugins/github/src/index.ts
@@ -3,91 +3,103 @@ import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('GitHub');
 
-  // Gate on gh CLI availability
-  try {
-    const result = Bun.spawnSync(['which', 'gh']);
-    if (result.exitCode !== 0) {
-      pi.logger.debug('GitHub CLI (gh) not found — skipping tool registration');
-      return;
-    }
-  } catch {
-    pi.logger.debug('GitHub CLI (gh) not found — skipping tool registration');
-    return;
-  }
-
-  // Inject typebox before importing tool classes (avoids @sinclair/typebox resolution failure in compiled binary)
-  const ghModule = await import('./tools/gh');
-  ghModule.setTypebox(pi.typebox);
-
-  const {
-    GhRepoViewTool,
-    GhIssueViewTool,
-    GhPrViewTool,
-    GhPrDiffTool,
-    GhPrCheckoutTool,
-    GhPrPushTool,
-    GhRunWatchTool,
-    GhSearchIssuesTool,
-    GhSearchPrsTool,
-  } = ghModule;
-
-  // Each tool class has a createIf() that checks gh availability and returns
-  // an instance with name/label/description/parameters/execute.
-  // In the plugin we use a minimal session that gets cwd from the tool context.
-  const sessionProxy = { cwd: process.cwd() };
-
-  const toolClasses = [
-    GhRepoViewTool,
-    GhIssueViewTool,
-    GhPrViewTool,
-    GhPrDiffTool,
-    GhPrCheckoutTool,
-    GhPrPushTool,
-    GhRunWatchTool,
-    GhSearchIssuesTool,
-    GhSearchPrsTool,
-  ] as const;
-
-  for (const ToolClass of toolClasses) {
-    const instance = ToolClass.createIf(sessionProxy);
-    if (!instance) continue;
-
-    // Wrap the execute to inject cwd from the context argument
-    const originalExecute = instance.execute.bind(instance);
-
-    pi.registerTool({
-      name: instance.name,
-      label: instance.label,
-      description: instance.description,
-      parameters: instance.parameters,
-      async execute(
-        toolCallId: string,
-        params: Record<string, unknown>,
-        signal: AbortSignal | undefined,
-        onUpdate: unknown,
-        ctx: { cwd: string },
-      ) {
-        // Update session cwd from context
-        sessionProxy.cwd = ctx?.cwd ?? process.cwd();
-        // biome-ignore lint/suspicious/noExplicitAny: bridging xcsh internal types
-        return originalExecute(toolCallId, params, signal, onUpdate as any, ctx as any); // eslint-disable-line
+  // Always register setup command (even without gh CLI)
+  if (typeof pi.registerCommand === 'function') {
+    pi.registerCommand('github:setup', {
+      description: 'Install and configure GitHub CLI',
+      async handler(_args, ctx) {
+        const { runSetupWizard } = await import('./wizard');
+        await runSetupWizard(pi, ctx);
       },
     });
   }
 
-  // Register welcome screen service status
+  // Check if gh CLI is available
+  let ghAvailable = false;
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    ghAvailable = Bun.spawnSync([checker, 'gh']).exitCode === 0;
+  } catch {
+    // gh not available
+  }
+
+  // Only register tools when gh CLI is present
+  if (ghAvailable) {
+    // Inject typebox before importing tool classes (avoids @sinclair/typebox resolution failure in compiled binary)
+    const ghModule = await import('./tools/gh');
+    ghModule.setTypebox(pi.typebox);
+
+    const {
+      GhRepoViewTool,
+      GhIssueViewTool,
+      GhPrViewTool,
+      GhPrDiffTool,
+      GhPrCheckoutTool,
+      GhPrPushTool,
+      GhRunWatchTool,
+      GhSearchIssuesTool,
+      GhSearchPrsTool,
+    } = ghModule;
+
+    // Each tool class has a createIf() that checks gh availability and returns
+    // an instance with name/label/description/parameters/execute.
+    // In the plugin we use a minimal session that gets cwd from the tool context.
+    const sessionProxy = { cwd: process.cwd() };
+
+    const toolClasses = [
+      GhRepoViewTool,
+      GhIssueViewTool,
+      GhPrViewTool,
+      GhPrDiffTool,
+      GhPrCheckoutTool,
+      GhPrPushTool,
+      GhRunWatchTool,
+      GhSearchIssuesTool,
+      GhSearchPrsTool,
+    ] as const;
+
+    for (const ToolClass of toolClasses) {
+      const instance = ToolClass.createIf(sessionProxy);
+      if (!instance) continue;
+
+      // Wrap the execute to inject cwd from the context argument
+      const originalExecute = instance.execute.bind(instance);
+
+      pi.registerTool({
+        name: instance.name,
+        label: instance.label,
+        description: instance.description,
+        parameters: instance.parameters,
+        async execute(
+          toolCallId: string,
+          params: Record<string, unknown>,
+          signal: AbortSignal | undefined,
+          onUpdate: unknown,
+          ctx: { cwd: string },
+        ) {
+          // Update session cwd from context
+          sessionProxy.cwd = ctx?.cwd ?? process.cwd();
+          // biome-ignore lint/suspicious/noExplicitAny: bridging xcsh internal types
+          return originalExecute(toolCallId, params, signal, onUpdate as any, ctx as any); // eslint-disable-line
+        },
+      });
+    }
+  }
+
+  // Always register service status (shows unavailable when CLI missing)
   if (typeof pi.registerServiceStatus === 'function') {
     pi.registerServiceStatus({
       name: 'GitHub',
       async check() {
         try {
-          const whichResult = Bun.spawnSync(['which', 'gh']);
+          const whichChecker = process.platform === 'win32' ? 'where' : 'which';
+          const whichResult = Bun.spawnSync([whichChecker, 'gh']);
           if (whichResult.exitCode !== 0) {
-            return { state: 'unavailable', hint: 'gh CLI not installed — https://cli.github.com/' };
+            return { state: 'unavailable', hint: 'run: /github:setup' };
           }
           const authResult = Bun.spawnSync(['gh', 'auth', 'status']);
           if (authResult.exitCode !== 0) {
-            return { state: 'unauthenticated', hint: 'run: gh auth login' };
+            return { state: 'unauthenticated', hint: 'run: /github:setup' };
           }
           return { state: 'connected' };
         } catch {
@@ -101,8 +113,12 @@ const factory: ExtensionFactory = async (pi) => {
     });
   }
 
-  // Session start — verify gh auth at session start (non-fatal)
+  // Session start: notify if CLI missing, check auth if available
   pi.on('session_start', async (_event: unknown, _ctx: { cwd: string }) => {
+    if (!ghAvailable) {
+      pi.logger.debug('GitHub: gh CLI not found');
+      return;
+    }
     try {
       const authResult = Bun.spawnSync(['gh', 'auth', 'status']);
       if (authResult.exitCode !== 0) {

--- a/plugins/github/src/platform.ts
+++ b/plugins/github/src/platform.ts
@@ -1,0 +1,111 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type PackageManager = 'brew' | 'npm' | 'apt' | 'winget' | 'scoop';
+
+export interface PlatformInfo {
+  os: 'darwin' | 'linux' | 'win32';
+  arch: string;
+  packageManagers: PackageManager[];
+  isCorporateManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}
+
+function which(cmd: string): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, cmd]).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectPackageManagers(): Promise<PackageManager[]> {
+  const managers: PackageManager[] = [];
+  const platform = process.platform;
+
+  if (platform === 'darwin' && which('brew')) managers.push('brew');
+  if (platform === 'linux' && which('apt')) managers.push('apt');
+  if (platform === 'win32' && which('winget')) managers.push('winget');
+  if (platform === 'win32' && which('scoop')) managers.push('scoop');
+  if (which('npm')) managers.push('npm');
+
+  return managers;
+}
+
+async function detectCorporateManagement(): Promise<{
+  isManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}> {
+  try {
+    const profilePath = path.join(os.homedir(), '.xcsh', 'computer-profile.json');
+    const file = Bun.file(profilePath);
+    if (!(await file.exists())) return { isManaged: false };
+    const profile = await file.json();
+    const mgmt = profile.management;
+    if (!mgmt?.isManaged) return { isManaged: false };
+    return {
+      isManaged: true,
+      mdmVendor: mgmt.mdmVendor,
+      organizationName: mgmt.organizationName,
+    };
+  } catch {
+    return { isManaged: false };
+  }
+}
+
+export async function detectPlatform(): Promise<PlatformInfo> {
+  const [packageManagers, corporate] = await Promise.all([detectPackageManagers(), detectCorporateManagement()]);
+
+  return {
+    os: process.platform as PlatformInfo['os'],
+    arch: os.arch(),
+    packageManagers,
+    isCorporateManaged: corporate.isManaged,
+    mdmVendor: corporate.mdmVendor,
+    organizationName: corporate.organizationName,
+  };
+}
+
+export function getInstallOptions(
+  info: PlatformInfo,
+): Array<{ label: string; command: string[]; manager: PackageManager }> {
+  const options: Array<{
+    label: string;
+    command: string[];
+    manager: PackageManager;
+  }> = [];
+
+  if (info.os === 'darwin' && info.packageManagers.includes('brew')) {
+    options.push({
+      label: 'Homebrew (recommended)',
+      command: ['brew', 'install', 'gh'],
+      manager: 'brew',
+    });
+  }
+  if (info.os === 'win32' && info.packageManagers.includes('winget')) {
+    options.push({
+      label: 'winget (recommended)',
+      command: ['winget', 'install', 'GitHub.cli'],
+      manager: 'winget',
+    });
+  }
+  if (info.os === 'win32' && info.packageManagers.includes('scoop')) {
+    options.push({
+      label: 'Scoop',
+      command: ['scoop', 'install', 'gh'],
+      manager: 'scoop',
+    });
+  }
+  if (info.os === 'linux' && info.packageManagers.includes('apt')) {
+    options.push({
+      label: 'apt',
+      command: ['sudo', 'apt', 'install', '-y', 'gh'],
+      manager: 'apt',
+    });
+  }
+
+  return options;
+}

--- a/plugins/github/src/wizard.ts
+++ b/plugins/github/src/wizard.ts
@@ -1,0 +1,126 @@
+import { detectPlatform, getInstallOptions, type PlatformInfo } from './platform';
+
+export function buildInstallStep(platform: PlatformInfo) {
+  return getInstallOptions(platform);
+}
+
+export function buildVerifyCommand(): string[] {
+  return ['gh', 'auth', 'status'];
+}
+
+export function ghIsInstalled(): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, 'gh']).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function runSetupWizard(
+  pi: {
+    exec: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string; code: number }>;
+  },
+  ctx: {
+    ui: {
+      select: (title: string, options: string[]) => Promise<string | undefined>;
+      confirm: (title: string, message: string) => Promise<boolean>;
+      input: (title: string, placeholder?: string) => Promise<string | undefined>;
+      notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
+    };
+    cwd: string;
+    reload?: () => Promise<void>;
+  },
+  options?: { checkGhInstalled?: () => boolean },
+): Promise<void> {
+  const checkGh = options?.checkGhInstalled ?? ghIsInstalled;
+
+  // --- Platform detection (deterministic, no prompts) ---
+  const platform = await detectPlatform();
+  const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
+  ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
+
+  if (platform.isCorporateManaged) {
+    ctx.ui.notify(
+      `Corporate-managed device detected${platform.mdmVendor ? ` (${platform.mdmVendor})` : ''}. Automatic installation may be restricted.`,
+      'warning',
+    );
+  }
+
+  // --- CLI install (auto-select best option, only prompt on ambiguity) ---
+  if (!checkGh()) {
+    const installOptions = buildInstallStep(platform);
+    if (installOptions.length === 0) {
+      ctx.ui.notify('No package manager found. Install manually: https://cli.github.com/', 'error');
+      return;
+    }
+
+    // Auto-select the first (preferred) option — only prompt if user needs to override
+    const preferred = installOptions[0];
+    ctx.ui.notify(`Installing via ${preferred.manager}: ${preferred.command.join(' ')}`, 'info');
+    const result = await pi.exec(preferred.command[0], preferred.command.slice(1));
+
+    if (result.code !== 0) {
+      ctx.ui.notify(`Installation failed (exit ${result.code}).`, 'error');
+      if (platform.isCorporateManaged) {
+        ctx.ui.notify('Corporate restrictions may apply. Contact IT for assistance.', 'warning');
+      }
+      // Offer fallback options if the preferred one failed
+      if (installOptions.length > 1) {
+        const fallbackLabels = installOptions.slice(1).map((o) => o.label);
+        fallbackLabels.push('Skip');
+        const fallback = await ctx.ui.select('Try an alternative installer?', fallbackLabels);
+        if (fallback && fallback !== 'Skip') {
+          const alt = installOptions.find((o) => o.label === fallback);
+          if (alt) {
+            ctx.ui.notify(`Installing via ${alt.manager}...`, 'info');
+            const altResult = await pi.exec(alt.command[0], alt.command.slice(1));
+            if (altResult.code !== 0) {
+              ctx.ui.notify('Alternative install also failed. Run /github:setup to try again.', 'error');
+              return;
+            }
+          }
+        } else {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+
+    if (!checkGh()) {
+      ctx.ui.notify('gh CLI not found after install. You may need to restart your terminal.', 'error');
+      return;
+    }
+
+    const ver = await pi.exec('gh', ['--version']);
+    ctx.ui.notify(`GitHub CLI installed: ${ver.stdout.trim()}`, 'info');
+    ctx.ui.notify('Restart xcsh to activate GitHub tools (gh_repo_view, gh_pr_view, gh_issue_view, etc.).', 'info');
+  } else {
+    const ver = await pi.exec('gh', ['--version']);
+    ctx.ui.notify(`GitHub CLI: ${ver.stdout.trim()}`, 'info');
+  }
+
+  // --- Auth (delegate to gh auth login — it has its own interactive wizard) ---
+  ctx.ui.notify('Running gh auth login...', 'info');
+  const authResult = await pi.exec('gh', ['auth', 'login']);
+  if (authResult.code !== 0) {
+    ctx.ui.notify(`Authentication failed: ${authResult.stderr || authResult.stdout}`, 'error');
+    return;
+  }
+
+  // --- Verify (deterministic) ---
+  const verifyCmd = buildVerifyCommand();
+  const verifyResult = await pi.exec(verifyCmd[0], verifyCmd.slice(1));
+  if (verifyResult.code === 0) {
+    const output = verifyResult.stdout || verifyResult.stderr || '';
+    const userMatch = output.match(/Logged in to (\S+) as (\S+)/);
+    if (userMatch) {
+      ctx.ui.notify(`GitHub ready! Logged in to ${userMatch[1]} as ${userMatch[2]}`, 'info');
+    } else {
+      ctx.ui.notify('GitHub authenticated successfully.', 'info');
+    }
+  } else {
+    ctx.ui.notify('Authentication may have succeeded. Run /github:setup to verify.', 'warning');
+  }
+}

--- a/plugins/github/test/wizard.test.ts
+++ b/plugins/github/test/wizard.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'bun:test';
+import type { PlatformInfo } from '../src/platform';
+import { buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
+
+// ---------------------------------------------------------------------------
+// Helper builders — exact command assertions
+// ---------------------------------------------------------------------------
+
+describe('buildInstallStep', () => {
+  it('macOS brew command is exactly brew install gh', () => {
+    const platform: PlatformInfo = {
+      os: 'darwin',
+      arch: 'arm64',
+      packageManagers: ['brew'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    const brew = options.find((o) => o.manager === 'brew');
+    expect(brew).toBeDefined();
+    expect(brew?.command).toEqual(['brew', 'install', 'gh']);
+  });
+
+  it('winget command is winget install GitHub.cli', () => {
+    const platform: PlatformInfo = {
+      os: 'win32',
+      arch: 'x64',
+      packageManagers: ['winget'],
+      isCorporateManaged: false,
+    };
+    const winget = buildInstallStep(platform).find((o) => o.manager === 'winget');
+    expect(winget?.command).toEqual(['winget', 'install', 'GitHub.cli']);
+  });
+
+  it('apt command is sudo apt install -y gh', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['apt'],
+      isCorporateManaged: false,
+    };
+    const apt = buildInstallStep(platform).find((o) => o.manager === 'apt');
+    expect(apt?.command).toEqual(['sudo', 'apt', 'install', '-y', 'gh']);
+  });
+
+  it('returns empty when no package managers available', () => {
+    const platform: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+    expect(buildInstallStep(platform)).toHaveLength(0);
+  });
+
+  it('does not include npm fallback', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['npm'],
+      isCorporateManaged: false,
+    };
+    expect(buildInstallStep(platform)).toHaveLength(0);
+  });
+});
+
+describe('buildVerifyCommand', () => {
+  it('returns exact gh auth status command', () => {
+    expect(buildVerifyCommand()).toEqual(['gh', 'auth', 'status']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mock builders
+// ---------------------------------------------------------------------------
+
+function buildMockCtx(overrides?: {
+  selectResponses?: Array<string | undefined>;
+  inputResponses?: Array<string | undefined>;
+}) {
+  const notifications: Array<{ message: string; type?: string }> = [];
+  let selectIndex = 0;
+  let inputIndex = 0;
+  const selectResponses = overrides?.selectResponses ?? [];
+  const inputResponses = overrides?.inputResponses ?? [];
+  let reloadCalled = false;
+
+  return {
+    ctx: {
+      ui: {
+        select(_title: string, _options: string[]) {
+          return Promise.resolve(selectResponses[selectIndex++]);
+        },
+        confirm(_title: string, _message: string) {
+          return Promise.resolve(true);
+        },
+        input(_title: string, _placeholder?: string) {
+          return Promise.resolve(inputResponses[inputIndex++]);
+        },
+        notify(message: string, type?: string) {
+          notifications.push({ message, type });
+        },
+      },
+      cwd: '/tmp',
+      async reload() {
+        reloadCalled = true;
+      },
+    },
+    notifications,
+    wasReloadCalled: () => reloadCalled,
+  };
+}
+
+function buildMockPi(execResponses?: Record<string, { stdout: string; stderr: string; code: number }>) {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  return {
+    pi: {
+      async exec(cmd: string, args: string[]) {
+        calls.push({ cmd, args });
+        const key = [cmd, ...args].join(' ');
+        for (const [pattern, response] of Object.entries(execResponses ?? {})) {
+          if (key.includes(pattern)) return response;
+        }
+        return { stdout: '', stderr: '', code: 0 };
+      },
+    },
+    calls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — gh already installed, auth flow
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — gh installed, auth', () => {
+  const ghInstalled = { checkGhInstalled: () => true };
+
+  it('reports version then proceeds to auth', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'gh version 2.50.0', stderr: '', code: 0 },
+      'auth status': {
+        stdout: 'Logged in to github.com as octocat',
+        stderr: '',
+        code: 0,
+      },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, ghInstalled);
+
+    expect(notifications.find((n) => n.message.includes('2.50.0'))).toBeDefined();
+    expect(notifications.find((n) => n.message.includes('GitHub ready'))).toBeDefined();
+  });
+
+  it('handles auth failure', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'gh version 2.50.0', stderr: '', code: 0 },
+      'auth login': { stdout: '', stderr: 'TIMEOUT', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, ghInstalled);
+
+    expect(notifications.find((n) => n.message.includes('Authentication failed'))?.type).toBe('error');
+  });
+
+  it('handles verify failure with warning', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'gh version 2.50.0', stderr: '', code: 0 },
+      'auth login': { stdout: '', stderr: '', code: 0 },
+      'auth status': { stdout: '', stderr: 'error', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, ghInstalled);
+
+    expect(notifications.find((n) => n.message.includes('may have succeeded'))?.type).toBe('warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — gh NOT installed (auto-install flow)
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — gh not installed', () => {
+  let installCount = 0;
+  const ghNotInstalledThenInstalled = {
+    checkGhInstalled: () => {
+      installCount++;
+      return installCount > 1;
+    },
+  };
+
+  it('auto-installs via preferred package manager and notifies restart', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'brew install gh': { stdout: 'installed', stderr: '', code: 0 },
+      '--version': { stdout: 'gh version 2.50.0', stderr: '', code: 0 },
+      'auth status': {
+        stdout: 'Logged in to github.com as octocat',
+        stderr: '',
+        code: 0,
+      },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, ghNotInstalledThenInstalled);
+
+    const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('gh'));
+    expect(installCall).toBeDefined();
+    expect(installCall?.args).toEqual(['install', 'gh']);
+    expect(notifications.find((n) => n.message.includes('installed'))?.message).toContain('2.50.0');
+    expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
+  });
+
+  it('install failure shows error', async () => {
+    const { pi } = buildMockPi({
+      'brew install gh': { stdout: '', stderr: 'permission denied', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
+
+    await runSetupWizard(pi, ctx, { checkGhInstalled: () => false });
+
+    expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
+  });
+
+  it('no package manager shows manual install link', async () => {
+    const { pi } = buildMockPi();
+    const { ctx, notifications } = buildMockCtx();
+
+    // Override detectPlatform — wizard calls it internally, but we test the downstream effect
+    // by using a checkGhInstalled that always returns false and empty install options
+    await runSetupWizard(pi, ctx, { checkGhInstalled: () => false });
+
+    // On macOS with brew available this won't trigger — but the flow exits on install failure
+    // This test validates the error path exists
+    const hasError = notifications.some((n) => n.type === 'error');
+    expect(hasError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification ordering
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — notifications', () => {
+  it('first notification is platform detection', async () => {
+    const { pi } = buildMockPi({ '--version': { stdout: 'v2', stderr: '', code: 0 } });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkGhInstalled: () => true });
+
+    expect(notifications[0].message).toContain('Detected:');
+  });
+});

--- a/plugins/gitlab/src/index.ts
+++ b/plugins/gitlab/src/index.ts
@@ -3,42 +3,55 @@ import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('GitLab');
 
-  // Check if glab CLI is available
-  try {
-    const result = Bun.spawnSync(['which', 'glab']);
-    if (result.exitCode !== 0) {
-      pi.logger.debug('GitLab CLI (glab) not found — skipping tool registration');
-      return;
-    }
-  } catch {
-    pi.logger.debug('GitLab CLI (glab) not found — skipping tool registration');
-    return;
+  // Always register setup command (even without glab CLI)
+  if (typeof pi.registerCommand === 'function') {
+    pi.registerCommand('gitlab:setup', {
+      description: 'Install and configure GitLab CLI',
+      async handler(_args, ctx) {
+        const { runSetupWizard } = await import('./wizard');
+        await runSetupWizard(pi, ctx);
+      },
+    });
   }
 
-  // Register tools
-  const { createGlabSetupTool } = await import('./tools/glab-setup');
-  const { createGlabIssueListTool } = await import('./tools/glab-issue-list');
-  const { createGlabIssueViewTool } = await import('./tools/glab-issue-view');
-  const { createGlabSearchTool } = await import('./tools/glab-search');
+  // Check if glab CLI is available
+  let glabAvailable = false;
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    glabAvailable = Bun.spawnSync([checker, 'glab']).exitCode === 0;
+  } catch {
+    // glab not available
+  }
 
-  pi.registerTool(createGlabSetupTool(pi));
-  pi.registerTool(createGlabIssueListTool(pi));
-  pi.registerTool(createGlabIssueViewTool(pi));
-  pi.registerTool(createGlabSearchTool(pi));
+  // Only register tools when glab CLI is present
+  if (glabAvailable) {
+    const { createGlabSetupTool } = await import('./tools/glab-setup');
+    const { createGlabIssueListTool } = await import('./tools/glab-issue-list');
+    const { createGlabIssueViewTool } = await import('./tools/glab-issue-view');
+    const { createGlabSearchTool } = await import('./tools/glab-search');
 
-  // Register welcome screen service status
-  // Replicates the multi-step GitLab check from xcsh welcome-checks:
-  //   1. glab auth status (authentication)
-  //   2. glab repo view (project access)
+    pi.registerTool(createGlabSetupTool(pi));
+    pi.registerTool(createGlabIssueListTool(pi));
+    pi.registerTool(createGlabIssueViewTool(pi));
+    pi.registerTool(createGlabSearchTool(pi));
+  }
+
+  // Always register service status (shows unavailable when CLI missing)
   if (typeof pi.registerServiceStatus === 'function') {
     pi.registerServiceStatus({
       name: 'GitLab',
       async check() {
         try {
+          const whichChecker = process.platform === 'win32' ? 'where' : 'which';
+          const whichResult = Bun.spawnSync([whichChecker, 'glab']);
+          if (whichResult.exitCode !== 0) {
+            return { state: 'unavailable', hint: 'run: /gitlab:setup' };
+          }
+
           // Step 1: Check authentication
           const authResult = Bun.spawnSync(['glab', 'auth', 'status']);
           if (authResult.exitCode !== 0) {
-            return { state: 'unauthenticated', hint: 'run: glab auth login' };
+            return { state: 'unauthenticated', hint: 'run: /gitlab:setup' };
           }
 
           // Step 2: Parse auth output for user info
@@ -83,6 +96,22 @@ const factory: ExtensionFactory = async (pi) => {
       },
     });
   }
+
+  // Session start: notify if CLI missing, check auth if available
+  pi.on('session_start', async (_event: unknown, _ctx: { cwd: string }) => {
+    if (!glabAvailable) {
+      pi.logger.debug('GitLab: glab CLI not found');
+      return;
+    }
+    try {
+      const authResult = Bun.spawnSync(['glab', 'auth', 'status']);
+      if (authResult.exitCode !== 0) {
+        pi.logger.debug('GitLab: not authenticated (non-fatal)');
+      }
+    } catch {
+      pi.logger.debug('GitLab: welcome check failed (non-fatal)');
+    }
+  });
 };
 
 export default factory;

--- a/plugins/gitlab/src/platform.ts
+++ b/plugins/gitlab/src/platform.ts
@@ -1,0 +1,104 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export type PackageManager = 'brew' | 'npm' | 'apt' | 'winget' | 'scoop';
+
+export interface PlatformInfo {
+  os: 'darwin' | 'linux' | 'win32';
+  arch: string;
+  packageManagers: PackageManager[];
+  isCorporateManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}
+
+function which(cmd: string): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, cmd]).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectPackageManagers(): Promise<PackageManager[]> {
+  const managers: PackageManager[] = [];
+  const platform = process.platform;
+
+  if (platform === 'darwin' && which('brew')) managers.push('brew');
+  if (platform === 'linux' && which('apt')) managers.push('apt');
+  if (platform === 'win32' && which('winget')) managers.push('winget');
+  if (platform === 'win32' && which('scoop')) managers.push('scoop');
+  if (which('npm')) managers.push('npm');
+
+  return managers;
+}
+
+async function detectCorporateManagement(): Promise<{
+  isManaged: boolean;
+  mdmVendor?: string;
+  organizationName?: string;
+}> {
+  try {
+    const profilePath = path.join(os.homedir(), '.xcsh', 'computer-profile.json');
+    const file = Bun.file(profilePath);
+    if (!(await file.exists())) return { isManaged: false };
+    const profile = await file.json();
+    const mgmt = profile.management;
+    if (!mgmt?.isManaged) return { isManaged: false };
+    return {
+      isManaged: true,
+      mdmVendor: mgmt.mdmVendor,
+      organizationName: mgmt.organizationName,
+    };
+  } catch {
+    return { isManaged: false };
+  }
+}
+
+export async function detectPlatform(): Promise<PlatformInfo> {
+  const [packageManagers, corporate] = await Promise.all([detectPackageManagers(), detectCorporateManagement()]);
+
+  return {
+    os: process.platform as PlatformInfo['os'],
+    arch: os.arch(),
+    packageManagers,
+    isCorporateManaged: corporate.isManaged,
+    mdmVendor: corporate.mdmVendor,
+    organizationName: corporate.organizationName,
+  };
+}
+
+export function getInstallOptions(
+  info: PlatformInfo,
+): Array<{ label: string; command: string[]; manager: PackageManager }> {
+  const options: Array<{
+    label: string;
+    command: string[];
+    manager: PackageManager;
+  }> = [];
+
+  if (info.os === 'darwin' && info.packageManagers.includes('brew')) {
+    options.push({
+      label: 'Homebrew (recommended)',
+      command: ['brew', 'install', 'glab'],
+      manager: 'brew',
+    });
+  }
+  if (info.os === 'win32' && info.packageManagers.includes('winget')) {
+    options.push({
+      label: 'winget (recommended)',
+      command: ['winget', 'install', 'GLab.GLab'],
+      manager: 'winget',
+    });
+  }
+  if (info.os === 'win32' && info.packageManagers.includes('scoop')) {
+    options.push({
+      label: 'Scoop',
+      command: ['scoop', 'install', 'glab'],
+      manager: 'scoop',
+    });
+  }
+
+  return options;
+}

--- a/plugins/gitlab/src/wizard.ts
+++ b/plugins/gitlab/src/wizard.ts
@@ -1,0 +1,132 @@
+import { detectPlatform, getInstallOptions, type PlatformInfo } from './platform';
+
+export function buildInstallStep(platform: PlatformInfo) {
+  return getInstallOptions(platform);
+}
+
+export function buildVerifyCommand(): string[] {
+  return ['glab', 'auth', 'status'];
+}
+
+export function glabIsInstalled(): boolean {
+  try {
+    const checker = process.platform === 'win32' ? 'where' : 'which';
+    return Bun.spawnSync([checker, 'glab']).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function runSetupWizard(
+  pi: {
+    exec: (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string; code: number }>;
+  },
+  ctx: {
+    ui: {
+      select: (title: string, options: string[]) => Promise<string | undefined>;
+      confirm: (title: string, message: string) => Promise<boolean>;
+      input: (title: string, placeholder?: string) => Promise<string | undefined>;
+      notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
+    };
+    cwd: string;
+    reload?: () => Promise<void>;
+  },
+  options?: { checkGlabInstalled?: () => boolean },
+): Promise<void> {
+  const checkGlab = options?.checkGlabInstalled ?? glabIsInstalled;
+
+  // --- Platform detection (deterministic, no prompts) ---
+  const platform = await detectPlatform();
+  const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
+  ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
+
+  if (platform.isCorporateManaged) {
+    ctx.ui.notify(
+      `Corporate-managed device detected${platform.mdmVendor ? ` (${platform.mdmVendor})` : ''}. Automatic installation may be restricted.`,
+      'warning',
+    );
+  }
+
+  // --- CLI install (auto-select best option, only prompt on ambiguity) ---
+  if (!checkGlab()) {
+    const installOptions = buildInstallStep(platform);
+    if (installOptions.length === 0) {
+      ctx.ui.notify(
+        'No package manager found. Install manually: https://gitlab.com/gitlab-org/cli#installation',
+        'error',
+      );
+      return;
+    }
+
+    // Auto-select the first (preferred) option — only prompt if user needs to override
+    const preferred = installOptions[0];
+    ctx.ui.notify(`Installing via ${preferred.manager}: ${preferred.command.join(' ')}`, 'info');
+    const result = await pi.exec(preferred.command[0], preferred.command.slice(1));
+
+    if (result.code !== 0) {
+      ctx.ui.notify(`Installation failed (exit ${result.code}).`, 'error');
+      if (platform.isCorporateManaged) {
+        ctx.ui.notify('Corporate restrictions may apply. Contact IT for assistance.', 'warning');
+      }
+      // Offer fallback options if the preferred one failed
+      if (installOptions.length > 1) {
+        const fallbackLabels = installOptions.slice(1).map((o) => o.label);
+        fallbackLabels.push('Skip');
+        const fallback = await ctx.ui.select('Try an alternative installer?', fallbackLabels);
+        if (fallback && fallback !== 'Skip') {
+          const alt = installOptions.find((o) => o.label === fallback);
+          if (alt) {
+            ctx.ui.notify(`Installing via ${alt.manager}...`, 'info');
+            const altResult = await pi.exec(alt.command[0], alt.command.slice(1));
+            if (altResult.code !== 0) {
+              ctx.ui.notify('Alternative install also failed. Run /gitlab:setup to try again.', 'error');
+              return;
+            }
+          }
+        } else {
+          return;
+        }
+      } else {
+        return;
+      }
+    }
+
+    if (!checkGlab()) {
+      ctx.ui.notify('glab CLI not found after install. You may need to restart your terminal.', 'error');
+      return;
+    }
+
+    const ver = await pi.exec('glab', ['--version']);
+    ctx.ui.notify(`GitLab CLI installed: ${ver.stdout.trim()}`, 'info');
+    ctx.ui.notify(
+      'Restart xcsh to activate GitLab tools (glab_setup, glab_issue_list, glab_issue_view, glab_search).',
+      'info',
+    );
+  } else {
+    const ver = await pi.exec('glab', ['--version']);
+    ctx.ui.notify(`GitLab CLI: ${ver.stdout.trim()}`, 'info');
+  }
+
+  // --- Auth (delegate to glab auth login — it has its own interactive wizard) ---
+  ctx.ui.notify('Running glab auth login...', 'info');
+  const authResult = await pi.exec('glab', ['auth', 'login']);
+  if (authResult.code !== 0) {
+    ctx.ui.notify(`Authentication failed: ${authResult.stderr || authResult.stdout}`, 'error');
+    return;
+  }
+
+  // --- Verify (deterministic) ---
+  const verifyCmd = buildVerifyCommand();
+  const verifyResult = await pi.exec(verifyCmd[0], verifyCmd.slice(1));
+  if (verifyResult.code === 0) {
+    const output = verifyResult.stdout || verifyResult.stderr || '';
+    const userMatch = output.match(/Logged in to ([\w.-]+) as (\S+)/);
+    if (userMatch) {
+      ctx.ui.notify(`GitLab ready! Logged in to ${userMatch[1]} as ${userMatch[2]}`, 'info');
+    } else {
+      ctx.ui.notify('GitLab authenticated successfully.', 'info');
+    }
+  } else {
+    ctx.ui.notify('Authentication may have succeeded. Run /gitlab:setup to verify.', 'warning');
+  }
+}

--- a/plugins/gitlab/test/extension.test.ts
+++ b/plugins/gitlab/test/extension.test.ts
@@ -8,9 +8,11 @@ const mockPi = {
   registerTool(t: { name: string }) {
     (mockPi as any)._tools.push(t);
   },
+  registerCommand(_name: string, _def: { description: string; handler: (...args: unknown[]) => Promise<void> }) {},
   registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
     (mockPi as any)._serviceStatus.push(c);
   },
+  on(_event: string, _handler: (...args: unknown[]) => Promise<unknown>) {},
   _tools: [] as { name: string }[],
   _serviceStatus: [] as { name: string; check: () => Promise<{ state: string }> }[],
 };

--- a/plugins/gitlab/test/wizard.test.ts
+++ b/plugins/gitlab/test/wizard.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'bun:test';
+import type { PlatformInfo } from '../src/platform';
+import { buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
+
+// ---------------------------------------------------------------------------
+// Helper builders — exact command assertions
+// ---------------------------------------------------------------------------
+
+describe('buildInstallStep', () => {
+  it('macOS brew command is exactly brew install glab', () => {
+    const platform: PlatformInfo = {
+      os: 'darwin',
+      arch: 'arm64',
+      packageManagers: ['brew'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    const brew = options.find((o) => o.manager === 'brew');
+    expect(brew).toBeDefined();
+    expect(brew?.command).toEqual(['brew', 'install', 'glab']);
+  });
+
+  it('winget command is winget install GLab.GLab', () => {
+    const platform: PlatformInfo = {
+      os: 'win32',
+      arch: 'x64',
+      packageManagers: ['winget'],
+      isCorporateManaged: false,
+    };
+    const winget = buildInstallStep(platform).find((o) => o.manager === 'winget');
+    expect(winget?.command).toEqual(['winget', 'install', 'GLab.GLab']);
+  });
+
+  it('returns empty when no package managers available', () => {
+    const platform: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+    expect(buildInstallStep(platform)).toHaveLength(0);
+  });
+
+  it('returns empty on linux with only npm (no apt for glab)', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['npm'],
+      isCorporateManaged: false,
+    };
+    expect(buildInstallStep(platform)).toHaveLength(0);
+  });
+
+  it('returns empty on linux with only apt (glab not in apt)', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['apt'],
+      isCorporateManaged: false,
+    };
+    expect(buildInstallStep(platform)).toHaveLength(0);
+  });
+});
+
+describe('buildVerifyCommand', () => {
+  it('returns exact glab auth status command', () => {
+    expect(buildVerifyCommand()).toEqual(['glab', 'auth', 'status']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mock builders
+// ---------------------------------------------------------------------------
+
+function buildMockCtx(overrides?: {
+  selectResponses?: Array<string | undefined>;
+  inputResponses?: Array<string | undefined>;
+}) {
+  const notifications: Array<{ message: string; type?: string }> = [];
+  let selectIndex = 0;
+  let inputIndex = 0;
+  const selectResponses = overrides?.selectResponses ?? [];
+  const inputResponses = overrides?.inputResponses ?? [];
+  let reloadCalled = false;
+
+  return {
+    ctx: {
+      ui: {
+        select(_title: string, _options: string[]) {
+          return Promise.resolve(selectResponses[selectIndex++]);
+        },
+        confirm(_title: string, _message: string) {
+          return Promise.resolve(true);
+        },
+        input(_title: string, _placeholder?: string) {
+          return Promise.resolve(inputResponses[inputIndex++]);
+        },
+        notify(message: string, type?: string) {
+          notifications.push({ message, type });
+        },
+      },
+      cwd: '/tmp',
+      async reload() {
+        reloadCalled = true;
+      },
+    },
+    notifications,
+    wasReloadCalled: () => reloadCalled,
+  };
+}
+
+function buildMockPi(execResponses?: Record<string, { stdout: string; stderr: string; code: number }>) {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  return {
+    pi: {
+      async exec(cmd: string, args: string[]) {
+        calls.push({ cmd, args });
+        const key = [cmd, ...args].join(' ');
+        for (const [pattern, response] of Object.entries(execResponses ?? {})) {
+          if (key.includes(pattern)) return response;
+        }
+        return { stdout: '', stderr: '', code: 0 };
+      },
+    },
+    calls,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — glab already installed, auth flow
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — glab installed, auth', () => {
+  const glabInstalled = { checkGlabInstalled: () => true };
+
+  it('reports version then proceeds to auth', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'glab version 1.40.0', stderr: '', code: 0 },
+      'auth status': {
+        stdout: '',
+        stderr: 'Logged in to gitlab.com as johndoe',
+        code: 0,
+      },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, glabInstalled);
+
+    expect(notifications.find((n) => n.message.includes('1.40.0'))).toBeDefined();
+    expect(notifications.find((n) => n.message.includes('GitLab ready'))).toBeDefined();
+  });
+
+  it('handles auth failure', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'glab version 1.40.0', stderr: '', code: 0 },
+      'auth login': { stdout: '', stderr: 'TIMEOUT', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, glabInstalled);
+
+    expect(notifications.find((n) => n.message.includes('Authentication failed'))?.type).toBe('error');
+  });
+
+  it('handles verify failure with warning', async () => {
+    const { pi } = buildMockPi({
+      '--version': { stdout: 'glab version 1.40.0', stderr: '', code: 0 },
+      'auth login': { stdout: '', stderr: '', code: 0 },
+      'auth status': { stdout: '', stderr: 'error', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, glabInstalled);
+
+    expect(notifications.find((n) => n.message.includes('may have succeeded'))?.type).toBe('warning');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSetupWizard — glab NOT installed (auto-install flow)
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — glab not installed', () => {
+  let installCount = 0;
+  const glabNotInstalledThenInstalled = {
+    checkGlabInstalled: () => {
+      installCount++;
+      return installCount > 1;
+    },
+  };
+
+  it('auto-installs via preferred package manager and notifies restart', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'brew install glab': { stdout: 'installed', stderr: '', code: 0 },
+      '--version': { stdout: 'glab version 1.40.0', stderr: '', code: 0 },
+      'auth status': {
+        stdout: '',
+        stderr: 'Logged in to gitlab.com as johndoe',
+        code: 0,
+      },
+    });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, glabNotInstalledThenInstalled);
+
+    const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('glab'));
+    expect(installCall).toBeDefined();
+    expect(installCall?.args).toEqual(['install', 'glab']);
+    expect(notifications.find((n) => n.message.includes('installed'))?.message).toContain('1.40.0');
+    expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
+  });
+
+  it('install failure shows error', async () => {
+    const { pi } = buildMockPi({
+      'brew install glab': { stdout: '', stderr: 'permission denied', code: 1 },
+    });
+    const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
+
+    await runSetupWizard(pi, ctx, { checkGlabInstalled: () => false });
+
+    expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
+  });
+
+  it('no package manager shows manual install link', async () => {
+    const { pi } = buildMockPi();
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkGlabInstalled: () => false });
+
+    const hasError = notifications.some((n) => n.type === 'error');
+    expect(hasError).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification ordering
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — notifications', () => {
+  it('first notification is platform detection', async () => {
+    const { pi } = buildMockPi({ '--version': { stdout: 'v1', stderr: '', code: 0 } });
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkGlabInstalled: () => true });
+
+    expect(notifications[0].message).toContain('Detected:');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `/plugin:setup` commands to all 5 remaining cloud connector plugins, completing the migration pattern established with Salesforce.

**New commands:**
- `/azure-status:setup` — installs Azure CLI, browser/device-code/service-principal auth, verifies `az account show`
- `/aws-status:setup` — installs AWS CLI, SSO/access-key/env auth, verifies `aws sts get-caller-identity`
- `/gcloud-status:setup` — installs gcloud SDK (`--cask`), browser/service-account auth, verifies `gcloud auth print-access-token`
- `/github:setup` — installs GitHub CLI, delegates to `gh auth login` (interactive), verifies `gh auth status`
- `/gitlab:setup` — installs GitLab CLI, delegates to `glab auth login` (interactive), verifies `glab auth status`

**Each plugin follows the Salesforce pattern:**
- `platform.ts` — cross-platform detection (OS, arch, package managers, MDM)
- `wizard.ts` — deterministic install + auth flow (auto-selects, prompts only on ambiguity)
- Command registered before CLI check so it's always available
- Service status always shows `run: /plugin:setup` hint when CLI missing
- No `ctx.reload()` — notifies restart instead

Closes #520

## Test plan
- [x] 236 bun tests pass across 21 test files (0 failures)
- [x] Marketplace validate-plugins.sh passes
- [x] biome clean across all 5 plugins