### PR TITLE
chore(salesforce): bump to 1.1.0 in both plugin.json and marketplace.json

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -202,7 +202,7 @@
     {
       "name": "salesforce",
       "description": "Salesforce pipeline intelligence \u2014 native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"


### PR DESCRIPTION
Closes #601

## Summary
- Bump salesforce version to 1.1.0 in both `plugin.json` and `marketplace.json` (CI validates they match)
- Fixes biome formatting in marketplace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)