### PR TITLE
fix(salesforce): read profile from disk when loadProfile not injected

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -202,7 +202,7 @@
     {
       "name": "salesforce",
       "description": "Salesforce pipeline intelligence \u2014 native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "f5xc-salesdemos"
       },

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "f5xc-salesdemos",
     "url": "https://github.com/f5xc-salesdemos"

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -42,14 +42,38 @@ const factory: ExtensionFactory = async (pi) => {
           const ctx = await loadSalesforceContext();
           if (ctx) return true;
           const loader = getLoadProfile();
-          if (!loader) return false;
-          const profile = await loader();
-          return !!profile.identifiers?.salesforceId;
+          if (loader) {
+            const profile = await loader();
+            return !!profile.identifiers?.salesforceId;
+          }
+          const os = await import('node:os');
+          const path = await import('node:path');
+          try {
+            const profile = await Bun.file(path.join(os.homedir(), '.xcsh', 'user-profile.json')).json();
+            return !!profile?.identifiers?.salesforceId;
+          } catch {
+            return false;
+          }
         },
         async collect() {
-          const { loadSalesforceContext, salesforceContextIsStale, seedSalesforceContext } = await import(
-            './context/salesforce-context'
-          );
+          const {
+            loadSalesforceContext,
+            salesforceContextIsStale,
+            seedSalesforceContext,
+            getLoadProfile,
+            setLoadProfile,
+          } = await import('./context/salesforce-context');
+          if (!getLoadProfile()) {
+            const os = await import('node:os');
+            const path = await import('node:path');
+            setLoadProfile(async () => {
+              try {
+                return await Bun.file(path.join(os.homedir(), '.xcsh', 'user-profile.json')).json();
+              } catch {
+                return {};
+              }
+            });
+          }
           const { mapSalesforceToProfile } = await import('./context/profile-mapper');
           let ctx = await loadSalesforceContext();
           if (!ctx || salesforceContextIsStale(ctx)) {


### PR DESCRIPTION
Closes #604

## Summary
- `available()` and `collect()` fall back to reading `~/.xcsh/user-profile.json` from disk when `pi.pi.loadProfile` is not injected
- Root cause: marketplace plugin cache loads extensions without the `pi.pi` context that the node_modules path provides
- Bumps to v1.2.0 to trigger auto-upgrade

## Test plan
- [x] 24 existing context tests pass
- [ ] Start xcsh, wait 60s, verify `~/.xcsh/user-profile.json` manager updates from Salesforce

🤖 Generated with [Claude Code](https://claude.com/claude-code)