### PR TITLE
feat: add hooks, status commands, agents, and test suites across 11 plugins

### DIFF
--- a/plugins/brand/agents/brand-operator.md
+++ b/plugins/brand/agents/brand-operator.md
@@ -18,7 +18,7 @@ Your role is to analyze files for brand compliance without modifying them.
 
 ## Capabilities
 
-- Read and analyze source files, stylesheets, templates, and content for brand compliance
+- Read and analyze source files, style sheets, templates, and content for brand compliance
 - Check color values against the approved palette
 - Verify typography choices match brand guidelines
 - Identify logo usage issues

--- a/plugins/brand/agents/brand-operator.md
+++ b/plugins/brand/agents/brand-operator.md
@@ -1,0 +1,31 @@
+---
+name: brand-operator
+description: Read-only agent for analyzing files against F5 brand compliance guidelines
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+disallowedTools:
+  - Write
+  - Edit
+  - Agent
+---
+
+You are the brand-operator agent for the F5 brand plugin.
+
+Your role is to analyze files for brand compliance without modifying them.
+
+## Capabilities
+
+- Read and analyze source files, stylesheets, templates, and content for brand compliance
+- Check color values against the approved palette
+- Verify typography choices match brand guidelines
+- Identify logo usage issues
+- Scan for accessibility compliance
+
+## Safety Rules
+
+- **NEVER** modify files — read-only analysis only
+- Report findings with severity levels: ERROR, WARNING, INFO
+- Reference specific brand guidelines for each finding

--- a/plugins/brand/commands/brand-status.md
+++ b/plugins/brand/commands/brand-status.md
@@ -1,0 +1,20 @@
+---
+description: >-
+  Check F5 brand asset availability and configuration status
+---
+
+Delegate to the brand-operator agent to check brand compliance readiness.
+
+## Delegation
+
+Spawn the brand-operator agent with the following instructions:
+
+1. Check if brand reference files exist in the plugin's references directory
+2. Verify color palette reference is accessible
+3. Verify typography rules reference is accessible
+4. Report:
+   - Brand reference files status (loaded/missing)
+   - Color palette: number of defined colors
+   - Typography rules: defined font families
+   - Available commands: /brand:review-brand
+5. If brand references are missing, note that the plugin may need reinstallation

--- a/plugins/brand/scripts/tests/run-tests.sh
+++ b/plugins/brand/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/brand/scripts/tests/test_agent.sh
+++ b/plugins/brand/scripts/tests/test_agent.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — brand-operator agent has frontmatter with tools and disallowedTools
+test_brand_operator_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/brand-operator.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools:' || {
+    echo "brand-operator missing tools in frontmatter"
+    return 1
+  }
+
+  for tool in Read Bash Glob Grep; do
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "brand-operator missing allowed tool: $tool"
+      return 1
+    }
+  done
+
+  echo "$fm" | grep -q 'disallowedTools:' || {
+    echo "brand-operator missing disallowedTools in frontmatter"
+    return 1
+  }
+
+  for tool in Write Edit Agent; do
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "brand-operator missing disallowed tool: $tool"
+      return 1
+    }
+  done
+}

--- a/plugins/brand/scripts/tests/test_security.sh
+++ b/plugins/brand/scripts/tests/test_security.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no external dependencies required.
+
+set -euo pipefail
+
+# T1.11 — no hardcoded credentials in plugin files
+test_no_hardcoded_credentials() {
+  local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}'
+  local scan_dirs=("$PLUGIN_ROOT")
+
+  local matches
+  matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --include='*.md' --include='*.json' --include='*.mdx' |
+    grep -v 'README.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded credentials found:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/brand/scripts/tests/test_structure.sh
+++ b/plugins/brand/scripts/tests/test_structure.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no external dependencies required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "brand" ] || {
+    echo "name=$name, expected brand"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching brand entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "brand") | .name' "$mj")
+  [ "$mp_name" = "brand" ] || {
+    echo "brand entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "brand") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "brand") | .source' "$mj")
+  [ "$src" = "./plugins/brand" ] || {
+    echo "source=$src, expected ./plugins/brand"
+    return 1
+  }
+}
+
+# T1.3 — all expected files exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "skills/guardian/SKILL.md"
+    "skills/reviewer/SKILL.md"
+    "skills/visual-content/SKILL.md"
+    "agents/brand-operator.md"
+    "commands/review-brand.md"
+    "commands/brand-status.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  for skill_dir in guardian reviewer visual-content; do
+    local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
+    local name_line
+    name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || {
+      echo "$skill_dir: missing name in frontmatter"
+      return 1
+    }
+
+    local desc_line
+    desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || {
+      echo "$skill_dir: missing description in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T1.5 — command files have description in frontmatter
+test_command_frontmatter() {
+  for cmd in review-brand brand-status; do
+    local file="$PLUGIN_ROOT/commands/${cmd}.md"
+    local desc
+    desc=$(frontmatter_value "$file" "description")
+    [ -n "$desc" ] || {
+      echo "$cmd: missing description"
+      return 1
+    }
+  done
+}
+
+# T1.6 — agent files exist with correct names
+test_agent_files_exist() {
+  local agent="brand-operator"
+  [ -f "$PLUGIN_ROOT/agents/${agent}.md" ] || {
+    echo "missing agent: ${agent}.md"
+    return 1
+  }
+}

--- a/plugins/cloudstatus/hooks/hooks.json
+++ b/plugins/cloudstatus/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -sf https://status.github.com/api/v2/status.json > /dev/null 2>&1 || echo 'WARNING: Cannot reach Statuspage API. Cloud status commands may fail.'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/cloudstatus/scripts/tests/run-tests.sh
+++ b/plugins/cloudstatus/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/cloudstatus/scripts/tests/test_agent.sh
+++ b/plugins/cloudstatus/scripts/tests/test_agent.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+AGENT_FILE="$PLUGIN_ROOT/agents/status-operator.md"
+
+# T2.1 — agent has frontmatter with tools list
+test_agent_has_tools() {
+  local fm
+  fm=$(extract_frontmatter "$AGENT_FILE")
+
+  echo "$fm" | grep -q 'tools:' || {
+    echo "status-operator: missing tools in frontmatter"
+    return 1
+  }
+}
+
+# T2.2 — agent has disallowedTools
+test_agent_has_disallowed_tools() {
+  local fm
+  fm=$(extract_frontmatter "$AGENT_FILE")
+
+  echo "$fm" | grep -q 'disallowedTools:' || {
+    echo "status-operator: missing disallowedTools in frontmatter"
+    return 1
+  }
+}
+
+# T2.3 — agent has name and description in frontmatter
+test_agent_has_name_description() {
+  local fm
+  fm=$(extract_frontmatter "$AGENT_FILE")
+
+  echo "$fm" | grep -q '^name:' || {
+    echo "status-operator: missing name in frontmatter"
+    return 1
+  }
+
+  echo "$fm" | grep -q 'description:' || {
+    echo "status-operator: missing description in frontmatter"
+    return 1
+  }
+}
+
+# T2.4 — agent contains response format instructions
+test_agent_response_format() {
+  grep -qi 'report\|template\|format' "$AGENT_FILE" || {
+    echo "status-operator: missing response format instructions"
+    return 1
+  }
+}

--- a/plugins/cloudstatus/scripts/tests/test_hook.sh
+++ b/plugins/cloudstatus/scripts/tests/test_hook.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Phase 2: SessionStart hook behavior.
+
+set -euo pipefail
+
+_get_hook_command() {
+  jq -r '.hooks.SessionStart[0].hooks[0].command' "$PLUGIN_ROOT/hooks/hooks.json"
+}
+
+# T2.10 — hook succeeds when curl is available and can reach the API
+test_hook_succeeds_when_curl_available() {
+  command -v curl >/dev/null 2>&1 || {
+    echo "SKIP: curl not installed"
+    return 0
+  }
+
+  local cmd
+  cmd=$(_get_hook_command)
+  # The hook should either produce no output (API reachable) or a WARNING
+  # Either way it should not exit non-zero
+  local out
+  out=$(bash -c "$cmd" 2>&1) || true
+  # If we got output, it should be a WARNING, not a crash
+  if [ -n "$out" ]; then
+    echo "$out" | grep -q 'WARNING' || {
+      echo "expected WARNING or empty output, got: $out"
+      return 1
+    }
+  fi
+}
+
+# T2.11 — hook outputs WARNING when curl can't reach the API
+test_hook_warns_when_api_unreachable() {
+  local cmd
+  cmd=$(_get_hook_command)
+  # Replace the URL with an unreachable one to simulate failure
+  local modified_cmd
+  modified_cmd=$(echo "$cmd" | sed 's|https://[^ ]*|https://localhost:1/unreachable|')
+  local out
+  out=$(bash -c "$modified_cmd" 2>&1) || true
+  echo "$out" | grep -q 'WARNING' || {
+    echo "expected WARNING in output, got: $out"
+    return 1
+  }
+}
+
+# T2.12 — hook command is syntactically valid shell
+test_hook_command_syntax() {
+  local cmd
+  cmd=$(_get_hook_command)
+  bash -n <<<"$cmd" || {
+    echo "hook command has syntax error"
+    return 1
+  }
+}

--- a/plugins/cloudstatus/scripts/tests/test_security.sh
+++ b/plugins/cloudstatus/scripts/tests/test_security.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no external tools required.
+
+set -euo pipefail
+
+# T1.20 — no hardcoded API keys in agent or skill files
+test_no_hardcoded_api_keys() {
+  local patterns='api_key[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|apikey[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|Bearer [A-Za-z0-9]{20,}'
+  local matches
+  matches=$(grep -rIin -E "$patterns" \
+    "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
+    --include='*.md' --include='*.json' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded API keys found:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.21 — no credential echo in agent files
+test_no_credential_echo() {
+  local matches
+  matches=$(grep -rIin -E 'echo.*\$(.*password|.*secret|.*token|.*api.key)' \
+    "$PLUGIN_ROOT/agents" \
+    --include='*.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Credential echo found in agent files:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.22 — no eval of user input in agent or skill files
+test_no_eval_user_input() {
+  local matches
+  matches=$(grep -rIin -E 'eval\s+.*\$\{?[a-zA-Z]' \
+    "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
+    --include='*.md' --include='*.sh' |
+    grep -v '#.*eval' |
+    grep -v 'references/' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "eval of user input found:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/cloudstatus/scripts/tests/test_structure.sh
+++ b/plugins/cloudstatus/scripts/tests/test_structure.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no external tools required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "cloudstatus" ] || {
+    echo "name=$name, expected cloudstatus"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching cloudstatus entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "cloudstatus") | .name' "$mj")
+  [ "$mp_name" = "cloudstatus" ] || {
+    echo "cloudstatus entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "cloudstatus") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "cloudstatus") | .source' "$mj")
+  [ "$src" = "./plugins/cloudstatus" ] || {
+    echo "source=$src, expected ./plugins/cloudstatus"
+    return 1
+  }
+}
+
+# T1.3 — expected files and directories exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "hooks/hooks.json"
+    "skills/monitor/SKILL.md"
+    "agents/status-operator.md"
+    "commands/cloud-status.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  local skill="$PLUGIN_ROOT/skills/monitor/SKILL.md"
+  local name_line
+  name_line=$(frontmatter_value "$skill" "name")
+  [ -n "$name_line" ] || {
+    echo "monitor: missing name in frontmatter"
+    return 1
+  }
+
+  local desc_line
+  desc_line=$(frontmatter_value "$skill" "description")
+  [ -n "$desc_line" ] || {
+    echo "monitor: missing description in frontmatter"
+    return 1
+  }
+}
+
+# T1.5 — hooks.json is valid JSON with correct structure
+test_hooks_json_structure() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  jq -e '.' "$hj" >/dev/null || {
+    echo "hooks.json is not valid JSON"
+    return 1
+  }
+
+  local hook_type
+  hook_type=$(jq -r '.hooks.SessionStart[0].hooks[0].type' "$hj")
+  [ "$hook_type" = "command" ] || {
+    echo "hook type=$hook_type, expected command"
+    return 1
+  }
+
+  local timeout
+  timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$hj")
+  [[ "$timeout" =~ ^[0-9]+$ ]] || {
+    echo "timeout is not a number: $timeout"
+    return 1
+  }
+}
+
+# T1.6 — hook command is syntactically valid shell
+test_hook_command_syntax() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  local cmd
+  cmd=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$hj")
+  bash -n <<<"$cmd" || {
+    echo "hook command has syntax error"
+    return 1
+  }
+}
+
+# T1.7 — command file has description in frontmatter
+test_command_frontmatter() {
+  local file="$PLUGIN_ROOT/commands/cloud-status.md"
+  local desc
+  desc=$(frontmatter_value "$file" "description")
+  [ -n "$desc" ] || {
+    echo "cloud-status: missing description"
+    return 1
+  }
+}
+
+# T1.8 — 1 skill directory exists
+test_skill_count() {
+  local count
+  count=$(find "$PLUGIN_ROOT/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+  [ "$count" -ge 1 ] || {
+    echo "expected at least 1 skill dir, found $count"
+    return 1
+  }
+}
+
+# T1.9 — 1 agent file exists
+test_agent_count() {
+  local count
+  count=$(find "$PLUGIN_ROOT/agents" -name '*.md' -type f | wc -l | tr -d ' ')
+  [ "$count" -ge 1 ] || {
+    echo "expected at least 1 agent file, found $count"
+    return 1
+  }
+}

--- a/plugins/devcontainer/commands/devcontainer-status.md
+++ b/plugins/devcontainer/commands/devcontainer-status.md
@@ -1,0 +1,21 @@
+---
+description: >-
+  Check container environment status and available development tools
+---
+
+Delegate to the container-introspector agent to check devcontainer status.
+
+## Delegation
+
+Spawn the container-introspector agent with the following instructions:
+
+1. Detect container runtime: check for `/.dockerenv` or `/run/.containerenv`
+2. If in a container, report container identity: `cat /etc/hostname 2>/dev/null`
+3. Count available development tools from the tool catalog
+4. Check key tools: `git --version`, `node --version`, `bun --version`, `python3 --version`
+5. Report:
+   - Container detected (yes/no)
+   - Container hostname
+   - Number of development tools available
+   - Key tool versions (git, node, bun, python3)
+6. If not in a container, note that some devcontainer features may not be available

--- a/plugins/devcontainer/hooks/hooks.json
+++ b/plugins/devcontainer/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f /.dockerenv || test -f /run/.containerenv || echo 'WARNING: Not running inside a container. Devcontainer features may be limited.'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/devcontainer/scripts/tests/run-tests.sh
+++ b/plugins/devcontainer/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/devcontainer/scripts/tests/test_agent.sh
+++ b/plugins/devcontainer/scripts/tests/test_agent.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — container-introspector.md has frontmatter with tools
+test_container_introspector_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/container-introspector.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools' || {
+    echo "container-introspector missing tools in frontmatter"
+    return 1
+  }
+}
+
+# T2.2 — container-maintainer.md has frontmatter with tools
+test_container_maintainer_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/container-maintainer.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools' || {
+    echo "container-maintainer missing tools in frontmatter"
+    return 1
+  }
+}
+
+# T2.3 — tool-advisor.md has frontmatter with tools
+test_tool_advisor_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/tool-advisor.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools' || {
+    echo "tool-advisor missing tools in frontmatter"
+    return 1
+  }
+}
+
+# T2.4 — tool-auditor.md has frontmatter with tools
+test_tool_auditor_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/tool-auditor.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools' || {
+    echo "tool-auditor missing tools in frontmatter"
+    return 1
+  }
+}

--- a/plugins/devcontainer/scripts/tests/test_hook.sh
+++ b/plugins/devcontainer/scripts/tests/test_hook.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Phase 2: SessionStart hook behavior.
+
+set -euo pipefail
+
+_get_hook_command() {
+  jq -r '.hooks.SessionStart[0].hooks[0].command' "$PLUGIN_ROOT/hooks/hooks.json"
+}
+
+# T2.1 — hook command has valid syntax
+test_hook_command_valid_syntax() {
+  local cmd
+  cmd=$(_get_hook_command)
+  bash -n <<<"$cmd" || {
+    echo "hook command has syntax error"
+    return 1
+  }
+}
+
+# T2.2 — hook outputs WARNING when not in a container
+test_hook_warns_when_not_in_container() {
+  local cmd
+  cmd=$(_get_hook_command)
+  # On macOS (not in a container), /.dockerenv and /run/.containerenv don't exist
+  if [ -f /.dockerenv ] || [ -f /run/.containerenv ]; then
+    echo "SKIP: running inside a container"
+    return 0
+  fi
+  local out
+  out=$(bash -c "$cmd" 2>&1) || true
+  echo "$out" | grep -q 'WARNING' || {
+    echo "expected WARNING in output, got: $out"
+    return 1
+  }
+}

--- a/plugins/devcontainer/scripts/tests/test_security.sh
+++ b/plugins/devcontainer/scripts/tests/test_security.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no container runtime required.
+
+set -euo pipefail
+
+# T1.11 — no hardcoded credentials in agent or skill files
+test_no_hardcoded_credentials() {
+  local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}|api_key=[A-Za-z0-9]'
+  local matches
+  matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
+    --include='*.md' --include='*.json' |
+    grep -v 'README.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded credentials found:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/devcontainer/scripts/tests/test_structure.sh
+++ b/plugins/devcontainer/scripts/tests/test_structure.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no container runtime required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "devcontainer" ] || {
+    echo "name=$name, expected devcontainer"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching devcontainer entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "devcontainer") | .name' "$mj")
+  [ "$mp_name" = "devcontainer" ] || {
+    echo "devcontainer entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "devcontainer") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "devcontainer") | .source' "$mj")
+  [ "$src" = "./plugins/devcontainer" ] || {
+    echo "source=$src, expected ./plugins/devcontainer"
+    return 1
+  }
+}
+
+# T1.3 — all expected files exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "hooks/hooks.json"
+    "skills/self-awareness/SKILL.md"
+    "skills/tool-catalog/SKILL.md"
+    "agents/container-introspector.md"
+    "agents/container-maintainer.md"
+    "agents/tool-advisor.md"
+    "agents/tool-auditor.md"
+    "commands/devcontainer-status.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  for skill_dir in self-awareness tool-catalog; do
+    local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
+    local name_line
+    name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || {
+      echo "$skill_dir: missing name in frontmatter"
+      return 1
+    }
+
+    local desc_line
+    desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || {
+      echo "$skill_dir: missing description in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T1.5 — hooks.json is valid JSON with correct structure
+test_hooks_json_structure() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  jq -e '.' "$hj" >/dev/null || {
+    echo "hooks.json is not valid JSON"
+    return 1
+  }
+
+  local hook_type
+  hook_type=$(jq -r '.hooks.SessionStart[0].hooks[0].type' "$hj")
+  [ "$hook_type" = "command" ] || {
+    echo "hook type=$hook_type, expected command"
+    return 1
+  }
+
+  local timeout
+  timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$hj")
+  [[ "$timeout" =~ ^[0-9]+$ ]] || {
+    echo "timeout is not a number: $timeout"
+    return 1
+  }
+}
+
+# T1.6 — hook command is syntactically valid shell
+test_hook_command_syntax() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  local cmd
+  cmd=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$hj")
+  bash -n <<<"$cmd" || {
+    echo "hook command has syntax error"
+    return 1
+  }
+}
+
+# T1.7 — command files have description in frontmatter
+test_command_frontmatter() {
+  local cmd="devcontainer-status"
+  local file="$PLUGIN_ROOT/commands/${cmd}.md"
+  local desc
+  desc=$(frontmatter_value "$file" "description")
+  [ -n "$desc" ] || {
+    echo "$cmd: missing description"
+    return 1
+  }
+}

--- a/plugins/docs-pipeline/agents/pipeline-operator.md
+++ b/plugins/docs-pipeline/agents/pipeline-operator.md
@@ -1,0 +1,30 @@
+---
+name: pipeline-operator
+description: Read-only agent for inspecting documentation pipeline configuration and running preview builds
+tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+disallowedTools:
+  - Write
+  - Edit
+  - Agent
+---
+
+You are the pipeline-operator agent for the docs-pipeline plugin.
+
+Your role is to manage documentation pipeline operations safely.
+
+## Capabilities
+
+- Inspect pipeline configuration and ownership rules
+- Run local documentation preview builds
+- Check managed file status and release dispatch chain
+- Verify content authoring environment readiness
+
+## Safety Rules
+
+- **NEVER** modify managed files directly — use the governance workflow
+- Report configuration state without making changes
+- For previews, use read-only build commands

--- a/plugins/docs-pipeline/commands/docs-pipeline-status.md
+++ b/plugins/docs-pipeline/commands/docs-pipeline-status.md
@@ -1,0 +1,20 @@
+---
+description: >-
+  Check documentation pipeline configuration and build readiness
+---
+
+Delegate to the pipeline-operator agent to check docs pipeline status.
+
+## Delegation
+
+Spawn the pipeline-operator agent with the following instructions:
+
+1. Check if pipeline configuration exists: look for `astro.config.*`, `package.json` with astro dependency
+2. Check if build tools are available: `bun --version` or `npm --version`
+3. Check managed files configuration: look for `.claude/governance.json`
+4. Report:
+   - Pipeline configuration detected (yes/no)
+   - Build tool available and version
+   - Managed files governance active (yes/no)
+   - Available commands: /docs-pipeline:preview-docs
+4. If pipeline not configured, suggest reviewing the plugin README

--- a/plugins/docs-pipeline/scripts/tests/run-tests.sh
+++ b/plugins/docs-pipeline/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/docs-pipeline/scripts/tests/test_agent.sh
+++ b/plugins/docs-pipeline/scripts/tests/test_agent.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — pipeline-operator agent has frontmatter with tools and disallowedTools
+test_pipeline_operator_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/pipeline-operator.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools:' || {
+    echo "pipeline-operator missing tools in frontmatter"
+    return 1
+  }
+
+  for tool in Read Bash Glob Grep; do
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "pipeline-operator missing allowed tool: $tool"
+      return 1
+    }
+  done
+
+  echo "$fm" | grep -q 'disallowedTools:' || {
+    echo "pipeline-operator missing disallowedTools in frontmatter"
+    return 1
+  }
+
+  for tool in Write Edit Agent; do
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "pipeline-operator missing disallowed tool: $tool"
+      return 1
+    }
+  done
+}

--- a/plugins/docs-pipeline/scripts/tests/test_security.sh
+++ b/plugins/docs-pipeline/scripts/tests/test_security.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no external dependencies required.
+
+set -euo pipefail
+
+# T1.11 — no hardcoded credentials in plugin files
+test_no_hardcoded_credentials() {
+  local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}'
+  local scan_dirs=("$PLUGIN_ROOT")
+
+  local matches
+  matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --include='*.md' --include='*.json' --include='*.mdx' |
+    grep -v 'README.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded credentials found:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/docs-pipeline/scripts/tests/test_structure.sh
+++ b/plugins/docs-pipeline/scripts/tests/test_structure.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no external dependencies required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "docs-pipeline" ] || {
+    echo "name=$name, expected docs-pipeline"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching docs-pipeline entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "docs-pipeline") | .name' "$mj")
+  [ "$mp_name" = "docs-pipeline" ] || {
+    echo "docs-pipeline entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "docs-pipeline") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "docs-pipeline") | .source' "$mj")
+  [ "$src" = "./plugins/docs-pipeline" ] || {
+    echo "source=$src, expected ./plugins/docs-pipeline"
+    return 1
+  }
+}
+
+# T1.3 — all expected files exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "skills/content-author/SKILL.md"
+    "skills/pipeline-navigator/SKILL.md"
+    "agents/pipeline-operator.md"
+    "commands/preview-docs.md"
+    "commands/docs-pipeline-status.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  for skill_dir in content-author pipeline-navigator; do
+    local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
+    local name_line
+    name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || {
+      echo "$skill_dir: missing name in frontmatter"
+      return 1
+    }
+
+    local desc_line
+    desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || {
+      echo "$skill_dir: missing description in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T1.5 — command files have description in frontmatter
+test_command_frontmatter() {
+  for cmd in preview-docs docs-pipeline-status; do
+    local file="$PLUGIN_ROOT/commands/${cmd}.md"
+    local desc
+    desc=$(frontmatter_value "$file" "description")
+    [ -n "$desc" ] || {
+      echo "$cmd: missing description"
+      return 1
+    }
+  done
+}
+
+# T1.6 — agent files exist with correct names
+test_agent_files_exist() {
+  local agent="pipeline-operator"
+  [ -f "$PLUGIN_ROOT/agents/${agent}.md" ] || {
+    echo "missing agent: ${agent}.md"
+    return 1
+  }
+}

--- a/plugins/docs-tools/commands/docs-tools-status.md
+++ b/plugins/docs-tools/commands/docs-tools-status.md
@@ -1,0 +1,19 @@
+---
+description: >-
+  Check MDX documentation tooling readiness and content review capabilities
+---
+
+Delegate to the mdx-content-reviewer agent to check docs tooling status.
+
+## Delegation
+
+Spawn the mdx-content-reviewer agent with the following instructions:
+
+1. Check if the current workspace has MDX content: look for `*.mdx` files
+2. Check if Astro/Starlight configuration exists: look for `astro.config.*` files
+3. Report:
+   - MDX files found in workspace (count)
+   - Astro/Starlight project detected (yes/no)
+   - Content review capabilities available
+   - Available commands: /docs-tools:review-mdx
+4. If no MDX files found, note that this plugin is designed for MDX documentation projects

--- a/plugins/docs-tools/scripts/tests/run-tests.sh
+++ b/plugins/docs-tools/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/docs-tools/scripts/tests/test_agent.sh
+++ b/plugins/docs-tools/scripts/tests/test_agent.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — mdx-content-reviewer agent has frontmatter with tools
+test_mdx_content_reviewer_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/mdx-content-reviewer.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools:' || {
+    echo "mdx-content-reviewer missing tools in frontmatter"
+    return 1
+  }
+
+  for tool in Read Glob Grep; do
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "mdx-content-reviewer missing allowed tool: $tool"
+      return 1
+    }
+  done
+}

--- a/plugins/docs-tools/scripts/tests/test_security.sh
+++ b/plugins/docs-tools/scripts/tests/test_security.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no external dependencies required.
+
+set -euo pipefail
+
+# T1.11 — no hardcoded credentials in plugin files
+test_no_hardcoded_credentials() {
+  local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}'
+  local scan_dirs=("$PLUGIN_ROOT")
+
+  local matches
+  matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --include='*.md' --include='*.json' --include='*.mdx' |
+    grep -v 'README.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded credentials found:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/docs-tools/scripts/tests/test_structure.sh
+++ b/plugins/docs-tools/scripts/tests/test_structure.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no external dependencies required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "docs-tools" ] || {
+    echo "name=$name, expected docs-tools"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching docs-tools entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "docs-tools") | .name' "$mj")
+  [ "$mp_name" = "docs-tools" ] || {
+    echo "docs-tools entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "docs-tools") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "docs-tools") | .source' "$mj")
+  [ "$src" = "./plugins/docs-tools" ] || {
+    echo "source=$src, expected ./plugins/docs-tools"
+    return 1
+  }
+}
+
+# T1.3 — all expected files exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "skills/content-reviewer/SKILL.md"
+    "agents/mdx-content-reviewer.md"
+    "commands/review-mdx.md"
+    "commands/docs-tools-status.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  local skill_dir="content-reviewer"
+  local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
+  local name_line
+  name_line=$(frontmatter_value "$skill" "name")
+  [ -n "$name_line" ] || {
+    echo "$skill_dir: missing name in frontmatter"
+    return 1
+  }
+
+  local desc_line
+  desc_line=$(frontmatter_value "$skill" "description")
+  [ -n "$desc_line" ] || {
+    echo "$skill_dir: missing description in frontmatter"
+    return 1
+  }
+}
+
+# T1.5 — command files have description in frontmatter
+test_command_frontmatter() {
+  for cmd in review-mdx docs-tools-status; do
+    local file="$PLUGIN_ROOT/commands/${cmd}.md"
+    local desc
+    desc=$(frontmatter_value "$file" "description")
+    [ -n "$desc" ] || {
+      echo "$cmd: missing description"
+      return 1
+    }
+  done
+}
+
+# T1.6 — agent files exist with correct names
+test_agent_files_exist() {
+  local agent="mdx-content-reviewer"
+  [ -f "$PLUGIN_ROOT/agents/${agent}.md" ] || {
+    echo "missing agent: ${agent}.md"
+    return 1
+  }
+}

--- a/plugins/firecrawl/commands/firecrawl-status.md
+++ b/plugins/firecrawl/commands/firecrawl-status.md
@@ -1,0 +1,18 @@
+---
+description: >-
+  Check Firecrawl API service status and connectivity on localhost:3002
+---
+
+Delegate to the firecrawl-operator agent to check Firecrawl service readiness.
+
+## Delegation
+
+Spawn the firecrawl-operator agent with the following instructions:
+
+1. Check if Firecrawl API is reachable: `curl -sf http://localhost:3002/ | head -c 200`
+2. If reachable, check version: `curl -sf http://localhost:3002/v1/health 2>/dev/null | jq -r '.version // "unknown"'`
+3. Report:
+   - Firecrawl service status (reachable/unreachable)
+   - Service version (if available)
+   - API endpoint: `http://localhost:3002`
+4. If not reachable, suggest checking that `ENABLE_FIRECRAWL=true` in devcontainer configuration

--- a/plugins/firecrawl/scripts/tests/run-tests.sh
+++ b/plugins/firecrawl/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/firecrawl/scripts/tests/test_agent.sh
+++ b/plugins/firecrawl/scripts/tests/test_agent.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — each agent file has frontmatter with disallowedTools or explicit tools list
+test_agent_has_disallowed_tools() {
+  for agent_file in "$PLUGIN_ROOT"/agents/*.md; do
+    [ -f "$agent_file" ] || continue
+    local name
+    name=$(basename "$agent_file")
+    local fm
+    fm=$(extract_frontmatter "$agent_file")
+
+    # Either disallowedTools OR a tools list is acceptable
+    # (researcher agents with Agent tool don't need disallowedTools)
+    echo "$fm" | grep -qE 'disallowedTools:|tools:' || {
+      echo "$name: missing disallowedTools or tools in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T2.2 — each agent file has name and description in frontmatter
+test_agent_has_name_description() {
+  for agent_file in "$PLUGIN_ROOT"/agents/*.md; do
+    [ -f "$agent_file" ] || continue
+    local name
+    name=$(basename "$agent_file")
+    local fm
+    fm=$(extract_frontmatter "$agent_file")
+
+    echo "$fm" | grep -q '^name:' || {
+      echo "$name: missing name in frontmatter"
+      return 1
+    }
+
+    echo "$fm" | grep -q 'description:' || {
+      echo "$name: missing description in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T2.3 — agent files contain response format instructions
+test_agent_response_format() {
+  for agent_file in "$PLUGIN_ROOT"/agents/*.md; do
+    [ -f "$agent_file" ] || continue
+    local name
+    name=$(basename "$agent_file")
+
+    grep -qi 'result\|report\|output\|response\|protocol\|format' "$agent_file" || {
+      echo "$name: missing response format instructions"
+      return 1
+    }
+  done
+}

--- a/plugins/firecrawl/scripts/tests/test_hook.sh
+++ b/plugins/firecrawl/scripts/tests/test_hook.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Phase 2: SessionStart hook behavior.
+
+set -euo pipefail
+
+_get_hook_command() {
+  jq -r '.hooks.SessionStart[0].hooks[0].command' "$PLUGIN_ROOT/hooks/hooks.json"
+}
+
+# T2.10 — hooks.json is valid JSON
+test_hooks_json_valid() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  jq -e '.' "$hj" >/dev/null || {
+    echo "hooks.json is not valid JSON"
+    return 1
+  }
+}
+
+# T2.11 — SessionStart hook has correct structure
+test_hook_structure() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+
+  local hook_type
+  hook_type=$(jq -r '.hooks.SessionStart[0].hooks[0].type' "$hj")
+  [ "$hook_type" = "command" ] || {
+    echo "hook type=$hook_type, expected command"
+    return 1
+  }
+
+  local timeout
+  timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$hj")
+  [[ "$timeout" =~ ^[0-9]+$ ]] || {
+    echo "timeout is not a number: $timeout"
+    return 1
+  }
+}
+
+# T2.12 — hook command is syntactically valid shell
+test_hook_command_syntax() {
+  local cmd
+  cmd=$(_get_hook_command)
+  bash -n <<<"$cmd" || {
+    echo "hook command has syntax error"
+    return 1
+  }
+}
+
+# T2.13 — hook command references localhost:3002
+test_hook_references_firecrawl_endpoint() {
+  local cmd
+  cmd=$(_get_hook_command)
+  echo "$cmd" | grep -q 'localhost:3002' || {
+    echo "hook command should reference localhost:3002"
+    return 1
+  }
+}

--- a/plugins/firecrawl/scripts/tests/test_security.sh
+++ b/plugins/firecrawl/scripts/tests/test_security.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no external tools required.
+
+set -euo pipefail
+
+# T1.20 — no hardcoded API keys in agent or skill files
+test_no_hardcoded_api_keys() {
+  local patterns='api_key[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|apikey[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|Bearer [A-Za-z0-9]{20,}'
+  local matches
+  matches=$(grep -rIin -E "$patterns" \
+    "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
+    --include='*.md' --include='*.json' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded API keys found:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.21 — no credential echo in agent files
+test_no_credential_echo() {
+  local matches
+  matches=$(grep -rIin -E 'echo.*\$(.*password|.*secret|.*token|.*api.key)' \
+    "$PLUGIN_ROOT/agents" \
+    --include='*.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Credential echo found in agent files:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.22 — no eval of user input in agent or skill files
+test_no_eval_user_input() {
+  local matches
+  matches=$(grep -rIin -E 'eval\s+.*\$\{?[a-zA-Z]' \
+    "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
+    --include='*.md' --include='*.sh' |
+    grep -v '#.*eval' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "eval of user input found:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/firecrawl/scripts/tests/test_structure.sh
+++ b/plugins/firecrawl/scripts/tests/test_structure.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no external tools required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "firecrawl" ] || {
+    echo "name=$name, expected firecrawl"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching firecrawl entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "firecrawl") | .name' "$mj")
+  [ "$mp_name" = "firecrawl" ] || {
+    echo "firecrawl entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "firecrawl") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "firecrawl") | .source' "$mj")
+  [ "$src" = "./plugins/firecrawl" ] || {
+    echo "source=$src, expected ./plugins/firecrawl"
+    return 1
+  }
+}
+
+# T1.3 — expected files and directories exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "hooks/hooks.json"
+    "skills/web-scraper/SKILL.md"
+    "agents/firecrawl-operator.md"
+    "agents/firecrawl-researcher.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  local skill="$PLUGIN_ROOT/skills/web-scraper/SKILL.md"
+  local name_line
+  name_line=$(frontmatter_value "$skill" "name")
+  [ -n "$name_line" ] || {
+    echo "web-scraper: missing name in frontmatter"
+    return 1
+  }
+
+  local desc_line
+  desc_line=$(frontmatter_value "$skill" "description")
+  [ -n "$desc_line" ] || {
+    echo "web-scraper: missing description in frontmatter"
+    return 1
+  }
+}
+
+# T1.5 — hooks.json exists and is valid JSON
+test_hooks_json_exists() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  jq -e '.' "$hj" >/dev/null || {
+    echo "hooks.json is not valid JSON"
+    return 1
+  }
+
+  jq -e '.hooks.SessionStart' "$hj" >/dev/null || {
+    echo "hooks.json missing SessionStart section"
+    return 1
+  }
+}
+
+# T1.6 — 1 skill directory exists
+test_skill_count() {
+  local count
+  count=$(find "$PLUGIN_ROOT/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+  [ "$count" -ge 1 ] || {
+    echo "expected at least 1 skill dir, found $count"
+    return 1
+  }
+}
+
+# T1.7 — 2 agent files exist
+test_agent_count() {
+  local count
+  count=$(find "$PLUGIN_ROOT/agents" -name '*.md' -type f | wc -l | tr -d ' ')
+  [ "$count" -ge 2 ] || {
+    echo "expected at least 2 agent files, found $count"
+    return 1
+  }
+}
+
+# T1.8 — 8 command files exist
+test_command_count() {
+  local count
+  count=$(find "$PLUGIN_ROOT/commands" -name '*.md' -type f | wc -l | tr -d ' ')
+  [ "$count" -ge 8 ] || {
+    echo "expected at least 8 command files, found $count"
+    return 1
+  }
+}
+
+# T1.9 — command files have description in frontmatter
+test_command_frontmatter() {
+  for cmd_file in "$PLUGIN_ROOT"/commands/*.md; do
+    [ -f "$cmd_file" ] || continue
+    local name
+    name=$(basename "$cmd_file")
+    local desc
+    desc=$(frontmatter_value "$cmd_file" "description")
+    [ -n "$desc" ] || {
+      echo "$name: missing description"
+      return 1
+    }
+  done
+}

--- a/plugins/github-ops/commands/github-ops-status.md
+++ b/plugins/github-ops/commands/github-ops-status.md
@@ -1,0 +1,24 @@
+---
+description: >-
+  Check GitHub CLI authentication, rate limits, and repository state
+---
+
+Delegate to the github-ops agent to check GitHub operations readiness.
+
+## Delegation
+
+Spawn the github-ops agent with the following instructions:
+
+1. Verify gh CLI is installed: `gh --version`
+2. Check authentication: `gh auth status`
+3. Check rate limits: `gh api rate_limit --jq '.rate | "remaining: \(.remaining)/\(.limit), resets: \(.reset | todate)"'`
+4. If in a git repository, get repo info: `gh repo view --json nameWithOwner,defaultBranchRef,url`
+5. Check current branch and worktree state: `git branch --show-current` and `git status --short | head -5`
+6. Report:
+   - gh CLI version
+   - Authentication status (user, hostname, token type)
+   - Rate limit remaining/total and reset time
+   - Current repo name and default branch (if in a git repo)
+   - Current branch and uncommitted changes count
+7. If not authenticated, suggest using `/github:gh-login`
+8. If gh CLI is not installed, suggest using `/github:setup`

--- a/plugins/meddpicc/commands/meddpicc-status.md
+++ b/plugins/meddpicc/commands/meddpicc-status.md
@@ -1,0 +1,18 @@
+---
+description: >-
+  Check MEDDPICC framework readiness and deal data availability
+---
+
+Delegate to the deal-analyst agent to check MEDDPICC framework status.
+
+## Delegation
+
+Spawn the deal-analyst agent with the following instructions:
+
+1. Verify MEDDPICC schema exists: check for `schema/meddpicc-schema.json`
+2. Check if any deal data files exist in the current workspace (*.json files matching schema)
+3. Report:
+   - Schema status (loaded/missing)
+   - Number of deal files found in workspace
+   - Available commands: /meddpicc:qualify-deal, /meddpicc:deal-review, /meddpicc:update-deal, /meddpicc:build-map, /meddpicc:champion-test
+4. If no deals found, suggest starting with `/meddpicc:qualify-deal`

--- a/plugins/meddpicc/scripts/tests/run-tests.sh
+++ b/plugins/meddpicc/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/meddpicc/scripts/tests/test_agent.sh
+++ b/plugins/meddpicc/scripts/tests/test_agent.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — deal-analyst.md has frontmatter with tools
+test_deal_analyst_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/deal-analyst.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools' || {
+    echo "deal-analyst missing tools in frontmatter"
+    return 1
+  }
+}

--- a/plugins/meddpicc/scripts/tests/test_security.sh
+++ b/plugins/meddpicc/scripts/tests/test_security.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no external dependencies required.
+
+set -euo pipefail
+
+# T1.11 — no hardcoded credentials in agent or skill files
+test_no_hardcoded_credentials() {
+  local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}|api_key=[A-Za-z0-9]'
+  local matches
+  matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
+    --include='*.md' --include='*.json' |
+    grep -v 'README.md' |
+    grep -v 'schema/' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded credentials found:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/meddpicc/scripts/tests/test_structure.sh
+++ b/plugins/meddpicc/scripts/tests/test_structure.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no external dependencies required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "meddpicc" ] || {
+    echo "name=$name, expected meddpicc"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching meddpicc entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "meddpicc") | .name' "$mj")
+  [ "$mp_name" = "meddpicc" ] || {
+    echo "meddpicc entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "meddpicc") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "meddpicc") | .source' "$mj")
+  [ "$src" = "./plugins/meddpicc" ] || {
+    echo "source=$src, expected ./plugins/meddpicc"
+    return 1
+  }
+}
+
+# T1.3 — all expected files exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "skills/champion-test/SKILL.md"
+    "skills/coach/SKILL.md"
+    "skills/deal-qualification/SKILL.md"
+    "skills/deal-review/SKILL.md"
+    "skills/deal-update/SKILL.md"
+    "skills/mutual-action-plan/SKILL.md"
+    "agents/deal-analyst.md"
+    "commands/build-map.md"
+    "commands/champion-test.md"
+    "commands/deal-review.md"
+    "commands/meddpicc-status.md"
+    "commands/qualify-deal.md"
+    "commands/update-deal.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — schema directory exists
+test_schema_directory_exists() {
+  [ -d "$PLUGIN_ROOT/schema" ] || {
+    echo "missing: schema/ directory"
+    return 1
+  }
+  [ -f "$PLUGIN_ROOT/schema/meddpicc-schema.json" ] || {
+    echo "missing: schema/meddpicc-schema.json"
+    return 1
+  }
+}
+
+# T1.5 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  for skill_dir in champion-test coach deal-qualification deal-review deal-update mutual-action-plan; do
+    local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
+    local name_line
+    name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || {
+      echo "$skill_dir: missing name in frontmatter"
+      return 1
+    }
+
+    local desc_line
+    desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || {
+      echo "$skill_dir: missing description in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T1.6 — command files have description in frontmatter
+test_command_frontmatter() {
+  for cmd in build-map champion-test deal-review meddpicc-status qualify-deal update-deal; do
+    local file="$PLUGIN_ROOT/commands/${cmd}.md"
+    local desc
+    desc=$(frontmatter_value "$file" "description")
+    [ -n "$desc" ] || {
+      echo "$cmd: missing description"
+      return 1
+    }
+  done
+}

--- a/plugins/osint-framework/package.json
+++ b/plugins/osint-framework/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "osint-framework",
+  "version": "1.0.0",
+  "description": "OSINT Framework tool catalog and investigation skills — 1,064 intelligence-gathering tools across 34 categories",
+  "license": "Apache-2.0"
+}

--- a/plugins/osint-framework/scripts/tests/run-tests.sh
+++ b/plugins/osint-framework/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/osint-framework/scripts/tests/test_agent.sh
+++ b/plugins/osint-framework/scripts/tests/test_agent.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — each agent file has frontmatter with disallowedTools
+test_agent_has_disallowed_tools() {
+  for agent_file in "$PLUGIN_ROOT"/agents/*.md; do
+    [ -f "$agent_file" ] || continue
+    local name
+    name=$(basename "$agent_file")
+    local fm
+    fm=$(extract_frontmatter "$agent_file")
+
+    echo "$fm" | grep -q 'disallowedTools:' || {
+      echo "$name: missing disallowedTools in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T2.2 — each agent file has name and description in frontmatter
+test_agent_has_name_description() {
+  for agent_file in "$PLUGIN_ROOT"/agents/*.md; do
+    [ -f "$agent_file" ] || continue
+    local name
+    name=$(basename "$agent_file")
+    local fm
+    fm=$(extract_frontmatter "$agent_file")
+
+    echo "$fm" | grep -q '^name:' || {
+      echo "$name: missing name in frontmatter"
+      return 1
+    }
+
+    echo "$fm" | grep -q 'description:' || {
+      echo "$name: missing description in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T2.3 — agent files contain response format instructions
+test_agent_response_format() {
+  for agent_file in "$PLUGIN_ROOT"/agents/*.md; do
+    [ -f "$agent_file" ] || continue
+    local name
+    name=$(basename "$agent_file")
+
+    grep -qi 'result\|report\|output\|response' "$agent_file" || {
+      echo "$name: missing response format instructions"
+      return 1
+    }
+  done
+}

--- a/plugins/osint-framework/scripts/tests/test_security.sh
+++ b/plugins/osint-framework/scripts/tests/test_security.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no external tools required.
+
+set -euo pipefail
+
+# T1.20 — no hardcoded API keys in agent or skill files
+test_no_hardcoded_api_keys() {
+  local patterns='api_key[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|apikey[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|Bearer [A-Za-z0-9]{20,}'
+  local matches
+  matches=$(grep -rIin -E "$patterns" \
+    "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
+    --include='*.md' --include='*.json' |
+    grep -v 'OPENCORPORATES_API_KEY' |
+    grep -v 'SHODAN_API_KEY' |
+    grep -v '\$\{.*API_KEY' |
+    grep -v 'YOUR_API_KEY' |
+    grep -v 'set .*API_KEY' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded API keys found:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.21 — no credential echo in agent files
+test_no_credential_echo() {
+  local matches
+  matches=$(grep -rIin -E 'echo.*\$(.*password|.*secret|.*token|.*api.key)' \
+    "$PLUGIN_ROOT/agents" \
+    --include='*.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Credential echo found in agent files:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.22 — no eval of user input in agent or skill files
+test_no_eval_user_input() {
+  local matches
+  matches=$(grep -rIin -E 'eval\s+.*\$\{?[a-zA-Z]' \
+    "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
+    --include='*.md' --include='*.sh' |
+    grep -v '#.*eval' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "eval of user input found:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.23 — no hardcoded passwords or secrets in skill reference files
+test_no_hardcoded_secrets_in_skills() {
+  local patterns='password[[:space:]]*=[[:space:]]*["\x27][^$][A-Za-z0-9]{5,}|secret[[:space:]]*=[[:space:]]*["\x27][^$][A-Za-z0-9]{5,}'
+  local matches
+  matches=$(grep -rIin -E "$patterns" \
+    "$PLUGIN_ROOT/skills" \
+    --include='*.md' --include='*.json' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded secrets found in skills:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/osint-framework/scripts/tests/test_structure.sh
+++ b/plugins/osint-framework/scripts/tests/test_structure.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no external tools required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "osint-framework" ] || {
+    echo "name=$name, expected osint-framework"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching osint-framework entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "osint-framework") | .name' "$mj")
+  [ "$mp_name" = "osint-framework" ] || {
+    echo "osint-framework entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "osint-framework") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "osint-framework") | .source' "$mj")
+  [ "$src" = "./plugins/osint-framework" ] || {
+    echo "source=$src, expected ./plugins/osint-framework"
+    return 1
+  }
+}
+
+# T1.3 — expected directories exist
+test_expected_directories() {
+  local dirs=(
+    "skills"
+    "agents"
+    "commands"
+    "hooks"
+  )
+  for d in "${dirs[@]}"; do
+    [ -d "$PLUGIN_ROOT/$d" ] || {
+      echo "missing directory: $d"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter in at least 5 sampled skill dirs has name+description
+test_skill_frontmatter() {
+  local count=0
+  local checked=0
+  for skill_dir in "$PLUGIN_ROOT"/skills/*/; do
+    [ -d "$skill_dir" ] || continue
+    local skill="$skill_dir/SKILL.md"
+    [ -f "$skill" ] || continue
+    checked=$((checked + 1))
+    [ "$checked" -gt 5 ] && break
+
+    local name_line
+    name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || {
+      echo "$(basename "$skill_dir"): missing name in frontmatter"
+      return 1
+    }
+
+    local desc_line
+    desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || {
+      echo "$(basename "$skill_dir"): missing description in frontmatter"
+      return 1
+    }
+    count=$((count + 1))
+  done
+
+  [ "$count" -ge 5 ] || {
+    echo "expected at least 5 skills with valid frontmatter, found $count"
+    return 1
+  }
+}
+
+# T1.5 — hooks.json is valid JSON with correct structure
+test_hooks_json_structure() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  jq -e '.' "$hj" >/dev/null || {
+    echo "hooks.json is not valid JSON"
+    return 1
+  }
+
+  jq -e '.hooks.PreToolUse' "$hj" >/dev/null || {
+    echo "hooks.json missing PreToolUse section"
+    return 1
+  }
+
+  local hook_type
+  hook_type=$(jq -r '.hooks.PreToolUse[0].hooks[0].type' "$hj")
+  [ "$hook_type" = "command" ] || {
+    echo "hook type=$hook_type, expected command"
+    return 1
+  }
+
+  local timeout
+  timeout=$(jq -r '.hooks.PreToolUse[0].hooks[0].timeout' "$hj")
+  [[ "$timeout" =~ ^[0-9]+$ ]] || {
+    echo "timeout is not a number: $timeout"
+    return 1
+  }
+}
+
+# T1.6 — at least 35 skill directories exist
+test_skill_count() {
+  local count
+  count=$(find "$PLUGIN_ROOT/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+  [ "$count" -ge 35 ] || {
+    echo "expected at least 35 skill dirs, found $count"
+    return 1
+  }
+}
+
+# T1.7 — 3 agent files exist
+test_agent_count() {
+  local count
+  count=$(find "$PLUGIN_ROOT/agents" -name '*.md' -type f | wc -l | tr -d ' ')
+  [ "$count" -ge 3 ] || {
+    echo "expected at least 3 agent files, found $count"
+    return 1
+  }
+}
+
+# T1.8 — 3 command files exist
+test_command_count() {
+  local count
+  count=$(find "$PLUGIN_ROOT/commands" -name '*.md' -type f | wc -l | tr -d ' ')
+  [ "$count" -ge 3 ] || {
+    echo "expected at least 3 command files, found $count"
+    return 1
+  }
+}

--- a/plugins/platform/commands/platform-status.md
+++ b/plugins/platform/commands/platform-status.md
@@ -1,0 +1,22 @@
+---
+description: >-
+  Check F5 Distributed Cloud platform API connectivity and authentication status
+---
+
+Delegate to the api-operator agent to check platform readiness.
+
+## Delegation
+
+Spawn the api-operator agent with the following instructions:
+
+1. Check if F5XC_API_TOKEN environment variable is set
+2. Check if F5XC_API_URL environment variable is set
+3. If both are set, verify token validity: `curl -s -o /dev/null -w '%{http_code}' -H "Authorization: APIToken ${F5XC_API_TOKEN}" "${F5XC_API_URL}/api/web/namespaces"`
+4. If token is valid (HTTP 200), list available namespaces
+5. Report:
+   - API URL (tenant endpoint)
+   - Token status (valid/expired/missing)
+   - Available namespaces (if authenticated)
+   - Console access status
+6. If token is missing or expired, suggest using `/platform:check-api-token`
+7. If API URL is not set, suggest setting F5XC_API_URL environment variable

--- a/plugins/platform/hooks/hooks.json
+++ b/plugins/platform/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -n \"${F5XC_API_TOKEN:-}\" || echo 'WARNING: F5XC_API_TOKEN is not set. Run /platform:check-api-token to configure API access.'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/platform/scripts/tests/run-tests.sh
+++ b/plugins/platform/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/platform/scripts/tests/test_agent.sh
+++ b/plugins/platform/scripts/tests/test_agent.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — api-operator.md has frontmatter with tools and disallowedTools
+test_api_operator_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/api-operator.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'disallowedTools' || {
+    echo "api-operator missing disallowedTools"
+    return 1
+  }
+}
+
+# T2.2 — config-analyzer.md has frontmatter with tools and disallowedTools
+test_config_analyzer_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/config-analyzer.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'disallowedTools' || {
+    echo "config-analyzer missing disallowedTools"
+    return 1
+  }
+}
+
+# T2.3 — console-operator.md has frontmatter with tools and disallowedTools
+test_console_operator_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/console-operator.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'disallowedTools' || {
+    echo "console-operator missing disallowedTools"
+    return 1
+  }
+}

--- a/plugins/platform/scripts/tests/test_hook.sh
+++ b/plugins/platform/scripts/tests/test_hook.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Phase 2: SessionStart hook behavior.
+
+set -euo pipefail
+
+_get_hook_command() {
+  jq -r '.hooks.SessionStart[0].hooks[0].command' "$PLUGIN_ROOT/hooks/hooks.json"
+}
+
+# T2.1 — hook succeeds silently when F5XC_API_TOKEN is set
+test_hook_succeeds_when_token_set() {
+  local cmd
+  cmd=$(_get_hook_command)
+  local out
+  out=$(F5XC_API_TOKEN="test-token" bash -c "$cmd" 2>&1)
+  [ -z "$out" ] || {
+    echo "expected empty output when token set, got: $out"
+    return 1
+  }
+}
+
+# T2.2 — hook outputs WARNING when F5XC_API_TOKEN is not set
+test_hook_warns_when_token_unset() {
+  local cmd
+  cmd=$(_get_hook_command)
+  local out
+  out=$(
+    unset F5XC_API_TOKEN
+    bash -c "$cmd" 2>&1
+  ) || true
+  echo "$out" | grep -q 'WARNING' || {
+    echo "expected WARNING in output, got: $out"
+    return 1
+  }
+}

--- a/plugins/platform/scripts/tests/test_security.sh
+++ b/plugins/platform/scripts/tests/test_security.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no API or org required.
+
+set -euo pipefail
+
+# T1.11 — no hardcoded API tokens in plugin files
+test_no_hardcoded_api_tokens() {
+  local patterns='F5XC_API_TOKEN=[A-Za-z0-9]|APIToken [A-Za-z0-9]{20,}|Bearer [A-Za-z0-9]{20,}'
+  local matches
+  matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
+    --include='*.md' --include='*.json' |
+    grep -v 'README.md' |
+    grep -v '\$F5XC_API_TOKEN' |
+    grep -v '\${F5XC_API_TOKEN' |
+    grep -v 'APIToken \$' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded API tokens found:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.12 — no credential echo in agent files
+test_no_credential_echo_in_agents() {
+  local agents_dir="$PLUGIN_ROOT/agents"
+  local matches
+  matches=$(grep -rIin -E 'echo.*\$F5XC_API_TOKEN|echo.*\$F5XC_API_URL.*TOKEN|print.*TOKEN' "$agents_dir" \
+    --include='*.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Credential echo found in agent files:"
+    echo "$matches"
+    return 1
+  fi
+}
+
+# T1.13 — no eval of user input in agent files
+test_no_eval_user_input() {
+  local agents_dir="$PLUGIN_ROOT/agents"
+  local matches
+  matches=$(grep -rIin -E 'eval.*\$|eval.*user|eval.*input' "$agents_dir" \
+    --include='*.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Eval of user input found in agent files:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/platform/scripts/tests/test_structure.sh
+++ b/plugins/platform/scripts/tests/test_structure.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no API or org required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "platform" ] || {
+    echo "name=$name, expected platform"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching platform entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "platform") | .name' "$mj")
+  [ "$mp_name" = "platform" ] || {
+    echo "platform entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "platform") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "platform") | .source' "$mj")
+  [ "$src" = "./plugins/platform" ] || {
+    echo "source=$src, expected ./plugins/platform"
+    return 1
+  }
+}
+
+# T1.3 — all expected files exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "hooks/hooks.json"
+    "skills/api-auth/SKILL.md"
+    "skills/api-index/SKILL.md"
+    "skills/api-operations/SKILL.md"
+    "skills/config-analysis/SKILL.md"
+    "skills/console-auth/SKILL.md"
+    "skills/console-index/SKILL.md"
+    "skills/console-navigator/SKILL.md"
+    "skills/platform-index/SKILL.md"
+    "agents/api-operator.md"
+    "agents/config-analyzer.md"
+    "agents/console-operator.md"
+    "commands/check-api-token.md"
+    "commands/login-console.md"
+    "commands/platform-status.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  for skill_dir in api-auth api-index api-operations config-analysis console-auth console-index console-navigator platform-index; do
+    local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
+    local name_line
+    name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || {
+      echo "$skill_dir: missing name in frontmatter"
+      return 1
+    }
+
+    local desc_line
+    desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || {
+      echo "$skill_dir: missing description in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T1.5 — hooks.json is valid JSON with correct structure
+test_hooks_json_structure() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  jq -e '.' "$hj" >/dev/null || {
+    echo "hooks.json is not valid JSON"
+    return 1
+  }
+
+  local hook_type
+  hook_type=$(jq -r '.hooks.SessionStart[0].hooks[0].type' "$hj")
+  [ "$hook_type" = "command" ] || {
+    echo "hook type=$hook_type, expected command"
+    return 1
+  }
+
+  local timeout
+  timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$hj")
+  [[ "$timeout" =~ ^[0-9]+$ ]] || {
+    echo "timeout is not a number: $timeout"
+    return 1
+  }
+}
+
+# T1.6 — hook command is syntactically valid shell
+test_hook_command_syntax() {
+  local hj="$PLUGIN_ROOT/hooks/hooks.json"
+  local cmd
+  cmd=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$hj")
+  bash -n <<<"$cmd" || {
+    echo "hook command has syntax error"
+    return 1
+  }
+}
+
+# T1.7 — command files have description in frontmatter
+test_command_frontmatter() {
+  for cmd in check-api-token login-console platform-status; do
+    local file="$PLUGIN_ROOT/commands/${cmd}.md"
+    local desc
+    desc=$(frontmatter_value "$file" "description")
+    [ -n "$desc" ] || {
+      echo "$cmd: missing description"
+      return 1
+    }
+  done
+}

--- a/plugins/sales-engineer/commands/sales-engineer-status.md
+++ b/plugins/sales-engineer/commands/sales-engineer-status.md
@@ -1,0 +1,19 @@
+---
+description: >-
+  Check sales engineering demo environment readiness and available workflows
+---
+
+Delegate to the demo-housekeeping agent to check sales engineer environment status.
+
+## Delegation
+
+Spawn the demo-housekeeping agent with the following instructions:
+
+1. Check workspace for demo configuration files
+2. Verify demo-related tools are available: `git --version`, check for infrastructure CLI tools
+3. Report:
+   - Available personas: demo-executor, presenter, subject-matter-expert
+   - Available workflows: demo-ops, demo-executor
+   - Workspace demo readiness (config files found/missing)
+   - Available commands: /sales-engineer:sales-engineer-status
+4. If demo environment needs setup, suggest reviewing the plugin README

--- a/plugins/sales-engineer/scripts/tests/run-tests.sh
+++ b/plugins/sales-engineer/scripts/tests/run-tests.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/../.." && pwd -P)"
+MARKETPLACE_ROOT="$(cd -- "$PLUGIN_ROOT/../.." && pwd -P)"
+
+export PLUGIN_ROOT
+export MARKETPLACE_ROOT
+
+filter="${1:-}"
+
+fail=0
+pass=0
+skip=0
+
+for file in "$HERE"/test_*.sh; do
+  [ -f "$file" ] || continue
+  before=$(declare -F | awk '{print $3}' | sort)
+  # shellcheck disable=SC1090
+  source "$file"
+  after=$(declare -F | awk '{print $3}' | sort)
+  new_fns=$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after") | grep '^test_' || true)
+  for fn in $new_fns; do
+    [ -n "$filter" ] && [[ "$fn" != *"$filter"* ]] && continue
+    tmp="$(mktemp -d)"
+    if out=$("$fn" 2>&1); then
+      if echo "$out" | grep -q '^SKIP:'; then
+        skip=$((skip + 1))
+        printf '  SKIP  %s  %s\n' "$fn" "$(echo "$out" | grep '^SKIP:' | head -1)"
+      else
+        pass=$((pass + 1))
+        printf '  PASS  %s\n' "$fn"
+      fi
+    else
+      fail=$((fail + 1))
+      printf '  FAIL  %s\n' "$fn"
+      printf '%s\n' "$out" | while IFS= read -r line; do printf '    %s\n' "$line"; done
+    fi
+    rm -rf "$tmp"
+  done
+done
+
+printf '\n%d passed, %d skipped, %d failed\n' "$pass" "$skip" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugins/sales-engineer/scripts/tests/test_agent.sh
+++ b/plugins/sales-engineer/scripts/tests/test_agent.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Phase 2: Agent contract validation.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+# T2.1 — demo-housekeeping agent has frontmatter with tools
+test_demo_housekeeping_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/demo-housekeeping.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools:' || {
+    echo "demo-housekeeping missing tools in frontmatter"
+    return 1
+  }
+
+  for tool in Read Bash Glob Grep; do
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "demo-housekeeping missing allowed tool: $tool"
+      return 1
+    }
+  done
+}
+
+# T2.2 — demo-researcher agent has frontmatter with tools
+test_demo_researcher_frontmatter() {
+  local agent="$PLUGIN_ROOT/agents/demo-researcher.md"
+  local fm
+  fm=$(extract_frontmatter "$agent")
+
+  echo "$fm" | grep -q 'tools:' || {
+    echo "demo-researcher missing tools in frontmatter"
+    return 1
+  }
+
+  for tool in Read Glob Grep; do
+    echo "$fm" | grep -qF "  - $tool" || {
+      echo "demo-researcher missing allowed tool: $tool"
+      return 1
+    }
+  done
+}

--- a/plugins/sales-engineer/scripts/tests/test_security.sh
+++ b/plugins/sales-engineer/scripts/tests/test_security.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Phase 1: Security validation — no external dependencies required.
+
+set -euo pipefail
+
+# T1.11 — no hardcoded credentials in plugin files
+test_no_hardcoded_credentials() {
+  local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}'
+  local scan_dirs=("$PLUGIN_ROOT")
+
+  local matches
+  matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --include='*.md' --include='*.json' --include='*.mdx' |
+    grep -v 'README.md' ||
+    true)
+
+  if [ -n "$matches" ]; then
+    echo "Possible hardcoded credentials found:"
+    echo "$matches"
+    return 1
+  fi
+}

--- a/plugins/sales-engineer/scripts/tests/test_structure.sh
+++ b/plugins/sales-engineer/scripts/tests/test_structure.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Phase 1: Structural validation — no external dependencies required.
+
+set -euo pipefail
+
+# --- helpers ---
+extract_frontmatter() {
+  awk '/^---$/{n++; next} n==1' "$1"
+}
+
+frontmatter_value() {
+  extract_frontmatter "$1" | grep "^${2}:" | head -1
+}
+
+# T1.1 — plugin.json is valid JSON with required fields
+test_plugin_json_valid() {
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+  jq -e '.name' "$pj" >/dev/null
+  jq -e '.description' "$pj" >/dev/null
+  jq -e '.version' "$pj" >/dev/null
+  jq -e '.author.name' "$pj" >/dev/null
+
+  local name
+  name=$(jq -r '.name' "$pj")
+  [ "$name" = "sales-engineer" ] || {
+    echo "name=$name, expected sales-engineer"
+    return 1
+  }
+
+  local ver
+  ver=$(jq -r '.version' "$pj")
+  [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+    echo "bad version: $ver"
+    return 1
+  }
+}
+
+# T1.2 — marketplace.json has a matching sales-engineer entry
+test_marketplace_entry() {
+  local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
+  local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
+
+  local mp_name
+  mp_name=$(jq -r '.plugins[] | select(.name == "sales-engineer") | .name' "$mj")
+  [ "$mp_name" = "sales-engineer" ] || {
+    echo "sales-engineer entry missing from marketplace.json"
+    return 1
+  }
+
+  local mp_ver
+  mp_ver=$(jq -r '.plugins[] | select(.name == "sales-engineer") | .version' "$mj")
+  local pj_ver
+  pj_ver=$(jq -r '.version' "$pj")
+  [ "$mp_ver" = "$pj_ver" ] || {
+    echo "version mismatch: marketplace=$mp_ver plugin=$pj_ver"
+    return 1
+  }
+
+  local src
+  src=$(jq -r '.plugins[] | select(.name == "sales-engineer") | .source' "$mj")
+  [ "$src" = "./plugins/sales-engineer" ] || {
+    echo "source=$src, expected ./plugins/sales-engineer"
+    return 1
+  }
+}
+
+# T1.3 — all expected files exist
+test_expected_files_exist() {
+  local files=(
+    ".xcsh-plugin/plugin.json"
+    "skills/demo-executor/SKILL.md"
+    "skills/demo-ops/SKILL.md"
+    "skills/persona/SKILL.md"
+    "skills/presenter/SKILL.md"
+    "skills/subject-matter-expert/SKILL.md"
+    "agents/demo-housekeeping.md"
+    "agents/demo-researcher.md"
+    "commands/sales-engineer-status.md"
+  )
+  for f in "${files[@]}"; do
+    [ -f "$PLUGIN_ROOT/$f" ] || {
+      echo "missing: $f"
+      return 1
+    }
+  done
+}
+
+# T1.4 — SKILL.md frontmatter has name and description
+test_skill_frontmatter() {
+  for skill_dir in demo-executor demo-ops persona presenter subject-matter-expert; do
+    local skill="$PLUGIN_ROOT/skills/$skill_dir/SKILL.md"
+    local name_line
+    name_line=$(frontmatter_value "$skill" "name")
+    [ -n "$name_line" ] || {
+      echo "$skill_dir: missing name in frontmatter"
+      return 1
+    }
+
+    local desc_line
+    desc_line=$(frontmatter_value "$skill" "description")
+    [ -n "$desc_line" ] || {
+      echo "$skill_dir: missing description in frontmatter"
+      return 1
+    }
+  done
+}
+
+# T1.5 — command files have description in frontmatter
+test_command_frontmatter() {
+  local cmd="sales-engineer-status"
+  local file="$PLUGIN_ROOT/commands/${cmd}.md"
+  local desc
+  desc=$(frontmatter_value "$file" "description")
+  [ -n "$desc" ] || {
+    echo "$cmd: missing description"
+    return 1
+  }
+}
+
+# T1.6 — agent files exist with correct names
+test_agent_files_exist() {
+  for agent in demo-housekeeping demo-researcher; do
+    [ -f "$PLUGIN_ROOT/agents/${agent}.md" ] || {
+      echo "missing agent: ${agent}.md"
+      return 1
+    }
+  done
+}


### PR DESCRIPTION
## Summary

Closes #533, closes #534, closes #535, closes #536, closes #537, closes #538, closes #539, closes #540, closes #541, closes #542, closes #543, closes #549

Brings all marketplace plugins to feature parity with the salesforce reference implementation:

- **platform** (#533): SessionStart hook (F5XC_API_TOKEN check), `/platform:platform-status` command, 15-test suite
- **meddpicc** (#534): `/meddpicc:meddpicc-status` command, 8-test suite (no hook — no external deps)
- **firecrawl** (#535): `/firecrawl:firecrawl-status` command, 19-test suite (hook already existed)
- **devcontainer** (#536): SessionStart hook (container detection), `/devcontainer:devcontainer-status` command, 14-test suite
- **sales-engineer** (#537): `/sales-engineer:sales-engineer-status` command, 9-test suite (no hook — no external deps)
- **cloudstatus** (#538): SessionStart hook (Statuspage API check), 18-test suite (status command already existed)
- **brand** (#539): `brand-operator` agent, `/brand:brand-status` command, 8-test suite (no hook — no external deps)
- **docs-tools** (#540): `/docs-tools:docs-tools-status` command, 8-test suite (no hook — no external deps)
- **docs-pipeline** (#541): `pipeline-operator` agent, `/docs-pipeline:docs-pipeline-status` command, 8-test suite (no hook — no external deps)
- **github-ops** (#542): `/github-ops:github-ops-status` command (hooks and tests already existed)
- **osint-framework** (#543): `package.json`, 15-test suite (hooks already existed)
- **Test template** (#549): Standardized `run-tests.sh` harness with dynamic function discovery, filter support, SKIP mechanism

## Test plan

- [x] `bash scripts/tests/run-tests.sh` in all 11 plugins — all pass (145 total new tests)
- [x] `bash scripts/validate-plugins.sh` — all 30 plugins validate
- [x] `shellcheck` — zero warnings on new files
- [x] `shfmt` — all new shell files formatted
- [x] `markdownlint` — zero errors on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)