### PR TITLE
feat(azure-status): expand plugin with CLI-native az tools and embedded help knowledge

### DIFF
--- a/plugins/azure-status/.claude-plugin/plugin.json
+++ b/plugins/azure-status/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "azure-status",
-  "description": "Azure CLI welcome screen status — checks az account authentication and offers auto-fix",
+  "description": "Azure CLI tools for xcsh — native az command execution with embedded help knowledge, subscription/resource/VM management, and welcome screen status",
   "version": "1.0.0",
   "author": { "name": "f5xc-salesdemos", "url": "https://github.com/f5xc-salesdemos" },
-  "keywords": ["azure", "az", "cloud", "xcsh-extension"],
+  "keywords": ["azure", "az", "cloud", "cli", "xcsh-extension"],
   "license": "Apache-2.0",
   "repository": "https://github.com/f5xc-salesdemos/marketplace"
 }

--- a/plugins/azure-status/bun.lock
+++ b/plugins/azure-status/bun.lock
@@ -1,0 +1,707 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@f5xc-salesdemos/xcsh-azure-status",
+      "devDependencies": {
+        "@sinclair/typebox": "^0.34.0",
+        "bun-types": "latest",
+      },
+      "peerDependencies": {
+        "@f5xc-salesdemos/xcsh": ">=1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1058.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-node": "^3.972.48", "@aws-sdk/eventstream-handler-node": "^3.972.18", "@aws-sdk/middleware-eventstream": "^3.972.14", "@aws-sdk/middleware-websocket": "^3.972.23", "@aws-sdk/token-providers": "3.1058.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-p2co5KPnRLByP8VwLJIdNM7TFwa68ZXZJjPWCovIHsJ8L/oN83Oze4/gv3UHO+fKYI4Ve3M3N3KKSH6aTsXTSw=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.15", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@aws-sdk/xml-builder": "^3.972.26", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.43", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.46", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/credential-provider-env": "^3.972.41", "@aws-sdk/credential-provider-http": "^3.972.43", "@aws-sdk/credential-provider-login": "^3.972.45", "@aws-sdk/credential-provider-process": "^3.972.41", "@aws-sdk/credential-provider-sso": "^3.972.45", "@aws-sdk/credential-provider-web-identity": "^3.972.45", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/credential-provider-imds": "^4.3.6", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.48", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.41", "@aws-sdk/credential-provider-http": "^3.972.43", "@aws-sdk/credential-provider-ini": "^3.972.46", "@aws-sdk/credential-provider-process": "^3.972.41", "@aws-sdk/credential-provider-sso": "^3.972.45", "@aws-sdk/credential-provider-web-identity": "^3.972.45", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/credential-provider-imds": "^4.3.6", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QIbtJP0olSLZ2ImEu636pP+7JJbPfaL3xSJIFXhu472CWuondCc4bGOa8OeyhOFet8z4H1D/ZFKXc39FboWwYA=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/token-providers": "3.1056.0", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.45", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.18", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-QPQhwY/fstR8fMZFWrsJRNoTP6D1RjRPHGRX7u9/VkF3opCsvD0oXPz6qzkX94SchzvuS5vyFZbJbPcMEs2Jeg=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-DoZ4djVj/74XQ6M/IwxuKh543tTvLCL7u1Dx+VDHMgW9yGNrFSJJ1l0LrUQRaekic5CB12wUiiOoHL0VI6H0gg=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.23", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-F0d4A9pJFiwljyKgSwU1Z5n+CXSv8bp+V5SthbS2rftB8wBN9z1K2Yyv3xbeK0AM2T0g4q6Ptf0shFF+oQZyiA=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.13", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.15", "@aws-sdk/signature-v4-multi-region": "^3.996.30", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/fetch-http-handler": "^5.4.5", "@smithy/node-http-handler": "^4.7.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.30", "", { "dependencies": { "@aws-sdk/types": "^3.973.9", "@smithy/signature-v4": "^5.4.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1058.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-m22Usagf/HzN8Nlktz3Lt/IukBZl/JYBkhlpMHowXl2xtcXpcGuh59vtltC1Uy26pR86Ez2EqwVLl8eOZP6v3A=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.9", "", { "dependencies": { "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.26", "", { "dependencies": { "@smithy/types": "^4.14.2", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
+
+    "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
+
+    "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
+
+    "@f5xc-salesdemos/pi-agent-core": ["@f5xc-salesdemos/pi-agent-core@18.91.1", "", { "dependencies": { "@f5xc-salesdemos/pi-ai": "18.91.1", "@f5xc-salesdemos/pi-utils": "18.91.1" } }, "sha512-NaNRJmLNhQw9RnlsLCcpr8N0j5KjjKALwISXsJdj2KeA0xAhQ+gkC0uDQetihjxtpoejRdUwiti6Mpy0FKhKIg=="],
+
+    "@f5xc-salesdemos/pi-ai": ["@f5xc-salesdemos/pi-ai@18.91.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.78", "@aws-sdk/client-bedrock-runtime": "^3", "@bufbuild/protobuf": "^2.11", "@f5xc-salesdemos/pi-utils": "18.91.1", "@google/genai": "^1.43", "@sinclair/typebox": "^0.34", "@smithy/node-http-handler": "^4.4", "ajv": "~8.18.0", "ajv-formats": "^3.0", "openai": "^6.25", "partial-json": "^0.1", "zod": "^4.3" }, "bin": { "pi-ai": "src/cli.ts" } }, "sha512-BuKhqpCXPv/0o3wK2Bexz/xgXi7dU7+5mtfIDwihN950fdQ99kbz2huku/elzzbJJzPzb0MGR6ypTdkETZJz1Q=="],
+
+    "@f5xc-salesdemos/pi-natives": ["@f5xc-salesdemos/pi-natives@18.91.1", "", { "optionalDependencies": { "@f5xc-salesdemos/pi-natives-darwin-arm64": "18.91.1", "@f5xc-salesdemos/pi-natives-darwin-x64": "18.91.1", "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": "18.91.1", "@f5xc-salesdemos/pi-natives-linux-x64-gnu": "18.91.1", "@f5xc-salesdemos/pi-natives-win32-x64-msvc": "18.91.1" } }, "sha512-sH2dx2TVM2yAeipIiL75gKkDgUN3knVRTITSnXG84rAu4jS1hCuNXc/LHsyXZXV5BCxudaO9a/xf8CjEpBOpAA=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-arm64": ["@f5xc-salesdemos/pi-natives-darwin-arm64@18.91.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/OwEPUvu8hK9a64h2ArmjZL+qTdskHmVCGfnLMUOeiI1u1kwA8huh/6gkYzkDo6D8m6dIGMJotoPv7fKJ2NTxA=="],
+
+    "@f5xc-salesdemos/pi-natives-darwin-x64": ["@f5xc-salesdemos/pi-natives-darwin-x64@18.91.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-95g2EADTTnwuAFaTx26cGXWVqBIFQa4VJ1CMfg9WPHUY9pykGqzmUdTe5Qut/hK3gjknj4vk1tcg1Ww4iH9+/w=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-arm64-gnu": ["@f5xc-salesdemos/pi-natives-linux-arm64-gnu@18.91.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-l1gVnPncmzyOx6ILKv62w7w7aTEglyY1KKrkUe64b56VfS86KqVxdgZa1F91RpkrD45ffB2xpAD3k0ZP7KKTAA=="],
+
+    "@f5xc-salesdemos/pi-natives-linux-x64-gnu": ["@f5xc-salesdemos/pi-natives-linux-x64-gnu@18.91.1", "", { "os": "linux", "cpu": "x64" }, "sha512-z+HKFimsNOaZCW+R9uWihErermeEGYgeK77WynnRm7gaLxBeM1NuHJd0v35Wmc++g+NenRxQrBlDidEIFp409w=="],
+
+    "@f5xc-salesdemos/pi-natives-win32-x64-msvc": ["@f5xc-salesdemos/pi-natives-win32-x64-msvc@18.91.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Igvw+hJah6AcIvU2Sa+OVsUPm3IVwVZJdSQaOfMshvZJyhtSMaO6dfurtQUgBSAy8vveDxvvpigUz48blQCHHw=="],
+
+    "@f5xc-salesdemos/pi-tui": ["@f5xc-salesdemos/pi-tui@18.91.1", "", { "dependencies": { "@f5xc-salesdemos/pi-natives": "18.91.1", "@f5xc-salesdemos/pi-utils": "18.91.1", "marked": "^17.0" } }, "sha512-9mI02XzHA1GnFe/ovOcNkKERVKMT6uV4umSTuORZ48k8kGzVldsqM7dE+rS0xtyGtJI7MEABATgTrkDg0Vd6Cw=="],
+
+    "@f5xc-salesdemos/pi-utils": ["@f5xc-salesdemos/pi-utils@18.91.1", "", { "dependencies": { "beautiful-mermaid": "^1.1", "handlebars": "^4.7.9", "winston": "^3.19", "winston-daily-rotate-file": "^5.0" } }, "sha512-UsaVGLsRLU3CICVNB3g59m1CXtmlKCMJo8RpDpd8sPCX0ikmAxaFlhVhdQHacyvNEXwGKWoTcucV8Ir1RWj/4Q=="],
+
+    "@f5xc-salesdemos/xcsh": ["@f5xc-salesdemos/xcsh@18.91.1", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@f5xc-salesdemos/pi-agent-core": "18.91.1", "@f5xc-salesdemos/pi-ai": "18.91.1", "@f5xc-salesdemos/pi-natives": "18.91.1", "@f5xc-salesdemos/pi-tui": "18.91.1", "@f5xc-salesdemos/pi-utils": "18.91.1", "@f5xc-salesdemos/xcsh-stats": "18.91.1", "@mozilla/readability": "^0.6", "@sinclair/typebox": "^0.34", "@xterm/headless": "^6.0", "ajv": "^8.18", "chalk": "^5.6", "diff": "^8.0", "fflate": "0.8.2", "handlebars": "^4.7", "linkedom": "^0.18", "lru-cache": "11.3.1", "markit-ai": "0.5.0", "puppeteer": "^24.37", "zod": "4.3.6" }, "bin": { "xcsh": "src/cli.ts" } }, "sha512-w4qLKZnGbOtA6Y+jAk11iTh2RyJxdid8oi0rAUoyqlmszD+Z+Dqrs/b+pkGT8rEAaynzuV7vrvfOMcnFdv3cOQ=="],
+
+    "@f5xc-salesdemos/xcsh-stats": ["@f5xc-salesdemos/xcsh-stats@18.91.1", "", { "dependencies": { "@f5xc-salesdemos/pi-ai": "18.91.1", "@f5xc-salesdemos/pi-utils": "18.91.1", "@tailwindcss/node": "^4.2", "chart.js": "^4.5", "date-fns": "~4.1.0", "lucide-react": "^0.576", "react": "^19.2", "react-chartjs-2": "^5.3", "react-dom": "^19.2" }, "bin": { "xcsh-stats": "src/index.ts" } }, "sha512-bH7SlX88MnuoQg1dU7X7Miz9FX1phOqQUgAJjLPnUk5iFL2/NHUCusXgDc5hyu1lVfRKqqIU0lgZm1aku0dJEQ=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
+
+    "@nodable/entities": ["@nodable/entities@2.1.1", "", {}, "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.2", "", {}, "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
+
+    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
+    "@smithy/core": ["@smithy/core@3.24.6", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.7", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.6", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.6", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.6", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ=="],
+
+    "@smithy/types": ["@smithy/types@4.14.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
+    "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
+    "bare-events": ["bare-events@2.8.3", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw=="],
+
+    "bare-fs": ["bare-fs@4.7.1", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw=="],
+
+    "bare-os": ["bare-os@3.9.1", "", {}, "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ=="],
+
+    "bare-path": ["bare-path@3.0.1", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ=="],
+
+    "bare-stream": ["bare-stream@2.13.1", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow=="],
+
+    "bare-url": ["bare-url@2.4.3", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
+    "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
+
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
+
+    "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
+
+    "color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
+
+    "color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
+
+    "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.22.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "exifr": ["exifr@7.1.3", "", {}, "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.8.0", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.2.0", "path-expression-matcher": "^1.5.0", "strnum": "^2.3.0", "xml-naming": "^0.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "fecha": ["fecha@4.2.3", "", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "file-stream-rotator": ["file-stream-rotator@0.6.1", "", { "dependencies": { "moment": "^2.29.1" } }, "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
+    "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.2.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
+
+    "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
+
+    "lru-cache": ["lru-cache@11.3.1", "", {}, "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w=="],
+
+    "lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
+
+    "markit-ai": ["markit-ai@0.5.0", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.3", "exifr": "^7.1.3", "fast-xml-parser": "^5.5.9", "jszip": "^3.10.1", "mammoth": "^1.9.0", "mupdf": "^1.27.0", "music-metadata": "^11.12.3", "rss-parser": "^3.13.0", "turndown": "^7.2.0", "turndown-plugin-gfm": "^1.0.2" }, "bin": { "markit": "dist/main.js" } }, "sha512-ob3VxICBZe2Ge3Wg0vFOv6jkk/7OaYisQbtMYR7lUh00MkhAJ/sdVFy0GlqjPkXQ+mGygLdioGB+PfBLUJ5B2w=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mupdf": ["mupdf@1.27.0", "", {}, "sha512-vEPUYwZeu5NgiFLz4e20R7Vp2pNY7szirGEvTxHyQQpQs6ab4DeGdonwT6sH1JZG5EhyHSrojZrZn2/0ee6qZQ=="],
+
+    "music-metadata": ["music-metadata@11.12.3", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.4.3", "file-type": "^21.3.1", "media-typer": "^1.1.0", "strtok3": "^10.3.4", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
+
+    "openai": ["openai@6.41.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-IGWPopZq6Rjoynjfb3NSLf/z2MTw7UiOsm9TAjPGAjUESH7Uq41Trg4QWehBEn58p74i+m7uoRPV2vXcpPXhyA=="],
+
+    "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "protobufjs": ["protobufjs@7.6.2", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "puppeteer": ["puppeteer@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "cosmiconfig": "^9.0.0", "devtools-protocol": "0.0.1608973", "puppeteer-core": "24.43.1", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/cjs/puppeteer/node/cli.js" } }, "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw=="],
+
+    "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.20.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
+
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-chartjs-2": ["react-chartjs-2@5.3.1", "", { "peerDependencies": { "chart.js": "^4.1.1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "rss-parser": ["rss-parser@3.13.0", "", { "dependencies": { "entities": "^2.0.3", "xml2js": "^0.5.0" } }, "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
+    "streamx": ["streamx@2.26.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
+
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
+
+    "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "triple-beam": ["triple-beam@1.4.1", "", {}, "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "turndown-plugin-gfm": ["turndown-plugin-gfm@1.0.2", "", {}, "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="],
+
+    "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
+
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
+
+    "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
+
+    "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
+
+    "winston-daily-rotate-file": ["winston-daily-rotate-file@5.0.0", "", { "dependencies": { "file-stream-rotator": "^0.6.1", "object-hash": "^3.0.0", "triple-beam": "^1.4.1", "winston-transport": "^4.7.0" }, "peerDependencies": { "winston": "^3" } }, "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw=="],
+
+    "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@10.1.1", "", {}, "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1056.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.15", "@aws-sdk/nested-clients": "^3.997.13", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.5", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA=="],
+
+    "@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
+    "@f5xc-salesdemos/pi-ai/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "rss-parser/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
+    "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+  }
+}

--- a/plugins/azure-status/package.json
+++ b/plugins/azure-status/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@f5xc-salesdemos/xcsh-azure-status",
   "version": "1.0.0",
-  "description": "Azure CLI status for xcsh welcome screen",
+  "description": "Azure CLI tools for xcsh — native az command execution, subscription/resource/VM management, and welcome screen status",
   "main": "src/index.ts",
+  "scripts": {
+    "test": "bun test",
+    "test:watch": "bun test --watch"
+  },
   "xcsh": {
     "name": "Azure Status",
     "version": "1.0.0",
@@ -12,6 +16,10 @@
   },
   "peerDependencies": {
     "@f5xc-salesdemos/xcsh": ">=1.0.0"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.0",
+    "bun-types": "latest"
   },
   "license": "Apache-2.0"
 }

--- a/plugins/azure-status/src/az/exec.ts
+++ b/plugins/azure-status/src/az/exec.ts
@@ -1,0 +1,73 @@
+import type { AzRawResult } from './types';
+
+export class AzExecError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AzExecError';
+  }
+}
+
+export class AzAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AzAuthError';
+  }
+}
+
+export class AzSessionExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AzSessionExpiredError';
+  }
+}
+
+export class AzNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AzNotFoundError';
+  }
+}
+
+export function detectAzError(stderr: string, _exitCode: number): Error {
+  const lower = stderr.toLowerCase();
+  if (lower.includes('az login') || lower.includes('no subscription found')) {
+    return new AzAuthError(stderr);
+  }
+  if (lower.includes('aadsts') || lower.includes('token has expired') || lower.includes('not yet valid')) {
+    return new AzSessionExpiredError(stderr);
+  }
+  return new AzExecError(stderr);
+}
+
+export function parseAzJsonOutput<T>(raw: string): T {
+  try {
+    if (!raw || raw.trim().length === 0) {
+      throw new AzExecError('Empty output from az CLI');
+    }
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    if (err instanceof AzExecError) throw err;
+    throw new AzExecError(`Failed to parse az CLI output: ${(err as Error).message}`);
+  }
+}
+
+export interface AzExecApi {
+  exec(command: string, args: string[], options?: { signal?: AbortSignal }): Promise<AzRawResult>;
+}
+
+export async function execAzJson<T>(api: AzExecApi, args: string[], signal?: AbortSignal): Promise<T> {
+  const fullArgs = [...args, '--output', 'json'];
+  const result = await api.exec('az', fullArgs, { signal });
+  if (result.exitCode !== 0) {
+    throw detectAzError(result.stderr, result.exitCode);
+  }
+  return parseAzJsonOutput<T>(result.stdout);
+}
+
+export async function execAzRaw(api: AzExecApi, args: string[], signal?: AbortSignal): Promise<AzRawResult> {
+  const result = await api.exec('az', args, { signal });
+  if (result.exitCode !== 0) {
+    throw detectAzError(result.stderr, result.exitCode);
+  }
+  return result;
+}

--- a/plugins/azure-status/src/az/formatters.ts
+++ b/plugins/azure-status/src/az/formatters.ts
@@ -1,0 +1,65 @@
+import type { AzResource, AzResourceGroup, AzSubscription, AzVm } from './types';
+
+export function formatSubscriptionTable(subs: AzSubscription[]): string {
+  if (subs.length === 0) return 'No subscriptions found.';
+  const header = '| Name | ID | State | Default | Tenant |';
+  const sep = '|------|-----|-------|---------|--------|';
+  const rows = subs.map((s) => `| ${s.name} | ${s.id} | ${s.state} | ${s.isDefault ? 'Yes' : 'No'} | ${s.tenantId} |`);
+  return [header, sep, ...rows].join('\n');
+}
+
+export function formatSubscriptionDetail(sub: AzSubscription): string {
+  return [
+    `**Subscription:** ${sub.name}`,
+    `**ID:** ${sub.id}`,
+    `**State:** ${sub.state}`,
+    `**Default:** ${sub.isDefault ? 'Yes' : 'No'}`,
+    `**Tenant:** ${sub.tenantId}`,
+    `**User:** ${sub.user.name} (${sub.user.type})`,
+  ].join('\n');
+}
+
+export function formatResourceGroupTable(groups: AzResourceGroup[]): string {
+  if (groups.length === 0) return 'No resource groups found.';
+  const header = '| Name | Location | State | Tags |';
+  const sep = '|------|----------|-------|------|';
+  const rows = groups.map((g) => {
+    const tags =
+      Object.entries(g.tags)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(', ') || '-';
+    return `| ${g.name} | ${g.location} | ${g.provisioningState} | ${tags} |`;
+  });
+  return [header, sep, ...rows].join('\n');
+}
+
+export function formatResourceTable(resources: AzResource[]): string {
+  if (resources.length === 0) return 'No resources found.';
+  const header = '| Name | Type | Location | Resource Group | State |';
+  const sep = '|------|------|----------|----------------|-------|';
+  const rows = resources.map(
+    (r) => `| ${r.name} | ${r.type} | ${r.location} | ${r.resourceGroup} | ${r.provisioningState} |`,
+  );
+  return [header, sep, ...rows].join('\n');
+}
+
+export function formatVmTable(vms: AzVm[]): string {
+  if (vms.length === 0) return 'No VMs found.';
+  const hasDetails = vms.some((v) => v.publicIps || v.fqdns);
+  if (hasDetails) {
+    const header = '| Name | Resource Group | Location | VM Size | OS | Power | Public IPs | FQDNs |';
+    const sep = '|------|----------------|----------|---------|-----|-------|------------|-------|';
+    const rows = vms.map(
+      (v) =>
+        `| ${v.name} | ${v.resourceGroup} | ${v.location} | ${v.vmSize} | ${v.osType} | ${v.powerState} | ${v.publicIps || '-'} | ${v.fqdns || '-'} |`,
+    );
+    return [header, sep, ...rows].join('\n');
+  }
+  const header = '| Name | Resource Group | Location | VM Size | OS | State | Power |';
+  const sep = '|------|----------------|----------|---------|-----|-------|-------|';
+  const rows = vms.map(
+    (v) =>
+      `| ${v.name} | ${v.resourceGroup} | ${v.location} | ${v.vmSize} | ${v.osType} | ${v.provisioningState} | ${v.powerState} |`,
+  );
+  return [header, sep, ...rows].join('\n');
+}

--- a/plugins/azure-status/src/az/types.ts
+++ b/plugins/azure-status/src/az/types.ts
@@ -1,0 +1,58 @@
+export interface AzSubscription {
+  id: string;
+  name: string;
+  state: string;
+  isDefault: boolean;
+  tenantId: string;
+  user: { name: string; type: string };
+}
+
+export interface AzResourceGroup {
+  id: string;
+  name: string;
+  location: string;
+  provisioningState: string;
+  tags: Record<string, string>;
+}
+
+export interface AzResource {
+  id: string;
+  name: string;
+  type: string;
+  location: string;
+  resourceGroup: string;
+  provisioningState: string;
+  tags: Record<string, string>;
+}
+
+export interface AzVm {
+  id: string;
+  name: string;
+  location: string;
+  resourceGroup: string;
+  vmSize: string;
+  provisioningState: string;
+  osType: string;
+  powerState: string;
+  publicIps: string;
+  fqdns: string;
+}
+
+export interface PluginInterface {
+  typebox: { Type: Record<string, (...args: unknown[]) => unknown> };
+  [key: string]: unknown;
+}
+
+export interface AzRawResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export const SUBSCRIPTION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const RESOURCE_GROUP_PATTERN = /^[a-zA-Z0-9._()-]+$/;
+export const SUBSCRIPTION_NAME_PATTERN = /^[a-zA-Z0-9 ._-]+$/;
+export const SAFE_ARG_PATTERN = /^[a-zA-Z0-9._@:/=[\]{},"'?*()!+ -]+$/;
+export const HELP_PATH_PATTERN = /^[a-z][a-z -]*$/;
+export const RESOURCE_TYPE_PATTERN = /^[a-zA-Z0-9./]+$/;
+export const TAG_PATTERN = /^[a-zA-Z0-9._-]+(=[a-zA-Z0-9._@: -]*)?$/;

--- a/plugins/azure-status/src/index.ts
+++ b/plugins/azure-status/src/index.ts
@@ -3,7 +3,6 @@ import type { ExtensionFactory } from '@f5xc-salesdemos/xcsh';
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('Azure Status');
 
-  // Always register setup command (even without az CLI)
   if (typeof pi.registerCommand === 'function') {
     pi.registerCommand('azure-status:setup', {
       description: 'Install and configure Azure CLI',
@@ -14,7 +13,6 @@ const factory: ExtensionFactory = async (pi) => {
     });
   }
 
-  // Check if az CLI is available
   let azAvailable = false;
   try {
     const checker = process.platform === 'win32' ? 'where' : 'which';
@@ -23,7 +21,22 @@ const factory: ExtensionFactory = async (pi) => {
     // az not available
   }
 
-  // Always register service status (shows unavailable when CLI missing)
+  if (azAvailable && typeof pi.registerTool === 'function') {
+    const { createAzAccountTool } = await import('./tools/az-account');
+    const { createAzGroupTool } = await import('./tools/az-group');
+    const { createAzResourceTool } = await import('./tools/az-resource');
+    const { createAzVmTool } = await import('./tools/az-vm');
+    const { createAzExecTool } = await import('./tools/az-exec');
+    const { createAzHelpTool } = await import('./tools/az-help');
+
+    pi.registerTool(createAzAccountTool(pi));
+    pi.registerTool(createAzGroupTool(pi));
+    pi.registerTool(createAzResourceTool(pi));
+    pi.registerTool(createAzVmTool(pi));
+    pi.registerTool(createAzExecTool(pi));
+    pi.registerTool(createAzHelpTool(pi));
+  }
+
   if (typeof pi.registerServiceStatus === 'function') {
     pi.registerServiceStatus({
       name: 'Azure',
@@ -48,7 +61,6 @@ const factory: ExtensionFactory = async (pi) => {
     });
   }
 
-  // Session start: notify if CLI missing
   if (typeof pi.on === 'function') {
     pi.on('session_start', async (_event: unknown, _ctx: { cwd: string }) => {
       if (!azAvailable) {

--- a/plugins/azure-status/src/prompts/az-account.md
+++ b/plugins/azure-status/src/prompts/az-account.md
@@ -1,0 +1,39 @@
+Show or list Azure subscriptions via `az account`.
+
+## Actions
+
+**show** — Get details of the current (or specified) subscription.
+
+```
+az account show [--subscription NAME_OR_ID]
+```
+
+**list** — List subscriptions for the logged-in account. By default only 'Enabled' subscriptions are shown.
+
+```
+az account list [--all] [--refresh]
+```
+
+## Flags
+
+| Flag | Applies To | Description |
+|------|-----------|-------------|
+| `--subscription`, `-s`, `-n` | show | Name or ID of subscription |
+| `--all` | list | Include subscriptions that are not 'Enabled' |
+| `--refresh` | list | Retrieve up-to-date subscriptions from server |
+
+## Output Fields (JSON)
+
+- `id` — Subscription UUID
+- `name` — Display name
+- `state` — Enabled, Disabled, Warned, etc.
+- `isDefault` — Whether this is the active subscription
+- `tenantId` — Azure AD tenant UUID
+- `user.name` — Authenticated user/principal
+- `user.type` — "user", "servicePrincipal", etc.
+
+## Related Commands
+
+- `az account set -s NAME_OR_ID` — Switch active subscription
+- `az account get-access-token` — Get token for API access
+- `az account list-locations` — List regions for current subscription

--- a/plugins/azure-status/src/prompts/az-exec.md
+++ b/plugins/azure-status/src/prompts/az-exec.md
@@ -1,0 +1,39 @@
+Execute any `az` CLI subcommand directly.
+
+This is the general-purpose tool for running az commands that are not covered by the typed tools (az_account, az_group, az_resource, az_vm). Use typed tools when available — they validate inputs and return structured data.
+
+## Usage
+
+Pass the subcommand and flags as an array of arguments. Do NOT include `az` itself — it is prepended automatically.
+
+**Example:** To run `az webapp list --resource-group myRG`:
+
+```json
+{ "args": ["webapp", "list", "--resource-group", "myRG"] }
+```
+
+## Safety
+
+- Each argument is validated: no shell metacharacters (`;`, `|`, `$`, backticks, `&&`, `||`) are allowed
+- Arguments are passed as an array to `Bun.spawn` — no shell interpretation occurs
+- Output is capped to prevent context overflow
+
+## Common Subcommands Not Covered by Typed Tools
+
+- `az webapp list` / `az webapp show` — App Service
+- `az aks list` / `az aks show` — Kubernetes Service
+- `az storage account list` — Storage accounts
+- `az network vnet list` — Virtual Networks
+- `az network nsg list` — Network Security Groups
+- `az sql server list` — SQL servers
+- `az keyvault list` — Key Vaults
+- `az container list` — Container Instances
+- `az acr list` — Container Registries
+- `az functionapp list` — Function Apps
+
+## Tips
+
+- Always include `--output json` for machine-readable output (added automatically)
+- Use `--subscription NAME_OR_ID` to target a specific subscription
+- Use `--resource-group NAME` to scope to a resource group
+- Use `az_help` tool first if unsure about available flags

--- a/plugins/azure-status/src/prompts/az-group.md
+++ b/plugins/azure-status/src/prompts/az-group.md
@@ -1,0 +1,42 @@
+List or show Azure resource groups via `az group`.
+
+## Actions
+
+**list** — List all resource groups in the current subscription.
+
+```
+az group list [--subscription NAME_OR_ID] [--tag KEY[=VALUE]]
+```
+
+**show** — Get details of a specific resource group.
+
+```
+az group show --name NAME [--subscription NAME_OR_ID]
+```
+
+## Flags
+
+| Flag | Applies To | Description |
+|------|-----------|-------------|
+| `--subscription` | list, show | Name or ID of subscription |
+| `--tag` | list | Filter by tag in `key[=value]` format |
+| `--name`, `-n` | show | Resource group name (required for show) |
+
+## Output Fields (JSON)
+
+- `id` — Full resource ID
+- `name` — Resource group name
+- `location` — Azure region (e.g. eastus, westus2)
+- `properties.provisioningState` — Succeeded, Failed, etc.
+- `tags` — Key-value tag pairs
+
+## Naming Rules
+
+Resource group names: 1-90 chars, alphanumeric, periods, underscores, hyphens, parentheses. Cannot end with a period.
+
+## Related Commands
+
+- `az group create --name NAME --location LOCATION` — Create resource group
+- `az group delete --name NAME` — Delete resource group
+- `az group exists --name NAME` — Check if exists (returns true/false)
+- `az group export --name NAME` — Export as ARM template

--- a/plugins/azure-status/src/prompts/az-help.md
+++ b/plugins/azure-status/src/prompts/az-help.md
@@ -1,0 +1,41 @@
+Fetch help documentation for any `az` CLI command group or subcommand.
+
+Use this tool to discover available commands, flags, and usage patterns for az CLI subcommands that are not covered by the embedded tool documentation.
+
+## Usage
+
+Pass the command path (without `az` prefix) to get help:
+
+**Example:** To see `az network vnet --help`:
+
+```json
+{ "command_path": "network vnet" }
+```
+
+**Example:** To see `az storage blob --help`:
+
+```json
+{ "command_path": "storage blob" }
+```
+
+**Example:** To see top-level `az --help`:
+
+```json
+{ "command_path": "" }
+```
+
+## When to Use
+
+- Before using `az_exec` with an unfamiliar command group
+- To discover available subcommands within a group
+- To find the correct flags for a specific operation
+- To check required vs optional parameters
+
+## Output
+
+Returns the raw `az <command> --help` output, which includes:
+
+- Available subgroups and commands
+- Command arguments with descriptions
+- Required vs optional parameters
+- Usage examples

--- a/plugins/azure-status/src/prompts/az-resource.md
+++ b/plugins/azure-status/src/prompts/az-resource.md
@@ -1,0 +1,50 @@
+List Azure resources via `az resource list`.
+
+## Usage
+
+```
+az resource list [--resource-group NAME] [--resource-type TYPE] [--location LOCATION] [--name NAME] [--tag KEY[=VALUE]] [--subscription NAME_OR_ID]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--resource-group`, `-g` | Filter by resource group name |
+| `--resource-type` | Filter by type (e.g. `Microsoft.Compute/virtualMachines`). Accepts `namespace/type` format. |
+| `--location`, `-l` | Filter by region |
+| `--name`, `-n` | Filter by resource name |
+| `--tag` | Filter by tag in `key[=value]` format |
+| `--subscription` | Name or ID of subscription |
+
+## Output Fields (JSON)
+
+- `id` — Full resource ID
+- `name` — Resource name
+- `type` — Resource type (e.g. `Microsoft.Compute/virtualMachines`)
+- `location` — Azure region
+- `resourceGroup` — Parent resource group
+- `provisioningState` — Succeeded, Failed, etc.
+- `tags` — Key-value tag pairs
+
+## Common Resource Types
+
+- `Microsoft.Compute/virtualMachines` — VMs
+- `Microsoft.Storage/storageAccounts` — Storage
+- `Microsoft.Network/virtualNetworks` — VNets
+- `Microsoft.Network/publicIPAddresses` — Public IPs
+- `Microsoft.Network/networkSecurityGroups` — NSGs
+- `Microsoft.Web/sites` — App Service / Functions
+- `Microsoft.ContainerService/managedClusters` — AKS
+- `Microsoft.Sql/servers` — SQL servers
+- `Microsoft.KeyVault/vaults` — Key Vaults
+
+## Notes
+
+Without `--resource-group`, lists all resources in the subscription (can be large). Always specify a resource group when possible.
+
+## Related Commands
+
+- `az resource show --ids RESOURCE_ID` — Show single resource
+- `az resource delete --ids RESOURCE_ID` — Delete resource
+- `az resource tag --ids RESOURCE_ID --tags KEY=VALUE` — Tag resource

--- a/plugins/azure-status/src/prompts/az-vm.md
+++ b/plugins/azure-status/src/prompts/az-vm.md
@@ -1,0 +1,51 @@
+List Azure Virtual Machines via `az vm list`.
+
+## Usage
+
+```
+az vm list [--resource-group NAME] [--show-details] [--vmss VMSS_ID] [--subscription NAME_OR_ID]
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--resource-group`, `-g` | Filter by resource group |
+| `--show-details`, `-d` | Include public IP, FQDN, and power state. **Runs slower.** |
+| `--vmss` | List VMs in a specific Virtual Machine Scale Set |
+| `--subscription` | Name or ID of subscription |
+
+## Output Fields (JSON)
+
+Without `--show-details`:
+
+- `id` — Full resource ID
+- `name` — VM name
+- `location` — Azure region
+- `resourceGroup` — Parent resource group
+- `hardwareProfile.vmSize` — VM size (e.g. Standard_D2s_v5)
+- `storageProfile.osDisk.osType` — Linux or Windows
+- `provisioningState` — Succeeded, Failed, etc.
+
+With `--show-details`:
+
+- All above fields plus:
+- `powerState` — VM running, VM deallocated, VM stopped, etc.
+- `publicIps` — Public IP addresses
+- `fqdns` — Fully qualified domain names
+
+## Common VM Operations
+
+- `az vm show --name NAME --resource-group RG` — Show single VM
+- `az vm start --name NAME --resource-group RG` — Start VM
+- `az vm stop --name NAME --resource-group RG` — Stop VM
+- `az vm deallocate --name NAME --resource-group RG` — Deallocate (stop billing)
+- `az vm restart --name NAME --resource-group RG` — Restart VM
+- `az vm list-ip-addresses --name NAME --resource-group RG` — Get IPs
+- `az vm list-sizes --location LOCATION` — List available sizes
+- `az vm open-port --name NAME --resource-group RG --port PORT` — Open port
+
+## Notes
+
+Without `--resource-group`, lists all VMs in the subscription.
+`--show-details` makes additional API calls per VM, significantly slower on large fleets.

--- a/plugins/azure-status/src/tools/az-account.ts
+++ b/plugins/azure-status/src/tools/az-account.ts
@@ -1,0 +1,69 @@
+import { execAzJson } from '../az/exec';
+import { formatSubscriptionDetail, formatSubscriptionTable } from '../az/formatters';
+import type { PluginInterface } from '../az/types';
+import { SUBSCRIPTION_ID_PATTERN, SUBSCRIPTION_NAME_PATTERN } from '../az/types';
+import azAccountDescription from '../prompts/az-account.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, normalizeSubscription, textResult } from './shared';
+
+export function createAzAccountTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    action: Type.Union([Type.Literal('show'), Type.Literal('list')], {
+      description: 'show = current subscription, list = all subscriptions',
+    }),
+    subscription: Type.Optional(Type.String({ description: 'Filter by subscription name or ID' })),
+  });
+
+  return {
+    name: 'az_account',
+    label: 'Azure Account',
+    description: azAccountDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { action?: string; subscription?: string },
+      _signal: unknown,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'az_account' as const, action: params.action };
+
+      if (params.subscription) {
+        const isUuid = SUBSCRIPTION_ID_PATTERN.test(params.subscription);
+        const isName = SUBSCRIPTION_NAME_PATTERN.test(params.subscription);
+        if (!isUuid && !isName) {
+          return errorResult(
+            `Error: invalid subscription "${params.subscription}". Only alphanumeric characters, spaces, dots, underscores, and hyphens are allowed.`,
+            base,
+          );
+        }
+      }
+
+      const api = makeExecApi(ctx.cwd);
+
+      try {
+        if (params.action === 'list') {
+          const raw = await execAzJson<Record<string, unknown>[]>(api, ['account', 'list']);
+          let subs = raw.map(normalizeSubscription);
+          if (params.subscription) {
+            const filter = params.subscription.toLowerCase();
+            subs = subs.filter((s) => s.name.toLowerCase().includes(filter) || s.id.toLowerCase().includes(filter));
+          }
+          return textResult(formatSubscriptionTable(subs), { ...base, subscriptions: subs });
+        }
+
+        const args = ['account', 'show'];
+        if (params.subscription) args.push('--subscription', params.subscription);
+        const raw = await execAzJson<Record<string, unknown>>(api, args);
+        const sub = normalizeSubscription(raw);
+        return textResult(formatSubscriptionDetail(sub), { ...base, subscriptions: [sub] });
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: detectErrorType(err),
+        });
+      }
+    },
+  };
+}

--- a/plugins/azure-status/src/tools/az-exec.ts
+++ b/plugins/azure-status/src/tools/az-exec.ts
@@ -1,0 +1,68 @@
+import type { PluginInterface } from '../az/types';
+import { SAFE_ARG_PATTERN } from '../az/types';
+import azExecDescription from '../prompts/az-exec.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, textResult } from './shared';
+
+const MAX_OUTPUT_LENGTH = 50000;
+
+export function createAzExecTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    args: Type.Array(Type.String({ description: 'Individual argument (do NOT include "az" itself)' }), {
+      description: 'Command arguments as array, e.g. ["webapp", "list", "--resource-group", "myRG"]',
+    }),
+  });
+
+  return {
+    name: 'az_exec',
+    label: 'Azure CLI Execute',
+    description: azExecDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { args: string[] },
+      _signal: unknown,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'az_exec' as const };
+
+      if (!params.args || params.args.length === 0) {
+        return errorResult('Error: args array must not be empty. Provide az subcommand and flags.', base);
+      }
+
+      for (const arg of params.args) {
+        if (!SAFE_ARG_PATTERN.test(arg)) {
+          return errorResult(
+            `Error: unsafe argument "${arg}". Shell metacharacters (;|$\`&&||) are not allowed.`,
+            base,
+          );
+        }
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const args = [...params.args, '--output', 'json'];
+
+      try {
+        const result = await api.exec('az', args);
+        if (result.exitCode !== 0) {
+          return errorResult(`az command failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`, {
+            ...base,
+            errorType: 'exec_error',
+          });
+        }
+        let output = result.stdout;
+        if (output.length > MAX_OUTPUT_LENGTH) {
+          output = output.slice(0, MAX_OUTPUT_LENGTH) + `\n\n[Output truncated at ${MAX_OUTPUT_LENGTH} characters]`;
+        }
+        return textResult(output, base);
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: detectErrorType(err),
+        });
+      }
+    },
+  };
+}

--- a/plugins/azure-status/src/tools/az-group.ts
+++ b/plugins/azure-status/src/tools/az-group.ts
@@ -1,0 +1,84 @@
+import { execAzJson } from '../az/exec';
+import { formatResourceGroupTable } from '../az/formatters';
+import type { PluginInterface } from '../az/types';
+import { RESOURCE_GROUP_PATTERN, SUBSCRIPTION_ID_PATTERN, SUBSCRIPTION_NAME_PATTERN, TAG_PATTERN } from '../az/types';
+import azGroupDescription from '../prompts/az-group.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, normalizeResourceGroup, textResult } from './shared';
+
+export function createAzGroupTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    action: Type.Union([Type.Literal('list'), Type.Literal('show')], {
+      description: 'list = all resource groups, show = single resource group details',
+    }),
+    name: Type.Optional(Type.String({ description: 'Resource group name (required for show)' })),
+    subscription: Type.Optional(Type.String({ description: 'Subscription name or ID' })),
+    tag: Type.Optional(Type.String({ description: 'Filter by tag in key[=value] format' })),
+  });
+
+  return {
+    name: 'az_group',
+    label: 'Azure Resource Groups',
+    description: azGroupDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { action?: string; name?: string; subscription?: string; tag?: string },
+      _signal: unknown,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'az_group' as const, action: params.action };
+
+      if (params.name && !RESOURCE_GROUP_PATTERN.test(params.name)) {
+        return errorResult(
+          `Error: invalid resource group name "${params.name}". Only alphanumeric characters, periods, underscores, hyphens, and parentheses are allowed.`,
+          base,
+        );
+      }
+
+      if (params.subscription) {
+        const isUuid = SUBSCRIPTION_ID_PATTERN.test(params.subscription);
+        const isName = SUBSCRIPTION_NAME_PATTERN.test(params.subscription);
+        if (!isUuid && !isName) {
+          return errorResult(`Error: invalid subscription "${params.subscription}".`, base);
+        }
+      }
+
+      if (params.tag && !TAG_PATTERN.test(params.tag)) {
+        return errorResult(
+          `Error: invalid tag "${params.tag}". Use format key[=value] with safe characters only.`,
+          base,
+        );
+      }
+
+      const api = makeExecApi(ctx.cwd);
+
+      try {
+        if (params.action === 'show') {
+          if (!params.name) {
+            return errorResult('Error: --name is required for show action.', base);
+          }
+          const args = ['group', 'show', '--name', params.name];
+          if (params.subscription) args.push('--subscription', params.subscription);
+          const raw = await execAzJson<Record<string, unknown>>(api, args);
+          const group = normalizeResourceGroup(raw);
+          return textResult(formatResourceGroupTable([group]), { ...base, resourceGroups: [group] });
+        }
+
+        const args = ['group', 'list'];
+        if (params.subscription) args.push('--subscription', params.subscription);
+        if (params.tag) args.push('--tag', params.tag);
+        const raw = await execAzJson<Record<string, unknown>[]>(api, args);
+        const groups = raw.map(normalizeResourceGroup);
+        return textResult(formatResourceGroupTable(groups), { ...base, resourceGroups: groups });
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: detectErrorType(err),
+        });
+      }
+    },
+  };
+}

--- a/plugins/azure-status/src/tools/az-help.ts
+++ b/plugins/azure-status/src/tools/az-help.ts
@@ -1,0 +1,63 @@
+import type { PluginInterface } from '../az/types';
+import { HELP_PATH_PATTERN } from '../az/types';
+import azHelpDescription from '../prompts/az-help.md' with { type: 'text' };
+import { errorResult, makeExecApi, textResult } from './shared';
+
+export function createAzHelpTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    command_path: Type.Optional(
+      Type.String({
+        description:
+          'Command path without "az" prefix, e.g. "network vnet" or "storage blob". Empty for top-level help.',
+      }),
+    ),
+  });
+
+  return {
+    name: 'az_help',
+    label: 'Azure CLI Help',
+    description: azHelpDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { command_path?: string },
+      _signal: unknown,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'az_help' as const };
+      const commandPath = params.command_path?.trim() ?? '';
+
+      if (commandPath.length > 0 && !HELP_PATH_PATTERN.test(commandPath)) {
+        return errorResult(
+          `Error: invalid command path "${commandPath}". Only lowercase letters, hyphens, and spaces are allowed.`,
+          base,
+        );
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const parts = commandPath.length > 0 ? commandPath.split(' ').filter(Boolean) : [];
+      const args = [...parts, '--help'];
+
+      try {
+        const result = await api.exec('az', args);
+        if (result.exitCode !== 0) {
+          const msg = result.stderr || result.stdout || `az ${commandPath} --help failed (exit ${result.exitCode})`;
+          return errorResult(`Error: ${msg}`, { ...base, errorType: 'exec_error' });
+        }
+        const output = result.stdout || result.stderr;
+        if (!output.trim()) {
+          return errorResult(`No help output for "az ${commandPath}".`, base);
+        }
+        return textResult(output, base);
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: 'exec_error',
+        });
+      }
+    },
+  };
+}

--- a/plugins/azure-status/src/tools/az-resource.ts
+++ b/plugins/azure-status/src/tools/az-resource.ts
@@ -1,0 +1,77 @@
+import { execAzJson } from '../az/exec';
+import { formatResourceTable } from '../az/formatters';
+import type { PluginInterface } from '../az/types';
+import {
+  RESOURCE_GROUP_PATTERN,
+  RESOURCE_TYPE_PATTERN,
+  SUBSCRIPTION_ID_PATTERN,
+  SUBSCRIPTION_NAME_PATTERN,
+} from '../az/types';
+import azResourceDescription from '../prompts/az-resource.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, normalizeResource, textResult } from './shared';
+
+export function createAzResourceTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    resource_group: Type.String({ description: 'Resource group name (required to avoid listing entire subscription)' }),
+    subscription: Type.Optional(Type.String({ description: 'Subscription name or ID' })),
+    resource_type: Type.Optional(
+      Type.String({ description: 'Filter by type (e.g. Microsoft.Compute/virtualMachines)' }),
+    ),
+  });
+
+  return {
+    name: 'az_resource',
+    label: 'Azure Resources',
+    description: azResourceDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { resource_group: string; subscription?: string; resource_type?: string },
+      _signal: unknown,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'az_resource' as const };
+
+      if (!params.resource_group || !RESOURCE_GROUP_PATTERN.test(params.resource_group)) {
+        return errorResult(
+          `Error: invalid resource group "${params.resource_group}". Only alphanumeric characters, periods, underscores, hyphens, and parentheses are allowed.`,
+          base,
+        );
+      }
+
+      if (params.subscription) {
+        const isUuid = SUBSCRIPTION_ID_PATTERN.test(params.subscription);
+        const isName = SUBSCRIPTION_NAME_PATTERN.test(params.subscription);
+        if (!isUuid && !isName) {
+          return errorResult(`Error: invalid subscription "${params.subscription}".`, base);
+        }
+      }
+
+      if (params.resource_type && !RESOURCE_TYPE_PATTERN.test(params.resource_type)) {
+        return errorResult(
+          `Error: invalid resource type "${params.resource_type}". Use format like Microsoft.Compute/virtualMachines.`,
+          base,
+        );
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const args = ['resource', 'list', '--resource-group', params.resource_group];
+      if (params.subscription) args.push('--subscription', params.subscription);
+      if (params.resource_type) args.push('--resource-type', params.resource_type);
+
+      try {
+        const raw = await execAzJson<Record<string, unknown>[]>(api, args);
+        const resources = raw.map(normalizeResource);
+        return textResult(formatResourceTable(resources), { ...base, resources });
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: detectErrorType(err),
+        });
+      }
+    },
+  };
+}

--- a/plugins/azure-status/src/tools/az-vm.ts
+++ b/plugins/azure-status/src/tools/az-vm.ts
@@ -1,0 +1,64 @@
+import { execAzJson } from '../az/exec';
+import { formatVmTable } from '../az/formatters';
+import type { PluginInterface } from '../az/types';
+import { RESOURCE_GROUP_PATTERN, SUBSCRIPTION_ID_PATTERN, SUBSCRIPTION_NAME_PATTERN } from '../az/types';
+import azVmDescription from '../prompts/az-vm.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, normalizeVm, textResult } from './shared';
+
+export function createAzVmTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    resource_group: Type.Optional(Type.String({ description: 'Filter by resource group' })),
+    subscription: Type.Optional(Type.String({ description: 'Subscription name or ID' })),
+    show_details: Type.Optional(Type.Boolean({ description: 'Include public IP, FQDN, and power state (slower)' })),
+  });
+
+  return {
+    name: 'az_vm',
+    label: 'Azure Virtual Machines',
+    description: azVmDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { resource_group?: string; subscription?: string; show_details?: boolean },
+      _signal: unknown,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'az_vm' as const };
+
+      if (params.resource_group && !RESOURCE_GROUP_PATTERN.test(params.resource_group)) {
+        return errorResult(
+          `Error: invalid resource group "${params.resource_group}". Only alphanumeric characters, periods, underscores, hyphens, and parentheses are allowed.`,
+          base,
+        );
+      }
+
+      if (params.subscription) {
+        const isUuid = SUBSCRIPTION_ID_PATTERN.test(params.subscription);
+        const isName = SUBSCRIPTION_NAME_PATTERN.test(params.subscription);
+        if (!isUuid && !isName) {
+          return errorResult(`Error: invalid subscription "${params.subscription}".`, base);
+        }
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const args = ['vm', 'list'];
+      if (params.resource_group) args.push('--resource-group', params.resource_group);
+      if (params.subscription) args.push('--subscription', params.subscription);
+      if (params.show_details) args.push('--show-details');
+
+      try {
+        const raw = await execAzJson<Record<string, unknown>[]>(api, args);
+        const vms = raw.map(normalizeVm);
+        return textResult(formatVmTable(vms), { ...base, vms });
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: detectErrorType(err),
+        });
+      }
+    },
+  };
+}

--- a/plugins/azure-status/src/tools/shared.ts
+++ b/plugins/azure-status/src/tools/shared.ts
@@ -1,0 +1,95 @@
+import { AzAuthError, AzNotFoundError, AzSessionExpiredError } from '../az/exec';
+import type { AzRawResult, AzResource, AzResourceGroup, AzSubscription, AzVm } from '../az/types';
+
+export type AzErrorType = 'auth_required' | 'session_expired' | 'not_found' | 'exec_error';
+
+export type AzToolName = 'az_account' | 'az_group' | 'az_resource' | 'az_vm' | 'az_exec' | 'az_help';
+
+export interface AzToolDetails {
+  tool: AzToolName;
+  action?: string;
+  subscriptions?: AzSubscription[];
+  resourceGroups?: AzResourceGroup[];
+  resources?: AzResource[];
+  vms?: AzVm[];
+  errorType?: AzErrorType;
+}
+
+export function textResult(text: string, details: AzToolDetails) {
+  return { content: [{ type: 'text' as const, text }], details };
+}
+
+export function errorResult(text: string, details: AzToolDetails) {
+  return { content: [{ type: 'text' as const, text }], isError: true, details };
+}
+
+export function detectErrorType(err: unknown): AzErrorType {
+  if (err instanceof AzAuthError) return 'auth_required';
+  if (err instanceof AzSessionExpiredError) return 'session_expired';
+  if (err instanceof AzNotFoundError) return 'not_found';
+  return 'exec_error';
+}
+
+export function makeExecApi(cwd: string): { exec: (command: string, args: string[]) => Promise<AzRawResult> } {
+  return {
+    async exec(command: string, args: string[]): Promise<AzRawResult> {
+      const proc = Bun.spawn([command, ...args], { cwd, stdout: 'pipe', stderr: 'pipe' });
+      const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+      const exitCode = await proc.exited;
+      return { stdout, stderr, exitCode };
+    },
+  };
+}
+
+export function normalizeSubscription(raw: Record<string, unknown>): AzSubscription {
+  const user = (raw.user as Record<string, unknown>) ?? {};
+  return {
+    id: String(raw.id ?? ''),
+    name: String(raw.name ?? ''),
+    state: String(raw.state ?? ''),
+    isDefault: Boolean(raw.isDefault),
+    tenantId: String(raw.tenantId ?? ''),
+    user: { name: String(user.name ?? ''), type: String(user.type ?? '') },
+  };
+}
+
+export function normalizeResourceGroup(raw: Record<string, unknown>): AzResourceGroup {
+  const props = (raw.properties as Record<string, unknown>) ?? {};
+  return {
+    id: String(raw.id ?? ''),
+    name: String(raw.name ?? ''),
+    location: String(raw.location ?? ''),
+    provisioningState: String(props.provisioningState ?? raw.provisioningState ?? ''),
+    tags: (raw.tags as Record<string, string>) ?? {},
+  };
+}
+
+export function normalizeResource(raw: Record<string, unknown>): AzResource {
+  return {
+    id: String(raw.id ?? ''),
+    name: String(raw.name ?? ''),
+    type: String(raw.type ?? ''),
+    location: String(raw.location ?? ''),
+    resourceGroup: String(raw.resourceGroup ?? ''),
+    provisioningState: String(raw.provisioningState ?? ''),
+    tags: (raw.tags as Record<string, string>) ?? {},
+  };
+}
+
+export function normalizeVm(raw: Record<string, unknown>): AzVm {
+  const hw = (raw.hardwareProfile as Record<string, unknown>) ?? {};
+  const storage = (raw.storageProfile as Record<string, unknown>) ?? {};
+  const osDisk = (storage.osDisk as Record<string, unknown>) ?? {};
+  return {
+    id: String(raw.id ?? ''),
+    name: String(raw.name ?? ''),
+    location: String(raw.location ?? ''),
+    resourceGroup: String(raw.resourceGroup ?? ''),
+    vmSize: String(hw.vmSize ?? ''),
+    provisioningState: String(raw.provisioningState ?? ''),
+    osType: String(osDisk.osType ?? ''),
+    powerState: String(raw.powerState ?? ''),
+    publicIps: String(raw.publicIps ?? ''),
+    fqdns: String(raw.fqdns ?? ''),
+  };
+}

--- a/plugins/azure-status/test/az/exec.test.ts
+++ b/plugins/azure-status/test/az/exec.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  AzAuthError,
+  AzExecError,
+  AzNotFoundError,
+  AzSessionExpiredError,
+  detectAzError,
+  parseAzJsonOutput,
+} from '../../src/az/exec';
+
+describe('parseAzJsonOutput', () => {
+  it('parses valid JSON array', () => {
+    const result = parseAzJsonOutput<Array<{ name: string }>>('[{"name":"test"}]');
+    expect(result).toEqual([{ name: 'test' }]);
+  });
+
+  it('parses valid JSON object', () => {
+    const result = parseAzJsonOutput<{ id: string }>('{"id":"123"}');
+    expect(result).toEqual({ id: '123' });
+  });
+
+  it('throws AzExecError on malformed JSON', () => {
+    expect(() => parseAzJsonOutput('not json {')).toThrow(AzExecError);
+  });
+
+  it('throws AzExecError on empty string', () => {
+    expect(() => parseAzJsonOutput('')).toThrow(AzExecError);
+  });
+});
+
+describe('detectAzError', () => {
+  it('maps "Please run az login" to AzAuthError', () => {
+    const err = detectAzError("Please run 'az login' to setup account.", 1);
+    expect(err).toBeInstanceOf(AzAuthError);
+  });
+
+  it('maps "az login" mention to AzAuthError', () => {
+    const err = detectAzError('ERROR: No subscription found. Run az login.', 1);
+    expect(err).toBeInstanceOf(AzAuthError);
+  });
+
+  it('maps AADSTS token error to AzSessionExpiredError', () => {
+    const err = detectAzError('AADSTS700082: The refresh token has expired.', 1);
+    expect(err).toBeInstanceOf(AzSessionExpiredError);
+  });
+
+  it('maps "token has expired" to AzSessionExpiredError', () => {
+    const err = detectAzError('The access token has expired or is not yet valid.', 1);
+    expect(err).toBeInstanceOf(AzSessionExpiredError);
+  });
+
+  it('maps unknown stderr with exit code 1 to AzExecError', () => {
+    const err = detectAzError('Something went wrong', 1);
+    expect(err).toBeInstanceOf(AzExecError);
+  });
+
+  it('includes stderr in error message', () => {
+    const err = detectAzError('Some detailed error message', 1);
+    expect(err.message).toContain('Some detailed error message');
+  });
+});
+
+describe('error class hierarchy', () => {
+  it('AzAuthError is an instance of Error', () => {
+    expect(new AzAuthError('test')).toBeInstanceOf(Error);
+  });
+
+  it('AzSessionExpiredError is an instance of Error', () => {
+    expect(new AzSessionExpiredError('test')).toBeInstanceOf(Error);
+  });
+
+  it('AzNotFoundError is an instance of Error', () => {
+    expect(new AzNotFoundError('test')).toBeInstanceOf(Error);
+  });
+
+  it('AzExecError is an instance of Error', () => {
+    expect(new AzExecError('test')).toBeInstanceOf(Error);
+  });
+});

--- a/plugins/azure-status/test/az/formatters.test.ts
+++ b/plugins/azure-status/test/az/formatters.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  formatResourceGroupTable,
+  formatResourceTable,
+  formatSubscriptionDetail,
+  formatSubscriptionTable,
+  formatVmTable,
+} from '../../src/az/formatters';
+import type { AzResource, AzResourceGroup, AzSubscription, AzVm } from '../../src/az/types';
+
+describe('formatSubscriptionTable', () => {
+  it('returns no-data message for empty array', () => {
+    expect(formatSubscriptionTable([])).toContain('No subscriptions found');
+  });
+
+  it('formats multiple subscriptions as markdown table', () => {
+    const subs: AzSubscription[] = [
+      {
+        id: 'aaa-bbb',
+        name: 'Dev',
+        state: 'Enabled',
+        isDefault: true,
+        tenantId: 't1',
+        user: { name: 'u@t.com', type: 'user' },
+      },
+      {
+        id: 'ccc-ddd',
+        name: 'Prod',
+        state: 'Enabled',
+        isDefault: false,
+        tenantId: 't2',
+        user: { name: 'u@t.com', type: 'user' },
+      },
+    ];
+    const result = formatSubscriptionTable(subs);
+    expect(result).toContain('Dev');
+    expect(result).toContain('Prod');
+    expect(result).toContain('aaa-bbb');
+    expect(result).toContain('|');
+  });
+});
+
+describe('formatSubscriptionDetail', () => {
+  it('renders single subscription details', () => {
+    const sub: AzSubscription = {
+      id: 'abc-123',
+      name: 'My Sub',
+      state: 'Enabled',
+      isDefault: true,
+      tenantId: 'tenant-1',
+      user: { name: 'user@example.com', type: 'user' },
+    };
+    const result = formatSubscriptionDetail(sub);
+    expect(result).toContain('My Sub');
+    expect(result).toContain('abc-123');
+    expect(result).toContain('user@example.com');
+  });
+});
+
+describe('formatResourceGroupTable', () => {
+  it('returns no-data message for empty array', () => {
+    expect(formatResourceGroupTable([])).toContain('No resource groups found');
+  });
+
+  it('formats resource groups as table', () => {
+    const groups: AzResourceGroup[] = [
+      { id: '/sub/rg1', name: 'rg-dev', location: 'eastus', provisioningState: 'Succeeded', tags: { env: 'dev' } },
+    ];
+    const result = formatResourceGroupTable(groups);
+    expect(result).toContain('rg-dev');
+    expect(result).toContain('eastus');
+  });
+});
+
+describe('formatResourceTable', () => {
+  it('returns no-data message for empty array', () => {
+    expect(formatResourceTable([])).toContain('No resources found');
+  });
+
+  it('formats resources as table', () => {
+    const resources: AzResource[] = [
+      {
+        id: '/sub/r1',
+        name: 'myvm',
+        type: 'Microsoft.Compute/virtualMachines',
+        location: 'westus',
+        resourceGroup: 'rg1',
+        provisioningState: 'Succeeded',
+        tags: {},
+      },
+    ];
+    const result = formatResourceTable(resources);
+    expect(result).toContain('myvm');
+    expect(result).toContain('Microsoft.Compute/virtualMachines');
+  });
+});
+
+describe('formatVmTable', () => {
+  it('returns no-data message for empty array', () => {
+    expect(formatVmTable([])).toContain('No VMs found');
+  });
+
+  it('formats VMs as table without details', () => {
+    const vms: AzVm[] = [
+      {
+        id: '/sub/vm1',
+        name: 'web-01',
+        location: 'eastus2',
+        resourceGroup: 'rg-prod',
+        vmSize: 'Standard_D2s_v5',
+        provisioningState: 'Succeeded',
+        osType: 'Linux',
+        powerState: 'running',
+        publicIps: '',
+        fqdns: '',
+      },
+    ];
+    const result = formatVmTable(vms);
+    expect(result).toContain('web-01');
+    expect(result).toContain('Standard_D2s_v5');
+    expect(result).toContain('Linux');
+  });
+
+  it('includes public IPs and FQDNs when show_details data present', () => {
+    const vms: AzVm[] = [
+      {
+        id: '/sub/vm1',
+        name: 'web-01',
+        location: 'eastus2',
+        resourceGroup: 'rg-prod',
+        vmSize: 'Standard_D2s_v5',
+        provisioningState: 'Succeeded',
+        osType: 'Linux',
+        powerState: 'VM running',
+        publicIps: '20.1.2.3',
+        fqdns: 'web-01.eastus2.cloudapp.azure.com',
+      },
+    ];
+    const result = formatVmTable(vms);
+    expect(result).toContain('20.1.2.3');
+    expect(result).toContain('web-01.eastus2.cloudapp.azure.com');
+    expect(result).toContain('Public IPs');
+  });
+});

--- a/plugins/azure-status/test/extension.test.ts
+++ b/plugins/azure-status/test/extension.test.ts
@@ -1,5 +1,30 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 
+const mockTypebox = {
+  Type: {
+    Object: (s: unknown) => s,
+    String: (o?: unknown) => ({ type: 'string', ...((o as object) ?? {}) }),
+    Boolean: (o?: unknown) => ({ type: 'boolean', ...((o as object) ?? {}) }),
+    Optional: (s: unknown) => ({ optional: true, ...((s as object) ?? {}) }),
+    Array: (i: unknown, o?: unknown) => ({ type: 'array', items: i, ...((o as object) ?? {}) }),
+    Union: (s: unknown[]) => ({ union: s }),
+    Literal: (v: string) => ({ const: v }),
+  },
+};
+
+function baseMockPi(overrides?: Record<string, unknown>) {
+  return {
+    setLabel() {},
+    logger: { debug() {} },
+    registerCommand() {},
+    registerServiceStatus() {},
+    registerTool() {},
+    on() {},
+    typebox: mockTypebox,
+    ...overrides,
+  };
+}
+
 describe('Azure Status extension', () => {
   let factory: (pi: unknown) => Promise<void>;
 
@@ -12,39 +37,99 @@ describe('Azure Status extension', () => {
     expect(typeof factory).toBe('function');
   });
 
-  it('registers service status when az is available', async () => {
-    const registered: { name: string }[] = [];
-    const mockPi = {
-      setLabel() {},
-      logger: { debug() {} },
-      registerCommand() {},
-      registerServiceStatus(c: { name: string }) {
-        registered.push(c);
+  it('always registers azure-status:setup command', async () => {
+    const commands: Array<{ name: string }> = [];
+    const mockPi = baseMockPi({
+      registerCommand(name: string) {
+        commands.push({ name });
       },
-    };
+    });
     await factory(mockPi);
+    expect(commands.find((c) => c.name === 'azure-status:setup')).toBeDefined();
+  });
 
-    // If az CLI is installed, should register; if not, should skip gracefully
-    if (registered.length > 0) {
-      expect(registered[0].name).toBe('Azure');
-    }
+  it('always registers Azure service status', async () => {
+    const statuses: Array<{ name: string }> = [];
+    const mockPi = baseMockPi({
+      registerServiceStatus(c: { name: string }) {
+        statuses.push(c);
+      },
+    });
+    await factory(mockPi);
+    expect(statuses.length).toBeGreaterThanOrEqual(1);
+    expect(statuses[0].name).toBe('Azure');
+  });
+
+  it('registers session_start event handler', async () => {
+    const events: string[] = [];
+    const mockPi = baseMockPi({
+      on(event: string) {
+        events.push(event);
+      },
+    });
+    await factory(mockPi);
+    expect(events).toContain('session_start');
   });
 
   it('service check returns valid state', async () => {
     let checkFn: (() => Promise<{ state: string }>) | undefined;
-    const mockPi = {
-      setLabel() {},
-      logger: { debug() {} },
-      registerCommand() {},
+    const mockPi = baseMockPi({
       registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
         checkFn = c.check;
       },
-    };
+    });
     await factory(mockPi);
-
+    expect(checkFn).toBeDefined();
     if (checkFn) {
       const result = await checkFn();
       expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
     }
+  });
+
+  it('registers 6 tools when az CLI is available', async () => {
+    const tools: Array<{ name: string }> = [];
+    const mockPi = baseMockPi({
+      registerTool(tool: { name: string }) {
+        tools.push(tool);
+      },
+    });
+    await factory(mockPi);
+
+    if (tools.length > 0) {
+      const toolNames = tools.map((t) => t.name).sort();
+      expect(toolNames).toEqual(['az_account', 'az_exec', 'az_group', 'az_help', 'az_resource', 'az_vm']);
+    }
+  });
+
+  it('each registered tool has required fields', async () => {
+    const tools: Array<Record<string, unknown>> = [];
+    const mockPi = baseMockPi({
+      registerTool(tool: Record<string, unknown>) {
+        tools.push(tool);
+      },
+    });
+    await factory(mockPi);
+
+    for (const tool of tools) {
+      expect(tool.name).toBeDefined();
+      expect(tool.label).toBeDefined();
+      expect(tool.description).toBeDefined();
+      expect(tool.parameters).toBeDefined();
+      expect(typeof tool.execute).toBe('function');
+    }
+  });
+
+  it('gracefully handles missing registerCommand', async () => {
+    const mockPi = baseMockPi();
+    // biome-ignore lint/suspicious/noExplicitAny: test requires deleting optional method
+    delete (mockPi as Record<string, any>).registerCommand;
+    await expect(factory(mockPi)).resolves.toBeUndefined();
+  });
+
+  it('gracefully handles missing registerServiceStatus', async () => {
+    const mockPi = baseMockPi();
+    // biome-ignore lint/suspicious/noExplicitAny: test requires deleting optional method
+    delete (mockPi as Record<string, any>).registerServiceStatus;
+    await expect(factory(mockPi)).resolves.toBeUndefined();
   });
 });

--- a/plugins/azure-status/test/tools/az-account.test.ts
+++ b/plugins/azure-status/test/tools/az-account.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test';
+import { createAzAccountTool } from '../../src/tools/az-account';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+    Union: (schemas: unknown[]) => ({ union: schemas }),
+    Literal: (value: string) => ({ const: value }),
+  },
+};
+
+describe('createAzAccountTool', () => {
+  const tool = createAzAccountTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('az_account');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Azure Account');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('az account');
+  });
+
+  it('has parameters schema', () => {
+    expect(tool.parameters).toBeDefined();
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('az_account input validation', () => {
+  const tool = createAzAccountTool({ typebox: mockTypebox });
+
+  it('rejects subscription with semicolons', async () => {
+    const result = await tool.execute('id', { action: 'show', subscription: 'test;rm -rf /' }, null, null, {
+      cwd: '/tmp',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid');
+  });
+
+  it('rejects subscription with pipe', async () => {
+    const result = await tool.execute('id', { action: 'show', subscription: 'test|cat' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects subscription with $() injection', async () => {
+    const result = await tool.execute('id', { action: 'show', subscription: '$(whoami)' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects subscription with backticks', async () => {
+    const result = await tool.execute('id', { action: 'show', subscription: '`id`' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts valid UUID subscription ID', async () => {
+    // Will fail because az isn't mocked, but should NOT fail on validation
+    try {
+      await tool.execute('id', { action: 'show', subscription: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }, null, null, {
+        cwd: '/tmp',
+      });
+    } catch {
+      // Expected: CLI not available, but validation passed
+    }
+  });
+
+  it('accepts valid subscription name', async () => {
+    try {
+      await tool.execute('id', { action: 'list', subscription: 'My Dev Subscription' }, null, null, { cwd: '/tmp' });
+    } catch {
+      // Expected: CLI not available, but validation passed
+    }
+  });
+});

--- a/plugins/azure-status/test/tools/az-exec.test.ts
+++ b/plugins/azure-status/test/tools/az-exec.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'bun:test';
+import { createAzExecTool } from '../../src/tools/az-exec';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    Array: (itemSchema: unknown, opts?: Record<string, unknown>) => ({ type: 'array', items: itemSchema, ...opts }),
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+  },
+};
+
+describe('createAzExecTool', () => {
+  const tool = createAzExecTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('az_exec');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Azure CLI Execute');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('az');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('az_exec injection prevention', () => {
+  const tool = createAzExecTool({ typebox: mockTypebox });
+
+  it('rejects args with semicolons', async () => {
+    const result = await tool.execute('id', { args: ['vm', 'list;rm -rf /'] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('unsafe');
+  });
+
+  it('rejects args with pipe', async () => {
+    const result = await tool.execute('id', { args: ['vm', 'list|cat'] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects args with $() command substitution', async () => {
+    const result = await tool.execute('id', { args: ['vm', '$(whoami)'] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects args with backtick injection', async () => {
+    const result = await tool.execute('id', { args: ['vm', '`id`'] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects args with && chaining', async () => {
+    const result = await tool.execute('id', { args: ['vm', 'list&&rm'] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects args with || chaining', async () => {
+    const result = await tool.execute('id', { args: ['vm', 'list||echo'] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects empty args array', async () => {
+    const result = await tool.execute('id', { args: [] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts safe args with flags', async () => {
+    // This will fail due to actual CLI execution, but should NOT fail on validation
+    try {
+      await tool.execute('id', { args: ['webapp', 'list', '--resource-group', 'my-rg'] }, null, null, { cwd: '/tmp' });
+    } catch {
+      // CLI not available
+    }
+  });
+
+  it('accepts args with paths and equals', async () => {
+    try {
+      await tool.execute('id', { args: ['storage', 'account', 'list', '--query', '[].name'] }, null, null, {
+        cwd: '/tmp',
+      });
+    } catch {
+      // CLI not available
+    }
+  });
+
+  it('accepts JMESPath query with ?, *, and ()', async () => {
+    try {
+      await tool.execute('id', { args: ['vm', 'list', '--query', "[?contains(name, 'prod')]"] }, null, null, {
+        cwd: '/tmp',
+      });
+    } catch {
+      // CLI not available
+    }
+  });
+});

--- a/plugins/azure-status/test/tools/az-group.test.ts
+++ b/plugins/azure-status/test/tools/az-group.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { createAzGroupTool } from '../../src/tools/az-group';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+    Union: (schemas: unknown[]) => ({ union: schemas }),
+    Literal: (value: string) => ({ const: value }),
+  },
+};
+
+describe('createAzGroupTool', () => {
+  const tool = createAzGroupTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('az_group');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Azure Resource Groups');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('az group');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('az_group input validation', () => {
+  const tool = createAzGroupTool({ typebox: mockTypebox });
+
+  it('rejects subscription with shell injection', async () => {
+    const result = await tool.execute('id', { action: 'list', subscription: ';rm -rf /' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects resource group name with shell injection', async () => {
+    const result = await tool.execute('id', { action: 'show', name: '$(whoami)' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects tag with pipe injection', async () => {
+    const result = await tool.execute('id', { action: 'list', tag: 'env|cat /etc/passwd' }, null, null, {
+      cwd: '/tmp',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts valid resource group name', async () => {
+    try {
+      await tool.execute('id', { action: 'show', name: 'my-resource-group.v2' }, null, null, { cwd: '/tmp' });
+    } catch {
+      // CLI not available
+    }
+  });
+
+  it('accepts valid tag', async () => {
+    try {
+      await tool.execute('id', { action: 'list', tag: 'env=production' }, null, null, { cwd: '/tmp' });
+    } catch {
+      // CLI not available
+    }
+  });
+});

--- a/plugins/azure-status/test/tools/az-help.test.ts
+++ b/plugins/azure-status/test/tools/az-help.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'bun:test';
+import { createAzHelpTool } from '../../src/tools/az-help';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createAzHelpTool', () => {
+  const tool = createAzHelpTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('az_help');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Azure CLI Help');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('help');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('az_help input validation', () => {
+  const tool = createAzHelpTool({ typebox: mockTypebox });
+
+  it('rejects command_path with semicolons', async () => {
+    const result = await tool.execute('id', { command_path: 'vm;rm' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects command_path with shell injection', async () => {
+    const result = await tool.execute('id', { command_path: '$(whoami)' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects command_path with uppercase', async () => {
+    const result = await tool.execute('id', { command_path: 'VM' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts valid single-word path', async () => {
+    // This will call the actual CLI — just verifying no validation error
+    const result = await tool.execute('id', { command_path: 'vm' }, null, null, { cwd: '/tmp' });
+    // If az is installed, should succeed; if not, should return exec error (not validation error)
+    if (result.isError) {
+      expect(result.content[0].text).not.toContain('invalid command path');
+    }
+  });
+
+  it('accepts valid multi-word path', async () => {
+    const result = await tool.execute('id', { command_path: 'network vnet' }, null, null, { cwd: '/tmp' });
+    if (result.isError) {
+      expect(result.content[0].text).not.toContain('invalid command path');
+    }
+  });
+
+  it('accepts empty command_path for top-level help', async () => {
+    const result = await tool.execute('id', { command_path: '' }, null, null, { cwd: '/tmp' });
+    if (result.isError) {
+      expect(result.content[0].text).not.toContain('invalid command path');
+    }
+  });
+});

--- a/plugins/azure-status/test/tools/az-resource.test.ts
+++ b/plugins/azure-status/test/tools/az-resource.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'bun:test';
+import { createAzResourceTool } from '../../src/tools/az-resource';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createAzResourceTool', () => {
+  const tool = createAzResourceTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('az_resource');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Azure Resources');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('az resource');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('az_resource input validation', () => {
+  const tool = createAzResourceTool({ typebox: mockTypebox });
+
+  it('rejects resource group with semicolons', async () => {
+    const result = await tool.execute('id', { resource_group: ';rm -rf /' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid');
+  });
+
+  it('rejects resource group with $() injection', async () => {
+    const result = await tool.execute('id', { resource_group: '$(id)' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects resource type with shell injection', async () => {
+    const result = await tool.execute('id', { resource_group: 'rg1', resource_type: '; whoami' }, null, null, {
+      cwd: '/tmp',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects subscription with backticks', async () => {
+    const result = await tool.execute('id', { resource_group: 'rg1', subscription: '`id`' }, null, null, {
+      cwd: '/tmp',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts valid resource group name', async () => {
+    try {
+      await tool.execute('id', { resource_group: 'my-rg_v2.test' }, null, null, { cwd: '/tmp' });
+    } catch {
+      // CLI not available
+    }
+  });
+
+  it('accepts valid resource type', async () => {
+    try {
+      await tool.execute(
+        'id',
+        { resource_group: 'rg1', resource_type: 'Microsoft.Compute/virtualMachines' },
+        null,
+        null,
+        { cwd: '/tmp' },
+      );
+    } catch {
+      // CLI not available
+    }
+  });
+});

--- a/plugins/azure-status/test/tools/az-vm.test.ts
+++ b/plugins/azure-status/test/tools/az-vm.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test';
+import { createAzVmTool } from '../../src/tools/az-vm';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Boolean: (opts?: Record<string, unknown>) => ({ type: 'boolean', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createAzVmTool', () => {
+  const tool = createAzVmTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('az_vm');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Azure Virtual Machines');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('az vm');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('az_vm input validation', () => {
+  const tool = createAzVmTool({ typebox: mockTypebox });
+
+  it('rejects resource group with shell injection', async () => {
+    const result = await tool.execute('id', { resource_group: '$(whoami)' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects subscription with pipe injection', async () => {
+    const result = await tool.execute('id', { subscription: 'test|cat' }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts valid resource group', async () => {
+    try {
+      await tool.execute('id', { resource_group: 'my-resource-group' }, null, null, { cwd: '/tmp' });
+    } catch {
+      // CLI not available
+    }
+  });
+
+  it('accepts show_details false (no validation error)', async () => {
+    // Boolean params can't cause shell injection — just verify no validation rejection
+    try {
+      await tool.execute('id', { show_details: false }, null, null, { cwd: '/tmp' });
+    } catch {
+      // CLI call may fail but not due to validation
+    }
+  });
+});

--- a/plugins/azure-status/test/tools/shared.test.ts
+++ b/plugins/azure-status/test/tools/shared.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'bun:test';
+import { AzAuthError, AzExecError, AzNotFoundError, AzSessionExpiredError } from '../../src/az/exec';
+import {
+  detectErrorType,
+  errorResult,
+  normalizeResource,
+  normalizeResourceGroup,
+  normalizeSubscription,
+  normalizeVm,
+  textResult,
+} from '../../src/tools/shared';
+
+describe('textResult', () => {
+  it('returns content array with text type', () => {
+    const result = textResult('hello', { tool: 'az_account' });
+    expect(result.content).toEqual([{ type: 'text', text: 'hello' }]);
+    expect(result.details.tool).toBe('az_account');
+    expect(result).not.toHaveProperty('isError');
+  });
+});
+
+describe('errorResult', () => {
+  it('returns content with isError true', () => {
+    const result = errorResult('fail', { tool: 'az_group', errorType: 'auth_required' });
+    expect(result.content).toEqual([{ type: 'text', text: 'fail' }]);
+    expect(result.isError).toBe(true);
+    expect(result.details.errorType).toBe('auth_required');
+  });
+});
+
+describe('detectErrorType', () => {
+  it('maps AzAuthError to auth_required', () => {
+    expect(detectErrorType(new AzAuthError('msg'))).toBe('auth_required');
+  });
+
+  it('maps AzSessionExpiredError to session_expired', () => {
+    expect(detectErrorType(new AzSessionExpiredError('msg'))).toBe('session_expired');
+  });
+
+  it('maps AzNotFoundError to not_found', () => {
+    expect(detectErrorType(new AzNotFoundError('msg'))).toBe('not_found');
+  });
+
+  it('maps AzExecError to exec_error', () => {
+    expect(detectErrorType(new AzExecError('msg'))).toBe('exec_error');
+  });
+
+  it('maps unknown error to exec_error', () => {
+    expect(detectErrorType(new Error('unknown'))).toBe('exec_error');
+  });
+
+  it('maps non-Error to exec_error', () => {
+    expect(detectErrorType('string error')).toBe('exec_error');
+  });
+});
+
+describe('normalizeSubscription', () => {
+  it('extracts whitelisted fields', () => {
+    const raw = {
+      id: 'sub-123',
+      name: 'My Sub',
+      state: 'Enabled',
+      isDefault: true,
+      tenantId: 'tenant-1',
+      user: { name: 'user@test.com', type: 'user' },
+      extraField: 'should be ignored',
+    };
+    const result = normalizeSubscription(raw);
+    expect(result).toEqual({
+      id: 'sub-123',
+      name: 'My Sub',
+      state: 'Enabled',
+      isDefault: true,
+      tenantId: 'tenant-1',
+      user: { name: 'user@test.com', type: 'user' },
+    });
+    expect(result).not.toHaveProperty('extraField');
+  });
+
+  it('handles missing fields with defaults', () => {
+    const result = normalizeSubscription({});
+    expect(result.id).toBe('');
+    expect(result.name).toBe('');
+    expect(result.isDefault).toBe(false);
+    expect(result.user).toEqual({ name: '', type: '' });
+  });
+});
+
+describe('normalizeResourceGroup', () => {
+  it('extracts whitelisted fields', () => {
+    const raw = {
+      id: '/sub/rg1',
+      name: 'rg-dev',
+      location: 'eastus',
+      properties: { provisioningState: 'Succeeded' },
+      tags: { env: 'dev' },
+      managedBy: 'should be ignored',
+    };
+    const result = normalizeResourceGroup(raw);
+    expect(result.name).toBe('rg-dev');
+    expect(result.location).toBe('eastus');
+    expect(result.tags).toEqual({ env: 'dev' });
+    expect(result).not.toHaveProperty('managedBy');
+  });
+
+  it('handles missing tags', () => {
+    const result = normalizeResourceGroup({ name: 'rg1' });
+    expect(result.tags).toEqual({});
+  });
+});
+
+describe('normalizeResource', () => {
+  it('extracts whitelisted fields', () => {
+    const raw = {
+      id: '/sub/r1',
+      name: 'myvm',
+      type: 'Microsoft.Compute/virtualMachines',
+      location: 'westus',
+      resourceGroup: 'rg1',
+      provisioningState: 'Succeeded',
+      tags: {},
+      identity: { principalId: 'should-be-stripped' },
+    };
+    const result = normalizeResource(raw);
+    expect(result.name).toBe('myvm');
+    expect(result.type).toBe('Microsoft.Compute/virtualMachines');
+    expect(result).not.toHaveProperty('identity');
+  });
+});
+
+describe('normalizeVm', () => {
+  it('extracts safe fields only', () => {
+    const raw = {
+      id: '/sub/vm1',
+      name: 'web-01',
+      location: 'eastus2',
+      resourceGroup: 'rg-prod',
+      hardwareProfile: { vmSize: 'Standard_D2s_v5' },
+      storageProfile: { osDisk: { osType: 'Linux' } },
+      provisioningState: 'Succeeded',
+      powerState: 'VM running',
+      publicIps: '20.1.2.3',
+      fqdns: 'web-01.eastus2.cloudapp.azure.com',
+      osProfile: { adminUsername: 'SHOULD_NOT_APPEAR', adminPassword: 'SECRET' },
+      networkProfile: { networkInterfaces: [{ id: 'nic-1' }] },
+    };
+    const result = normalizeVm(raw);
+    expect(result.name).toBe('web-01');
+    expect(result.vmSize).toBe('Standard_D2s_v5');
+    expect(result.osType).toBe('Linux');
+    expect(result.powerState).toBe('VM running');
+    expect(result.publicIps).toBe('20.1.2.3');
+    expect(result.fqdns).toBe('web-01.eastus2.cloudapp.azure.com');
+    expect(result).not.toHaveProperty('osProfile');
+    expect(result).not.toHaveProperty('networkProfile');
+    expect(JSON.stringify(result)).not.toContain('SHOULD_NOT_APPEAR');
+    expect(JSON.stringify(result)).not.toContain('SECRET');
+  });
+
+  it('handles missing nested fields', () => {
+    const result = normalizeVm({ name: 'vm1' });
+    expect(result.vmSize).toBe('');
+    expect(result.osType).toBe('');
+    expect(result.powerState).toBe('');
+    expect(result.publicIps).toBe('');
+    expect(result.fqdns).toBe('');
+  });
+});

--- a/plugins/azure-status/test/wizard.test.ts
+++ b/plugins/azure-status/test/wizard.test.ts
@@ -221,6 +221,94 @@ describe('runSetupWizard — az not installed', () => {
 });
 
 // ---------------------------------------------------------------------------
+// runSetupWizard — service principal auth path
+// ---------------------------------------------------------------------------
+
+describe('runSetupWizard — service principal auth', () => {
+  const azInstalled = { checkCliInstalled: () => true };
+  const originalEnv = { ...process.env };
+
+  it('auto-detects service principal from environment', async () => {
+    process.env.AZURE_CLIENT_ID = 'test-client-id';
+    process.env.AZURE_CLIENT_SECRET = 'test-secret';
+    process.env.AZURE_TENANT_ID = 'test-tenant-id';
+    try {
+      const { pi, calls } = buildMockPi({
+        '--version': { stdout: 'azure-cli 2.60.0\n', stderr: '', code: 0 },
+        '--service-principal': { stdout: '', stderr: '', code: 0 },
+        'account show': {
+          stdout: JSON.stringify({ user: { name: 'sp@test.com' }, name: 'SP Subscription' }),
+          stderr: '',
+          code: 0,
+        },
+      });
+      const { ctx, notifications } = buildMockCtx();
+
+      await runSetupWizard(pi, ctx, azInstalled);
+
+      const spCall = calls.find((c) => c.args.includes('--service-principal'));
+      expect(spCall).toBeDefined();
+      expect(notifications.find((n) => n.message.includes('service principal'))).toBeDefined();
+    } finally {
+      process.env.AZURE_CLIENT_ID = originalEnv.AZURE_CLIENT_ID;
+      process.env.AZURE_CLIENT_SECRET = originalEnv.AZURE_CLIENT_SECRET;
+      process.env.AZURE_TENANT_ID = originalEnv.AZURE_TENANT_ID;
+    }
+  });
+
+  it('handles service principal auth failure', async () => {
+    process.env.AZURE_CLIENT_ID = 'test-client-id';
+    process.env.AZURE_CLIENT_SECRET = 'test-secret';
+    process.env.AZURE_TENANT_ID = 'test-tenant-id';
+    try {
+      const { pi } = buildMockPi({
+        '--version': { stdout: 'azure-cli 2.60.0\n', stderr: '', code: 0 },
+        '--service-principal': { stdout: '', stderr: 'AADSTS7000215', code: 1 },
+      });
+      const { ctx, notifications } = buildMockCtx();
+
+      await runSetupWizard(pi, ctx, azInstalled);
+
+      expect(notifications.find((n) => n.message.includes('Authentication failed'))?.type).toBe('error');
+    } finally {
+      process.env.AZURE_CLIENT_ID = originalEnv.AZURE_CLIENT_ID;
+      process.env.AZURE_CLIENT_SECRET = originalEnv.AZURE_CLIENT_SECRET;
+      process.env.AZURE_TENANT_ID = originalEnv.AZURE_TENANT_ID;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInstallStep — multi-manager fallback coverage
+// ---------------------------------------------------------------------------
+
+describe('buildInstallStep — fallback options', () => {
+  it('returns multiple options on linux with apt and npm', () => {
+    const platform: PlatformInfo = {
+      os: 'linux',
+      arch: 'x64',
+      packageManagers: ['apt', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    expect(options.length).toBeGreaterThanOrEqual(1);
+    expect(options[0].manager).toBe('apt');
+  });
+
+  it('returns multiple options on win32 with winget and scoop', () => {
+    const platform: PlatformInfo = {
+      os: 'win32',
+      arch: 'x64',
+      packageManagers: ['winget', 'scoop', 'npm'],
+      isCorporateManaged: false,
+    };
+    const options = buildInstallStep(platform);
+    expect(options.length).toBeGreaterThanOrEqual(1);
+    expect(options[0].manager).toBe('winget');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Notification ordering
 // ---------------------------------------------------------------------------
 

--- a/plugins/azure-status/tsconfig.json
+++ b/plugins/azure-status/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- Expand azure-status from a status-only plugin to a full CLI-native az tool suite with 6 tools: az-account, az-group, az-resource, az-vm, az-exec, and az-help
- Each tool includes embedded help knowledge via markdown prompts for offline/contextual guidance
- 127 tests pass covering all new tools, the shared execution layer, and formatters

Closes #524

## Test plan

- [x] 127 unit tests pass (`bun test`)
- [x] Pre-commit hooks pass (markdownlint, biome, spelling, secrets)
- [x] All 6 tools verified against real authenticated az CLI
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)