### PR TITLE
feat(meddpicc): deterministic schema-centric engine + resolver manifest

### DIFF
--- a/plugins/meddpicc/.xcsh-plugin/resources.json
+++ b/plugins/meddpicc/.xcsh-plugin/resources.json
@@ -1,0 +1,13 @@
+{
+  "schema": "schema/meddpicc-schema.json",
+  "example": "schema/example-deal.json",
+  "engine": {
+    "runtime": "bun",
+    "entry": "engine/cli.ts",
+    "commands": ["validate", "next", "score", "check-mappings"]
+  },
+  "mappings": {
+    "cell": "skills/deal-qualification/references/cell-mapping.json",
+    "sfdc": "skills/deal-qualification/references/sfdc-field-mapping.json"
+  }
+}

--- a/plugins/meddpicc/agents/deal-analyst.md
+++ b/plugins/meddpicc/agents/deal-analyst.md
@@ -59,8 +59,20 @@ Competition), assess:
 
 ### Step 3 — Score and report
 
-Use the scoring rubric (0–4 per element) to produce an objective
-assessment. Include evidence citations for every score.
+You are read-only and **cannot run the plugin engine**. Source
+scores as follows:
+
+- **When a deal JSON with engine-computed scores is available**
+  (`scoring.elementScores`, `scoring.overallScore`,
+  `scoring.overallRating` populated by the qualification/update/review
+  skills), report those as the authoritative scores — the engine's
+  `score` output is the source of truth. Do not recompute or
+  contradict them.
+- **When no such file exists** (analyzing raw notes, CRM exports,
+  etc.), produce your own independent 0–4 assessment per element
+  using the scoring rubric, and label it as your estimate.
+
+Either way, include evidence citations for every element.
 
 ### Step 4 — Recommend actions
 
@@ -95,7 +107,7 @@ Every response must follow this structure:
 | Champion | X/4 | [citations] | [gaps] |
 | Competition | X/4 | [citations] | [gaps] |
 
-### Overall Score: X/32
+### Overall Score: X/32 [source: engine `score` output, or independent estimate]
 ### Risk Level: [Low / Medium / High / Critical]
 
 ### Priority Actions
@@ -113,9 +125,13 @@ Every response must follow this structure:
 
 ## Execution Rules
 
-1. **Read-only** — never create, modify, or delete files
-2. **Evidence-based** — every score must cite specific evidence
-3. **Honest** — do not inflate scores; gaps are valuable findings
-4. **Structured** — always use the output contract format
-5. **Actionable** — every gap must have a recommended next action
-6. **Role-aware** — assign actions to the appropriate team role
+1. **Read-only** — never create, modify, or delete files; you have
+   no Bash and cannot run the engine
+2. **Engine-authoritative** — when a deal JSON carries
+   engine-computed scores, report those; only produce an independent
+   0–4 estimate when no engine-scored file is available
+3. **Evidence-based** — every score must cite specific evidence
+4. **Honest** — do not inflate scores; gaps are valuable findings
+5. **Structured** — always use the output contract format
+6. **Actionable** — every gap must have a recommended next action
+7. **Role-aware** — assign actions to the appropriate team role

--- a/plugins/meddpicc/agents/deal-analyst.md
+++ b/plugins/meddpicc/agents/deal-analyst.md
@@ -62,15 +62,21 @@ Competition), assess:
 You are read-only and **cannot run the plugin engine**. Source
 scores as follows:
 
-- **When a deal JSON with engine-computed scores is available**
-  (`scoring.elementScores`, `scoring.overallScore`,
-  `scoring.overallRating` populated by the qualification/update/review
-  skills), report those as the authoritative scores — the engine's
-  `score` output is the source of truth. Do not recompute or
-  contradict them.
+- **When a deal JSON with engine-computed per-element scores is
+  available** (`scoring.elementScores`, populated by the
+  qualification/update/review skills), report those 8 per-element
+  scores as authoritative — they are the maintained source of truth.
+  Do not recompute or contradict them. **Derive the overall yourself**
+  from those 8 `elementScores` (do not read `scoring.overallScore` or
+  `scoring.overallRating` — those fields are no longer maintained and
+  may hold stale or default values):
+  - overall = sum of the 8 `elementScores`, reported as `X/32`;
+  - rating from the documented thresholds: sum <= 13 → Red,
+    sum <= 25 → Yellow, else Green.
 - **When no such file exists** (analyzing raw notes, CRM exports,
   etc.), produce your own independent 0–4 assessment per element
-  using the scoring rubric, and label it as your estimate.
+  using the scoring rubric, and label it as your estimate; derive the
+  overall from your per-element estimates using the same rule above.
 
 Either way, include evidence citations for every element.
 
@@ -127,9 +133,12 @@ Every response must follow this structure:
 
 1. **Read-only** — never create, modify, or delete files; you have
    no Bash and cannot run the engine
-2. **Engine-authoritative** — when a deal JSON carries
-   engine-computed scores, report those; only produce an independent
-   0–4 estimate when no engine-scored file is available
+2. **Engine-authoritative per element** — when a deal JSON carries
+   engine-computed `scoring.elementScores`, report those 8 per-element
+   scores; derive the overall (`X/32` and Red/Yellow/Green) from them
+   rather than reading `scoring.overallScore`/`scoring.overallRating`.
+   Only produce an independent 0–4 estimate when no engine-scored file
+   is available
 3. **Evidence-based** — every score must cite specific evidence
 4. **Honest** — do not inflate scores; gaps are valuable findings
 5. **Structured** — always use the output contract format

--- a/plugins/meddpicc/commands/meddpicc-status.md
+++ b/plugins/meddpicc/commands/meddpicc-status.md
@@ -3,16 +3,40 @@ description: >-
   Check MEDDPICC framework readiness and deal data availability
 ---
 
-Delegate to the deal-analyst agent to check MEDDPICC framework status.
+Report MEDDPICC framework readiness and per-deal status. The
+deterministic status (ordering, completion, scores) comes from the
+plugin engine — never count files or compute scores by hand.
 
-## Delegation
+## Protocol
 
-Spawn the deal-analyst agent with the following instructions:
+1. Verify the MEDDPICC schema exists: check for
+   `schema/meddpicc-schema.json`. Report it as loaded or missing.
+2. Find deal data files in the current workspace (`*.json` files
+   conforming to the schema).
+3. **If no deal file is found**, report schema status and the
+   available commands, then suggest starting with
+   `/meddpicc:qualify-deal`. Stop here.
+4. **For each deal file found**, run the engine (it is the source
+   of truth for status and scores):
 
-1. Verify MEDDPICC schema exists: check for `schema/meddpicc-schema.json`
-2. Check if any deal data files exist in the current workspace (*.json files matching schema)
-3. Report:
-   - Schema status (loaded/missing)
-   - Number of deal files found in workspace
-   - Available commands: /meddpicc:qualify-deal, /meddpicc:deal-review, /meddpicc:update-deal, /meddpicc:build-map, /meddpicc:champion-test
-4. If no deals found, suggest starting with `/meddpicc:qualify-deal`
+   ```bash
+   bun xcsh://plugin/meddpicc/file/engine/cli.ts next  <deal.json>
+   bun xcsh://plugin/meddpicc/file/engine/cli.ts score <deal.json>
+   ```
+
+   (Local/dev equivalent: `bun "$PLUGIN_ROOT/engine/cli.ts" …`.)
+
+   Report from their output:
+   - Completion: the `completionStatus` map and the
+     `nextIncompleteSection` (the resume point), in the engine's
+     canonical `order` — do not tally sections by hand.
+   - Scores: `sum` (`X/32`), `overallScore` (percentage), and
+     `overallRating` (Red/Yellow/Green) from `score`.
+5. Report the available commands: `/meddpicc:qualify-deal`,
+   `/meddpicc:deal-review`, `/meddpicc:update-deal`,
+   `/meddpicc:build-map`, `/meddpicc:champion-test`.
+
+For deeper, evidence-cited qualitative analysis of a deal, delegate
+to the read-only `deal-analyst` agent — but note that agent cannot
+run the engine, so the deterministic status above must come from
+this command's engine calls.

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+
+const engineDir = import.meta.dir;
+const example = path.join(engineDir, "..", "schema", "example-deal.json");
+
+async function run(args: string[]): Promise<{ code: number; out: string }> {
+	const proc = Bun.spawn(["bun", path.join(engineDir, "cli.ts"), ...args], { stdout: "pipe", stderr: "pipe" });
+	const out = await new Response(proc.stdout).text();
+	const code = await proc.exited;
+	return { code, out };
+}
+
+describe("cli", () => {
+	test("score", async () => {
+		const { code, out } = await run(["score", example]);
+		expect(code).toBe(0);
+		const r = JSON.parse(out);
+		expect(r.sum).toBe(21);
+		expect(r.overallScore).toBe(65.6);
+		expect(r.overallRating).toBe("Yellow");
+	});
+	test("next", async () => {
+		const { out } = await run(["next", example]);
+		expect(JSON.parse(out).nextIncompleteSection).toBe("decisionProcess");
+	});
+	test("validate", async () => {
+		const { code, out } = await run(["validate", example]);
+		expect(code).toBe(0);
+		expect(JSON.parse(out).valid).toBe(true);
+	});
+	test("check-mappings", async () => {
+		const { code, out } = await run(["check-mappings"]);
+		expect(code).toBe(0);
+		expect(JSON.parse(out).ok).toBe(true);
+	});
+	test("unknown command exits non-zero", async () => {
+		const { code } = await run(["bogus", example]);
+		expect(code).toBe(1);
+	});
+});

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -1,41 +1,41 @@
-import { describe, expect, test } from "bun:test";
-import * as path from "node:path";
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
 
 const engineDir = import.meta.dir;
-const example = path.join(engineDir, "..", "schema", "example-deal.json");
+const example = path.join(engineDir, '..', 'schema', 'example-deal.json');
 
 async function run(args: string[]): Promise<{ code: number; out: string }> {
-	const proc = Bun.spawn(["bun", path.join(engineDir, "cli.ts"), ...args], { stdout: "pipe", stderr: "pipe" });
-	const out = await new Response(proc.stdout).text();
-	const code = await proc.exited;
-	return { code, out };
+  const proc = Bun.spawn(['bun', path.join(engineDir, 'cli.ts'), ...args], { stdout: 'pipe', stderr: 'pipe' });
+  const out = await new Response(proc.stdout).text();
+  const code = await proc.exited;
+  return { code, out };
 }
 
-describe("cli", () => {
-	test("score", async () => {
-		const { code, out } = await run(["score", example]);
-		expect(code).toBe(0);
-		const r = JSON.parse(out);
-		expect(r.sum).toBe(21);
-		expect(r.overallScore).toBe(65.6);
-		expect(r.overallRating).toBe("Yellow");
-	});
-	test("next", async () => {
-		const { out } = await run(["next", example]);
-		expect(JSON.parse(out).nextIncompleteSection).toBe("decisionProcess");
-	});
-	test("validate", async () => {
-		const { code, out } = await run(["validate", example]);
-		expect(code).toBe(0);
-		expect(JSON.parse(out).valid).toBe(true);
-	});
-	test("check-mappings", async () => {
-		const { code, out } = await run(["check-mappings"]);
-		expect(code).toBe(0);
-		expect(JSON.parse(out).ok).toBe(true);
-	});
-	test("unknown command exits non-zero", async () => {
-		const { code } = await run(["bogus", example]);
-		expect(code).toBe(1);
-	});
+describe('cli', () => {
+  test('score', async () => {
+    const { code, out } = await run(['score', example]);
+    expect(code).toBe(0);
+    const r = JSON.parse(out);
+    expect(r.sum).toBe(21);
+    expect(r.overallScore).toBe(65.6);
+    expect(r.overallRating).toBe('Yellow');
+  });
+  test('next', async () => {
+    const { out } = await run(['next', example]);
+    expect(JSON.parse(out).nextIncompleteSection).toBe('decisionProcess');
+  });
+  test('validate', async () => {
+    const { code, out } = await run(['validate', example]);
+    expect(code).toBe(0);
+    expect(JSON.parse(out).valid).toBe(true);
+  });
+  test('check-mappings', async () => {
+    const { code, out } = await run(['check-mappings']);
+    expect(code).toBe(0);
+    expect(JSON.parse(out).ok).toBe(true);
+  });
+  test('unknown command exits non-zero', async () => {
+    const { code } = await run(['bogus', example]);
+    expect(code).toBe(1);
+  });
 });

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -1,63 +1,63 @@
 #!/usr/bin/env bun
-import * as path from "node:path";
-import { checkMappings } from "./mappings";
-import { computeCompletion } from "./completion";
-import { computeScore } from "./score";
-import { validateDeal } from "./validate";
+import * as path from 'node:path';
+import { computeCompletion } from './completion';
+import { checkMappings } from './mappings';
+import { computeScore } from './score';
+import { validateDeal } from './validate';
 
-const PLUGIN_ROOT = path.join(import.meta.dir, "..");
-const SCHEMA_PATH = path.join(PLUGIN_ROOT, "schema", "meddpicc-schema.json");
-const CELL_PATH = path.join(PLUGIN_ROOT, "skills", "deal-qualification", "references", "cell-mapping.json");
-const SFDC_PATH = path.join(PLUGIN_ROOT, "skills", "deal-qualification", "references", "sfdc-field-mapping.json");
+const PLUGIN_ROOT = path.join(import.meta.dir, '..');
+const SCHEMA_PATH = path.join(PLUGIN_ROOT, 'schema', 'meddpicc-schema.json');
+const CELL_PATH = path.join(PLUGIN_ROOT, 'skills', 'deal-qualification', 'references', 'cell-mapping.json');
+const SFDC_PATH = path.join(PLUGIN_ROOT, 'skills', 'deal-qualification', 'references', 'sfdc-field-mapping.json');
 
 async function readJson(p: string): Promise<unknown> {
-	return JSON.parse(await Bun.file(p).text());
+  return JSON.parse(await Bun.file(p).text());
 }
 
 function print(data: unknown): void {
-	process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
 }
 
 function flag(args: string[], name: string): string | undefined {
-	const i = args.indexOf(name);
-	return i >= 0 ? args[i + 1] : undefined;
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : undefined;
 }
 
 async function main(): Promise<number> {
-	const [command, ...rest] = process.argv.slice(2);
+  const [command, ...rest] = process.argv.slice(2);
 
-	if (command === "validate" || command === "next" || command === "score") {
-		const dealPath = rest[0];
-		if (!dealPath) {
-			process.stderr.write(`Usage: cli.ts ${command} <deal.json>\n`);
-			return 1;
-		}
-		const deal = await readJson(dealPath);
-		if (command === "score") {
-			print(computeScore(deal));
-			return 0;
-		}
-		if (command === "next") {
-			print(computeCompletion(deal));
-			return 0;
-		}
-		const schema = await readJson(SCHEMA_PATH);
-		const result = validateDeal(deal, schema);
-		print(result);
-		return result.valid ? 0 : 1;
-	}
+  if (command === 'validate' || command === 'next' || command === 'score') {
+    const dealPath = rest[0];
+    if (!dealPath) {
+      process.stderr.write(`Usage: cli.ts ${command} <deal.json>\n`);
+      return 1;
+    }
+    const deal = await readJson(dealPath);
+    if (command === 'score') {
+      print(computeScore(deal));
+      return 0;
+    }
+    if (command === 'next') {
+      print(computeCompletion(deal));
+      return 0;
+    }
+    const schema = await readJson(SCHEMA_PATH);
+    const result = validateDeal(deal, schema);
+    print(result);
+    return result.valid ? 0 : 1;
+  }
 
-	if (command === "check-mappings") {
-		const schema = await readJson(flag(rest, "--schema") ?? SCHEMA_PATH);
-		const cell = await readJson(flag(rest, "--cell") ?? CELL_PATH);
-		const sfdc = await readJson(flag(rest, "--sfdc") ?? SFDC_PATH);
-		const result = checkMappings(schema, cell, sfdc);
-		print(result);
-		return result.ok ? 0 : 1;
-	}
+  if (command === 'check-mappings') {
+    const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
+    const cell = await readJson(flag(rest, '--cell') ?? CELL_PATH);
+    const sfdc = await readJson(flag(rest, '--sfdc') ?? SFDC_PATH);
+    const result = checkMappings(schema, cell, sfdc);
+    print(result);
+    return result.ok ? 0 : 1;
+  }
 
-	process.stderr.write(`Unknown command: ${command ?? "(none)"}\nCommands: validate, next, score, check-mappings\n`);
-	return 1;
+  process.stderr.write(`Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, check-mappings\n`);
+  return 1;
 }
 
 process.exit(await main());

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+import * as path from "node:path";
+import { checkMappings } from "./mappings";
+import { computeCompletion } from "./completion";
+import { computeScore } from "./score";
+import { validateDeal } from "./validate";
+
+const PLUGIN_ROOT = path.join(import.meta.dir, "..");
+const SCHEMA_PATH = path.join(PLUGIN_ROOT, "schema", "meddpicc-schema.json");
+const CELL_PATH = path.join(PLUGIN_ROOT, "skills", "deal-qualification", "references", "cell-mapping.json");
+const SFDC_PATH = path.join(PLUGIN_ROOT, "skills", "deal-qualification", "references", "sfdc-field-mapping.json");
+
+async function readJson(p: string): Promise<unknown> {
+	return JSON.parse(await Bun.file(p).text());
+}
+
+function print(data: unknown): void {
+	process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+}
+
+function flag(args: string[], name: string): string | undefined {
+	const i = args.indexOf(name);
+	return i >= 0 ? args[i + 1] : undefined;
+}
+
+async function main(): Promise<number> {
+	const [command, ...rest] = process.argv.slice(2);
+
+	if (command === "validate" || command === "next" || command === "score") {
+		const dealPath = rest[0];
+		if (!dealPath) {
+			process.stderr.write(`Usage: cli.ts ${command} <deal.json>\n`);
+			return 1;
+		}
+		const deal = await readJson(dealPath);
+		if (command === "score") {
+			print(computeScore(deal));
+			return 0;
+		}
+		if (command === "next") {
+			print(computeCompletion(deal));
+			return 0;
+		}
+		const schema = await readJson(SCHEMA_PATH);
+		const result = validateDeal(deal, schema);
+		print(result);
+		return result.valid ? 0 : 1;
+	}
+
+	if (command === "check-mappings") {
+		const schema = await readJson(flag(rest, "--schema") ?? SCHEMA_PATH);
+		const cell = await readJson(flag(rest, "--cell") ?? CELL_PATH);
+		const sfdc = await readJson(flag(rest, "--sfdc") ?? SFDC_PATH);
+		const result = checkMappings(schema, cell, sfdc);
+		print(result);
+		return result.ok ? 0 : 1;
+	}
+
+	process.stderr.write(`Unknown command: ${command ?? "(none)"}\nCommands: validate, next, score, check-mappings\n`);
+	return 1;
+}
+
+process.exit(await main());

--- a/plugins/meddpicc/engine/completion.test.ts
+++ b/plugins/meddpicc/engine/completion.test.ts
@@ -1,36 +1,34 @@
-import { describe, expect, test } from "bun:test";
-import * as path from "node:path";
-import { computeCompletion } from "./completion";
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { computeCompletion } from './completion';
 
-const example = JSON.parse(
-	await Bun.file(path.join(import.meta.dir, "..", "schema", "example-deal.json")).text(),
-);
+const example = JSON.parse(await Bun.file(path.join(import.meta.dir, '..', 'schema', 'example-deal.json')).text());
 
-describe("computeCompletion", () => {
-	test("reproduces evidence-based statuses for the example", () => {
-		const r = computeCompletion(example);
-		expect(r.completionStatus).toEqual({
-			metrics: "complete",
-			economicBuyer: "complete",
-			decisionCriteria: "complete",
-			decisionProcess: "partial",
-			paperProcess: "not_started",
-			implicateThePain: "complete",
-			champion: "complete",
-			competition: "partial",
-			threeWhys: "complete",
-			stakeholders: "complete",
-			salesStrategy: "complete",
-			closePlan: "complete",
-			team: "complete",
-		});
-	});
-	test("next incomplete section is decisionProcess", () => {
-		expect(computeCompletion(example).nextIncompleteSection).toBe("decisionProcess");
-	});
-	test("empty deal -> first section is next", () => {
-		const r = computeCompletion({});
-		expect(r.completionStatus.metrics).toBe("not_started");
-		expect(r.nextIncompleteSection).toBe("metrics");
-	});
+describe('computeCompletion', () => {
+  test('reproduces evidence-based statuses for the example', () => {
+    const r = computeCompletion(example);
+    expect(r.completionStatus).toEqual({
+      metrics: 'complete',
+      economicBuyer: 'complete',
+      decisionCriteria: 'complete',
+      decisionProcess: 'partial',
+      paperProcess: 'not_started',
+      implicateThePain: 'complete',
+      champion: 'complete',
+      competition: 'partial',
+      threeWhys: 'complete',
+      stakeholders: 'complete',
+      salesStrategy: 'complete',
+      closePlan: 'complete',
+      team: 'complete',
+    });
+  });
+  test('next incomplete section is decisionProcess', () => {
+    expect(computeCompletion(example).nextIncompleteSection).toBe('decisionProcess');
+  });
+  test('empty deal -> first section is next', () => {
+    const r = computeCompletion({});
+    expect(r.completionStatus.metrics).toBe('not_started');
+    expect(r.nextIncompleteSection).toBe('metrics');
+  });
 });

--- a/plugins/meddpicc/engine/completion.test.ts
+++ b/plugins/meddpicc/engine/completion.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { computeCompletion } from "./completion";
+
+const example = JSON.parse(
+	await Bun.file(path.join(import.meta.dir, "..", "schema", "example-deal.json")).text(),
+);
+
+describe("computeCompletion", () => {
+	test("reproduces evidence-based statuses for the example", () => {
+		const r = computeCompletion(example);
+		expect(r.completionStatus).toEqual({
+			metrics: "complete",
+			economicBuyer: "complete",
+			decisionCriteria: "complete",
+			decisionProcess: "partial",
+			paperProcess: "not_started",
+			implicateThePain: "complete",
+			champion: "complete",
+			competition: "partial",
+			threeWhys: "complete",
+			stakeholders: "complete",
+			salesStrategy: "complete",
+			closePlan: "complete",
+			team: "complete",
+		});
+	});
+	test("next incomplete section is decisionProcess", () => {
+		expect(computeCompletion(example).nextIncompleteSection).toBe("decisionProcess");
+	});
+	test("empty deal -> first section is next", () => {
+		const r = computeCompletion({});
+		expect(r.completionStatus.metrics).toBe("not_started");
+		expect(r.nextIncompleteSection).toBe("metrics");
+	});
+});

--- a/plugins/meddpicc/engine/completion.ts
+++ b/plugins/meddpicc/engine/completion.ts
@@ -1,0 +1,93 @@
+import { QUALIFICATION_ELEMENTS, SECTION_ORDER, type SectionStatus } from "./sections";
+
+export interface CompletionResult {
+	order: readonly string[];
+	completionStatus: Record<string, SectionStatus>;
+	nextIncompleteSection: string | null;
+}
+
+function nonEmptyString(v: unknown): boolean {
+	return typeof v === "string" && v.trim().length > 0;
+}
+
+function hasNonEmptyResponse(responses: unknown): boolean {
+	return Array.isArray(responses) && responses.some(nonEmptyString);
+}
+
+function qualStatus(el: Record<string, unknown> | undefined): SectionStatus {
+	if (!el) return "not_started";
+	const score = typeof el.score === "number" ? el.score : 0;
+	const responses = hasNonEmptyResponse(el.responses);
+	const evidence = nonEmptyString(el.evidence);
+	if (score >= 3 && responses && evidence) return "complete";
+	if (score === 0 && !responses && !evidence) return "not_started";
+	return "partial";
+}
+
+type Deal = Record<string, unknown>;
+
+function threeWhysStatus(deal: Deal): SectionStatus {
+	const tw = deal.threeWhys as { f5?: Record<string, unknown> } | undefined;
+	if (!tw || !tw.f5) return "not_started";
+	const f5 = tw.f5;
+	const all = nonEmptyString(f5.whyAnything) && nonEmptyString(f5.whyF5) && nonEmptyString(f5.whyNow);
+	const any = nonEmptyString(f5.whyAnything) || nonEmptyString(f5.whyF5) || nonEmptyString(f5.whyNow);
+	return all ? "complete" : any ? "partial" : "not_started";
+}
+
+function stakeholdersStatus(deal: Deal): SectionStatus {
+	const list = deal.stakeholders;
+	if (!Array.isArray(list) || list.length === 0) return "not_started";
+	const complete = list.every(
+		s => nonEmptyString((s as Record<string, unknown>).name) &&
+			nonEmptyString((s as Record<string, unknown>).title) &&
+			nonEmptyString((s as Record<string, unknown>).roleInDeal),
+	);
+	return complete ? "complete" : "partial";
+}
+
+function salesStrategyStatus(deal: Deal): SectionStatus {
+	const ss = deal.salesStrategy as Record<string, unknown> | undefined;
+	if (!ss) return "not_started";
+	const dvp = nonEmptyString(ss.differentiatedValueProposition);
+	const win = nonEmptyString(ss.winStrategy);
+	if (dvp && win) return "complete";
+	return dvp || win ? "partial" : "not_started";
+}
+
+function closePlanStatus(deal: Deal): SectionStatus {
+	const cp = deal.closePlan as { milestones?: unknown; criticalActions?: unknown } | undefined;
+	if (!cp) return "not_started";
+	const m = Array.isArray(cp.milestones) && cp.milestones.length > 0;
+	const a = Array.isArray(cp.criticalActions) && cp.criticalActions.length > 0;
+	if (m && a) return "complete";
+	return m || a ? "partial" : "not_started";
+}
+
+function teamStatus(deal: Deal): SectionStatus {
+	const team = deal.team as { f5?: unknown; partner?: unknown } | undefined;
+	if (!team) return "not_started";
+	const f5 = Array.isArray(team.f5) && team.f5.length > 0;
+	const partner = Array.isArray(team.partner) && team.partner.length > 0;
+	if (f5) return "complete";
+	return partner ? "partial" : "not_started";
+}
+
+export function computeCompletion(deal: unknown): CompletionResult {
+	const d = (deal ?? {}) as Deal;
+	const qualification = (d.qualification ?? {}) as Record<string, Record<string, unknown>>;
+	const completionStatus: Record<string, SectionStatus> = {};
+
+	for (const el of QUALIFICATION_ELEMENTS) {
+		completionStatus[el] = qualStatus(qualification[el]);
+	}
+	completionStatus.threeWhys = threeWhysStatus(d);
+	completionStatus.stakeholders = stakeholdersStatus(d);
+	completionStatus.salesStrategy = salesStrategyStatus(d);
+	completionStatus.closePlan = closePlanStatus(d);
+	completionStatus.team = teamStatus(d);
+
+	const nextIncompleteSection = SECTION_ORDER.find(s => completionStatus[s] !== "complete") ?? null;
+
+	return { order: SECTION_ORDER, completionStatus, nextIncompleteSection };
+}

--- a/plugins/meddpicc/engine/completion.ts
+++ b/plugins/meddpicc/engine/completion.ts
@@ -1,93 +1,94 @@
-import { QUALIFICATION_ELEMENTS, SECTION_ORDER, type SectionStatus } from "./sections";
+import { QUALIFICATION_ELEMENTS, SECTION_ORDER, type SectionStatus } from './sections';
 
 export interface CompletionResult {
-	order: readonly string[];
-	completionStatus: Record<string, SectionStatus>;
-	nextIncompleteSection: string | null;
+  order: readonly string[];
+  completionStatus: Record<string, SectionStatus>;
+  nextIncompleteSection: string | null;
 }
 
 function nonEmptyString(v: unknown): boolean {
-	return typeof v === "string" && v.trim().length > 0;
+  return typeof v === 'string' && v.trim().length > 0;
 }
 
 function hasNonEmptyResponse(responses: unknown): boolean {
-	return Array.isArray(responses) && responses.some(nonEmptyString);
+  return Array.isArray(responses) && responses.some(nonEmptyString);
 }
 
 function qualStatus(el: Record<string, unknown> | undefined): SectionStatus {
-	if (!el) return "not_started";
-	const score = typeof el.score === "number" ? el.score : 0;
-	const responses = hasNonEmptyResponse(el.responses);
-	const evidence = nonEmptyString(el.evidence);
-	if (score >= 3 && responses && evidence) return "complete";
-	if (score === 0 && !responses && !evidence) return "not_started";
-	return "partial";
+  if (!el) return 'not_started';
+  const score = typeof el.score === 'number' ? el.score : 0;
+  const responses = hasNonEmptyResponse(el.responses);
+  const evidence = nonEmptyString(el.evidence);
+  if (score >= 3 && responses && evidence) return 'complete';
+  if (score === 0 && !responses && !evidence) return 'not_started';
+  return 'partial';
 }
 
 type Deal = Record<string, unknown>;
 
 function threeWhysStatus(deal: Deal): SectionStatus {
-	const tw = deal.threeWhys as { f5?: Record<string, unknown> } | undefined;
-	if (!tw || !tw.f5) return "not_started";
-	const f5 = tw.f5;
-	const all = nonEmptyString(f5.whyAnything) && nonEmptyString(f5.whyF5) && nonEmptyString(f5.whyNow);
-	const any = nonEmptyString(f5.whyAnything) || nonEmptyString(f5.whyF5) || nonEmptyString(f5.whyNow);
-	return all ? "complete" : any ? "partial" : "not_started";
+  const tw = deal.threeWhys as { f5?: Record<string, unknown> } | undefined;
+  if (!tw || !tw.f5) return 'not_started';
+  const f5 = tw.f5;
+  const all = nonEmptyString(f5.whyAnything) && nonEmptyString(f5.whyF5) && nonEmptyString(f5.whyNow);
+  const any = nonEmptyString(f5.whyAnything) || nonEmptyString(f5.whyF5) || nonEmptyString(f5.whyNow);
+  return all ? 'complete' : any ? 'partial' : 'not_started';
 }
 
 function stakeholdersStatus(deal: Deal): SectionStatus {
-	const list = deal.stakeholders;
-	if (!Array.isArray(list) || list.length === 0) return "not_started";
-	const complete = list.every(
-		s => nonEmptyString((s as Record<string, unknown>).name) &&
-			nonEmptyString((s as Record<string, unknown>).title) &&
-			nonEmptyString((s as Record<string, unknown>).roleInDeal),
-	);
-	return complete ? "complete" : "partial";
+  const list = deal.stakeholders;
+  if (!Array.isArray(list) || list.length === 0) return 'not_started';
+  const complete = list.every(
+    (s) =>
+      nonEmptyString((s as Record<string, unknown>).name) &&
+      nonEmptyString((s as Record<string, unknown>).title) &&
+      nonEmptyString((s as Record<string, unknown>).roleInDeal),
+  );
+  return complete ? 'complete' : 'partial';
 }
 
 function salesStrategyStatus(deal: Deal): SectionStatus {
-	const ss = deal.salesStrategy as Record<string, unknown> | undefined;
-	if (!ss) return "not_started";
-	const dvp = nonEmptyString(ss.differentiatedValueProposition);
-	const win = nonEmptyString(ss.winStrategy);
-	if (dvp && win) return "complete";
-	return dvp || win ? "partial" : "not_started";
+  const ss = deal.salesStrategy as Record<string, unknown> | undefined;
+  if (!ss) return 'not_started';
+  const dvp = nonEmptyString(ss.differentiatedValueProposition);
+  const win = nonEmptyString(ss.winStrategy);
+  if (dvp && win) return 'complete';
+  return dvp || win ? 'partial' : 'not_started';
 }
 
 function closePlanStatus(deal: Deal): SectionStatus {
-	const cp = deal.closePlan as { milestones?: unknown; criticalActions?: unknown } | undefined;
-	if (!cp) return "not_started";
-	const m = Array.isArray(cp.milestones) && cp.milestones.length > 0;
-	const a = Array.isArray(cp.criticalActions) && cp.criticalActions.length > 0;
-	if (m && a) return "complete";
-	return m || a ? "partial" : "not_started";
+  const cp = deal.closePlan as { milestones?: unknown; criticalActions?: unknown } | undefined;
+  if (!cp) return 'not_started';
+  const m = Array.isArray(cp.milestones) && cp.milestones.length > 0;
+  const a = Array.isArray(cp.criticalActions) && cp.criticalActions.length > 0;
+  if (m && a) return 'complete';
+  return m || a ? 'partial' : 'not_started';
 }
 
 function teamStatus(deal: Deal): SectionStatus {
-	const team = deal.team as { f5?: unknown; partner?: unknown } | undefined;
-	if (!team) return "not_started";
-	const f5 = Array.isArray(team.f5) && team.f5.length > 0;
-	const partner = Array.isArray(team.partner) && team.partner.length > 0;
-	if (f5) return "complete";
-	return partner ? "partial" : "not_started";
+  const team = deal.team as { f5?: unknown; partner?: unknown } | undefined;
+  if (!team) return 'not_started';
+  const f5 = Array.isArray(team.f5) && team.f5.length > 0;
+  const partner = Array.isArray(team.partner) && team.partner.length > 0;
+  if (f5) return 'complete';
+  return partner ? 'partial' : 'not_started';
 }
 
 export function computeCompletion(deal: unknown): CompletionResult {
-	const d = (deal ?? {}) as Deal;
-	const qualification = (d.qualification ?? {}) as Record<string, Record<string, unknown>>;
-	const completionStatus: Record<string, SectionStatus> = {};
+  const d = (deal ?? {}) as Deal;
+  const qualification = (d.qualification ?? {}) as Record<string, Record<string, unknown>>;
+  const completionStatus: Record<string, SectionStatus> = {};
 
-	for (const el of QUALIFICATION_ELEMENTS) {
-		completionStatus[el] = qualStatus(qualification[el]);
-	}
-	completionStatus.threeWhys = threeWhysStatus(d);
-	completionStatus.stakeholders = stakeholdersStatus(d);
-	completionStatus.salesStrategy = salesStrategyStatus(d);
-	completionStatus.closePlan = closePlanStatus(d);
-	completionStatus.team = teamStatus(d);
+  for (const el of QUALIFICATION_ELEMENTS) {
+    completionStatus[el] = qualStatus(qualification[el]);
+  }
+  completionStatus.threeWhys = threeWhysStatus(d);
+  completionStatus.stakeholders = stakeholdersStatus(d);
+  completionStatus.salesStrategy = salesStrategyStatus(d);
+  completionStatus.closePlan = closePlanStatus(d);
+  completionStatus.team = teamStatus(d);
 
-	const nextIncompleteSection = SECTION_ORDER.find(s => completionStatus[s] !== "complete") ?? null;
+  const nextIncompleteSection = SECTION_ORDER.find((s) => completionStatus[s] !== 'complete') ?? null;
 
-	return { order: SECTION_ORDER, completionStatus, nextIncompleteSection };
+  return { order: SECTION_ORDER, completionStatus, nextIncompleteSection };
 }

--- a/plugins/meddpicc/engine/mappings.test.ts
+++ b/plugins/meddpicc/engine/mappings.test.ts
@@ -1,28 +1,28 @@
-import { describe, expect, test } from "bun:test";
-import * as path from "node:path";
-import { checkMappings } from "./mappings";
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { checkMappings } from './mappings';
 
-const dir = path.join(import.meta.dir, "..");
-const schema = JSON.parse(await Bun.file(path.join(dir, "schema", "meddpicc-schema.json")).text());
-const refs = path.join(dir, "skills", "deal-qualification", "references");
-const cell = JSON.parse(await Bun.file(path.join(refs, "cell-mapping.json")).text());
-const sfdc = JSON.parse(await Bun.file(path.join(refs, "sfdc-field-mapping.json")).text());
+const dir = path.join(import.meta.dir, '..');
+const schema = JSON.parse(await Bun.file(path.join(dir, 'schema', 'meddpicc-schema.json')).text());
+const refs = path.join(dir, 'skills', 'deal-qualification', 'references');
+const cell = JSON.parse(await Bun.file(path.join(refs, 'cell-mapping.json')).text());
+const sfdc = JSON.parse(await Bun.file(path.join(refs, 'sfdc-field-mapping.json')).text());
 
-describe("checkMappings", () => {
-	test("shipped mappings conform to the schema", () => {
-		const r = checkMappings(schema, cell, sfdc);
-		expect(r.failures_debug ?? r).toBeDefined(); // keep output visible on failure
-		expect(r.ok).toBe(true);
-		expect(r.cell.failures).toEqual([]);
-		expect(r.sfdc.failures).toEqual([]);
-		expect(r.cell.checked).toBe(67);
-		expect(r.sfdc.checked).toBe(10);
-	});
-	test("detects a broken cell jsonPath", () => {
-		const broken = structuredClone(cell);
-		broken.staticFields[0].jsonPath = `${broken.staticFields[0].jsonPath}TYPO`;
-		const r = checkMappings(schema, broken, sfdc);
-		expect(r.ok).toBe(false);
-		expect(r.cell.failures.some(f => f.endsWith("TYPO"))).toBe(true);
-	});
+describe('checkMappings', () => {
+  test('shipped mappings conform to the schema', () => {
+    const r = checkMappings(schema, cell, sfdc);
+    expect(r.failures_debug ?? r).toBeDefined(); // keep output visible on failure
+    expect(r.ok).toBe(true);
+    expect(r.cell.failures).toEqual([]);
+    expect(r.sfdc.failures).toEqual([]);
+    expect(r.cell.checked).toBe(67);
+    expect(r.sfdc.checked).toBe(10);
+  });
+  test('detects a broken cell jsonPath', () => {
+    const broken = structuredClone(cell);
+    broken.staticFields[0].jsonPath = `${broken.staticFields[0].jsonPath}TYPO`;
+    const r = checkMappings(schema, broken, sfdc);
+    expect(r.ok).toBe(false);
+    expect(r.cell.failures.some((f) => f.endsWith('TYPO'))).toBe(true);
+  });
 });

--- a/plugins/meddpicc/engine/mappings.test.ts
+++ b/plugins/meddpicc/engine/mappings.test.ts
@@ -15,6 +15,8 @@ describe("checkMappings", () => {
 		expect(r.ok).toBe(true);
 		expect(r.cell.failures).toEqual([]);
 		expect(r.sfdc.failures).toEqual([]);
+		expect(r.cell.checked).toBe(67);
+		expect(r.sfdc.checked).toBe(10);
 	});
 	test("detects a broken cell jsonPath", () => {
 		const broken = structuredClone(cell);

--- a/plugins/meddpicc/engine/mappings.test.ts
+++ b/plugins/meddpicc/engine/mappings.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { checkMappings } from "./mappings";
+
+const dir = path.join(import.meta.dir, "..");
+const schema = JSON.parse(await Bun.file(path.join(dir, "schema", "meddpicc-schema.json")).text());
+const refs = path.join(dir, "skills", "deal-qualification", "references");
+const cell = JSON.parse(await Bun.file(path.join(refs, "cell-mapping.json")).text());
+const sfdc = JSON.parse(await Bun.file(path.join(refs, "sfdc-field-mapping.json")).text());
+
+describe("checkMappings", () => {
+	test("shipped mappings conform to the schema", () => {
+		const r = checkMappings(schema, cell, sfdc);
+		expect(r.failures_debug ?? r).toBeDefined(); // keep output visible on failure
+		expect(r.ok).toBe(true);
+		expect(r.cell.failures).toEqual([]);
+		expect(r.sfdc.failures).toEqual([]);
+	});
+	test("detects a broken cell jsonPath", () => {
+		const broken = structuredClone(cell);
+		broken.staticFields[0].jsonPath = `${broken.staticFields[0].jsonPath}TYPO`;
+		const r = checkMappings(schema, broken, sfdc);
+		expect(r.ok).toBe(false);
+		expect(r.cell.failures.some(f => f.endsWith("TYPO"))).toBe(true);
+	});
+});

--- a/plugins/meddpicc/engine/mappings.ts
+++ b/plugins/meddpicc/engine/mappings.ts
@@ -1,0 +1,37 @@
+import { resolveSchemaPath } from "./schema-path";
+
+export interface MappingCheck {
+	ok: boolean;
+	cell: { checked: number; failures: string[] };
+	sfdc: { checked: number; failures: string[] };
+}
+
+interface CellMapping {
+	staticFields?: Array<{ jsonPath: string }>;
+	dynamicSections?: Array<{ jsonPath: string; columns?: Record<string, string> }>;
+}
+interface SfdcMapping {
+	fieldMappings?: Array<{ schemaPath: string }>;
+}
+
+export function checkMappings(schema: unknown, cellMapping: unknown, sfdcMapping: unknown): MappingCheck {
+	const cell = (cellMapping ?? {}) as CellMapping;
+	const sfdc = (sfdcMapping ?? {}) as SfdcMapping;
+
+	const cellPaths: string[] = [];
+	for (const f of cell.staticFields ?? []) cellPaths.push(f.jsonPath);
+	for (const sec of cell.dynamicSections ?? []) {
+		cellPaths.push(sec.jsonPath);
+		for (const field of Object.keys(sec.columns ?? {})) cellPaths.push(`${sec.jsonPath}.${field}`);
+	}
+	const cellFailures = cellPaths.filter(p => !resolveSchemaPath(schema, p));
+
+	const sfdcPaths = (sfdc.fieldMappings ?? []).map(m => m.schemaPath);
+	const sfdcFailures = sfdcPaths.filter(p => !resolveSchemaPath(schema, p));
+
+	return {
+		ok: cellFailures.length === 0 && sfdcFailures.length === 0,
+		cell: { checked: cellPaths.length, failures: cellFailures },
+		sfdc: { checked: sfdcPaths.length, failures: sfdcFailures },
+	};
+}

--- a/plugins/meddpicc/engine/mappings.ts
+++ b/plugins/meddpicc/engine/mappings.ts
@@ -1,37 +1,37 @@
-import { resolveSchemaPath } from "./schema-path";
+import { resolveSchemaPath } from './schema-path';
 
 export interface MappingCheck {
-	ok: boolean;
-	cell: { checked: number; failures: string[] };
-	sfdc: { checked: number; failures: string[] };
+  ok: boolean;
+  cell: { checked: number; failures: string[] };
+  sfdc: { checked: number; failures: string[] };
 }
 
 interface CellMapping {
-	staticFields?: Array<{ jsonPath: string }>;
-	dynamicSections?: Array<{ jsonPath: string; columns?: Record<string, string> }>;
+  staticFields?: Array<{ jsonPath: string }>;
+  dynamicSections?: Array<{ jsonPath: string; columns?: Record<string, string> }>;
 }
 interface SfdcMapping {
-	fieldMappings?: Array<{ schemaPath: string }>;
+  fieldMappings?: Array<{ schemaPath: string }>;
 }
 
 export function checkMappings(schema: unknown, cellMapping: unknown, sfdcMapping: unknown): MappingCheck {
-	const cell = (cellMapping ?? {}) as CellMapping;
-	const sfdc = (sfdcMapping ?? {}) as SfdcMapping;
+  const cell = (cellMapping ?? {}) as CellMapping;
+  const sfdc = (sfdcMapping ?? {}) as SfdcMapping;
 
-	const cellPaths: string[] = [];
-	for (const f of cell.staticFields ?? []) cellPaths.push(f.jsonPath);
-	for (const sec of cell.dynamicSections ?? []) {
-		cellPaths.push(sec.jsonPath);
-		for (const field of Object.keys(sec.columns ?? {})) cellPaths.push(`${sec.jsonPath}.${field}`);
-	}
-	const cellFailures = cellPaths.filter(p => !resolveSchemaPath(schema, p));
+  const cellPaths: string[] = [];
+  for (const f of cell.staticFields ?? []) cellPaths.push(f.jsonPath);
+  for (const sec of cell.dynamicSections ?? []) {
+    cellPaths.push(sec.jsonPath);
+    for (const field of Object.keys(sec.columns ?? {})) cellPaths.push(`${sec.jsonPath}.${field}`);
+  }
+  const cellFailures = cellPaths.filter((p) => !resolveSchemaPath(schema, p));
 
-	const sfdcPaths = (sfdc.fieldMappings ?? []).map(m => m.schemaPath);
-	const sfdcFailures = sfdcPaths.filter(p => !resolveSchemaPath(schema, p));
+  const sfdcPaths = (sfdc.fieldMappings ?? []).map((m) => m.schemaPath);
+  const sfdcFailures = sfdcPaths.filter((p) => !resolveSchemaPath(schema, p));
 
-	return {
-		ok: cellFailures.length === 0 && sfdcFailures.length === 0,
-		cell: { checked: cellPaths.length, failures: cellFailures },
-		sfdc: { checked: sfdcPaths.length, failures: sfdcFailures },
-	};
+  return {
+    ok: cellFailures.length === 0 && sfdcFailures.length === 0,
+    cell: { checked: cellPaths.length, failures: cellFailures },
+    sfdc: { checked: sfdcPaths.length, failures: sfdcFailures },
+  };
 }

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@meddpicc/engine",
+  "version": "2.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
+  }
+}

--- a/plugins/meddpicc/engine/schema-path.test.ts
+++ b/plugins/meddpicc/engine/schema-path.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { resolveSchemaPath } from "./schema-path";
+
+const schema = JSON.parse(
+	await Bun.file(path.join(import.meta.dir, "..", "schema", "meddpicc-schema.json")).text(),
+);
+
+describe("resolveSchemaPath", () => {
+	test("resolves simple nested object paths", () => {
+		expect(resolveSchemaPath(schema, "metadata.accountName")).toBe(true);
+		expect(resolveSchemaPath(schema, "metadata.revenue.pAndIplusAcvx")).toBe(true);
+	});
+	test("resolves through allOf + $ref + array items", () => {
+		expect(resolveSchemaPath(schema, "qualification.metrics.responses[0]")).toBe(true);
+		expect(resolveSchemaPath(schema, "qualification.champion.score")).toBe(true);
+	});
+	test("auto-descends arrays for column-style paths", () => {
+		expect(resolveSchemaPath(schema, "stakeholders.name")).toBe(true);
+		expect(resolveSchemaPath(schema, "closePlan.milestones.description")).toBe(true);
+	});
+	test("returns false for a non-existent path", () => {
+		expect(resolveSchemaPath(schema, "metadata.revenue.pAndIplusAcvxTYPO")).toBe(false);
+		expect(resolveSchemaPath(schema, "qualification.metrics.bogusField")).toBe(false);
+	});
+});

--- a/plugins/meddpicc/engine/schema-path.test.ts
+++ b/plugins/meddpicc/engine/schema-path.test.ts
@@ -1,26 +1,24 @@
-import { describe, expect, test } from "bun:test";
-import * as path from "node:path";
-import { resolveSchemaPath } from "./schema-path";
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { resolveSchemaPath } from './schema-path';
 
-const schema = JSON.parse(
-	await Bun.file(path.join(import.meta.dir, "..", "schema", "meddpicc-schema.json")).text(),
-);
+const schema = JSON.parse(await Bun.file(path.join(import.meta.dir, '..', 'schema', 'meddpicc-schema.json')).text());
 
-describe("resolveSchemaPath", () => {
-	test("resolves simple nested object paths", () => {
-		expect(resolveSchemaPath(schema, "metadata.accountName")).toBe(true);
-		expect(resolveSchemaPath(schema, "metadata.revenue.pAndIplusAcvx")).toBe(true);
-	});
-	test("resolves through allOf + $ref + array items", () => {
-		expect(resolveSchemaPath(schema, "qualification.metrics.responses[0]")).toBe(true);
-		expect(resolveSchemaPath(schema, "qualification.champion.score")).toBe(true);
-	});
-	test("auto-descends arrays for column-style paths", () => {
-		expect(resolveSchemaPath(schema, "stakeholders.name")).toBe(true);
-		expect(resolveSchemaPath(schema, "closePlan.milestones.description")).toBe(true);
-	});
-	test("returns false for a non-existent path", () => {
-		expect(resolveSchemaPath(schema, "metadata.revenue.pAndIplusAcvxTYPO")).toBe(false);
-		expect(resolveSchemaPath(schema, "qualification.metrics.bogusField")).toBe(false);
-	});
+describe('resolveSchemaPath', () => {
+  test('resolves simple nested object paths', () => {
+    expect(resolveSchemaPath(schema, 'metadata.accountName')).toBe(true);
+    expect(resolveSchemaPath(schema, 'metadata.revenue.pAndIplusAcvx')).toBe(true);
+  });
+  test('resolves through allOf + $ref + array items', () => {
+    expect(resolveSchemaPath(schema, 'qualification.metrics.responses[0]')).toBe(true);
+    expect(resolveSchemaPath(schema, 'qualification.champion.score')).toBe(true);
+  });
+  test('auto-descends arrays for column-style paths', () => {
+    expect(resolveSchemaPath(schema, 'stakeholders.name')).toBe(true);
+    expect(resolveSchemaPath(schema, 'closePlan.milestones.description')).toBe(true);
+  });
+  test('returns false for a non-existent path', () => {
+    expect(resolveSchemaPath(schema, 'metadata.revenue.pAndIplusAcvxTYPO')).toBe(false);
+    expect(resolveSchemaPath(schema, 'qualification.metrics.bogusField')).toBe(false);
+  });
 });

--- a/plugins/meddpicc/engine/schema-path.test.ts
+++ b/plugins/meddpicc/engine/schema-path.test.ts
@@ -21,4 +21,7 @@ describe('resolveSchemaPath', () => {
     expect(resolveSchemaPath(schema, 'metadata.revenue.pAndIplusAcvxTYPO')).toBe(false);
     expect(resolveSchemaPath(schema, 'qualification.metrics.bogusField')).toBe(false);
   });
+  test('returns false for an empty path', () => {
+    expect(resolveSchemaPath(schema, '')).toBe(false);
+  });
 });

--- a/plugins/meddpicc/engine/schema-path.ts
+++ b/plugins/meddpicc/engine/schema-path.ts
@@ -1,0 +1,92 @@
+/**
+ * Resolve a dotted/indexed JSON path (e.g. "qualification.metrics.responses[0]",
+ * "stakeholders.name") against a JSON Schema (draft 2020-12), following
+ * properties / items / $ref (#/$defs/*) / allOf. Returns whether it resolves.
+ */
+
+type Schema = Record<string, unknown>;
+
+/** Split "a.b[0].c" -> ["a", "b", "[0]", "c"]. */
+function tokenize(path: string): string[] {
+	const tokens: string[] = [];
+	for (const part of path.split(".")) {
+		const m = part.match(/^([^[\]]*)((?:\[\d+\])*)$/);
+		if (!m) {
+			tokens.push(part);
+			continue;
+		}
+		if (m[1]) tokens.push(m[1]);
+		const indices = m[2].match(/\[\d+\]/g);
+		if (indices) tokens.push(...indices);
+	}
+	return tokens;
+}
+
+function deref(node: unknown, root: Schema): Schema | undefined {
+	if (!node || typeof node !== "object") return undefined;
+	let cur = node as Schema;
+	// Follow local $ref chains: "#/$defs/foo".
+	let guard = 0;
+	while (typeof cur.$ref === "string" && guard++ < 20) {
+		const ref = cur.$ref;
+		if (!ref.startsWith("#/")) return undefined;
+		let target: unknown = root;
+		for (const seg of ref.slice(2).split("/")) {
+			target = (target as Schema | undefined)?.[seg];
+		}
+		if (!target || typeof target !== "object") return undefined;
+		cur = target as Schema;
+	}
+	return cur;
+}
+
+/** Merge allOf subschemas' properties/items into a single view. */
+function flatten(node: Schema, root: Schema): Schema {
+	const merged: Schema = { ...node };
+	const props: Record<string, unknown> = { ...((node.properties as Record<string, unknown>) ?? {}) };
+	if (Array.isArray(node.allOf)) {
+		for (const sub of node.allOf) {
+			const d = deref(sub, root);
+			if (!d) continue;
+			const f = flatten(d, root);
+			Object.assign(props, (f.properties as Record<string, unknown>) ?? {});
+			if (!merged.items && f.items) merged.items = f.items;
+			if (!merged.type && f.type) merged.type = f.type;
+		}
+	}
+	merged.properties = props;
+	return merged;
+}
+
+function normalize(node: unknown, root: Schema): Schema | undefined {
+	const d = deref(node, root);
+	if (!d) return undefined;
+	return flatten(d, root);
+}
+
+export function resolveSchemaPath(rootSchema: unknown, dottedPath: string): boolean {
+	if (!rootSchema || typeof rootSchema !== "object") return false;
+	const root = rootSchema as Schema;
+	let node: Schema | undefined = normalize(root, root);
+
+	for (const tok of tokenize(dottedPath)) {
+		if (!node) return false;
+
+		if (tok.startsWith("[")) {
+			node = node.items ? normalize(node.items, root) : undefined;
+			continue;
+		}
+
+		// Auto-descend an array when the next token is a property name (column-style path).
+		if (node.type === "array" || node.items) {
+			node = node.items ? normalize(node.items, root) : undefined;
+			if (!node) return false;
+		}
+
+		const props = (node.properties as Record<string, unknown>) ?? {};
+		if (!(tok in props)) return false;
+		node = normalize(props[tok], root);
+	}
+
+	return node !== undefined;
+}

--- a/plugins/meddpicc/engine/schema-path.ts
+++ b/plugins/meddpicc/engine/schema-path.ts
@@ -8,85 +8,85 @@ type Schema = Record<string, unknown>;
 
 /** Split "a.b[0].c" -> ["a", "b", "[0]", "c"]. */
 function tokenize(path: string): string[] {
-	const tokens: string[] = [];
-	for (const part of path.split(".")) {
-		const m = part.match(/^([^[\]]*)((?:\[\d+\])*)$/);
-		if (!m) {
-			tokens.push(part);
-			continue;
-		}
-		if (m[1]) tokens.push(m[1]);
-		const indices = m[2].match(/\[\d+\]/g);
-		if (indices) tokens.push(...indices);
-	}
-	return tokens;
+  const tokens: string[] = [];
+  for (const part of path.split('.')) {
+    const m = part.match(/^([^[\]]*)((?:\[\d+\])*)$/);
+    if (!m) {
+      tokens.push(part);
+      continue;
+    }
+    if (m[1]) tokens.push(m[1]);
+    const indices = m[2].match(/\[\d+\]/g);
+    if (indices) tokens.push(...indices);
+  }
+  return tokens;
 }
 
 function deref(node: unknown, root: Schema): Schema | undefined {
-	if (!node || typeof node !== "object") return undefined;
-	let cur = node as Schema;
-	// Follow local $ref chains: "#/$defs/foo".
-	let guard = 0;
-	while (typeof cur.$ref === "string" && guard++ < 20) {
-		const ref = cur.$ref;
-		if (!ref.startsWith("#/")) return undefined;
-		let target: unknown = root;
-		for (const seg of ref.slice(2).split("/")) {
-			target = (target as Schema | undefined)?.[seg];
-		}
-		if (!target || typeof target !== "object") return undefined;
-		cur = target as Schema;
-	}
-	return cur;
+  if (!node || typeof node !== 'object') return undefined;
+  let cur = node as Schema;
+  // Follow local $ref chains: "#/$defs/foo".
+  let guard = 0;
+  while (typeof cur.$ref === 'string' && guard++ < 20) {
+    const ref = cur.$ref;
+    if (!ref.startsWith('#/')) return undefined;
+    let target: unknown = root;
+    for (const seg of ref.slice(2).split('/')) {
+      target = (target as Schema | undefined)?.[seg];
+    }
+    if (!target || typeof target !== 'object') return undefined;
+    cur = target as Schema;
+  }
+  return cur;
 }
 
 /** Merge allOf subschemas' properties/items into a single view. */
 function flatten(node: Schema, root: Schema): Schema {
-	const merged: Schema = { ...node };
-	const props: Record<string, unknown> = { ...((node.properties as Record<string, unknown>) ?? {}) };
-	if (Array.isArray(node.allOf)) {
-		for (const sub of node.allOf) {
-			const d = deref(sub, root);
-			if (!d) continue;
-			const f = flatten(d, root);
-			Object.assign(props, (f.properties as Record<string, unknown>) ?? {});
-			if (!merged.items && f.items) merged.items = f.items;
-			if (!merged.type && f.type) merged.type = f.type;
-		}
-	}
-	merged.properties = props;
-	return merged;
+  const merged: Schema = { ...node };
+  const props: Record<string, unknown> = { ...((node.properties as Record<string, unknown>) ?? {}) };
+  if (Array.isArray(node.allOf)) {
+    for (const sub of node.allOf) {
+      const d = deref(sub, root);
+      if (!d) continue;
+      const f = flatten(d, root);
+      Object.assign(props, (f.properties as Record<string, unknown>) ?? {});
+      if (!merged.items && f.items) merged.items = f.items;
+      if (!merged.type && f.type) merged.type = f.type;
+    }
+  }
+  merged.properties = props;
+  return merged;
 }
 
 function normalize(node: unknown, root: Schema): Schema | undefined {
-	const d = deref(node, root);
-	if (!d) return undefined;
-	return flatten(d, root);
+  const d = deref(node, root);
+  if (!d) return undefined;
+  return flatten(d, root);
 }
 
 export function resolveSchemaPath(rootSchema: unknown, dottedPath: string): boolean {
-	if (!rootSchema || typeof rootSchema !== "object") return false;
-	const root = rootSchema as Schema;
-	let node: Schema | undefined = normalize(root, root);
+  if (!rootSchema || typeof rootSchema !== 'object') return false;
+  const root = rootSchema as Schema;
+  let node: Schema | undefined = normalize(root, root);
 
-	for (const tok of tokenize(dottedPath)) {
-		if (!node) return false;
+  for (const tok of tokenize(dottedPath)) {
+    if (!node) return false;
 
-		if (tok.startsWith("[")) {
-			node = node.items ? normalize(node.items, root) : undefined;
-			continue;
-		}
+    if (tok.startsWith('[')) {
+      node = node.items ? normalize(node.items, root) : undefined;
+      continue;
+    }
 
-		// Auto-descend an array when the next token is a property name (column-style path).
-		if (node.type === "array" || node.items) {
-			node = node.items ? normalize(node.items, root) : undefined;
-			if (!node) return false;
-		}
+    // Auto-descend an array when the next token is a property name (column-style path).
+    if (node.type === 'array' || node.items) {
+      node = node.items ? normalize(node.items, root) : undefined;
+      if (!node) return false;
+    }
 
-		const props = (node.properties as Record<string, unknown>) ?? {};
-		if (!(tok in props)) return false;
-		node = normalize(props[tok], root);
-	}
+    const props = (node.properties as Record<string, unknown>) ?? {};
+    if (!(tok in props)) return false;
+    node = normalize(props[tok], root);
+  }
 
-	return node !== undefined;
+  return node !== undefined;
 }

--- a/plugins/meddpicc/engine/schema-path.ts
+++ b/plugins/meddpicc/engine/schema-path.ts
@@ -65,6 +65,7 @@ function normalize(node: unknown, root: Schema): Schema | undefined {
 }
 
 export function resolveSchemaPath(rootSchema: unknown, dottedPath: string): boolean {
+  if (dottedPath === '') return false;
   if (!rootSchema || typeof rootSchema !== 'object') return false;
   const root = rootSchema as Schema;
   let node: Schema | undefined = normalize(root, root);

--- a/plugins/meddpicc/engine/score.test.ts
+++ b/plugins/meddpicc/engine/score.test.ts
@@ -1,29 +1,39 @@
-import { describe, expect, test } from "bun:test";
-import { computeScore } from "./score";
+import { describe, expect, test } from 'bun:test';
+import { computeScore } from './score';
 
-const example = { scoring: { elementScores: {
-	metrics: 3, economicBuyer: 3, decisionCriteria: 3, decisionProcess: 2,
-	paperProcess: 0, implicateThePain: 4, champion: 4, competition: 2,
-} } };
+const example = {
+  scoring: {
+    elementScores: {
+      metrics: 3,
+      economicBuyer: 3,
+      decisionCriteria: 3,
+      decisionProcess: 2,
+      paperProcess: 0,
+      implicateThePain: 4,
+      champion: 4,
+      competition: 2,
+    },
+  },
+};
 
-describe("computeScore", () => {
-	test("sums the 8 element scores from the example to 21 / 65.6 / Yellow", () => {
-		const r = computeScore(example);
-		expect(r.sum).toBe(21);
-		expect(r.overallScore).toBe(65.6);
-		expect(r.overallRating).toBe("Yellow");
-	});
-	test("Red boundary at 13, Green boundary at 26", () => {
-		const at13 = computeScore({ scoring: { elementScores: { metrics: 13 } } });
-		expect(at13.overallRating).toBe("Red");
-		const at14 = computeScore({ scoring: { elementScores: { metrics: 14 } } });
-		expect(at14.overallRating).toBe("Yellow");
-		const at26 = computeScore({ scoring: { elementScores: { metrics: 26 } } });
-		expect(at26.overallRating).toBe("Green");
-	});
-	test("missing scores count as 0", () => {
-		const r = computeScore({});
-		expect(r.sum).toBe(0);
-		expect(r.overallRating).toBe("Red");
-	});
+describe('computeScore', () => {
+  test('sums the 8 element scores from the example to 21 / 65.6 / Yellow', () => {
+    const r = computeScore(example);
+    expect(r.sum).toBe(21);
+    expect(r.overallScore).toBe(65.6);
+    expect(r.overallRating).toBe('Yellow');
+  });
+  test('Red boundary at 13, Green boundary at 26', () => {
+    const at13 = computeScore({ scoring: { elementScores: { metrics: 13 } } });
+    expect(at13.overallRating).toBe('Red');
+    const at14 = computeScore({ scoring: { elementScores: { metrics: 14 } } });
+    expect(at14.overallRating).toBe('Yellow');
+    const at26 = computeScore({ scoring: { elementScores: { metrics: 26 } } });
+    expect(at26.overallRating).toBe('Green');
+  });
+  test('missing scores count as 0', () => {
+    const r = computeScore({});
+    expect(r.sum).toBe(0);
+    expect(r.overallRating).toBe('Red');
+  });
 });

--- a/plugins/meddpicc/engine/score.test.ts
+++ b/plugins/meddpicc/engine/score.test.ts
@@ -23,11 +23,13 @@ describe('computeScore', () => {
     expect(r.overallScore).toBe(65.6);
     expect(r.overallRating).toBe('Yellow');
   });
-  test('Red boundary at 13, Green boundary at 26', () => {
+  test('Red boundary at 13, Yellow upper boundary at 25, Green boundary at 26', () => {
     const at13 = computeScore({ scoring: { elementScores: { metrics: 13 } } });
     expect(at13.overallRating).toBe('Red');
     const at14 = computeScore({ scoring: { elementScores: { metrics: 14 } } });
     expect(at14.overallRating).toBe('Yellow');
+    const at25 = computeScore({ scoring: { elementScores: { metrics: 25 } } });
+    expect(at25.overallRating).toBe('Yellow');
     const at26 = computeScore({ scoring: { elementScores: { metrics: 26 } } });
     expect(at26.overallRating).toBe('Green');
   });
@@ -35,5 +37,9 @@ describe('computeScore', () => {
     const r = computeScore({});
     expect(r.sum).toBe(0);
     expect(r.overallRating).toBe('Red');
+  });
+  test('sums only the 8 QUALIFICATION_ELEMENTS, ignoring stray keys', () => {
+    const r = computeScore({ scoring: { elementScores: { metrics: 3, bogus: 100 } } });
+    expect(r.sum).toBe(3);
   });
 });

--- a/plugins/meddpicc/engine/score.test.ts
+++ b/plugins/meddpicc/engine/score.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { computeScore } from "./score";
+
+const example = { scoring: { elementScores: {
+	metrics: 3, economicBuyer: 3, decisionCriteria: 3, decisionProcess: 2,
+	paperProcess: 0, implicateThePain: 4, champion: 4, competition: 2,
+} } };
+
+describe("computeScore", () => {
+	test("sums the 8 element scores from the example to 21 / 65.6 / Yellow", () => {
+		const r = computeScore(example);
+		expect(r.sum).toBe(21);
+		expect(r.overallScore).toBe(65.6);
+		expect(r.overallRating).toBe("Yellow");
+	});
+	test("Red boundary at 13, Green boundary at 26", () => {
+		const at13 = computeScore({ scoring: { elementScores: { metrics: 13 } } });
+		expect(at13.overallRating).toBe("Red");
+		const at14 = computeScore({ scoring: { elementScores: { metrics: 14 } } });
+		expect(at14.overallRating).toBe("Yellow");
+		const at26 = computeScore({ scoring: { elementScores: { metrics: 26 } } });
+		expect(at26.overallRating).toBe("Green");
+	});
+	test("missing scores count as 0", () => {
+		const r = computeScore({});
+		expect(r.sum).toBe(0);
+		expect(r.overallRating).toBe("Red");
+	});
+});

--- a/plugins/meddpicc/engine/score.ts
+++ b/plugins/meddpicc/engine/score.ts
@@ -1,0 +1,29 @@
+import { QUALIFICATION_ELEMENTS } from "./sections";
+
+export interface ScoreResult {
+	elementScores: Record<string, number>;
+	sum: number;
+	overallScore: number;
+	overallRating: "Red" | "Yellow" | "Green";
+}
+
+function ratingFor(sum: number): ScoreResult["overallRating"] {
+	if (sum <= 13) return "Red";
+	if (sum <= 25) return "Yellow";
+	return "Green";
+}
+
+export function computeScore(deal: unknown): ScoreResult {
+	const scores = (deal as { scoring?: { elementScores?: Record<string, unknown> } })?.scoring?.elementScores ?? {};
+	const elementScores: Record<string, number> = {};
+	let sum = 0;
+	for (const el of QUALIFICATION_ELEMENTS) {
+		const raw = scores[el];
+		const n = typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
+		elementScores[el] = n;
+		sum += n;
+	}
+	// Round to 1 decimal for deterministic, stable output (e.g. 21/32*100 = 65.625 -> 65.6).
+	const overallScore = Math.round((sum / 32) * 1000) / 10;
+	return { elementScores, sum, overallScore, overallRating: ratingFor(sum) };
+}

--- a/plugins/meddpicc/engine/score.ts
+++ b/plugins/meddpicc/engine/score.ts
@@ -1,29 +1,29 @@
-import { QUALIFICATION_ELEMENTS } from "./sections";
+import { QUALIFICATION_ELEMENTS } from './sections';
 
 export interface ScoreResult {
-	elementScores: Record<string, number>;
-	sum: number;
-	overallScore: number;
-	overallRating: "Red" | "Yellow" | "Green";
+  elementScores: Record<string, number>;
+  sum: number;
+  overallScore: number;
+  overallRating: 'Red' | 'Yellow' | 'Green';
 }
 
-function ratingFor(sum: number): ScoreResult["overallRating"] {
-	if (sum <= 13) return "Red";
-	if (sum <= 25) return "Yellow";
-	return "Green";
+function ratingFor(sum: number): ScoreResult['overallRating'] {
+  if (sum <= 13) return 'Red';
+  if (sum <= 25) return 'Yellow';
+  return 'Green';
 }
 
 export function computeScore(deal: unknown): ScoreResult {
-	const scores = (deal as { scoring?: { elementScores?: Record<string, unknown> } })?.scoring?.elementScores ?? {};
-	const elementScores: Record<string, number> = {};
-	let sum = 0;
-	for (const el of QUALIFICATION_ELEMENTS) {
-		const raw = scores[el];
-		const n = typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
-		elementScores[el] = n;
-		sum += n;
-	}
-	// Round to 1 decimal for deterministic, stable output (e.g. 21/32*100 = 65.625 -> 65.6).
-	const overallScore = Math.round((sum / 32) * 1000) / 10;
-	return { elementScores, sum, overallScore, overallRating: ratingFor(sum) };
+  const scores = (deal as { scoring?: { elementScores?: Record<string, unknown> } })?.scoring?.elementScores ?? {};
+  const elementScores: Record<string, number> = {};
+  let sum = 0;
+  for (const el of QUALIFICATION_ELEMENTS) {
+    const raw = scores[el];
+    const n = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0;
+    elementScores[el] = n;
+    sum += n;
+  }
+  // Round to 1 decimal for deterministic, stable output (e.g. 21/32*100 = 65.625 -> 65.6).
+  const overallScore = Math.round((sum / 32) * 1000) / 10;
+  return { elementScores, sum, overallScore, overallRating: ratingFor(sum) };
 }

--- a/plugins/meddpicc/engine/sections.test.ts
+++ b/plugins/meddpicc/engine/sections.test.ts
@@ -1,15 +1,25 @@
-import { describe, expect, test } from "bun:test";
-import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from "./sections";
+import { describe, expect, test } from 'bun:test';
+import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
 
-describe("sections", () => {
-	test("canonical order has 13 sections in the schema's completionStatus order", () => {
-		expect(SECTION_ORDER).toEqual([
-			"metrics", "economicBuyer", "decisionCriteria", "decisionProcess", "paperProcess",
-			"implicateThePain", "champion", "competition",
-			"threeWhys", "stakeholders", "salesStrategy", "closePlan", "team",
-		]);
-	});
-	test("qualification elements are the first 8", () => {
-		expect(QUALIFICATION_ELEMENTS).toEqual(SECTION_ORDER.slice(0, 8));
-	});
+describe('sections', () => {
+  test("canonical order has 13 sections in the schema's completionStatus order", () => {
+    expect(SECTION_ORDER).toEqual([
+      'metrics',
+      'economicBuyer',
+      'decisionCriteria',
+      'decisionProcess',
+      'paperProcess',
+      'implicateThePain',
+      'champion',
+      'competition',
+      'threeWhys',
+      'stakeholders',
+      'salesStrategy',
+      'closePlan',
+      'team',
+    ]);
+  });
+  test('qualification elements are the first 8', () => {
+    expect(QUALIFICATION_ELEMENTS).toEqual(SECTION_ORDER.slice(0, 8));
+  });
 });

--- a/plugins/meddpicc/engine/sections.test.ts
+++ b/plugins/meddpicc/engine/sections.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from "./sections";
+
+describe("sections", () => {
+	test("canonical order has 13 sections in the schema's completionStatus order", () => {
+		expect(SECTION_ORDER).toEqual([
+			"metrics", "economicBuyer", "decisionCriteria", "decisionProcess", "paperProcess",
+			"implicateThePain", "champion", "competition",
+			"threeWhys", "stakeholders", "salesStrategy", "closePlan", "team",
+		]);
+	});
+	test("qualification elements are the first 8", () => {
+		expect(QUALIFICATION_ELEMENTS).toEqual(SECTION_ORDER.slice(0, 8));
+	});
+});

--- a/plugins/meddpicc/engine/sections.ts
+++ b/plugins/meddpicc/engine/sections.ts
@@ -1,22 +1,22 @@
 /** The MEDDPICC section model — the single source of ordering/keys for the plugin. */
 
-export type SectionStatus = "not_started" | "partial" | "complete";
+export type SectionStatus = 'not_started' | 'partial' | 'complete';
 
 /** Canonical order, matching metadata.completionStatus key order in the schema. */
 export const SECTION_ORDER = [
-	"metrics",
-	"economicBuyer",
-	"decisionCriteria",
-	"decisionProcess",
-	"paperProcess",
-	"implicateThePain",
-	"champion",
-	"competition",
-	"threeWhys",
-	"stakeholders",
-	"salesStrategy",
-	"closePlan",
-	"team",
+  'metrics',
+  'economicBuyer',
+  'decisionCriteria',
+  'decisionProcess',
+  'paperProcess',
+  'implicateThePain',
+  'champion',
+  'competition',
+  'threeWhys',
+  'stakeholders',
+  'salesStrategy',
+  'closePlan',
+  'team',
 ] as const;
 
 /** The 8 scored MEDDPICC elements (live under `qualification`). */

--- a/plugins/meddpicc/engine/sections.ts
+++ b/plugins/meddpicc/engine/sections.ts
@@ -1,0 +1,23 @@
+/** The MEDDPICC section model — the single source of ordering/keys for the plugin. */
+
+export type SectionStatus = "not_started" | "partial" | "complete";
+
+/** Canonical order, matching metadata.completionStatus key order in the schema. */
+export const SECTION_ORDER = [
+	"metrics",
+	"economicBuyer",
+	"decisionCriteria",
+	"decisionProcess",
+	"paperProcess",
+	"implicateThePain",
+	"champion",
+	"competition",
+	"threeWhys",
+	"stakeholders",
+	"salesStrategy",
+	"closePlan",
+	"team",
+] as const;
+
+/** The 8 scored MEDDPICC elements (live under `qualification`). */
+export const QUALIFICATION_ELEMENTS = SECTION_ORDER.slice(0, 8);

--- a/plugins/meddpicc/engine/validate.test.ts
+++ b/plugins/meddpicc/engine/validate.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
+import { validateDeal } from "./validate";
+
+const dir = path.join(import.meta.dir, "..", "schema");
+const schema = JSON.parse(await Bun.file(path.join(dir, "meddpicc-schema.json")).text());
+const example = JSON.parse(await Bun.file(path.join(dir, "example-deal.json")).text());
+
+describe("validateDeal", () => {
+	test("the example deal is valid", () => {
+		const r = validateDeal(example, schema);
+		expect(r.valid).toBe(true);
+		expect(r.errors).toEqual([]);
+	});
+	test("missing required metadata is invalid", () => {
+		const r = validateDeal({ qualification: {} }, schema);
+		expect(r.valid).toBe(false);
+		expect(r.errors.length).toBeGreaterThan(0);
+	});
+	test("an out-of-range score is invalid", () => {
+		const bad = structuredClone(example);
+		bad.qualification.metrics.score = 9;
+		const r = validateDeal(bad, schema);
+		expect(r.valid).toBe(false);
+		expect(r.errors.some(e => e.instancePath.includes("/qualification/metrics/score"))).toBe(true);
+	});
+});

--- a/plugins/meddpicc/engine/validate.test.ts
+++ b/plugins/meddpicc/engine/validate.test.ts
@@ -1,27 +1,27 @@
-import { describe, expect, test } from "bun:test";
-import * as path from "node:path";
-import { validateDeal } from "./validate";
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { validateDeal } from './validate';
 
-const dir = path.join(import.meta.dir, "..", "schema");
-const schema = JSON.parse(await Bun.file(path.join(dir, "meddpicc-schema.json")).text());
-const example = JSON.parse(await Bun.file(path.join(dir, "example-deal.json")).text());
+const dir = path.join(import.meta.dir, '..', 'schema');
+const schema = JSON.parse(await Bun.file(path.join(dir, 'meddpicc-schema.json')).text());
+const example = JSON.parse(await Bun.file(path.join(dir, 'example-deal.json')).text());
 
-describe("validateDeal", () => {
-	test("the example deal is valid", () => {
-		const r = validateDeal(example, schema);
-		expect(r.valid).toBe(true);
-		expect(r.errors).toEqual([]);
-	});
-	test("missing required metadata is invalid", () => {
-		const r = validateDeal({ qualification: {} }, schema);
-		expect(r.valid).toBe(false);
-		expect(r.errors.length).toBeGreaterThan(0);
-	});
-	test("an out-of-range score is invalid", () => {
-		const bad = structuredClone(example);
-		bad.qualification.metrics.score = 9;
-		const r = validateDeal(bad, schema);
-		expect(r.valid).toBe(false);
-		expect(r.errors.some(e => e.instancePath.includes("/qualification/metrics/score"))).toBe(true);
-	});
+describe('validateDeal', () => {
+  test('the example deal is valid', () => {
+    const r = validateDeal(example, schema);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+  test('missing required metadata is invalid', () => {
+    const r = validateDeal({ qualification: {} }, schema);
+    expect(r.valid).toBe(false);
+    expect(r.errors.length).toBeGreaterThan(0);
+  });
+  test('an out-of-range score is invalid', () => {
+    const bad = structuredClone(example);
+    bad.qualification.metrics.score = 9;
+    const r = validateDeal(bad, schema);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.instancePath.includes('/qualification/metrics/score'))).toBe(true);
+  });
 });

--- a/plugins/meddpicc/engine/validate.ts
+++ b/plugins/meddpicc/engine/validate.ts
@@ -1,21 +1,21 @@
-import Ajv2020 from "ajv/dist/2020";
-import addFormats from "ajv-formats";
+import Ajv2020 from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
 
 export interface ValidationResult {
-	valid: boolean;
-	errors: Array<{ instancePath: string; keyword: string; message: string; schemaPath: string }>;
+  valid: boolean;
+  errors: Array<{ instancePath: string; keyword: string; message: string; schemaPath: string }>;
 }
 
 export function validateDeal(deal: unknown, schema: unknown): ValidationResult {
-	const ajv = new Ajv2020({ allErrors: true, strict: false });
-	addFormats(ajv);
-	const validateFn = ajv.compile(schema as object);
-	const valid = validateFn(deal) as boolean;
-	const errors = (validateFn.errors ?? []).map(e => ({
-		instancePath: e.instancePath,
-		keyword: e.keyword,
-		message: e.message ?? "",
-		schemaPath: e.schemaPath,
-	}));
-	return { valid, errors };
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validateFn = ajv.compile(schema as object);
+  const valid = validateFn(deal) as boolean;
+  const errors = (validateFn.errors ?? []).map((e) => ({
+    instancePath: e.instancePath,
+    keyword: e.keyword,
+    message: e.message ?? '',
+    schemaPath: e.schemaPath,
+  }));
+  return { valid, errors };
 }

--- a/plugins/meddpicc/engine/validate.ts
+++ b/plugins/meddpicc/engine/validate.ts
@@ -1,0 +1,21 @@
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+
+export interface ValidationResult {
+	valid: boolean;
+	errors: Array<{ instancePath: string; keyword: string; message: string; schemaPath: string }>;
+}
+
+export function validateDeal(deal: unknown, schema: unknown): ValidationResult {
+	const ajv = new Ajv2020({ allErrors: true, strict: false });
+	addFormats(ajv);
+	const validateFn = ajv.compile(schema as object);
+	const valid = validateFn(deal) as boolean;
+	const errors = (validateFn.errors ?? []).map(e => ({
+		instancePath: e.instancePath,
+		keyword: e.keyword,
+		message: e.message ?? "",
+		schemaPath: e.schemaPath,
+	}));
+	return { valid, errors };
+}

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/tests/test_engine.sh
+++ b/plugins/meddpicc/scripts/tests/test_engine.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# End-to-end acceptance for the MEDDPICC engine CLI.
+
+_engine_precheck() {
+	command -v bun >/dev/null 2>&1 || { echo "SKIP: bun unavailable"; return 1; }
+}
+
+test_engine_score_matches_example() {
+	_engine_precheck || return 0
+	local out
+	out=$(bun "$PLUGIN_ROOT/engine/cli.ts" score "$PLUGIN_ROOT/schema/example-deal.json")
+	[ "$(jq -r '.sum' <<<"$out")" = "21" ] || { echo "sum != 21: $out"; return 1; }
+	[ "$(jq -r '.overallScore' <<<"$out")" = "65.6" ] || { echo "overallScore != 65.6"; return 1; }
+	[ "$(jq -r '.overallRating' <<<"$out")" = "Yellow" ] || { echo "rating != Yellow"; return 1; }
+}
+
+test_engine_validate_ok() {
+	_engine_precheck || return 0
+	bun "$PLUGIN_ROOT/engine/cli.ts" validate "$PLUGIN_ROOT/schema/example-deal.json" >/dev/null || { echo "validate failed"; return 1; }
+}
+
+test_engine_next_resume() {
+	_engine_precheck || return 0
+	local out
+	out=$(bun "$PLUGIN_ROOT/engine/cli.ts" next "$PLUGIN_ROOT/schema/example-deal.json")
+	[ "$(jq -r '.nextIncompleteSection' <<<"$out")" = "decisionProcess" ] || { echo "next != decisionProcess: $out"; return 1; }
+}
+
+test_engine_check_mappings_ok() {
+	_engine_precheck || return 0
+	bun "$PLUGIN_ROOT/engine/cli.ts" check-mappings >/dev/null || { echo "check-mappings failed on shipped files"; return 1; }
+}
+
+test_engine_check_mappings_detects_broken() {
+	_engine_precheck || return 0
+	local tmp; tmp=$(mktemp -d)
+	cp "$PLUGIN_ROOT/skills/deal-qualification/references/cell-mapping.json" "$tmp/cell.json"
+	# Corrupt the first staticFields jsonPath.
+	jq '.staticFields[0].jsonPath = (.staticFields[0].jsonPath + "TYPO")' "$tmp/cell.json" > "$tmp/cell-broken.json"
+	if bun "$PLUGIN_ROOT/engine/cli.ts" check-mappings --cell "$tmp/cell-broken.json" >/dev/null 2>&1; then
+		echo "expected non-zero exit for broken mapping"; rm -rf "$tmp"; return 1
+	fi
+	rm -rf "$tmp"
+}

--- a/plugins/meddpicc/scripts/tests/test_engine.sh
+++ b/plugins/meddpicc/scripts/tests/test_engine.sh
@@ -2,43 +2,67 @@
 # End-to-end acceptance for the MEDDPICC engine CLI.
 
 _engine_precheck() {
-	command -v bun >/dev/null 2>&1 || { echo "SKIP: bun unavailable"; return 1; }
+  command -v bun >/dev/null 2>&1 || {
+    echo "SKIP: bun unavailable"
+    return 1
+  }
 }
 
 test_engine_score_matches_example() {
-	_engine_precheck || return 0
-	local out
-	out=$(bun "$PLUGIN_ROOT/engine/cli.ts" score "$PLUGIN_ROOT/schema/example-deal.json")
-	[ "$(jq -r '.sum' <<<"$out")" = "21" ] || { echo "sum != 21: $out"; return 1; }
-	[ "$(jq -r '.overallScore' <<<"$out")" = "65.6" ] || { echo "overallScore != 65.6"; return 1; }
-	[ "$(jq -r '.overallRating' <<<"$out")" = "Yellow" ] || { echo "rating != Yellow"; return 1; }
+  _engine_precheck || return 0
+  local out
+  out=$(bun "$PLUGIN_ROOT/engine/cli.ts" score "$PLUGIN_ROOT/schema/example-deal.json")
+  [ "$(jq -r '.sum' <<<"$out")" = "21" ] || {
+    echo "sum != 21: $out"
+    return 1
+  }
+  [ "$(jq -r '.overallScore' <<<"$out")" = "65.6" ] || {
+    echo "overallScore != 65.6"
+    return 1
+  }
+  [ "$(jq -r '.overallRating' <<<"$out")" = "Yellow" ] || {
+    echo "rating != Yellow"
+    return 1
+  }
 }
 
 test_engine_validate_ok() {
-	_engine_precheck || return 0
-	bun "$PLUGIN_ROOT/engine/cli.ts" validate "$PLUGIN_ROOT/schema/example-deal.json" >/dev/null || { echo "validate failed"; return 1; }
+  _engine_precheck || return 0
+  bun "$PLUGIN_ROOT/engine/cli.ts" validate "$PLUGIN_ROOT/schema/example-deal.json" >/dev/null || {
+    echo "validate failed"
+    return 1
+  }
 }
 
 test_engine_next_resume() {
-	_engine_precheck || return 0
-	local out
-	out=$(bun "$PLUGIN_ROOT/engine/cli.ts" next "$PLUGIN_ROOT/schema/example-deal.json")
-	[ "$(jq -r '.nextIncompleteSection' <<<"$out")" = "decisionProcess" ] || { echo "next != decisionProcess: $out"; return 1; }
+  _engine_precheck || return 0
+  local out
+  out=$(bun "$PLUGIN_ROOT/engine/cli.ts" next "$PLUGIN_ROOT/schema/example-deal.json")
+  [ "$(jq -r '.nextIncompleteSection' <<<"$out")" = "decisionProcess" ] || {
+    echo "next != decisionProcess: $out"
+    return 1
+  }
 }
 
 test_engine_check_mappings_ok() {
-	_engine_precheck || return 0
-	bun "$PLUGIN_ROOT/engine/cli.ts" check-mappings >/dev/null || { echo "check-mappings failed on shipped files"; return 1; }
+  _engine_precheck || return 0
+  bun "$PLUGIN_ROOT/engine/cli.ts" check-mappings >/dev/null || {
+    echo "check-mappings failed on shipped files"
+    return 1
+  }
 }
 
 test_engine_check_mappings_detects_broken() {
-	_engine_precheck || return 0
-	local tmp; tmp=$(mktemp -d)
-	cp "$PLUGIN_ROOT/skills/deal-qualification/references/cell-mapping.json" "$tmp/cell.json"
-	# Corrupt the first staticFields jsonPath.
-	jq '.staticFields[0].jsonPath = (.staticFields[0].jsonPath + "TYPO")' "$tmp/cell.json" > "$tmp/cell-broken.json"
-	if bun "$PLUGIN_ROOT/engine/cli.ts" check-mappings --cell "$tmp/cell-broken.json" >/dev/null 2>&1; then
-		echo "expected non-zero exit for broken mapping"; rm -rf "$tmp"; return 1
-	fi
-	rm -rf "$tmp"
+  _engine_precheck || return 0
+  local tmp
+  tmp=$(mktemp -d)
+  cp "$PLUGIN_ROOT/skills/deal-qualification/references/cell-mapping.json" "$tmp/cell.json"
+  # Corrupt the first staticFields jsonPath.
+  jq '.staticFields[0].jsonPath = (.staticFields[0].jsonPath + "TYPO")' "$tmp/cell.json" >"$tmp/cell-broken.json"
+  if bun "$PLUGIN_ROOT/engine/cli.ts" check-mappings --cell "$tmp/cell-broken.json" >/dev/null 2>&1; then
+    echo "expected non-zero exit for broken mapping"
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$tmp"
 }

--- a/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
+++ b/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
@@ -2,16 +2,28 @@
 # Tests for .xcsh-plugin/resources.json
 
 test_resources_manifest_paths_exist() {
-	local manifest="$PLUGIN_ROOT/.xcsh-plugin/resources.json"
-	if [ ! -f "$manifest" ]; then echo "resources.json missing"; return 1; fi
-	local schema engine_entry
-	schema=$(jq -r '.schema' "$manifest")
-	engine_entry=$(jq -r '.engine.entry' "$manifest")
-	[ -f "$PLUGIN_ROOT/$schema" ] || { echo "schema path missing: $schema"; return 1; }
-	[ -f "$PLUGIN_ROOT/$engine_entry" ] || { echo "engine.entry missing: $engine_entry"; return 1; }
-	# every mappings.* path resolves
-	local p
-	for p in $(jq -r '.mappings // {} | to_entries[] | .value' "$manifest"); do
-		[ -f "$PLUGIN_ROOT/$p" ] || { echo "mapping path missing: $p"; return 1; }
-	done
+  local manifest="$PLUGIN_ROOT/.xcsh-plugin/resources.json"
+  if [ ! -f "$manifest" ]; then
+    echo "resources.json missing"
+    return 1
+  fi
+  local schema engine_entry
+  schema=$(jq -r '.schema' "$manifest")
+  engine_entry=$(jq -r '.engine.entry' "$manifest")
+  [ -f "$PLUGIN_ROOT/$schema" ] || {
+    echo "schema path missing: $schema"
+    return 1
+  }
+  [ -f "$PLUGIN_ROOT/$engine_entry" ] || {
+    echo "engine.entry missing: $engine_entry"
+    return 1
+  }
+  # every mappings.* path resolves
+  local p
+  for p in $(jq -r '.mappings // {} | to_entries[] | .value' "$manifest"); do
+    [ -f "$PLUGIN_ROOT/$p" ] || {
+      echo "mapping path missing: $p"
+      return 1
+    }
+  done
 }

--- a/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
+++ b/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Tests for .xcsh-plugin/resources.json
+
+test_resources_manifest_paths_exist() {
+	local manifest="$PLUGIN_ROOT/.xcsh-plugin/resources.json"
+	if [ ! -f "$manifest" ]; then echo "resources.json missing"; return 1; fi
+	local schema engine_entry
+	schema=$(jq -r '.schema' "$manifest")
+	engine_entry=$(jq -r '.engine.entry' "$manifest")
+	[ -f "$PLUGIN_ROOT/$schema" ] || { echo "schema path missing: $schema"; return 1; }
+	[ -f "$PLUGIN_ROOT/$engine_entry" ] || { echo "engine.entry missing: $engine_entry"; return 1; }
+	# every mappings.* path resolves
+	local p
+	for p in $(jq -r '.mappings // {} | to_entries[] | .value' "$manifest"); do
+		[ -f "$PLUGIN_ROOT/$p" ] || { echo "mapping path missing: $p"; return 1; }
+	done
+}

--- a/plugins/meddpicc/scripts/tests/test_version_consistency.sh
+++ b/plugins/meddpicc/scripts/tests/test_version_consistency.sh
@@ -2,12 +2,12 @@
 # All three manifests must declare the same version.
 
 test_versions_match() {
-	local pkg plugin mkt
-	pkg=$(jq -r '.version' "$PLUGIN_ROOT/package.json")
-	plugin=$(jq -r '.version' "$PLUGIN_ROOT/.xcsh-plugin/plugin.json")
-	mkt=$(jq -r '.plugins[] | select(.name=="meddpicc") | .version' "$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json")
-	if [ "$pkg" != "$plugin" ] || [ "$pkg" != "$mkt" ]; then
-		echo "version mismatch: package.json=$pkg plugin.json=$plugin marketplace=$mkt"
-		return 1
-	fi
+  local pkg plugin mkt
+  pkg=$(jq -r '.version' "$PLUGIN_ROOT/package.json")
+  plugin=$(jq -r '.version' "$PLUGIN_ROOT/.xcsh-plugin/plugin.json")
+  mkt=$(jq -r '.plugins[] | select(.name=="meddpicc") | .version' "$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json")
+  if [ "$pkg" != "$plugin" ] || [ "$pkg" != "$mkt" ]; then
+    echo "version mismatch: package.json=$pkg plugin.json=$plugin marketplace=$mkt"
+    return 1
+  fi
 }

--- a/plugins/meddpicc/scripts/tests/test_version_consistency.sh
+++ b/plugins/meddpicc/scripts/tests/test_version_consistency.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# All three manifests must declare the same version.
+
+test_versions_match() {
+	local pkg plugin mkt
+	pkg=$(jq -r '.version' "$PLUGIN_ROOT/package.json")
+	plugin=$(jq -r '.version' "$PLUGIN_ROOT/.xcsh-plugin/plugin.json")
+	mkt=$(jq -r '.plugins[] | select(.name=="meddpicc") | .version' "$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json")
+	if [ "$pkg" != "$plugin" ] || [ "$pkg" != "$mkt" ]; then
+		echo "version mismatch: package.json=$pkg plugin.json=$plugin marketplace=$mkt"
+		return 1
+	fi
+}

--- a/plugins/meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/meddpicc/skills/deal-qualification/SKILL.md
@@ -26,20 +26,18 @@ review produces a JSON file conforming to this schema. The schema
 embeds guiding questions and scoring rubric definitions for each
 MEDDPICC element.
 
-## Element Key Reference
+## Engine (deterministic source of truth)
 
-Use these exact JSON keys in all jq paths:
+State, ordering, scoring, validation, and mapping conformance are computed by the plugin engine — never by hand. Invoke it in bash:
 
-| Display Name | JSON Key | jq Path |
-| ------------ | -------- | ------- |
-| Metrics (M) | `metrics` | `.qualification.metrics` |
-| Economic Buyer (E) | `economicBuyer` | `.qualification.economicBuyer` |
-| Decision Criteria (D1) | `decisionCriteria` | `.qualification.decisionCriteria` |
-| Decision Process (D2) | `decisionProcess` | `.qualification.decisionProcess` |
-| Paper Process (P) | `paperProcess` | `.qualification.paperProcess` |
-| Identify Pain (I) | `implicateThePain` | `.qualification.implicateThePain` |
-| Champion (C1) | `champion` | `.qualification.champion` |
-| Competition (C2) | `competition` | `.qualification.competition` |
+- Resume point / status: `bun xcsh://plugin/meddpicc/file/engine/cli.ts next <deal.json>`
+  → JSON `{ order, completionStatus, nextIncompleteSection }`. Ask targeted questions for `nextIncompleteSection` and any `partial`/`not_started` sections, in `order`.
+- Scores: after each element write, run `bun xcsh://plugin/meddpicc/file/engine/cli.ts score <deal.json>` and relay `sum` / `overallScore` / `overallRating`.
+- Validation: after writes, run `bun xcsh://plugin/meddpicc/file/engine/cli.ts validate <deal.json>`; if `valid` is false, fix the reported `errors` before continuing.
+
+For local/dev use without the `xcsh://` resolver, the equivalent is `bun "$PLUGIN_ROOT/engine/cli.ts" <command> <deal.json>`.
+
+Element display names map to `qualification.<key>` where `<key>` is one of: metrics, economicBuyer, decisionCriteria, decisionProcess, paperProcess, implicateThePain, champion, competition (canonical order defined by the engine; do not re-derive by hand).
 
 ## Data Persistence Protocol
 
@@ -97,8 +95,8 @@ jq --arg status "Discovery" --arg close "2026-09-30" \
 
 **MEDDPICC element completion** — after scoring each element, write
 responses, score, evidence, notes, completionStatus, and
-elementScore. Replace `metrics` with the correct key from the
-Element Key Reference table:
+elementScore. Replace `metrics` with the correct key (see the
+Engine section for the display-name → key mapping):
 
 ```bash
 jq --arg r0 "Answer to question 1" \
@@ -115,17 +113,11 @@ jq --arg r0 "Answer to question 1" \
   "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
 ```
 
-**Overall score calculation** — after all 8 elements are scored:
-
-```bash
-jq '(.scoring.elementScores | to_entries | map(.value) | add) as $sum |
-  .scoring.overallScore = ($sum / 32 * 100) |
-  .scoring.overallRating = (
-    if $sum <= 13 then "Red"
-    elif $sum <= 25 then "Yellow"
-    else "Green" end)' \
-  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
-```
+**Overall score** — do **not** compute this by hand. After element
+writes, read `sum` / `overallScore` / `overallRating` from the engine
+(`bun xcsh://plugin/meddpicc/file/engine/cli.ts score <deal.json>` —
+see the Engine section). The engine is the source of truth for the
+overall score; `jq` is used only for the individual field writes above.
 
 **Array append** — for stakeholders, milestones, actions, team.
 Stakeholders require `name`, `title`, and `roleInDeal`. Initialize
@@ -186,8 +178,9 @@ User provides a deal or account name with no existing JSON file.
 6. After all 8 elements: collect Three Whys, stakeholders, sales
    strategy, close plan, and team. **Write:** after each section,
    update the section data and its `completionStatus` with `jq`.
-7. **Write:** calculate and write `scoring.overallScore` and
-   `scoring.overallRating` with the overall score `jq` pattern.
+7. Report scores from the engine: run `score` for
+   `sum` / `overallScore` / `overallRating` and relay them (see the
+   Engine section). Do not compute the overall score by hand.
 
 The file is always up to date — there is no final "save" step. The
 user can pause at any time without data loss because every answer
@@ -201,9 +194,12 @@ is an existing JSON file for this deal.
 **If existing JSON file found:**
 
 1. Read the file and set the `DEAL_FILE` shell variable
-2. Check `completionStatus` for incomplete sections
+2. Run the engine's `next` command to get `completionStatus`,
+   the canonical `order`, and `nextIncompleteSection` — do not
+   scan `completionStatus` by hand (see the Engine section)
 3. Present a summary of what's complete and what's missing
-4. Ask targeted questions only for incomplete/partial sections
+4. Ask targeted questions for `nextIncompleteSection` and any
+   `partial`/`not_started` sections, in `order`
 5. **Write:** use `jq` to update each completed section
    immediately (same protocol as Mode 1)
 
@@ -228,8 +224,8 @@ User invokes with an existing complete deal.
 2. Present current scores and gaps
 3. Allow the user to update any section — **Write:** use `jq` to
    persist each change immediately
-4. **Write:** recalculate `scoring.overallScore` and
-   `scoring.overallRating` with the overall score `jq` pattern
+4. Report the recomputed scores from the engine's `score` output
+   (see the Engine section) — do not recalculate by hand
 
 ## File Location
 
@@ -259,6 +255,9 @@ detailed scoring criteria.
 | 0 | **Unknown** | No evidence or not yet explored |
 
 ### Overall Score Calculation
+
+The engine's `score` command computes this — do not calculate it by
+hand. For reference, it applies:
 
 - **Formula:** `(sum of 8 element scores / 32) × 100`
 - **Rating:** Red (0-13/32), Yellow (14-25/32), Green (26-32/32)

--- a/plugins/meddpicc/skills/deal-review/SKILL.md
+++ b/plugins/meddpicc/skills/deal-review/SKILL.md
@@ -51,20 +51,22 @@ jq '<expression>' "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_
 - Never use `!=` in jq — use `| not` instead
 - Never use `!` in Bash — use `cmd || { handle; }` instead
 
-## Element Key Reference
+## Engine (deterministic source of truth)
 
-Use these exact JSON keys in all jq paths (display name ≠ key):
+Ordering and scoring are computed by the plugin engine — never by
+hand. After element updates, recompute scores with
+`bun xcsh://plugin/meddpicc/file/engine/cli.ts score <deal.json>`
+and relay `sum` / `overallScore` / `overallRating`. (Local/dev
+equivalent: `bun "$PLUGIN_ROOT/engine/cli.ts" score <deal.json>`.)
+Build the weekly delta table by comparing the engine's per-element
+`elementScores` against the `previousElementScores` snapshot taken
+at Step 1 (load).
 
-| Display Name | JSON Key | jq Path |
-| ------------ | -------- | ------- |
-| Metrics (M) | `metrics` | `.qualification.metrics` |
-| Economic Buyer (E) | `economicBuyer` | `.qualification.economicBuyer` |
-| Decision Criteria (D1) | `decisionCriteria` | `.qualification.decisionCriteria` |
-| Decision Process (D2) | `decisionProcess` | `.qualification.decisionProcess` |
-| Paper Process (P) | `paperProcess` | `.qualification.paperProcess` |
-| Identify Pain (I) | `implicateThePain` | `.qualification.implicateThePain` |
-| Champion (C1) | `champion` | `.qualification.champion` |
-| Competition (C2) | `competition` | `.qualification.competition` |
+Element display names map to `qualification.<key>` where `<key>` is
+one of: metrics, economicBuyer, decisionCriteria, decisionProcess,
+paperProcess, implicateThePain, champion, competition (canonical
+order defined by the engine; do not re-derive by hand). Use these
+exact keys in all `jq` paths — display name ≠ key.
 
 ### Key jq patterns for reviews
 
@@ -79,7 +81,8 @@ jq --arg new "[2026-05-20 weekly-review] Fred confirmed ARB slot June 2" \
 ```
 
 **Score + completionStatus update** — update element score after
-evidence review. Replace `metrics` with the correct key above:
+evidence review. Replace `metrics` with the correct key (see the
+Engine section):
 
 ```bash
 jq --argjson score 3 \
@@ -114,20 +117,15 @@ jq '.scoring.previousElementScores = .scoring.elementScores' \
   "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
 ```
 
-**Recalculate overall score** — run after all element updates:
+**Overall score** — do **not** recompute this by hand. After all
+element updates, read `sum` / `overallScore` / `overallRating` from
+the engine's `score` command (see the Engine section). `jq` is used
+only for the element writes and the `previousElementScores`
+snapshot above.
 
-```bash
-jq '(.scoring.elementScores | to_entries | map(.value) | add) as $sum |
-  .scoring.overallScore = ($sum / 32 * 100) |
-  .scoring.overallRating = (
-    if $sum <= 13 then "Red"
-    elif $sum <= 25 then "Yellow"
-    else "Green" end)' \
-  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
-```
-
-**Scorecard display:** `scoring.overallScore` stores a percentage.
-To display `X/32`, sum `scoring.elementScores` values directly.
+**Scorecard display:** take `sum` (the `X` in `X/32`),
+`overallScore` (percentage), and `overallRating` from the engine's
+`score` output — do not back-compute them from stored fields.
 
 ## Review Protocol
 
@@ -147,11 +145,13 @@ Check for an existing deal JSON file:
 
 ### Step 2 — Establish context
 
-Present the current deal state from the JSON:
+Present the current deal state, taking scores from the engine's
+`score` output (see the Engine section) rather than reading them by
+hand:
 
 - Deal name, account, stage, close date
-- Current MEDDPICC scores (element-by-element)
-- Overall score and rating (Red/Yellow/Green)
+- Current MEDDPICC scores (element-by-element, from `elementScores`)
+- Overall score and rating (`overallScore` / `overallRating`)
 - Last review date
 
 ### Step 3 — Evidence inspection
@@ -225,8 +225,9 @@ For the final writes:
      "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
    ```
 
-2. **Write:** recalculate overall score and rating using the
-   recalculate jq pattern (see Data Persistence Protocol)
+2. Recompute scores with the engine's `score` command (see the
+   Engine section) and use `sum` / `overallScore` / `overallRating`
+   in the report — do not recalculate by hand
 3. Present the review output
 
 ## Output Format
@@ -268,6 +269,11 @@ For the final writes:
 
 ### Next Review: [date]
 ```
+
+In the Evidence Delta table, **Previous Score** is read from the
+`previousElementScores` snapshot (taken at Step 1) and **Current
+Score** from the engine's `score` `elementScores`; **Change** is
+their difference. Do not compute these from the raw JSON by hand.
 
 If the user requests XLS output, render using the same process as
 deal-qualification (template + cell mapping).

--- a/plugins/meddpicc/skills/deal-update/SKILL.md
+++ b/plugins/meddpicc/skills/deal-update/SKILL.md
@@ -34,24 +34,22 @@ arrives throughout the deal cycle.
 - Prospect site or public filings analysis
 - News articles about the account or competitors
 
-## Element Key Reference
+## Engine (deterministic source of truth)
 
-The JSON schema uses these exact keys. Always use these paths in
-`jq` — never use display names or abbreviations:
+Ordering and scoring are computed by the plugin engine — never by
+hand. After applying confirmed writes, recompute scores with
+`bun xcsh://plugin/meddpicc/file/engine/cli.ts score <deal.json>`
+and relay `sum` / `overallScore` / `overallRating`. (Local/dev
+equivalent: `bun "$PLUGIN_ROOT/engine/cli.ts" score <deal.json>`.)
 
-| Display Name | JSON Key | jq Path |
-| ------------ | -------- | ------- |
-| Metrics (M) | `metrics` | `.qualification.metrics` |
-| Economic Buyer (E) | `economicBuyer` | `.qualification.economicBuyer` |
-| Decision Criteria (D1) | `decisionCriteria` | `.qualification.decisionCriteria` |
-| Decision Process (D2) | `decisionProcess` | `.qualification.decisionProcess` |
-| Paper Process (P) | `paperProcess` | `.qualification.paperProcess` |
-| Identify Pain (I) | `implicateThePain` | `.qualification.implicateThePain` |
-| Champion (C1) | `champion` | `.qualification.champion` |
-| Competition (C2) | `competition` | `.qualification.competition` |
-
-The corresponding `completionStatus` and `elementScores` keys use
-the same names: `.metadata.completionStatus.implicateThePain`,
+Element display names map to `qualification.<key>` where `<key>` is
+one of: metrics, economicBuyer, decisionCriteria, decisionProcess,
+paperProcess, implicateThePain, champion, competition (canonical
+order defined by the engine; do not re-derive by hand). Always use
+these exact keys in `jq` paths — never display names or
+abbreviations. The corresponding `completionStatus` and
+`elementScores` keys use the same names:
+`.metadata.completionStatus.implicateThePain`,
 `.scoring.elementScores.implicateThePain`, etc.
 
 ## Data Persistence Protocol
@@ -96,22 +94,15 @@ jq --arg new "[2026-05-06 meeting-notes] Board-level visibility on these metrics
 
 ### Score update pattern
 
-After updating an element, write the score and recalculate overall.
-Replace `metrics` with the correct key from the Element Key
-Reference table above:
+After updating an element, write its score with `jq` (replace
+`metrics` with the correct key — see the Engine section). Do **not**
+recalculate the overall score by hand; recompute it with the
+engine's `score` command afterward (see the Engine section).
 
 ```bash
 jq --argjson score 3 \
   '.qualification.metrics.score = $score |
    .scoring.elementScores.metrics = $score' \
-  "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
-
-jq '(.scoring.elementScores | to_entries | map(.value) | add) as $sum |
-  .scoring.overallScore = ($sum / 32 * 100) |
-  .scoring.overallRating = (
-    if $sum <= 13 then "Red"
-    elif $sum <= 25 then "Yellow"
-    else "Green" end)' \
   "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
 ```
 
@@ -128,9 +119,9 @@ jq --argjson s '{"name":"Jane Doe","title":"CISO","roleInDeal":"Influencer","mus
 
 ### Scorecard display
 
-`scoring.overallScore` stores a percentage (0–100). To display
-`X/32`, sum `scoring.elementScores` values directly — do not
-back-compute from the percentage.
+Take `sum` (the `X` in `X/32`), `overallScore` (percentage), and
+`overallRating` from the engine's `score` output — do not
+back-compute them from stored fields.
 
 ## Ingestion Protocol
 
@@ -157,8 +148,8 @@ If no date is explicit, use today's date.
 ### Step 3 — Extract MEDDPICC intelligence
 
 Read the input and systematically scan for signals relevant to
-each MEDDPICC element. Use the **Element Key Reference** table
-above for the correct JSON key when writing updates.
+each MEDDPICC element. Use the key mapping in the **Engine**
+section above for the correct JSON key when writing updates.
 
 If no signal is found for an element in the input, **leave it
 unchanged** — do not propose setting it to score 1 or adding
@@ -355,12 +346,15 @@ Write types:
 - **Evidence append:** Use the evidence append pattern above
 - **Notes append:** Same pattern but on `.notes` field
 - **Response replace:** Use `--arg` for string values
-- **Score update:** Update element score + recalculate overall
+- **Score update:** Write the element score with `jq` (see the
+  Score update pattern)
 - **Stakeholder add:** Use array append pattern
 - **Action item add:** Append to `closePlan.criticalActions`
 - **Milestone add:** Append to `closePlan.milestones`
 
-After all writes, run the overall score recalculation jq.
+After all writes, recompute scores with the engine's `score`
+command and relay `sum` / `overallScore` / `overallRating` (see
+the Engine section).
 
 ### Step 8 — Updated scorecard
 


### PR DESCRIPTION
Closes #781

## Summary

Adds a deterministic TypeScript engine (Bun/Node + ajv 2020-12) that owns the mechanical truth of a MEDDPICC deal JSON, plus a `.xcsh-plugin/resources.json` manifest so the generic `xcsh://plugin/meddpicc/…` resolver (xcsh core PR) can locate and run it. The three interactive skills now **delegate** ordering/scoring/validation to the engine (DRY), keeping `jq` only for field writes.

## Engine (`plugins/meddpicc/engine/`, ajv 2020-12)

- `sections.ts` — canonical 13-section order (single source; replaces the display→key table duplicated across 3 skills).
- `score.ts` — deterministic rollup: sum of the 8 element scores, `overallScore` (1-decimal), Red/Yellow/Green.
- `schema-path.ts` — resolves dotted/indexed JSON paths through `properties`/`items`/`$ref`/`allOf`.
- `completion.ts` — **evidence-based** completion state + next-incomplete (complete = score≥3 AND responses AND evidence).
- `validate.ts` — `Ajv2020` + `ajv-formats`.
- `mappings.ts` — **schema-conformance** of `cell-mapping.json` (67 paths) & `sfdc-field-mapping.json` (10 paths) — the gate that didn't exist before.
- `cli.ts` — `validate | next | score | check-mappings`, deterministic JSON, exit codes.

Verified on `schema/example-deal.json`: score sum **21 → 65.6 → Yellow**; `next` → **decisionProcess**; validate clean; check-mappings ok (67/10).

## Also

- `.xcsh-plugin/resources.json` manifest (schema, example, engine, mappings).
- Fixed version drift: `package.json` 1.0.0 → **2.1.0** (matches plugin.json + marketplace entry).
- Rewired `deal-qualification`, `deal-update`, `deal-review`, `meddpicc-status`, and the read-only `deal-analyst` to the engine (analyst derives overall from `elementScores`; no Bash added).
- Bash harness: `test_engine.sh`, `test_version_consistency.sh`, `test_resources_manifest.sh`.

## Testing

- `cd plugins/meddpicc/engine && bun test` — 24 pass.
- `bash scripts/tests/run-tests.sh` — 15 pass, 0 fail.
- Full pre-commit (biome, markdownlint, shellcheck, spelling, governance) — green.

## Notes

- Engine is fully exercised standalone; the `xcsh://plugin/meddpicc/…` protocol invocation depends on the sibling xcsh-core resolver PR.
- Out of scope (later): live Office add-in render; closing mapping *coverage* gaps (now detectable via `check-mappings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)