### PR TITLE
feat: add console-discover and console-inspect skills

### DIFF
--- a/plugins/platform/skills/console-discover/SKILL.md
+++ b/plugins/platform/skills/console-discover/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: console-discover
+description: >-
+  Crawl the F5 Distributed Cloud console navigation tree and
+  discover all menu sections, routes, and page types. Outputs
+  YAML catalog entries matching the console repo schemas
+  (navigation tree, route definitions). Use when populating
+  or refreshing the console catalog with the full menu structure.
+user-invocable: true
+---
+
+# Console Discover
+
+Crawl the F5 XC console sidebar navigation and extract the
+complete menu tree with routes, labels, and page types. Outputs
+YAML files matching the `f5xc-salesdemos/console` catalog schemas.
+
+## Prerequisites
+
+- Chrome DevTools MCP server connected
+- Browser open to the F5 XC console (authenticated)
+- If not authenticated, invoke `console-auth` first
+
+## Environment Variables
+
+| Variable | Required | Default | Purpose |
+| ---------- | ---------- | --------- | --------- |
+| `F5XC_API_URL` | No | Auto-detected from browser URL | Tenant URL |
+| `F5XC_NAMESPACE` | No | — | Default namespace for route patterns |
+
+## Discovery Procedure
+
+### Step 1: Verify session
+
+Read `references/session-detection.md` from the `console-auth`
+skill. Execute session health check. If re-auth needed, invoke
+`console-auth`.
+
+### Step 2: Navigate to console home
+
+```
+navigate_page(url=<tenant-url>/web/home)
+wait_for(text=["Dashboard", "Home"], timeout=15000)
+take_snapshot()
+```
+
+### Step 3: Extract sidebar navigation
+
+Use `take_snapshot()` to capture the full accessibility tree.
+Identify the sidebar/navigation region. Extract all menu items
+with their:
+
+- **Label** — visible text
+- **Nesting level** — parent/child hierarchy
+- **Link target** — href or route URL
+- **Expandable state** — whether the item has sub-items
+
+For collapsed menu sections, click to expand and re-snapshot:
+
+```
+click(uid=<collapsed-section-uid>)
+take_snapshot()
+```
+
+Repeat until all sections are expanded and captured.
+
+### Step 4: Build navigation tree
+
+Assemble the extracted menu items into a tree structure matching
+the `urn:f5xc:console:navigation:v1` schema:
+
+```yaml
+schema: "urn:f5xc:console:navigation:v1"
+console_version: "<detected-version>"
+discovered_at: "<today's date>"
+
+tree:
+  - id: "<kebab-case-id>"
+    label: "<menu label>"
+    menu_path: ["<parent>", "<child>"]
+    route: "<url-path>"
+    route_file: "routes/<area>/<name>.yaml"
+    children:
+      - id: "<child-id>"
+        ...
+```
+
+### Step 5: Classify each route
+
+For each discovered route, navigate to it and classify the page:
+
+```
+navigate_page(url=<route-url>)
+take_snapshot()
+```
+
+Determine:
+- **Screen type**: list, detail, form, wizard, dashboard, settings
+- **Primary controls**: buttons, search, filters
+- **Table presence**: columns, row actions
+- **Tab presence**: tab labels
+
+Record the classification for `console-inspect` to process later.
+
+### Step 6: Output results
+
+Write the navigation tree YAML to the console catalog:
+
+```
+catalog/navigation/console-tree.yaml
+```
+
+For each classified route, write a skeleton route file:
+
+```
+catalog/routes/<area>/<name>.yaml
+```
+
+Report:
+```
+## Discovery: COMPLETE
+- Sections found: <count>
+- Routes discovered: <count>
+- Page types: <breakdown>
+- Output: catalog/navigation/console-tree.yaml
+- Skeleton routes: <count> files in catalog/routes/
+```
+
+## Output Schema
+
+All output files must validate against the JSON Schemas in
+`f5xc-salesdemos/console/schemas/`. Run `npm run validate`
+in the console repo after writing files.
+
+## Incremental Discovery
+
+When re-running discovery:
+1. Read existing `catalog/navigation/console-tree.yaml`
+2. Compare with freshly discovered tree
+3. Mark new entries as `confidence: "draft"`
+4. Mark removed entries as `confidence: "stale"`
+5. Preserve `confidence: "validated"` entries unchanged

--- a/plugins/platform/skills/console-inspect/SKILL.md
+++ b/plugins/platform/skills/console-inspect/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: console-inspect
+description: >-
+  Inspect a specific F5 XC console route and extract detailed
+  screen metadata: form fields, table columns, controls,
+  selectors, and API field mappings. Outputs resource and
+  workflow YAML catalog entries. Use when cataloging a specific
+  console page or resource in detail.
+user-invocable: true
+---
+
+# Console Inspect
+
+Inspect a single F5 XC console route and extract its complete
+UI structure — form sections, fields, table columns, controls,
+selectors, and available operations. Outputs resource mapping
+and workflow YAML files for the `f5xc-salesdemos/console` catalog.
+
+## Prerequisites
+
+- Chrome DevTools MCP server connected
+- Browser open to the F5 XC console (authenticated)
+- Target route known (from `console-discover` or user input)
+
+## Environment Variables
+
+| Variable | Required | Default | Purpose |
+| ---------- | ---------- | --------- | --------- |
+| `F5XC_API_URL` | No | Auto-detected from browser URL | Tenant URL |
+| `F5XC_NAMESPACE` | No | — | Namespace for parameterized routes |
+
+## Inspection Procedure
+
+### Step 1: Navigate to target route
+
+```
+navigate_page(url=<target-route>)
+wait_for(text=[<expected-heading>], timeout=15000)
+take_snapshot()
+```
+
+### Step 2: Identify screen type
+
+From the snapshot, determine the screen type:
+
+- **List screen**: has a data table with rows and columns
+- **Detail screen**: shows resource properties and tabs
+- **Form screen**: has input fields for creating/editing
+- **Wizard screen**: multi-step form with progress indicator
+
+### Step 3: Extract screen structure
+
+#### For list screens:
+
+Extract table metadata:
+```
+evaluate_script(function="() => {
+  const headers = [...document.querySelectorAll('th')].map(th => ({
+    label: th.textContent.trim(),
+    testId: th.getAttribute('data-testid')
+  }));
+  return JSON.stringify(headers);
+}")
+```
+
+Extract row actions by clicking the actions menu on any row:
+```
+click(uid=<first-row-actions-button>)
+take_snapshot()
+```
+
+Record available actions (Edit, Delete, Clone, etc.) and their
+selectors.
+
+#### For form screens:
+
+Click the "Add" or "Create" button to open the creation form:
+```
+click(uid=<add-button>)
+take_snapshot()
+```
+
+Extract all form fields:
+```
+evaluate_script(function="() => {
+  const fields = [...document.querySelectorAll('input, select, textarea')].map(el => ({
+    type: el.tagName.toLowerCase() === 'select' ? 'select' : el.type,
+    name: el.name || el.getAttribute('data-testid'),
+    label: el.closest('label')?.textContent?.trim() || el.getAttribute('aria-label'),
+    required: el.required,
+    testId: el.getAttribute('data-testid')
+  }));
+  return JSON.stringify(fields);
+}")
+```
+
+For each collapsible section, expand it and re-extract:
+```
+click(uid=<collapsed-section>)
+take_snapshot()
+```
+
+#### For detail screens:
+
+Extract tab labels and their content areas:
+```
+take_snapshot()
+```
+
+Click through each tab and record its structure:
+```
+click(uid=<tab-uid>)
+take_snapshot()
+```
+
+### Step 4: Map API fields
+
+If the resource has a known API kind (from api-specs-enriched),
+cross-reference form field names with API schema field paths.
+Record the mapping in `api_field` for each form field.
+
+### Step 5: Generate catalog files
+
+#### Route file (`catalog/routes/<area>/<name>.yaml`)
+
+```yaml
+schema: "urn:f5xc:console:route:v1"
+id: "<resource-id>"
+label: "<page heading>"
+route:
+  pattern: "<url-pattern-with-params>"
+  params:
+    namespace:
+      required: true
+  supports_direct_link: true
+  breadcrumbs: [<extracted-breadcrumbs>]
+context:
+  requires_login: true
+  requires_namespace: true
+screen:
+  type: "<detected-type>"
+  primary_resource: "<resource-id>"
+  controls: [<extracted-controls>]
+  table: <extracted-table-def>  # for list screens
+operations: [<detected-operations>]
+metadata:
+  confidence: "draft"
+  discovered_at: "<today>"
+  console_version: "<detected>"
+```
+
+#### Resource file (`catalog/resources/<name>.yaml`)
+
+```yaml
+schema: "urn:f5xc:console:resource:v1"
+id: "<resource-id>"
+label: "<resource label>"
+api:
+  kind: "<api-kind>"
+  crud_endpoints: <mapped-endpoints>
+console:
+  list_route: "routes/<area>/<name>.yaml"
+  navigation:
+    menu_path: [<from-navigation-tree>]
+form:
+  sections: [<extracted-sections-and-fields>]
+metadata:
+  confidence: "draft"
+  discovered_at: "<today>"
+  console_version: "<detected>"
+```
+
+#### Workflow files (`catalog/workflows/<name>/create.yaml`, etc.)
+
+Generate step-by-step workflows from the observed interaction
+sequence. Each step records:
+- action (navigate, click, fill, select, assert)
+- selector (prefer data-testid, fallback to CSS)
+- wait_for condition
+- human-readable description
+
+### Step 6: Capture screenshots
+
+Take a screenshot of each key state for documentation:
+
+```
+take_screenshot(filePath="<console-repo>/docs/screenshots/<resource>-list.png")
+take_screenshot(filePath="<console-repo>/docs/screenshots/<resource>-create.png")
+```
+
+### Step 7: Report results
+
+```
+## Inspection: COMPLETE
+- Resource: <name>
+- Screen type: <type>
+- Form sections: <count>
+- Form fields: <count>
+- Operations detected: <list>
+- Selectors extracted: <count> (data-testid: <count>, css: <count>)
+- Files written:
+  - catalog/routes/<area>/<name>.yaml
+  - catalog/resources/<name>.yaml
+  - catalog/workflows/<name>/create.yaml
+  - catalog/workflows/<name>/delete.yaml
+```
+
+## Validation
+
+After writing files, run validation in the console repo:
+
+```bash
+cd <console-repo-path>
+npm run validate
+npm run lint
+```
+
+Fix any schema violations before committing.

--- a/plugins/platform/skills/console-inspect/SKILL.md
+++ b/plugins/platform/skills/console-inspect/SKILL.md
@@ -50,7 +50,7 @@ From the snapshot, determine the screen type:
 
 ### Step 3: Extract screen structure
 
-#### For list screens:
+#### For list screens
 
 Extract table metadata:
 ```
@@ -72,7 +72,7 @@ take_snapshot()
 Record available actions (Edit, Delete, Clone, etc.) and their
 selectors.
 
-#### For form screens:
+#### For form screens
 
 Click the "Add" or "Create" button to open the creation form:
 ```
@@ -100,7 +100,7 @@ click(uid=<collapsed-section>)
 take_snapshot()
 ```
 
-#### For detail screens:
+#### For detail screens
 
 Extract tab labels and their content areas:
 ```


### PR DESCRIPTION
## Summary
- Add `console-discover` skill — crawls console navigation tree, extracts routes, outputs catalog YAML
- Add `console-inspect` skill — inspects a single route, extracts form fields/selectors/controls, outputs resource and workflow YAML

Both skills output files matching the `f5xc-salesdemos/console` catalog schemas and use Chrome DevTools MCP for browser access.

## Test plan
- [ ] Verify SKILL.md files have valid frontmatter
- [ ] Verify skill names don't conflict with existing skills
- [ ] Manual test: invoke `console-discover` with authenticated browser session

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)