### PR TITLE
feat(brand): enhance reviewer with screenshot, terminology, skip, and sync rules

### DIFF
--- a/plugins/brand/skills/reviewer/SKILL.md
+++ b/plugins/brand/skills/reviewer/SKILL.md
@@ -43,7 +43,7 @@ Grep/Glob searches in a single turn wherever possible.
 Scan files for hex color values. Flag any hex color that does
 not appear in the F5 45-color palette.
 
-**Allowed hex values** (the official palette):
+**Allowed hex values** (the official palette — last synced with docs-theme: 2026-06-02):
 
 Red family: `#e4002b`, `#f7b2bf`, `#f06680`, `#a70020`, `#720016`
 Tangerine: `#f29a36`, `#ffe4c4`, `#ffbd61`, `#a35700`, `#7a4100`
@@ -64,7 +64,10 @@ Icon vars: `#0f1e57`, `#e5eaff`, `#e6e9f3`, `#1a2a6c`
   (e.g., `color: #e4002b` instead of `var(--f5-red)`)
 
 **Skip**: hex values inside code blocks, inline code spans, and
-`export const` blocks.
+`export const` blocks. The skip applies transitively — any content
+inside a skipped block is also skipped, regardless of nesting depth
+(e.g., inline styles inside HTML strings inside JavaScript inside
+an `export const` are all skipped).
 
 ## Check 2: Typography compliance
 
@@ -126,6 +129,9 @@ Find Screenshot component usages and check for both
 `light` and `dark` props:
 
 - Screenshot with only one variant → SUGGESTION
+- Screenshot where `light` and `dark` props reference the same
+  file path → SUGGESTION ("light and dark props reference the
+  same image; capture a separate dark-mode screenshot")
 
 ### Contrast (best effort)
 
@@ -144,7 +150,10 @@ naming issues.
 **Rules:**
 
 - "F5 XC" or "F5XC" without prior "F5 Distributed Cloud"
-  expansion in the same file → SUGGESTION
+  expansion in the same file → SUGGESTION. However, if a peer
+  `index.mdx` in the same directory contains the expansion
+  "F5 Distributed Cloud", downgrade to INFO (the directory
+  scope establishes the expansion for all sibling pages).
 - Lowercase product names that should be capitalized:
   "bot defense" → "Bot Defense",
   "web app and API protection" → "Web App and API Protection",


### PR DESCRIPTION
## Summary

Closes #63, closes #64, closes #65, closes #66

Four brand-reviewer SKILL.md enhancements discovered during the first production run of `/review-brand` against the csd repository:

- **#63 (Screenshot dual-variant)**: Detect when `light` and `dark` props on Screenshot components reference the same file path — flag as SUGGESTION to capture a separate dark-mode screenshot
- **#64 (Directory-scoped expansion)**: When a file uses "F5 XC" without expansion, but a peer `index.mdx` in the same directory contains "F5 Distributed Cloud", downgrade from SUGGESTION to INFO
- **#65 (Transitive skip rule)**: Clarify that the code-block skip rule applies transitively — nested content inside skipped blocks (e.g., inline styles inside HTML inside JS inside `export const`) is also skipped
- **#66 (Palette sync timestamp)**: Add sync timestamp to the 45-color palette header so staleness against docs-theme is visible

Also closed #552 and #139 (governance sync) — the drifted files (README.md, .gitignore) are intentionally marketplace-specific.

## Test plan

- [x] `bash plugins/brand/scripts/tests/run-tests.sh` — 8 pass, 0 fail
- [x] `bash scripts/validate-plugins.sh` — all 30 plugins pass
- [x] Markdownlint — 0 errors on modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)