### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -2,6 +2,8 @@
   "threshold": 10,
   "reporters": ["console"],
   "ignore": [
+    "**/*.yaml",
+    "**/*.yml",
     "**/.github/workflows/**",
     "**/workflows/**",
     "**/node_modules/**",


### PR DESCRIPTION
Closes #677

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .jscpd.json