### PR TITLE
fix(salesforce): check salesforceId for collector availability when no cache

### DIFF
--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -38,9 +38,13 @@ const factory: ExtensionFactory = async (pi) => {
         name: 'Salesforce',
         authoritativeFields: ['manager', 'partner', 'territories'],
         async available() {
-          const { loadSalesforceContext } = await import('./context/salesforce-context');
+          const { loadSalesforceContext, getLoadProfile } = await import('./context/salesforce-context');
           const ctx = await loadSalesforceContext();
-          return ctx !== null;
+          if (ctx) return true;
+          const loader = getLoadProfile();
+          if (!loader) return false;
+          const profile = await loader();
+          return !!profile.identifiers?.salesforceId;
         },
         async collect() {
           const { loadSalesforceContext, salesforceContextIsStale, seedSalesforceContext } = await import(


### PR DESCRIPTION
Closes #595

## Summary
- Collector's `available()` was returning false when `salesforce-context.json` didn't exist (first session or cache cleared)
- Now falls back to checking if user profile has a `salesforceId`, meaning SF discovery can proceed
- Root cause of manager still showing Paul Slosberg after v19.15.0 upgrade

## Test plan
- [ ] Delete `~/.xcsh/salesforce-context.json`, start new session, verify manager updates from Salesforce

🤖 Generated with [Claude Code](https://claude.com/claude-code)