### PR TITLE
feat(salesforce): register profile collector for person-data sync

### DIFF
--- a/plugins/salesforce/src/context/profile-mapper.ts
+++ b/plugins/salesforce/src/context/profile-mapper.ts
@@ -1,0 +1,42 @@
+import type { SalesforceContext, SalesforcePartner } from './salesforce-context';
+
+interface ProfilePartial {
+  manager?: { givenName?: string; familyName?: string };
+  partner?: { id?: string; name: string; title?: string; role?: string };
+  territories?: string[];
+  role?: string;
+}
+
+function splitName(fullName: string): { givenName: string; familyName?: string } {
+  const parts = fullName.trim().split(/\s+/);
+  return {
+    givenName: parts[0],
+    familyName: parts.length > 1 ? parts.slice(1).join(' ') : undefined,
+  };
+}
+
+function mapPartner(p: SalesforcePartner): ProfilePartial['partner'] {
+  return { id: p.id, name: p.name, title: p.title, role: p.role };
+}
+
+export function mapSalesforceToProfile(ctx: SalesforceContext): ProfilePartial {
+  const result: ProfilePartial = {};
+
+  if (ctx.managerName) {
+    result.manager = splitName(ctx.managerName);
+  }
+
+  if (ctx.discoveredPartner) {
+    result.partner = mapPartner(ctx.discoveredPartner);
+  }
+
+  if (ctx.territories && ctx.territories.length > 0) {
+    result.territories = ctx.territories;
+  }
+
+  if (ctx.discoveredRole) {
+    result.role = ctx.discoveredRole;
+  }
+
+  return result;
+}

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -31,6 +31,31 @@ const factory: ExtensionFactory = async (pi) => {
       setLoadProfile(pi.pi.loadProfile);
     }
 
+    // Register profile collector for person-data sync
+    if (typeof pi.registerProfileCollector === 'function') {
+      pi.registerProfileCollector({
+        id: 'salesforce',
+        name: 'Salesforce',
+        async available() {
+          const { loadSalesforceContext } = await import('./context/salesforce-context');
+          const ctx = await loadSalesforceContext();
+          return ctx !== null;
+        },
+        async collect() {
+          const { loadSalesforceContext, salesforceContextIsStale, seedSalesforceContext } = await import(
+            './context/salesforce-context'
+          );
+          const { mapSalesforceToProfile } = await import('./context/profile-mapper');
+          let ctx = await loadSalesforceContext();
+          if (!ctx || salesforceContextIsStale(ctx)) {
+            ctx = await seedSalesforceContext();
+          }
+          if (!ctx) return {};
+          return mapSalesforceToProfile(ctx);
+        },
+      });
+    }
+
     // Register tools
     const { createSfSetupTool } = await import('./tools/sf-setup');
     const { createSfQueryTool } = await import('./tools/sf-query');


### PR DESCRIPTION
Closes #592

## Summary
- Salesforce plugin registers a `ProfileCollector` via `pi.registerProfileCollector()` to sync discovered org data (manager, role, partner, territories) back to `user-profile.json`
- Adds `profile-mapper.ts` that transforms `SalesforceContext` fields into `Partial<UserProfile>`
- Depends on f5xc-salesdemos/xcsh#1222

## Test plan
- [ ] Unit test `mapSalesforceToProfile()` for name splitting, partner mapping, empty-field handling
- [ ] Integration: with xcsh changes, verify Salesforce collector registered and runs at session startup
- [ ] Manual: change manager in Salesforce org, start new session, verify `~/.xcsh/user-profile.json` reflects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)