### PR TITLE
chore(salesforce): bump version to 1.1.0 for profile reconciliation

### DIFF
--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"


### PR DESCRIPTION
Closes #601

## Summary
- Bump salesforce plugin from 1.0.0 to 1.1.0 so `marketplace.autoUpdate=auto` triggers a cache refresh
- Without a version bump, the version-keyed plugin cache serves the old v1.0.0 code that has no `registerProfileCollector` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)