### PR TITLE
fix(azure): make az_exec natively accept valid az CLI (JMESPath --query)

### DIFF
--- a/plugins/azure/autoresearch.checks.sh
+++ b/plugins/azure/autoresearch.checks.sh
@@ -49,7 +49,7 @@ fi
 # ── Check 4: Security patterns intact ─────────────────────────────────────
 echo ""
 echo "=== Check 4: security patterns ==="
-PATTERNS=("SAFE_ARG_PATTERN" "SUBSCRIPTION_ID_PATTERN" "RESOURCE_GROUP_PATTERN" "SUBSCRIPTION_NAME_PATTERN" "HELP_PATH_PATTERN" "RESOURCE_TYPE_PATTERN" "TAG_PATTERN")
+PATTERNS=("SUBSCRIPTION_ID_PATTERN" "RESOURCE_GROUP_PATTERN" "SUBSCRIPTION_NAME_PATTERN" "HELP_PATH_PATTERN" "RESOURCE_TYPE_PATTERN" "TAG_PATTERN")
 ALL_PATTERNS_OK=true
 for pattern in "${PATTERNS[@]}"; do
   if ! grep -q "export const $pattern" src/az/types.ts; then
@@ -58,8 +58,16 @@ for pattern in "${PATTERNS[@]}"; do
     ALL_PATTERNS_OK=false
   fi
 done
-if ! grep -q "SAFE_ARG_PATTERN" src/tools/az-exec.ts; then
-  echo "FAIL: SAFE_ARG_PATTERN not used in src/tools/az-exec.ts"
+# az_exec security invariant: argv-only spawn (no shell) is the injection control.
+# Per-character shell-metacharacter filtering must NOT be reintroduced (it breaks valid
+# JMESPath --query). Require the argv hygiene guard and the read-only verb guardrail.
+if ! grep -q "hasControlChars" src/tools/az-exec.ts; then
+  echo "FAIL: argv hygiene guard (hasControlChars) missing from src/tools/az-exec.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+if ! grep -q "MUTATING_VERBS" src/tools/az-exec.ts; then
+  echo "FAIL: read-only guardrail (MUTATING_VERBS) missing from src/tools/az-exec.ts"
   ERRORS=$((ERRORS + 1))
   ALL_PATTERNS_OK=false
 fi

--- a/plugins/azure/autoresearch.md
+++ b/plugins/azure/autoresearch.md
@@ -33,8 +33,8 @@ Composite formula: `accuracy * (1 / (1 + avg_turns / 10)) * (1 / (1 + avg_tokens
 ## Constraints
 
 - All existing tests must pass (bun test exit 0)
-- Security validation patterns must remain exported from src/az/types.ts: SAFE_ARG_PATTERN, SUBSCRIPTION_ID_PATTERN, RESOURCE_GROUP_PATTERN, SUBSCRIPTION_NAME_PATTERN, HELP_PATH_PATTERN, RESOURCE_TYPE_PATTERN, TAG_PATTERN
-- SAFE_ARG_PATTERN must be used in src/tools/az-exec.ts
+- Field-specific validation patterns must remain exported from src/az/types.ts: SUBSCRIPTION_ID_PATTERN, RESOURCE_GROUP_PATTERN, SUBSCRIPTION_NAME_PATTERN, HELP_PATH_PATTERN, RESOURCE_TYPE_PATTERN, TAG_PATTERN
+- Security invariant for az_exec: `az` is spawned argv-only (no shell), so the argv boundary is the injection control — do NOT reintroduce per-character "shell metacharacter" filtering, which only breaks valid `az --query` (JMESPath) syntax. Keep only argv hygiene (reject control/NUL bytes) and the read-only-by-default verb guardrail.
 - All 6 tool names must remain: az_account, az_group, az_resource, az_vm, az_exec, az_help
 - Tool parameter names and types must not change
 - Biome lint must pass with no new errors

--- a/plugins/azure/src/az/types.ts
+++ b/plugins/azure/src/az/types.ts
@@ -52,7 +52,6 @@ export interface AzRawResult {
 export const SUBSCRIPTION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 export const RESOURCE_GROUP_PATTERN = /^[a-zA-Z0-9._()-]+$/;
 export const SUBSCRIPTION_NAME_PATTERN = /^[a-zA-Z0-9 ._-]+$/;
-export const SAFE_ARG_PATTERN = /^[a-zA-Z0-9._@:/=[\]{},"'?*()!+ -]+$/;
 export const HELP_PATH_PATTERN = /^[a-z][a-z -]*$/;
 export const RESOURCE_TYPE_PATTERN = /^[a-zA-Z0-9./]+$/;
 export const TAG_PATTERN = /^[a-zA-Z0-9._-]+(=[a-zA-Z0-9._@: -]*)?$/;

--- a/plugins/azure/src/prompts/az-exec.md
+++ b/plugins/azure/src/prompts/az-exec.md
@@ -14,9 +14,22 @@ Pass the subcommand and flags as an array of arguments. Do NOT include `az` itse
 
 ## Safety
 
-- Each argument is validated: no shell metacharacters (`;`, `|`, `$`, backticks, `&&`, `||`) are allowed
-- Arguments are passed as an array to `Bun.spawn` — no shell interpretation occurs
-- Output is capped to prevent context overflow
+- Arguments are passed as an array directly to the `az` binary — **no shell** is involved, so shell metacharacters are inert and never filtered. Any valid `az` invocation runs, including full JMESPath `--query` syntax.
+- **Read-only by default:** mutating verbs (`create`, `delete`, `update`, `set`, `purge`, `start`, `stop`, `restart`, `scale`, `restore`, …) are blocked. Run write/destructive operations through an explicitly confirmed path (delegate to the `cli-operator` agent), not `az_exec`.
+- Output is capped to prevent context overflow.
+
+## Querying with `--query` (JMESPath)
+
+The full JMESPath grammar is supported — pass the expression as a single argument value. Common patterns:
+
+- Field projection: `--query "[].{name:name, location:location}"`
+- Filter: `--query "[?location=='eastus']"`
+- Substring match: `--query "[?contains(name, 'prod')]"`
+- Backtick literals (numbers/booleans/quoted enums): `` --query "[?powerState==`VM running`]" ``
+- OR / AND / NOT: `--query "[?a=='x' || b=='y']"`, `--query "[?a && b]"`, `--query "[?!disabled]"`
+- Pipe to post-process a projection: `--query "[].name | [0]"`
+
+All of the above — including `||`, `|`, and backticks — are accepted verbatim.
 
 ## Common Subcommands Not Covered by Typed Tools
 
@@ -33,7 +46,7 @@ Pass the subcommand and flags as an array of arguments. Do NOT include `az` itse
 
 ## Tips
 
-- Always include `--output json` for machine-readable output (added automatically)
+- `--output json` is added automatically unless you pass your own `--output`/`-o` (e.g. `-o table`, `-o tsv`), which is respected
 - Use `--subscription NAME_OR_ID` to target a specific subscription
 - Use `--resource-group NAME` to scope to a resource group
 - Use `az_help` tool first if unsure about available flags

--- a/plugins/azure/src/tools/az-exec.ts
+++ b/plugins/azure/src/tools/az-exec.ts
@@ -1,9 +1,101 @@
 import type { PluginInterface } from '../az/types';
-import { SAFE_ARG_PATTERN } from '../az/types';
 import azExecDescription from '../prompts/az-exec.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, textResult } from './shared';
 
 const MAX_OUTPUT_LENGTH = 50000;
+
+// `az` is spawned argv-style (Bun.spawn(['az', ...args])) with NO shell, so shell
+// metacharacters are inert — the argv boundary is the real command-injection control
+// (per OWASP / CISA guidance). We therefore do NOT filter shell metacharacters, which
+// would only break valid Azure CLI `--query` (JMESPath) syntax such as `||`, backtick
+// literals, and pipes. The one genuine hygiene concern is a NUL/control byte, which
+// malforms an execve argv.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matching control bytes for argv hygiene
+const CONTROL_CHAR_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F]/;
+
+export function hasControlChars(arg: string): boolean {
+  return CONTROL_CHAR_PATTERN.test(arg);
+}
+
+// Read-only-by-default guardrail. `az` verbs are conventional; we block clearly
+// mutating verbs so writes must go through an explicit, confirmed path (the
+// cli-operator agent). Reads (list*, show, get*, check*, ...) pass by default.
+export const MUTATING_VERBS: ReadonlySet<string> = new Set([
+  'create',
+  'new',
+  'delete',
+  'remove',
+  'purge',
+  'update',
+  'set',
+  'add',
+  'start',
+  'stop',
+  'restart',
+  'deallocate',
+  'redeploy',
+  'reset',
+  'regenerate',
+  'renew',
+  'rotate',
+  'move',
+  'invoke',
+  'execute',
+  'enable',
+  'disable',
+  'attach',
+  'detach',
+  'approve',
+  'reject',
+  'cancel',
+  'revoke',
+  'grant',
+  'assign',
+  'unassign',
+  'lock',
+  'unlock',
+  'register',
+  'unregister',
+  'scale',
+  'migrate',
+  'failover',
+  'restore',
+  'deploy',
+  'install',
+  'uninstall',
+  'upgrade',
+  'publish',
+  'import',
+  'upload',
+  'activate',
+  'deactivate',
+  'associate',
+  'disassociate',
+  'generate',
+]);
+
+// The az verb is the last positional token before the first flag, e.g.
+// `network routeserver peering list-learned-routes -g rg` -> `list-learned-routes`.
+export function findVerb(args: string[]): string | null {
+  let verb: string | null = null;
+  for (const arg of args) {
+    if (arg.startsWith('-')) break;
+    verb = arg;
+  }
+  return verb;
+}
+
+export function isMutating(args: string[]): boolean {
+  const verb = findVerb(args);
+  return verb !== null && MUTATING_VERBS.has(verb);
+}
+
+// Default to JSON for machine-readable output, but respect a caller-supplied
+// --output / -o so `-o table` and `-o tsv` work instead of being overridden.
+export function buildAzArgs(args: string[]): string[] {
+  const hasOutput = args.some((a) => a === '--output' || a === '-o');
+  return hasOutput ? [...args] : [...args, '--output', 'json'];
+}
 
 export function createAzExecTool(pi: PluginInterface) {
   const { Type } = pi.typebox;
@@ -33,16 +125,22 @@ export function createAzExecTool(pi: PluginInterface) {
       }
 
       for (const arg of params.args) {
-        if (!SAFE_ARG_PATTERN.test(arg)) {
-          return errorResult(
-            `Error: unsafe argument "${arg}". Shell metacharacters (;|$\`&&||) are not allowed.`,
-            base,
-          );
+        if (hasControlChars(arg)) {
+          return errorResult(`Error: argument contains a control character and cannot be passed to az: "${arg}"`, base);
         }
       }
 
+      if (isMutating(params.args)) {
+        return errorResult(
+          `Error: "${findVerb(params.args)}" is a mutating operation. az_exec is read-only by default. ` +
+            'Run write/destructive operations through an explicitly confirmed path (delegate to the ' +
+            'azure:cli-operator agent) rather than az_exec.',
+          base,
+        );
+      }
+
       const api = makeExecApi(ctx.cwd);
-      const args = [...params.args, '--output', 'json'];
+      const args = buildAzArgs(params.args);
 
       try {
         const result = await api.exec('az', args);
@@ -54,7 +152,7 @@ export function createAzExecTool(pi: PluginInterface) {
         }
         let output = result.stdout;
         if (output.length > MAX_OUTPUT_LENGTH) {
-          output = output.slice(0, MAX_OUTPUT_LENGTH) + `\n\n[Output truncated at ${MAX_OUTPUT_LENGTH} characters]`;
+          output = `${output.slice(0, MAX_OUTPUT_LENGTH)}\n\n[Output truncated at ${MAX_OUTPUT_LENGTH} characters]`;
         }
         return textResult(output, base);
       } catch (err) {

--- a/plugins/azure/src/tools/az-exec.ts
+++ b/plugins/azure/src/tools/az-exec.ts
@@ -74,34 +74,33 @@ export const MUTATING_VERBS: ReadonlySet<string> = new Set([
   'generate',
 ]);
 
-// Positional tokens are the az command path + verb. Flags, and the value that
-// immediately follows a value-taking flag, are excluded. Global flags such as
-// `--subscription`/`--debug` may appear ANYWHERE, including before the command
-// group, so we must not stop scanning at the first flag — doing so would let a
-// destructive op hide behind a leading flag (e.g. `--subscription X group delete`).
+// Every argument that is not itself a flag. We deliberately do NOT try to exclude
+// "flag values" (the `foo` in `-n foo`): telling value-taking flags apart from
+// boolean switches (`--debug`, `--yes`, ...) without the full az grammar is
+// error-prone, and any mistake lets a destructive verb slip through a switch
+// (e.g. `group --debug delete`) or a leading global flag
+// (e.g. `--subscription X group delete`). For a read-only *security* guardrail we
+// fail safe and treat every non-flag token as a candidate verb.
 export function getPositionals(args: string[]): string[] {
-  const positionals: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg.startsWith('-')) continue;
-    const prev = args[i - 1];
-    // Skip the value of a space-form value-taking flag (e.g. `-n foo`, `--name foo`).
-    // `--flag=value` is itself flag-shaped and already skipped above.
-    if (prev?.startsWith('-') && !prev.includes('=')) continue;
-    positionals.push(arg);
-  }
-  return positionals;
+  return args.filter((arg) => !arg.startsWith('-'));
 }
 
-// The verb for messaging is the last positional (e.g.
-// `network routeserver peering list-learned-routes -g rg` -> `list-learned-routes`).
+// The command verb, for display only: the last positional token before the first
+// flag (e.g. `network routeserver peering list-learned-routes -g rg`
+// -> `list-learned-routes`).
 export function findVerb(args: string[]): string | null {
-  return getPositionals(args).at(-1) ?? null;
+  let verb: string | null = null;
+  for (const arg of args) {
+    if (arg.startsWith('-')) break;
+    verb = arg;
+  }
+  return verb;
 }
 
-// Fail safe: a command is mutating if ANY positional token is a mutating verb,
-// regardless of its position relative to flags. This prevents flag-first argument
-// ordering from bypassing the read-only guardrail.
+// Mutating if ANY non-flag token is a mutating verb, regardless of position.
+// Fail-safe: a flag value that happens to equal a verb (e.g. a resource literally
+// named "delete") is blocked rather than risk a destructive false negative — a
+// safe, rare failure that JMESPath `--query` values never trigger.
 export function findMutatingVerb(args: string[]): string | null {
   return getPositionals(args).find((tok) => MUTATING_VERBS.has(tok)) ?? null;
 }

--- a/plugins/azure/src/tools/az-exec.ts
+++ b/plugins/azure/src/tools/az-exec.ts
@@ -74,20 +74,40 @@ export const MUTATING_VERBS: ReadonlySet<string> = new Set([
   'generate',
 ]);
 
-// The az verb is the last positional token before the first flag, e.g.
-// `network routeserver peering list-learned-routes -g rg` -> `list-learned-routes`.
-export function findVerb(args: string[]): string | null {
-  let verb: string | null = null;
-  for (const arg of args) {
-    if (arg.startsWith('-')) break;
-    verb = arg;
+// Positional tokens are the az command path + verb. Flags, and the value that
+// immediately follows a value-taking flag, are excluded. Global flags such as
+// `--subscription`/`--debug` may appear ANYWHERE, including before the command
+// group, so we must not stop scanning at the first flag — doing so would let a
+// destructive op hide behind a leading flag (e.g. `--subscription X group delete`).
+export function getPositionals(args: string[]): string[] {
+  const positionals: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('-')) continue;
+    const prev = args[i - 1];
+    // Skip the value of a space-form value-taking flag (e.g. `-n foo`, `--name foo`).
+    // `--flag=value` is itself flag-shaped and already skipped above.
+    if (prev?.startsWith('-') && !prev.includes('=')) continue;
+    positionals.push(arg);
   }
-  return verb;
+  return positionals;
+}
+
+// The verb for messaging is the last positional (e.g.
+// `network routeserver peering list-learned-routes -g rg` -> `list-learned-routes`).
+export function findVerb(args: string[]): string | null {
+  return getPositionals(args).at(-1) ?? null;
+}
+
+// Fail safe: a command is mutating if ANY positional token is a mutating verb,
+// regardless of its position relative to flags. This prevents flag-first argument
+// ordering from bypassing the read-only guardrail.
+export function findMutatingVerb(args: string[]): string | null {
+  return getPositionals(args).find((tok) => MUTATING_VERBS.has(tok)) ?? null;
 }
 
 export function isMutating(args: string[]): boolean {
-  const verb = findVerb(args);
-  return verb !== null && MUTATING_VERBS.has(verb);
+  return findMutatingVerb(args) !== null;
 }
 
 // Default to JSON for machine-readable output, but respect a caller-supplied
@@ -130,9 +150,10 @@ export function createAzExecTool(pi: PluginInterface) {
         }
       }
 
-      if (isMutating(params.args)) {
+      const mutatingVerb = findMutatingVerb(params.args);
+      if (mutatingVerb !== null) {
         return errorResult(
-          `Error: "${findVerb(params.args)}" is a mutating operation. az_exec is read-only by default. ` +
+          `Error: "${mutatingVerb}" is a mutating operation. az_exec is read-only by default. ` +
             'Run write/destructive operations through an explicitly confirmed path (delegate to the ' +
             'azure:cli-operator agent) rather than az_exec.',
           base,

--- a/plugins/azure/test/tools/az-exec.test.ts
+++ b/plugins/azure/test/tools/az-exec.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'bun:test';
-import { createAzExecTool } from '../../src/tools/az-exec';
+import {
+  buildAzArgs,
+  createAzExecTool,
+  findVerb,
+  hasControlChars,
+  isMutating,
+  MUTATING_VERBS,
+} from '../../src/tools/az-exec';
 
 const mockTypebox = {
   Type: {
@@ -29,71 +36,117 @@ describe('createAzExecTool', () => {
   });
 });
 
-describe('az_exec injection prevention', () => {
+// The `az` binary is spawned argv-style (Bun.spawn(['az', ...])) with NO shell,
+// so shell metacharacters are inert. Valid JMESPath `--query` values MUST be
+// accepted by the tool — the argv boundary is the real security control.
+describe('findVerb', () => {
+  it('returns the last leading positional token (the az verb)', () => {
+    expect(findVerb(['vm', 'list'])).toBe('list');
+    expect(findVerb(['group', 'delete', '--name', 'x'])).toBe('delete');
+    expect(findVerb(['storage', 'account', 'create', '-n', 'foo'])).toBe('create');
+  });
+
+  it('treats the token before the first flag as the verb', () => {
+    expect(findVerb(['network', 'routeserver', 'peering', 'list-learned-routes', '-g', 'rg'])).toBe(
+      'list-learned-routes',
+    );
+  });
+
+  it('returns null when the first token is a flag', () => {
+    expect(findVerb(['--help'])).toBeNull();
+  });
+});
+
+describe('isMutating (read-only-by-default guardrail)', () => {
+  it('passes read verbs', () => {
+    expect(isMutating(['vm', 'list'])).toBe(false);
+    expect(isMutating(['account', 'show'])).toBe(false);
+    expect(isMutating(['network', 'routeserver', 'peering', 'list-learned-routes', '-g', 'rg'])).toBe(false);
+    expect(isMutating(['aks', 'get-credentials', '-n', 'c'])).toBe(false);
+  });
+
+  it('flags destructive / mutating verbs', () => {
+    expect(isMutating(['group', 'delete', '--name', 'x'])).toBe(true);
+    expect(isMutating(['vm', 'create', '-n', 'x'])).toBe(true);
+    expect(isMutating(['keyvault', 'purge', '-n', 'x'])).toBe(true);
+    expect(isMutating(['network', 'nsg', 'rule', 'update', '-n', 'x'])).toBe(true);
+  });
+
+  it('exposes a non-empty verb set', () => {
+    expect(MUTATING_VERBS.size).toBeGreaterThan(10);
+    expect(MUTATING_VERBS.has('delete')).toBe(true);
+    expect(MUTATING_VERBS.has('list')).toBe(false);
+  });
+});
+
+describe('hasControlChars (argv hygiene)', () => {
+  it('rejects NUL bytes', () => {
+    expect(hasControlChars('foo\x00bar')).toBe(true);
+  });
+
+  it('accepts ordinary values including JMESPath metacharacters', () => {
+    expect(hasControlChars("RouteServiceRole_IN_0[?contains(network,'10.0.0.1')] || value[?x]")).toBe(false);
+    expect(hasControlChars('[?state==`Running`]')).toBe(false);
+    expect(hasControlChars('people[*].name | [0]')).toBe(false);
+  });
+});
+
+describe('buildAzArgs (output flag handling)', () => {
+  it('appends --output json when the caller did not specify output', () => {
+    expect(buildAzArgs(['vm', 'list'])).toEqual(['vm', 'list', '--output', 'json']);
+  });
+
+  it('respects a caller-supplied --output', () => {
+    expect(buildAzArgs(['vm', 'list', '--output', 'table'])).toEqual(['vm', 'list', '--output', 'table']);
+  });
+
+  it('respects a caller-supplied -o short flag', () => {
+    expect(buildAzArgs(['vm', 'list', '-o', 'tsv'])).toEqual(['vm', 'list', '-o', 'tsv']);
+  });
+});
+
+describe('az_exec execute', () => {
   const tool = createAzExecTool({ typebox: mockTypebox });
-
-  it('rejects args with semicolons', async () => {
-    const result = await tool.execute('id', { args: ['vm', 'list;rm -rf /'] }, null, null, { cwd: '/tmp' });
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('unsafe');
-  });
-
-  it('rejects args with pipe', async () => {
-    const result = await tool.execute('id', { args: ['vm', 'list|cat'] }, null, null, { cwd: '/tmp' });
-    expect(result.isError).toBe(true);
-  });
-
-  it('rejects args with $() command substitution', async () => {
-    const result = await tool.execute('id', { args: ['vm', '$(whoami)'] }, null, null, { cwd: '/tmp' });
-    expect(result.isError).toBe(true);
-  });
-
-  it('rejects args with backtick injection', async () => {
-    const result = await tool.execute('id', { args: ['vm', '`id`'] }, null, null, { cwd: '/tmp' });
-    expect(result.isError).toBe(true);
-  });
-
-  it('rejects args with && chaining', async () => {
-    const result = await tool.execute('id', { args: ['vm', 'list&&rm'] }, null, null, { cwd: '/tmp' });
-    expect(result.isError).toBe(true);
-  });
-
-  it('rejects args with || chaining', async () => {
-    const result = await tool.execute('id', { args: ['vm', 'list||echo'] }, null, null, { cwd: '/tmp' });
-    expect(result.isError).toBe(true);
-  });
 
   it('rejects empty args array', async () => {
     const result = await tool.execute('id', { args: [] }, null, null, { cwd: '/tmp' });
     expect(result.isError).toBe(true);
   });
 
-  it('accepts safe args with flags', async () => {
-    // This will fail due to actual CLI execution, but should NOT fail on validation
-    try {
-      await tool.execute('id', { args: ['webapp', 'list', '--resource-group', 'my-rg'] }, null, null, { cwd: '/tmp' });
-    } catch {
-      // CLI not available
-    }
+  it('rejects args containing a NUL byte with a clear message', async () => {
+    const result = await tool.execute('id', { args: ['vm', 'list\x00'] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.toLowerCase()).toContain('control character');
   });
 
-  it('accepts args with paths and equals', async () => {
-    try {
-      await tool.execute('id', { args: ['storage', 'account', 'list', '--query', '[].name'] }, null, null, {
-        cwd: '/tmp',
-      });
-    } catch {
-      // CLI not available
-    }
+  it('blocks destructive verbs deterministically with an actionable message', async () => {
+    const result = await tool.execute('id', { args: ['group', 'delete', '--name', 'x'] }, null, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.toLowerCase()).toContain('read-only');
   });
 
-  it('accepts JMESPath query with ?, *, and ()', async () => {
-    try {
-      await tool.execute('id', { args: ['vm', 'list', '--query', "[?contains(name, 'prod')]"] }, null, null, {
-        cwd: '/tmp',
-      });
-    } catch {
-      // CLI not available
+  it('does NOT reject valid JMESPath with || (the reported failure)', async () => {
+    const query = "RouteServiceRole_IN_0[?contains(network,'10.250.0.10')] || value[?contains(network,'10.250.0.10')]";
+    const result = await tool.execute(
+      'id',
+      { args: ['network', 'routeserver', 'peering', 'list-learned-routes', '--query', query] },
+      null,
+      null,
+      { cwd: '/tmp' },
+    );
+    // az may not be installed in CI; either way this must NOT be a validation rejection.
+    const text = result.content[0].text.toLowerCase();
+    expect(text).not.toContain('unsafe argument');
+    expect(text).not.toContain('control character');
+    expect(text).not.toContain('read-only');
+  });
+
+  it('does NOT reject JMESPath backtick literals or pipes', async () => {
+    for (const query of ['[?powerState==`VM running`]', 'people[*].name | [0]']) {
+      const result = await tool.execute('id', { args: ['vm', 'list', '--query', query] }, null, null, { cwd: '/tmp' });
+      const text = result.content[0].text.toLowerCase();
+      expect(text).not.toContain('unsafe argument');
+      expect(text).not.toContain('control character');
     }
   });
 });

--- a/plugins/azure/test/tools/az-exec.test.ts
+++ b/plugins/azure/test/tools/az-exec.test.ts
@@ -79,10 +79,18 @@ describe('isMutating (read-only-by-default guardrail)', () => {
     expect(isMutating(['--only-show-errors', 'vm', 'create', '-n', 'x'])).toBe(true);
   });
 
-  it('does not false-positive on a mutating word used as a flag value', () => {
-    // A resource literally named "delete" passed as a flag value is not the verb.
-    expect(isMutating(['group', 'show', '--name', 'delete'])).toBe(false);
-    expect(isMutating(['group', 'show', '-n', 'create'])).toBe(false);
+  it('cannot be bypassed by a boolean switch immediately before the verb', () => {
+    // Boolean switches take no value, so the verb must not be treated as their value.
+    expect(isMutating(['group', '--debug', 'delete'])).toBe(true);
+    expect(isMutating(['vm', '--verbose', 'create', '-n', 'x'])).toBe(true);
+  });
+
+  it('fail-safe: blocks a mutating word even when used as a flag value', () => {
+    // Deliberate, safe over-block: distinguishing value-taking flags from boolean
+    // switches without the full az grammar is error-prone, so any non-flag token
+    // equal to a mutating verb is blocked. Reads keyed on names like "delete" are
+    // rare and fail safely; JMESPath --query values never trigger this.
+    expect(isMutating(['group', 'show', '--name', 'delete'])).toBe(true);
   });
 
   it('exposes a non-empty verb set', () => {

--- a/plugins/azure/test/tools/az-exec.test.ts
+++ b/plugins/azure/test/tools/az-exec.test.ts
@@ -72,6 +72,19 @@ describe('isMutating (read-only-by-default guardrail)', () => {
     expect(isMutating(['network', 'nsg', 'rule', 'update', '-n', 'x'])).toBe(true);
   });
 
+  it('cannot be bypassed by placing a global flag before the command', () => {
+    // Global flags (--subscription, --debug, ...) may precede the command group.
+    expect(isMutating(['--subscription', 'my-sub', 'group', 'delete', '--name', 'x'])).toBe(true);
+    expect(isMutating(['--debug', 'group', 'delete'])).toBe(true);
+    expect(isMutating(['--only-show-errors', 'vm', 'create', '-n', 'x'])).toBe(true);
+  });
+
+  it('does not false-positive on a mutating word used as a flag value', () => {
+    // A resource literally named "delete" passed as a flag value is not the verb.
+    expect(isMutating(['group', 'show', '--name', 'delete'])).toBe(false);
+    expect(isMutating(['group', 'show', '-n', 'create'])).toBe(false);
+  });
+
   it('exposes a non-empty verb set', () => {
     expect(MUTATING_VERBS.size).toBeGreaterThan(10);
     expect(MUTATING_VERBS.has('delete')).toBe(true);


### PR DESCRIPTION
## Summary

`az_exec` ("Azure CLI Execute") intermittently rejected **valid** `az` commands whose `--query` used JMESPath `||`, pipes, or backtick literals:

> `Error: unsafe argument "...". Shell metacharacters (;|$\`&&||) are not allowed.`

Root cause: a per-argument character allowlist (`SAFE_ARG_PATTERN`) guarding against shell injection **that cannot occur** — `az` is spawned argv-style via `Bun.spawn(['az', ...args])` with no shell (verified end-to-end through the host runtime). Per [OWASP](https://owasp.org/www-community/attacks/Command_Injection) and [CISA Secure-by-Design](https://www.cisa.gov/resources-tools/resources/secure-design-alert-eliminating-os-command-injection-vulnerabilities), the argv boundary *is* the injection control; the filter was redundant and only broke valid Azure CLI syntax.

## Changes

- **Remove the character filter** from `az_exec` (and the dead `SAFE_ARG_PATTERN` export). Keep only correct argv hygiene — reject control/NUL bytes.
- **Add a deterministic read-only-by-default guardrail** — block mutating verbs (`create`/`delete`/`update`/…) with an actionable message; reads pass through. Makes `cli-operator`'s stated read-only posture enforced in code, replacing theater with real safety.
- **Respect caller-supplied `--output`/`-o`** instead of always forcing `--output json`.
- **Document `--query`/JMESPath** in the tool prompt (previously undocumented) so the agent forms correct queries first-try; remove the self-contradictory metacharacter bullet.
- **Update tests + autoresearch contract/checks** to the argv-no-shell invariant.

## Verification (against real authenticated `az` 2.88.0)

- The **exact reported command** (`network routeserver peering list-learned-routes … --query "… || value[?contains(network,'10.250.0.10')]"`) now returns **live BGP route data** — no "unsafe argument".
- JMESPath `||`, backtick literal, and pipe queries all execute against real resources.
- `-o table` honored (not overridden to JSON).
- Destructive verb (`group delete`) blocked deterministically with an actionable message.
- `bun test` → 133 pass; biome lint clean; all pre-commit hooks pass.

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)
