### PR TITLE
feat: mark cloud connector plugins as recommended with prerequisites

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -225,7 +225,9 @@
       "tags": ["salesforce", "development", "cli", "crm", "xcsh-extension"],
       "license": "Apache-2.0",
       "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/salesforce",
-      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "recommended": true,
+      "prerequisites": [{ "tool": "sf", "installCmd": "brew install sf", "detectCmd": "sf version" }]
     },
     {
       "name": "cloudstatus",
@@ -264,7 +266,9 @@
       "tags": ["azure", "cloud", "xcsh-extension"],
       "license": "Apache-2.0",
       "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/azure",
-      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "recommended": true,
+      "prerequisites": [{ "tool": "az", "installCmd": "brew install azure-cli", "detectCmd": "az version" }]
     },
     {
       "name": "aws",
@@ -279,7 +283,9 @@
       "tags": ["aws", "cloud", "xcsh-extension"],
       "license": "Apache-2.0",
       "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/aws",
-      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "recommended": true,
+      "prerequisites": [{ "tool": "aws", "installCmd": "brew install awscli", "detectCmd": "aws --version" }]
     },
     {
       "name": "gcloud",
@@ -294,7 +300,9 @@
       "tags": ["gcloud", "google", "cloud", "xcsh-extension"],
       "license": "Apache-2.0",
       "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/gcloud",
-      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "recommended": true,
+      "prerequisites": [{ "tool": "gcloud", "installCmd": "brew install google-cloud-sdk", "detectCmd": "gcloud version" }]
     },
     {
       "name": "gitlab",
@@ -309,7 +317,9 @@
       "tags": ["gitlab", "development", "cli", "xcsh-extension"],
       "license": "Apache-2.0",
       "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/gitlab",
-      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "recommended": true,
+      "prerequisites": [{ "tool": "glab", "installCmd": "brew install glab", "detectCmd": "glab version" }]
     },
     {
       "name": "github",
@@ -324,7 +334,9 @@
       "tags": ["github", "development", "cli", "xcsh-extension"],
       "license": "Apache-2.0",
       "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/github",
-      "repository": "https://github.com/f5xc-salesdemos/marketplace"
+      "repository": "https://github.com/f5xc-salesdemos/marketplace",
+      "recommended": true,
+      "prerequisites": [{ "tool": "gh", "installCmd": "brew install gh", "detectCmd": "gh version" }]
     }
   ]
 }

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -302,7 +302,9 @@
       "homepage": "https://github.com/f5xc-salesdemos/marketplace/tree/main/plugins/gcloud",
       "repository": "https://github.com/f5xc-salesdemos/marketplace",
       "recommended": true,
-      "prerequisites": [{ "tool": "gcloud", "installCmd": "brew install google-cloud-sdk", "detectCmd": "gcloud version" }]
+      "prerequisites": [
+        { "tool": "gcloud", "installCmd": "brew install google-cloud-sdk", "detectCmd": "gcloud version" }
+      ]
     },
     {
       "name": "gitlab",


### PR DESCRIPTION
## Summary

- Add `"recommended": true` to 6 cloud connector plugins: salesforce, azure, aws, gcloud, github, gitlab
- Add `"prerequisites"` array with CLI tool name, brew install command, and detection command
- Enables the xcsh `/plugin setup` guided onboarding flow

## Test plan

- [x] `scripts/validate-plugins.sh` passes for all 18 plugins
- [x] marketplace.json valid JSON
- [ ] xcsh `/plugin` dashboard shows "Recommended" tab with these 6 plugins

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)