### PR TITLE
Spec 3: gitlab plugin → CLI-Plugin Capability Contract (re-open of #804)

### DIFF
--- a/.plans/2026-07-23-gitlab-contract-spec3-design.md
+++ b/.plans/2026-07-23-gitlab-contract-spec3-design.md
@@ -1,0 +1,100 @@
+# GitLab Plugin → Capability Contract (Spec 3) — Design
+
+- **Issue:** #803
+- **Status:** design approved (single PR)
+- **Date:** 2026-07-23
+
+## Context
+
+Spec 3 brings the `gitlab` plugin up to the CLI-Plugin Capability Contract
+(`.plans/cli-plugin-contract.md`), mirroring Spec 2's GitHub work. GitLab starts
+further along than GitHub did: it already has error-taxonomy classes
+(`src/glab/exec.ts`), an extracted formatters module (`src/glab/formatters.ts`), a
+`glab api`/GraphQL layer, and the full consistency layer (auth skill, router,
+`cli-operator` agent, wizard, hooks, context injection, service status). So Spec 3 is
+smaller than Spec 2 — mostly wiring and two new tools.
+
+Registration style differs from GitHub: GitLab uses Azure-style factory functions
+`createGlab*Tool(pi)` reading `pi.typebox.Type` (no `setTypebox` shim). New tools slot
+in the same way.
+
+## Gaps to close
+
+1. **Error taxonomy wiring.** Classification is inline in `execGlab()`; there is no
+   standalone `detectGlabError()`. `detectErrorType()` never maps `GlabNotFoundError`
+   → `not_found` (bug), and `errorType` is declared on `GlabToolDetails` but never set.
+   No central wrapper.
+2. **Signal + hygiene.** `src/tools/shared.ts` `makeExecApi` deliberately does NOT
+   thread `AbortSignal` into `Bun.spawn` (a comment documents a prior stale-signal
+   false-cancel), and there is no control-char argv hygiene.
+3. **No `glab_exec` passthrough, no `glab_help` discovery tool.**
+4. **No `--output json` / `glab api` query docs.**
+5. **No benchmark/autoresearch harness; thin per-module tests.**
+6. **Duplicate `GlabToolDetails`** in `src/renderers/glab-renderer.ts` (missing
+   `errorType`).
+
+## Design decisions
+
+- **`detectGlabError(stderr, stdout, code, opts?)`** in `src/glab/exec.ts` returns the
+  right subclass (auth / not-found / rate-limit / exec), with a shared `GlabExecError`
+  base (mirror GitHub's `Gh*Error` shape). Add `GlabRateLimitError`. Keep messages
+  identical to today's inline strings where they exist. Fix `detectErrorType` to map
+  `not_found`, and extend `GlabErrorType` to `auth_required | not_found | rate_limited |
+  exec_error`. Reconcile the duplicate `GlabToolDetails` down to one definition
+  (`shared.ts`) that both the tools and the renderer import.
+- **Central `errorType` mapping** in `index.ts`: because tools are factory objects,
+  wrap each registered tool's `execute` (a small `withErrorType(tool)` helper applied
+  where `pi.registerTool(...)` is called) that catches a thrown `Glab*Error`, re-throws
+  abort, and returns an `errorResult` carrying `details.errorType`. Preserves the
+  existing per-tool `GlabAuthError`→friendly-text behavior where it already exists
+  (apply the wrapper so it does not double-handle auth — the wrapper only adds
+  `errorType` on results that are still thrown past the tool).
+- **Signal + hygiene:** thread `signal` into `Bun.spawn`, but preserve the fix the
+  comment describes — do not pre-check `signal.aborted` in a way that re-introduces the
+  false-cancel; add a test. Add `hasControlChars` rejection in the new `glab_exec` path
+  (and optionally the shared path).
+- **`glab_exec`** (`src/tools/glab-exec.ts` + `src/tools/glab-exec-guard.ts`): read-only
+  allowlist keyed on the leaf verb — `READ_VERBS = {list, view, diff, show, get,
+  status}`, `READ_TOP = {search, version, help}` — plus `glab api` allowed only when its
+  effective method is GET. glab's `api` flags differ from gh: `-F/--field` (typed),
+  `-f/--raw-field` (string), `--input`; default method is POST when any body flag is
+  present. Adapt GitHub's `effectiveApiMethod` to these names. Block everything else
+  (fail-safe). Reuse the argv-no-shell + control-char pattern.
+- **`glab_help`** (`src/tools/glab-help.ts`): `glab <path> --help` via the exec layer,
+  with the same path guard as GitHub (`/^[a-z][a-z -]*$/`, reject parts starting with
+  `-`).
+- **Query docs** (`src/prompts/glab-exec.md`, `glab-help.md`): document `--output json`
+  and `glab api` (GET-only via `glab_exec`), and explicitly note glab uses `--output
+  json` (not GitHub's `--json`/`--jq`) and that `-F`/`-f` semantics are swapped vs
+  GitHub. Add pointers in the existing tool prompts.
+- **Benchmark + autoresearch harness:** `benchmarks/{mock-glab.sh, scenarios.ts,
+  fixtures/*}` + `autoresearch.{sh,checks.sh,md,ideas.md}`, wired to the real
+  `createGlab*Tool` exports and gitlab security invariants (`findMutation`,
+  `hasControlChars`); reference `plugins/gitlab`.
+
+## Task sequencing (single branch)
+
+1. `detectGlabError` + taxonomy fixes (exec.ts, shared.ts) + reconcile duplicate
+   `GlabToolDetails`. 2. Central `errorType` wrapper in index.ts. 3. Signal threading +
+   control-char hygiene. 4. `glab_help`. 5. `glab_exec` + guard + query docs. 6.
+   Benchmark/autoresearch harness. 7. Verify + PR. Tests (TDD) where there is logic
+   (detect, guard, path validation); docs for query prompts.
+
+## Verification
+
+- `cd plugins/gitlab && bun test` green (incl. new `detectGlabError`, guard, help-path,
+  and signal tests, and the reconciled details); `bun run benchmarks/scenarios.ts`
+  prints a composite metric; `npx biome check plugins/gitlab/src/` clean; markdown +
+  textlint (brand capitalization; use the "empty lines" term) clean; pre-commit
+  clean.
+- Manual smoke (if `glab` authed): `glab_help` returns help; `glab_exec` runs a read
+  (`issue list --output json`) and refuses `mr merge` / `api -X POST`; existing tools
+  unchanged.
+- Workflow: issue #803 → branch `feat/gitlab-contract-parity-803` → PR → CI →
+  auto-merge. Never touch `main`.
+
+## Non-goals
+
+- Specs 4–6 (salesforce, aws, gcloud).
+- Adding new typed MR/pipeline tools (only the contract-required passthrough/help/docs
+  and wiring); typed-tool breadth can be a later enhancement.

--- a/.plans/2026-07-23-gitlab-contract-spec3-design.md
+++ b/.plans/2026-07-23-gitlab-contract-spec3-design.md
@@ -69,7 +69,7 @@ in the same way.
   GitHub. Add pointers in the existing tool prompts.
 - **Benchmark + autoresearch harness:** `benchmarks/{mock-glab.sh, scenarios.ts,
   fixtures/*}` + `autoresearch.{sh,checks.sh,md,ideas.md}`, wired to the real
-  `createGlab*Tool` exports and gitlab security invariants (`findMutation`,
+  `createGlab*Tool` exports and GitLab security invariants (`findMutation`,
   `hasControlChars`); reference `plugins/gitlab`.
 
 ## Task sequencing (single branch)

--- a/plugins/gitlab/autoresearch.checks.sh
+++ b/plugins/gitlab/autoresearch.checks.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Post-experiment validation gate for the GitLab plugin autoresearch.
+# All checks must pass for a run to be logged as "keep".
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+ERRORS=0
+
+# ── Check 1: All tests pass ────────────────────────────────────────────────
+echo "=== Check 1: bun test ==="
+if bun test 2>&1 | tail -3; then
+  echo "PASS: all tests passed"
+else
+  echo "FAIL: bun test failed"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Check 2: Biome lint clean ──────────────────────────────────────────────
+echo ""
+echo "=== Check 2: biome check ==="
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BIOME_OUTPUT="$(cd "$REPO_ROOT" && npx biome check plugins/gitlab/src/ 2>&1 || true)"
+BIOME_ERRORS="$(echo "$BIOME_OUTPUT" | grep -c 'error:' || true)"
+if [ "$BIOME_ERRORS" -eq 0 ]; then
+  echo "PASS: biome check clean"
+else
+  echo "FAIL: biome check found $BIOME_ERRORS error(s)"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Check 3: All 6 tool factories in index.ts ──────────────────────────────
+echo ""
+echo "=== Check 3: tool registrations ==="
+TOOL_FACTORIES=(
+  "createGlabSetupTool"
+  "createGlabIssueListTool"
+  "createGlabIssueViewTool"
+  "createGlabSearchTool"
+  "createGlabHelpTool"
+  "createGlabExecTool"
+)
+ALL_TOOLS_OK=true
+for tool in "${TOOL_FACTORIES[@]}"; do
+  if ! grep -q "$tool" src/index.ts; then
+    echo "FAIL: $tool not found in src/index.ts"
+    ERRORS=$((ERRORS + 1))
+    ALL_TOOLS_OK=false
+  fi
+done
+if [ "$ALL_TOOLS_OK" = true ]; then
+  echo "PASS: all 6 tool factories registered"
+fi
+
+# ── Check 4: Security invariants intact ────────────────────────────────────
+echo ""
+echo "=== Check 4: security invariants ==="
+ALL_PATTERNS_OK=true
+# glab_exec guardrail: argv hygiene (control-char reject) + read-only allowlist.
+# The argv boundary is the injection control; do NOT reintroduce per-character
+# shell-metacharacter filtering (it breaks valid glab expressions).
+if ! grep -q "hasControlChars" src/tools/shared.ts; then
+  echo "FAIL: argv hygiene guard (hasControlChars) missing from src/tools/shared.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+if ! grep -q "findMutation" src/tools/glab-exec-guard.ts; then
+  echo "FAIL: read-only guardrail (findMutation) missing from src/tools/glab-exec-guard.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+# Error taxonomy classifier for typed error results.
+if ! grep -q "detectGlabError" src/glab/exec.ts; then
+  echo "FAIL: error classifier (detectGlabError) missing from src/glab/exec.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+if [ "$ALL_PATTERNS_OK" = true ]; then
+  echo "PASS: all security invariants intact"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "CHECKS FAILED: $ERRORS error(s)"
+  exit 1
+fi
+echo "ALL CHECKS PASSED"
+exit 0

--- a/plugins/gitlab/autoresearch.ideas.md
+++ b/plugins/gitlab/autoresearch.ideas.md
@@ -1,0 +1,33 @@
+# Autoresearch Ideas — GitLab Plugin
+
+## Prompt Optimization
+
+- [ ] Compress tool descriptions: keep flag names, parameter types, and one-line summaries; drop prose
+- [ ] Add inline `--output json` field examples to glab_issue_list and glab_search prompts (reduces glab_help round-trips)
+- [ ] Reinforce the glab-vs-gh flag contrast (`--output json`, not `--json`/`--jq`) where the model is most likely to guess wrong
+- [ ] Cross-tool hints: "use glab_help to discover flags before glab_exec"
+- [ ] Clarify when to prefer typed tools over glab_exec so the model does not reach for the passthrough first
+
+## Error Handling
+
+- [ ] Map more glab stderr signatures in src/glab/exec.ts to typed errors (auth, not-found, rate-limit)
+- [ ] Include the fix command in "not authenticated" errors (run: `/gitlab:setup`)
+- [ ] Add structured retry hints to error results (e.g. retry_with: glab_issue_view)
+
+## Formatter Improvements
+
+- [ ] Shorten column labels in the issue summary table without losing meaning
+- [ ] Consistent "no results" messaging across formatIssueTable and formatIssueDetail
+- [ ] Trim redundant empty lines emitted by the detail formatter
+
+## Token Efficiency
+
+- [ ] Audit the per-file prompt byte budget across the 6 prompts; target the largest first
+- [ ] Merge near-duplicate guidance shared by glab_issue_view and glab_issue_list prompts
+- [ ] Remove markdown that adds tokens without improving model parsing (horizontal rules, extra headings)
+
+## Guardrail Coverage
+
+- [ ] Extend benchmark scenarios for glab_exec: graphql-with-body block, `-F` body implies POST block
+- [ ] Add a REST-plus-GraphQL dedup search scenario driven by a populated graphql fixture
+- [ ] Keep the read-only allowlist fail-safe: new read verbs are opt-in, never a blanket allow

--- a/plugins/gitlab/autoresearch.ideas.md
+++ b/plugins/gitlab/autoresearch.ideas.md
@@ -28,6 +28,6 @@
 
 ## Guardrail Coverage
 
-- [ ] Extend benchmark scenarios for glab_exec: graphql-with-body block, `-F` body implies POST block
-- [ ] Add a REST-plus-GraphQL dedup search scenario driven by a populated graphql fixture
+- [ ] Extend benchmark scenarios for glab_exec: GraphQL-with-body block, `-F` body implies POST block
+- [ ] Add a REST-plus-GraphQL dedup search scenario driven by a populated GraphQL fixture
 - [ ] Keep the read-only allowlist fail-safe: new read verbs are opt-in, never a blanket allow

--- a/plugins/gitlab/autoresearch.md
+++ b/plugins/gitlab/autoresearch.md
@@ -1,0 +1,43 @@
+# GitLab Plugin — Autoresearch Contract
+
+Optimize the GitLab plugin's intelligence quality: improve prompt accuracy, reduce tool
+invocation turns, and minimize token cost while maintaining all security invariants.
+
+Composite formula: `accuracy * (1 / (1 + avg_turns / 10)) * (1 / (1 + avg_tokens / 10000))`
+
+## Benchmark
+
+- command: bash autoresearch.sh
+- primary metric: composite_score
+- metric unit:
+- direction: higher
+- secondary metrics: accuracy, avg_turns, avg_tokens, live_accuracy
+
+## Files in Scope
+
+- src/prompts/
+- src/tools/
+- src/glab/formatters.ts
+- src/glab/exec.ts
+
+## Off Limits
+
+- src/index.ts
+- src/tools/shared.ts
+- src/wizard.ts
+- test/
+- benchmarks/
+
+## Constraints
+
+- All existing tests must pass (bun test exit 0)
+- glab_exec guardrail must stay present: `findMutation` (read-only allowlist) and `hasControlChars`
+  (argv hygiene) remain in src/tools/glab-exec-guard.ts and src/tools/shared.ts. glab is spawned
+  argv-only (no shell), so the argv boundary is the injection control — do NOT reintroduce
+  per-character shell-metacharacter filtering, which only breaks valid glab expressions.
+- Error taxonomy must stay intact: `detectGlabError` remains exported from src/glab/exec.ts and keeps
+  classifying stderr into GlabAuthError, GlabRateLimitError, and GlabNotFoundError.
+- All 6 tool names must remain stable: glab_setup, glab_issue_list, glab_issue_view, glab_search,
+  glab_help, glab_exec
+- Tool parameter names and types must not change
+- Biome lint must pass with no new errors

--- a/plugins/gitlab/autoresearch.sh
+++ b/plugins/gitlab/autoresearch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Benchmark harness for the GitLab plugin autoresearch.
+# Outputs METRIC and ASI lines consumed by the xcsh /autoresearch command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== Gate: existing tests ==="
+if ! bun test 2>&1 | tail -3; then
+  echo "ERROR: Tests failed. Aborting benchmark." >&2
+  exit 1
+fi
+echo ""
+
+echo "=== Running benchmark scenarios ==="
+bun run benchmarks/scenarios.ts

--- a/plugins/gitlab/benchmarks/fixtures/issue-list.json
+++ b/plugins/gitlab/benchmarks/fixtures/issue-list.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 101,
+    "iid": 42,
+    "title": "Fix the startup crash",
+    "description": "App crashes on boot.",
+    "state": "opened",
+    "labels": ["bug", "priority::high"],
+    "assignees": [{ "username": "octocat", "name": "Mona Octocat" }],
+    "author": { "username": "hubot", "name": "Hubot" },
+    "milestone": null,
+    "created_at": "2026-06-01T08:00:00Z",
+    "updated_at": "2026-06-02T08:00:00Z",
+    "web_url": "https://gitlab.com/group/repo/-/issues/42",
+    "references": { "full": "group/repo#42" },
+    "issue_type": "issue"
+  }
+]

--- a/plugins/gitlab/benchmarks/fixtures/issue-view.json
+++ b/plugins/gitlab/benchmarks/fixtures/issue-view.json
@@ -1,0 +1,34 @@
+{
+  "id": 202,
+  "iid": 7,
+  "title": "Investigate login timeout",
+  "description": "Users report timeouts on login.",
+  "state": "opened",
+  "labels": ["bug"],
+  "assignees": [{ "username": "octocat", "name": "Mona Octocat" }],
+  "author": { "username": "hubot", "name": "Hubot" },
+  "milestone": { "title": "v1.0", "iid": 1 },
+  "created_at": "2026-06-01T08:00:00Z",
+  "updated_at": "2026-06-02T08:00:00Z",
+  "web_url": "https://gitlab.com/group/repo/-/issues/7",
+  "references": { "full": "group/repo#7" },
+  "issue_type": "issue",
+  "notes": [
+    {
+      "id": 1,
+      "body": "I can reproduce this on staging.",
+      "author": { "username": "alice", "name": "Alice" },
+      "created_at": "2026-06-01T09:00:00Z",
+      "updated_at": "2026-06-01T09:00:00Z",
+      "system": false
+    },
+    {
+      "id": 2,
+      "body": "changed the description",
+      "author": { "username": "system", "name": "system" },
+      "created_at": "2026-06-01T09:05:00Z",
+      "updated_at": "2026-06-01T09:05:00Z",
+      "system": true
+    }
+  ]
+}

--- a/plugins/gitlab/benchmarks/fixtures/search-graphql.json
+++ b/plugins/gitlab/benchmarks/fixtures/search-graphql.json
@@ -1,0 +1,1 @@
+{ "data": { "project": { "issues": { "nodes": [] } } } }

--- a/plugins/gitlab/benchmarks/fixtures/search.json
+++ b/plugins/gitlab/benchmarks/fixtures/search.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 303,
+    "iid": 15,
+    "title": "Login timeout on Safari",
+    "description": "Timeout observed only on Safari.",
+    "state": "opened",
+    "labels": ["bug"],
+    "assignees": [],
+    "author": { "username": "carol", "name": "Carol" },
+    "milestone": null,
+    "created_at": "2026-05-01T00:00:00Z",
+    "updated_at": "2026-05-02T00:00:00Z",
+    "web_url": "https://gitlab.com/group/repo/-/issues/15",
+    "references": { "full": "group/repo#15" },
+    "issue_type": "issue"
+  }
+]

--- a/plugins/gitlab/benchmarks/mock-glab.sh
+++ b/plugins/gitlab/benchmarks/mock-glab.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Mock glab CLI for benchmark scenarios.
+#
+# Priority 1 (mirrors mock-gh.sh contract): emit $MOCK_GLAB_FIXTURE when set.
+# Priority 2: emit $MOCK_GLAB_HELP when set.
+# Priority 3: route by argv to a fixture under $GLAB_BENCH_FIXTURES.
+#
+# Argv routing exists because Bun resolves inherited-spawn binaries and env from
+# the PATH/env captured at process startup and does not observe later
+# process.env mutations. The unmodified tool layer spawns `glab` with inherited
+# env, so it cannot pass MOCK_GLAB_FIXTURE per call; routing on the argv the tool
+# actually sends keeps the mock deterministic.
+if [ -n "$MOCK_GLAB_FIXTURE" ] && [ -f "$MOCK_GLAB_FIXTURE" ]; then
+  cat "$MOCK_GLAB_FIXTURE"
+  exit 0
+fi
+
+if [ -n "$MOCK_GLAB_HELP" ]; then
+  echo "$MOCK_GLAB_HELP"
+  exit 0
+fi
+
+args="$*"
+
+case "$args" in
+*--help*)
+  echo "glab $args"
+  exit 0
+  ;;
+esac
+
+if [ -n "$GLAB_BENCH_FIXTURES" ]; then
+  case "$args" in
+  *graphql*)
+    cat "$GLAB_BENCH_FIXTURES/search-graphql.json"
+    exit 0
+    ;;
+  *"issue view"*)
+    cat "$GLAB_BENCH_FIXTURES/issue-view.json"
+    exit 0
+    ;;
+  *--search*)
+    cat "$GLAB_BENCH_FIXTURES/search.json"
+    exit 0
+    ;;
+  *"issue list"*)
+    cat "$GLAB_BENCH_FIXTURES/issue-list.json"
+    exit 0
+    ;;
+  esac
+fi
+
+echo "mock-glab: no fixture for args: $args" >&2
+exit 1

--- a/plugins/gitlab/benchmarks/scenarios.ts
+++ b/plugins/gitlab/benchmarks/scenarios.ts
@@ -1,0 +1,318 @@
+import { mkdtempSync, readdirSync, readFileSync, statSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PLUGIN_ROOT = join(import.meta.dir, '..');
+const FIXTURES_DIR = join(import.meta.dir, 'fixtures');
+const MOCK_GLAB = join(import.meta.dir, 'mock-glab.sh');
+
+// ---------------------------------------------------------------------------
+// PATH-injected mock bootstrap
+//
+// Bun resolves inherited-spawn binaries from the PATH captured at process
+// startup and does not observe later process.env mutations. The unmodified
+// tool layer (src/tools/shared.ts -> makeExecApi) spawns `glab` with inherited
+// env, so injecting a mock via a runtime process.env.PATH mutation is invisible
+// to it. Instead we re-exec this benchmark once with the mock symlinked onto
+// PATH *before* the child process starts, so the tools resolve `glab` to the
+// mock. The mock routes by argv to fixtures in GLAB_BENCH_FIXTURES; the live
+// spot-check still reaches the real glab via GLAB_BENCH_ORIG_PATH.
+// ---------------------------------------------------------------------------
+
+if (!process.env.GLAB_BENCH_CHILD) {
+  const mockBinDir = mkdtempSync(join(tmpdir(), 'glab-bench-'));
+  symlinkSync(MOCK_GLAB, join(mockBinDir, 'glab'));
+  const origPath = process.env.PATH ?? '';
+  const child = Bun.spawn([process.execPath, import.meta.path], {
+    env: {
+      ...process.env,
+      PATH: `${mockBinDir}:${origPath}`,
+      GLAB_BENCH_CHILD: '1',
+      GLAB_BENCH_ORIG_PATH: origPath,
+      GLAB_BENCH_FIXTURES: FIXTURES_DIR,
+    },
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  process.exit(await child.exited);
+}
+
+const Typebox = await import('@sinclair/typebox');
+const { createGlabExecTool } = await import('../src/tools/glab-exec');
+const { createGlabHelpTool } = await import('../src/tools/glab-help');
+const { createGlabIssueListTool } = await import('../src/tools/glab-issue-list');
+const { createGlabIssueViewTool } = await import('../src/tools/glab-issue-view');
+const { createGlabSearchTool } = await import('../src/tools/glab-search');
+
+// The GitLab tools are factory-style: createGlab*Tool(pi) reads pi.typebox to
+// build its parameter schema. Construct the minimal pi stub the factories need.
+const pi = { typebox: { Type: Typebox.Type } };
+
+const glabIssueList = createGlabIssueListTool(pi);
+const glabIssueView = createGlabIssueViewTool(pi);
+const glabSearch = createGlabSearchTool(pi);
+const glabHelp = createGlabHelpTool(pi);
+const glabExec = createGlabExecTool(pi);
+
+const SESSION = { cwd: '/tmp' };
+const PROJECT = 'group/repo';
+
+// ---------------------------------------------------------------------------
+// Scenario infrastructure
+// ---------------------------------------------------------------------------
+
+interface ScenarioResult {
+  pass: boolean;
+  score: number;
+}
+
+interface Scenario {
+  name: string;
+  run: () => Promise<ScenarioResult>;
+}
+
+function checkResult(
+  result: { content: Array<{ text: string }>; isError?: boolean },
+  expected: { isError?: boolean; contains?: string[]; notContains?: string[] },
+): ScenarioResult {
+  const text = result.content[0]?.text ?? '';
+  const isError = result.isError ?? false;
+
+  if (expected.isError !== undefined && expected.isError !== isError) {
+    return { pass: false, score: 0 };
+  }
+
+  let matched = 0;
+  let total = 0;
+
+  for (const s of expected.contains ?? []) {
+    total++;
+    if (text.includes(s)) matched++;
+  }
+
+  for (const s of expected.notContains ?? []) {
+    total++;
+    if (!text.includes(s)) matched++;
+  }
+
+  if (total === 0) return { pass: !isError || expected.isError === true, score: 1 };
+  const score = matched / total;
+  return { pass: score >= 0.8, score };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario definitions
+// ---------------------------------------------------------------------------
+
+const scenarios: Scenario[] = [
+  {
+    name: 'issue-list',
+    async run() {
+      const result = await glabIssueList.execute('t', { project: PROJECT }, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['42', 'Fix the startup crash', 'opened', 'octocat', 'bug'],
+      });
+    },
+  },
+  {
+    name: 'issue-view',
+    async run() {
+      const result = await glabIssueView.execute(
+        't',
+        { issue: '7', project: PROJECT, comments: true },
+        undefined,
+        undefined,
+        SESSION,
+      );
+      return checkResult(result, {
+        isError: false,
+        contains: ['Issue #7', 'Investigate login timeout', 'opened', '@hubot', 'I can reproduce this'],
+        notContains: ['changed the description'],
+      });
+    },
+  },
+  {
+    name: 'search',
+    async run() {
+      const result = await glabSearch.execute(
+        't',
+        { query: 'login timeout', project: PROJECT },
+        undefined,
+        undefined,
+        SESSION,
+      );
+      return checkResult(result, {
+        isError: false,
+        contains: ['15', 'Login timeout on Safari', 'opened'],
+      });
+    },
+  },
+  {
+    name: 'help-valid',
+    async run() {
+      const result = await glabHelp.execute('t', { command_path: 'issue list' }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: false, contains: ['glab issue list'] });
+    },
+  },
+  {
+    name: 'exec-read-issue-list',
+    async run() {
+      const result = await glabExec.execute(
+        't',
+        { args: ['issue', 'list', '--output', 'json'] },
+        undefined,
+        undefined,
+        SESSION,
+      );
+      return checkResult(result, { isError: false, contains: ['Fix the startup crash', '"iid": 42'] });
+    },
+  },
+  {
+    name: 'exec-control-char-rejected',
+    async run() {
+      const result = await glabExec.execute(
+        't',
+        { args: ['issue', 'view', 'bad\u0000arg'] },
+        undefined,
+        undefined,
+        SESSION,
+      );
+      return checkResult(result, { isError: true, contains: ['control character'] });
+    },
+  },
+  {
+    name: 'exec-mr-merge-blocked',
+    async run() {
+      const result = await glabExec.execute('t', { args: ['mr', 'merge', '5'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: true, contains: ['read-only'] });
+    },
+  },
+  {
+    name: 'exec-api-form-blocked',
+    async run() {
+      const result = await glabExec.execute('t', { args: ['api', '--form', 'x', 'y'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: true, contains: ['read-only', 'POST'] });
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Accuracy scoring
+// ---------------------------------------------------------------------------
+
+async function measureAccuracy(): Promise<number> {
+  let totalScore = 0;
+  for (const scenario of scenarios) {
+    try {
+      const { score } = await scenario.run();
+      totalScore += score;
+    } catch {}
+  }
+  return totalScore / scenarios.length;
+}
+
+// ---------------------------------------------------------------------------
+// Turn efficiency
+// ---------------------------------------------------------------------------
+
+function measureTurnEfficiency(): number {
+  const promptsDir = join(PLUGIN_ROOT, 'src', 'prompts');
+  const promptContent = readdirSync(promptsDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => readFileSync(join(promptsDir, f), 'utf-8'))
+    .join('\n');
+
+  const tasks = [
+    { minTurns: 1, keywords: ['project', 'state', '--output json'] },
+    { minTurns: 1, keywords: ['issue', 'comments', 'glab_exec'] },
+    { minTurns: 1, keywords: ['search', 'labels', 'glab_exec'] },
+    { minTurns: 1, keywords: ['command_path', 'glab_help'] },
+    { minTurns: 1, keywords: ['--output json', 'glab api', 'glab_help'] },
+  ];
+
+  let totalTurns = 0;
+  for (const task of tasks) {
+    let turns = task.minTurns;
+    const missing = task.keywords.filter((kw) => !promptContent.toLowerCase().includes(kw.toLowerCase()));
+    turns += missing.length;
+    totalTurns += turns;
+  }
+  return totalTurns / tasks.length;
+}
+
+// ---------------------------------------------------------------------------
+// Token efficiency
+// ---------------------------------------------------------------------------
+
+function measureTokenEfficiency(): number {
+  const promptsDir = join(PLUGIN_ROOT, 'src', 'prompts');
+  let totalBytes = 0;
+  for (const f of readdirSync(promptsDir).filter((f) => f.endsWith('.md'))) {
+    totalBytes += statSync(join(promptsDir, f)).size;
+  }
+  return totalBytes;
+}
+
+// ---------------------------------------------------------------------------
+// Live CLI spot-check (real glab via the pre-mock PATH)
+// ---------------------------------------------------------------------------
+
+async function measureLiveAccuracy(): Promise<number> {
+  const liveEnv = { ...process.env, PATH: process.env.GLAB_BENCH_ORIG_PATH ?? process.env.PATH };
+  try {
+    const check = Bun.spawnSync(['glab', 'auth', 'status'], { env: liveEnv });
+    if (check.exitCode !== 0) return 0;
+  } catch {
+    return 0;
+  }
+
+  const checks = [
+    {
+      cmd: ['glab', 'repo', 'view', '--output', 'json'],
+      validate: (s: string) => typeof JSON.parse(s).path_with_namespace === 'string',
+    },
+    {
+      cmd: ['glab', 'api', 'user'],
+      validate: (s: string) => typeof JSON.parse(s).username === 'string',
+    },
+  ];
+
+  let passed = 0;
+  for (const c of checks) {
+    try {
+      const proc = Bun.spawn(c.cmd, { stdout: 'pipe', stderr: 'pipe', env: liveEnv });
+      const stdout = await new Response(proc.stdout).text();
+      await proc.exited;
+      if (c.validate(stdout)) passed++;
+    } catch {
+      // skip
+    }
+  }
+  return passed / checks.length;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const accuracy = await measureAccuracy();
+  const avgTurns = measureTurnEfficiency();
+  const avgTokens = measureTokenEfficiency();
+  const liveAccuracy = await measureLiveAccuracy();
+
+  const composite = accuracy * (1 / (1 + avgTurns / 10)) * (1 / (1 + avgTokens / 10000));
+
+  console.log(`METRIC accuracy=${accuracy.toFixed(4)}`);
+  console.log(`METRIC avg_turns=${avgTurns.toFixed(2)}`);
+  console.log(`METRIC avg_tokens=${avgTokens}`);
+  console.log(`METRIC live_accuracy=${liveAccuracy.toFixed(4)}`);
+  console.log(`METRIC composite_score=${composite.toFixed(6)}`);
+  console.log(`ASI hypothesis=${process.env.AUTORESEARCH_HYPOTHESIS ?? 'baseline'}`);
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});

--- a/plugins/gitlab/src/glab/exec.ts
+++ b/plugins/gitlab/src/glab/exec.ts
@@ -10,28 +10,66 @@ export interface GlabExecApi {
   exec(command: string, args: string[], options?: { signal?: AbortSignal; cwd?: string }): Promise<GlabExecResult>;
 }
 
-export class GlabAuthError extends Error {
-  constructor(message: string) {
-    super(`GitLab auth error: ${message}. Run glab_setup with action "login".`);
+export class GlabExecError extends Error {
+  constructor(
+    message: string,
+    public readonly code = 1,
+  ) {
+    super(message);
+    this.name = 'GlabExecError';
+  }
+}
+
+export class GlabAuthError extends GlabExecError {
+  constructor(message: string, code = 1) {
+    super(`GitLab auth error: ${message}. Run glab_setup with action "login".`, code);
     this.name = 'GlabAuthError';
   }
 }
 
-export class GlabNotFoundError extends Error {
-  constructor(message: string) {
-    super(`GitLab resource not found (404/403): ${message}`);
+export class GlabNotFoundError extends GlabExecError {
+  constructor(message: string, code = 1) {
+    super(`GitLab resource not found (404/403): ${message}`, code);
     this.name = 'GlabNotFoundError';
   }
 }
 
-export class GlabExecError extends Error {
-  constructor(
-    message: string,
-    public readonly code: number,
-  ) {
-    super(`glab command failed (exit ${code}): ${message}`);
-    this.name = 'GlabExecError';
+export class GlabRateLimitError extends GlabExecError {
+  constructor(message: string, code = 1) {
+    super(`GitLab API rate limit reached: ${message}`, code);
+    this.name = 'GlabRateLimitError';
   }
+}
+
+/**
+ * Classify a failed glab invocation into the appropriate GlabExecError
+ * subclass by inspecting stderr (falling back to stdout). Precedence:
+ * auth > rate-limit > not-found > generic.
+ */
+export function detectGlabError(
+  stderr: string,
+  stdout: string,
+  code: number,
+  _opts?: { args?: readonly string[] },
+): GlabExecError {
+  const raw = (stderr || stdout).trim();
+  const lower = raw.toLowerCase();
+
+  if (lower.includes('auth') || lower.includes('not logged in') || lower.includes('token')) {
+    return new GlabAuthError(raw, code);
+  }
+  if (lower.includes('429') || lower.includes('rate limit') || lower.includes('secondary rate limit')) {
+    return new GlabRateLimitError(raw, code);
+  }
+  if (
+    lower.includes('404') ||
+    lower.includes('403') ||
+    lower.includes('not found') ||
+    lower.includes('could not resolve')
+  ) {
+    return new GlabNotFoundError(raw, code);
+  }
+  return new GlabExecError(`glab command failed (exit ${code}): ${raw}`, code);
 }
 
 export async function checkInstalled(pi: GlabExecApi): Promise<boolean> {
@@ -50,14 +88,7 @@ export async function execGlab(pi: GlabExecApi, args: string[], signal?: AbortSi
   // cancelled when killed AND no stdout was captured (actual signal kill).
   if (result.killed && !result.stdout && result.code !== 0) throw new Error('Command was cancelled');
   if (result.code !== 0) {
-    const stderr = result.stderr.toLowerCase();
-    if (stderr.includes('auth') || stderr.includes('not logged in') || stderr.includes('token')) {
-      throw new GlabAuthError(result.stderr);
-    }
-    if (stderr.includes('404') || stderr.includes('403') || stderr.includes('not found')) {
-      throw new GlabNotFoundError(result.stderr);
-    }
-    throw new GlabExecError(result.stderr, result.code);
+    throw detectGlabError(result.stderr, result.stdout, result.code, { args });
   }
   return result;
 }

--- a/plugins/gitlab/src/index.ts
+++ b/plugins/gitlab/src/index.ts
@@ -61,12 +61,14 @@ const factory: ExtensionFactory = async (pi) => {
     const { createGlabIssueViewTool } = await import('./tools/glab-issue-view');
     const { createGlabSearchTool } = await import('./tools/glab-search');
     const { createGlabHelpTool } = await import('./tools/glab-help');
+    const { createGlabExecTool } = await import('./tools/glab-exec');
 
     pi.registerTool(withErrorType(createGlabSetupTool(pi)));
     pi.registerTool(withErrorType(createGlabIssueListTool(pi)));
     pi.registerTool(withErrorType(createGlabIssueViewTool(pi)));
     pi.registerTool(withErrorType(createGlabSearchTool(pi)));
     pi.registerTool(withErrorType(createGlabHelpTool(pi)));
+    pi.registerTool(withErrorType(createGlabExecTool(pi)));
   }
 
   // Always register service status (shows unavailable when CLI missing)

--- a/plugins/gitlab/src/index.ts
+++ b/plugins/gitlab/src/index.ts
@@ -1,8 +1,34 @@
 import type { ExtensionFactory } from '@f5-sales-demo/xcsh';
+import { renderError, ToolAbortError } from '@f5-sales-demo/xcsh/tools/tool-errors';
+import { detectErrorType, errorResult } from './tools/shared';
 
 function sanitizeHintField(value: unknown, maxLen = 200): string {
   if (typeof value !== 'string') return '';
   return value.replace(/[^\x20-\x7E]/g, '').slice(0, maxLen);
+}
+
+/**
+ * Wrap a factory tool so any error that still propagates out of its execute()
+ * is converted into a structured error result carrying details.errorType.
+ *
+ * The per-tool handlers already catch GlabAuthError and return a friendly
+ * textResult (a normal, non-error result); those never reach this wrapper.
+ * A ToolAbortError is re-thrown so the agent loop can distinguish user
+ * cancellation from a genuine tool failure.
+ */
+function withErrorType<T extends { execute: (...args: never[]) => Promise<unknown> }>(tool: T): T {
+  const originalExecute = tool.execute.bind(tool) as (...args: unknown[]) => Promise<unknown>;
+  return {
+    ...tool,
+    execute: (async (...args: unknown[]) => {
+      try {
+        return await originalExecute(...args);
+      } catch (err) {
+        if (err instanceof ToolAbortError) throw err;
+        return errorResult(renderError(err), { errorType: detectErrorType(err) });
+      }
+    }) as T['execute'],
+  };
 }
 
 const factory: ExtensionFactory = async (pi) => {
@@ -35,10 +61,10 @@ const factory: ExtensionFactory = async (pi) => {
     const { createGlabIssueViewTool } = await import('./tools/glab-issue-view');
     const { createGlabSearchTool } = await import('./tools/glab-search');
 
-    pi.registerTool(createGlabSetupTool(pi));
-    pi.registerTool(createGlabIssueListTool(pi));
-    pi.registerTool(createGlabIssueViewTool(pi));
-    pi.registerTool(createGlabSearchTool(pi));
+    pi.registerTool(withErrorType(createGlabSetupTool(pi)));
+    pi.registerTool(withErrorType(createGlabIssueListTool(pi)));
+    pi.registerTool(withErrorType(createGlabIssueViewTool(pi)));
+    pi.registerTool(withErrorType(createGlabSearchTool(pi)));
   }
 
   // Always register service status (shows unavailable when CLI missing)

--- a/plugins/gitlab/src/index.ts
+++ b/plugins/gitlab/src/index.ts
@@ -60,11 +60,13 @@ const factory: ExtensionFactory = async (pi) => {
     const { createGlabIssueListTool } = await import('./tools/glab-issue-list');
     const { createGlabIssueViewTool } = await import('./tools/glab-issue-view');
     const { createGlabSearchTool } = await import('./tools/glab-search');
+    const { createGlabHelpTool } = await import('./tools/glab-help');
 
     pi.registerTool(withErrorType(createGlabSetupTool(pi)));
     pi.registerTool(withErrorType(createGlabIssueListTool(pi)));
     pi.registerTool(withErrorType(createGlabIssueViewTool(pi)));
     pi.registerTool(withErrorType(createGlabSearchTool(pi)));
+    pi.registerTool(withErrorType(createGlabHelpTool(pi)));
   }
 
   // Always register service status (shows unavailable when CLI missing)

--- a/plugins/gitlab/src/index.ts
+++ b/plugins/gitlab/src/index.ts
@@ -1,6 +1,5 @@
 import type { ExtensionFactory } from '@f5-sales-demo/xcsh';
-import { renderError, ToolAbortError } from '@f5-sales-demo/xcsh/tools/tool-errors';
-import { detectErrorType, errorResult } from './tools/shared';
+import { detectErrorType, errorResult, renderError } from './tools/shared';
 
 function sanitizeHintField(value: unknown, maxLen = 200): string {
   if (typeof value !== 'string') return '';
@@ -13,10 +12,11 @@ function sanitizeHintField(value: unknown, maxLen = 200): string {
  *
  * The per-tool handlers already catch GlabAuthError and return a friendly
  * textResult (a normal, non-error result); those never reach this wrapper.
- * A ToolAbortError is re-thrown so the agent loop can distinguish user
- * cancellation from a genuine tool failure.
+ * A cancellation (thrown by execGlab as `Error('Command was cancelled')`) is
+ * re-thrown so the agent loop can distinguish user cancellation from a genuine
+ * tool failure.
  */
-function withErrorType<T extends { execute: (...args: never[]) => Promise<unknown> }>(tool: T): T {
+export function withErrorType<T extends { execute: (...args: never[]) => Promise<unknown> }>(tool: T): T {
   const originalExecute = tool.execute.bind(tool) as (...args: unknown[]) => Promise<unknown>;
   return {
     ...tool,
@@ -24,7 +24,7 @@ function withErrorType<T extends { execute: (...args: never[]) => Promise<unknow
       try {
         return await originalExecute(...args);
       } catch (err) {
-        if (err instanceof ToolAbortError) throw err;
+        if (err instanceof Error && err.message === 'Command was cancelled') throw err;
         return errorResult(renderError(err), { errorType: detectErrorType(err) });
       }
     }) as T['execute'],

--- a/plugins/gitlab/src/prompts/glab-exec.md
+++ b/plugins/gitlab/src/prompts/glab-exec.md
@@ -1,0 +1,22 @@
+Run any read-only `glab` (GitLab CLI) command. Pass arguments as an array without the `glab` prefix, e.g. `["issue", "list", "--output", "json"]`.
+
+## Safety
+
+- Arguments are passed argv-style to `glab` with no shell, so shell metacharacters are inert.
+- Read-only by an allowlist (fail-safe: anything unrecognized is blocked). A command is allowed only when its leaf verb is a known read (`list`, `view`, `diff`, `show`, `get`, `status`), plus the top-level `glab search`, `glab version`, and `glab help`.
+- `glab api` is allowed only when it resolves to a GET: no `-X`/`--method` naming a mutating method, and no body flag (`-F`/`--field`, `-f`/`--raw-field`, `--input`), since any of those makes glab send a POST. Use `glab api` through `glab_exec` for GET reads only.
+- Everything else is blocked: write verbs (`create`, `merge`, `close`, `delete`, `update`, ...), `glab api` POST/PUT/PATCH/DELETE requests, and custom aliases. Run writes through an explicitly confirmed path, not `glab_exec`.
+- Prefer the typed tools (`glab_issue_view`, `glab_issue_list`, `glab_search`, ...) when they cover your need — they return structured data.
+
+## Querying with `--output json`
+
+The GitLab CLI shapes output with `--output json` (NOT gh's `--json`/`--jq` — glab has no built-in jq projection). It emits the full JSON payload; pipe or post-process fields yourself:
+
+- Full JSON: `glab issue list --output json`
+- Single resource: `glab mr view 5 --output json`
+
+Note the flag differences from the GitHub CLI: glab uses `--output json` where gh uses `--json <fields>`, and glab's `glab api` body flags are `-F`/`--field` (typed field) and `-f`/`--raw-field` (raw string field) — the opposite letters carry different typing semantics than you might expect, so both trigger a POST and are blocked here.
+
+## Discovering flags
+
+Use `glab_help` (e.g. `glab_help` with `command_path: "issue list"`) to discover a command's available flags and output options, then run the actual query through `glab_exec`.

--- a/plugins/gitlab/src/prompts/glab-exec.md
+++ b/plugins/gitlab/src/prompts/glab-exec.md
@@ -4,7 +4,7 @@ Run any read-only `glab` (GitLab CLI) command. Pass arguments as an array withou
 
 - Arguments are passed argv-style to `glab` with no shell, so shell metacharacters are inert.
 - Read-only by an allowlist (fail-safe: anything unrecognized is blocked). A command is allowed only when its leaf verb is a known read (`list`, `view`, `diff`, `show`, `get`, `status`), plus the top-level `glab search`, `glab version`, and `glab help`.
-- `glab api` is allowed only when it resolves to a GET: no `-X`/`--method` naming a mutating method, and no body flag (`-F`/`--field`, `-f`/`--raw-field`, `--input`), since any of those makes glab send a POST. Use `glab api` through `glab_exec` for GET reads only.
+- `glab api` is allowed only when it resolves to a GET: no `-X`/`--method` naming a mutating method, and no body flag (`-F`/`--field`, `-f`/`--raw-field`, `--input`, `--form`), since any of those makes glab send a POST. Use `glab api` through `glab_exec` for GET reads only.
 - Everything else is blocked: write verbs (`create`, `merge`, `close`, `delete`, `update`, ...), `glab api` POST/PUT/PATCH/DELETE requests, and custom aliases. Run writes through an explicitly confirmed path, not `glab_exec`.
 - Prefer the typed tools (`glab_issue_view`, `glab_issue_list`, `glab_search`, ...) when they cover your need — they return structured data.
 

--- a/plugins/gitlab/src/prompts/glab-help.md
+++ b/plugins/gitlab/src/prompts/glab-help.md
@@ -1,0 +1,7 @@
+Show GitLab CLI help for a command path. Use this before running a query when unsure of a command's subcommands or flags.
+
+<instruction>
+Provide `command_path` (optional): the command path without the `glab` prefix, lowercase words separated by spaces, e.g. `issue`, `issue list`, `mr`, `api`. Omit for top-level help.
+
+Runs `glab <command_path> --help` and returns the help text verbatim. Discover a command's flags and output options here, then run the actual query.
+</instruction>

--- a/plugins/gitlab/src/prompts/glab-issue-list.md
+++ b/plugins/gitlab/src/prompts/glab-issue-list.md
@@ -4,4 +4,6 @@ List GitLab issues with structured filters via glab CLI. Returns a markdown summ
 Use for "show open bugs", "list issues assigned to X", "show high priority issues".
 Supports: state (opened/closed/all), labels, assignee, search text, milestone, sort field, order direction, limit.
 Defaults to the configured project. Pass project explicitly to override.
+
+For ad-hoc reads beyond these filters, use `glab_exec` with `--output json` (glab's JSON flag — NOT gh's `--json`), or `glab api <path>` for GET-only raw API queries.
 </instruction>

--- a/plugins/gitlab/src/prompts/glab-issue-view.md
+++ b/plugins/gitlab/src/prompts/glab-issue-view.md
@@ -4,4 +4,6 @@ View a single GitLab issue with full details, description, and comments via glab
 Use when the user asks to "show issue #N" or "view details of issue X".
 Returns structured markdown with title, state, author, labels, assignee, milestone, description, and comments thread.
 System notes (automated messages) are filtered out.
+
+For other resource types (merge requests, pipelines, ...), use `glab_exec` with `--output json` (glab's JSON flag — NOT gh's `--json`), or `glab api <path>` for GET-only raw API queries.
 </instruction>

--- a/plugins/gitlab/src/prompts/glab-search.md
+++ b/plugins/gitlab/src/prompts/glab-search.md
@@ -4,4 +4,6 @@ Full-text search across GitLab issue titles, descriptions, labels, and comments 
 Use for "find issues about Tempus", "search for login timeout bugs", "bugs mentioning Safari".
 Three-tier search: REST API (fast, titles+descriptions), GraphQL (includes comments), client-side dedup.
 Supports state filtering and label filtering alongside text search.
+
+For structured field queries or other resource types, use `glab_exec` with `--output json` (glab's JSON flag — NOT gh's `--json`), or `glab api <path>` for GET-only raw API queries.
 </instruction>

--- a/plugins/gitlab/src/renderers/glab-renderer.ts
+++ b/plugins/gitlab/src/renderers/glab-renderer.ts
@@ -8,17 +8,10 @@
  * a plain-text fallback for non-TUI contexts.
  */
 
-import type { GlabIssue } from '../glab/types';
+import type { GlabToolDetails } from '../tools/shared';
 
-// Re-export the details type for renderer consumers
-export interface GlabToolDetails {
-  tool?: 'glab_setup' | 'glab_issue_list' | 'glab_issue_view' | 'glab_search';
-  items?: GlabIssue[];
-  issue?: GlabIssue;
-  total?: number;
-  project?: string;
-  query?: string;
-}
+// Re-export the single details type definition for renderer consumers
+export type { GlabToolDetails };
 
 export type GlabRenderArgs = {
   action?: string;

--- a/plugins/gitlab/src/tools/glab-exec-guard.ts
+++ b/plugins/gitlab/src/tools/glab-exec-guard.ts
@@ -17,26 +17,70 @@ const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH
 // Resolve the HTTP method `glab api` will actually use:
 // explicit --method/-X (any form) wins; otherwise glab sends POST when any body
 // flag (-F/--field, -f/--raw-field, --input, --form) is present, else GET.
+//
+// glab is a cobra/pflag CLI, so a boolean short flag may CLUSTER ahead of a
+// value-taking short flag inside a single token: `-iF title=x` parses as
+// `-i` (include, boolean) + `-F` (field, value from the next arg), and `-iX POST`
+// as include + method. Prefix matching on the token misses these, so we inspect
+// the whole single-dash letter run — never just the char at index 1 — for the
+// field (f/F) and method (X) letters. Over-flagging here is fail-safe: at worst
+// it treats a read as a body/method write and blocks it; it never allows a write.
 export function effectiveApiMethod(args: string[]): string {
   let explicit: string | null = null;
+  let hasBody = false;
+
+  const setExplicit = (raw: string): void => {
+    const up = (raw ?? '').toUpperCase();
+    if (up) explicit = up;
+  };
+
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === '-X' || a === '--method') explicit = (args[i + 1] ?? '').toUpperCase() || explicit;
-    else if (a.startsWith('--method=')) explicit = a.slice('--method='.length).toUpperCase() || explicit;
-    else if (a.startsWith('-X') && a.length > 2) explicit = a.slice(2).replace(/^=/, '').toUpperCase() || explicit;
-  }
-  if (explicit) return explicit;
-  const hasBody = args.some(
-    (a) =>
-      a === '-f' ||
-      a === '-F' ||
+
+    // Long-form (double-dash) flags — unchanged detection.
+    if (a === '--method') {
+      setExplicit(args[i + 1] ?? '');
+      continue;
+    }
+    if (a.startsWith('--method=')) {
+      setExplicit(a.slice('--method='.length));
+      continue;
+    }
+    if (
       a === '--field' ||
       a === '--raw-field' ||
       a === '--input' ||
       a === '--form' ||
-      /^--(field|raw-field|input|form)=/.test(a) ||
-      /^-[fF]./.test(a),
-  );
+      /^--(field|raw-field|input|form)=/.test(a)
+    ) {
+      hasBody = true;
+      continue;
+    }
+    if (a.startsWith('--')) continue;
+
+    // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading
+    // '-' and inspect the letter run up to the first '=' (or end) so a boolean
+    // short flag clustered ahead of a value flag can't hide the value flag.
+    if (/^-[A-Za-z]/.test(a)) {
+      const body = a.slice(1);
+      const eq = body.indexOf('=');
+      const letters = eq === -1 ? body : body.slice(0, eq);
+
+      // Field flag anywhere in the cluster → this token carries a body.
+      if (letters.includes('f') || letters.includes('F')) hasBody = true;
+
+      // Method flag anywhere in the cluster → value is whatever follows the X
+      // in the same token (leading '=' stripped), else the next arg.
+      const xIdx = letters.indexOf('X');
+      if (xIdx !== -1) {
+        const after = body.slice(xIdx + 1).replace(/^=/, '');
+        if (after) setExplicit(after);
+        else setExplicit(args[i + 1] ?? '');
+      }
+    }
+  }
+
+  if (explicit) return explicit;
   return hasBody ? 'POST' : 'GET';
 }
 

--- a/plugins/gitlab/src/tools/glab-exec-guard.ts
+++ b/plugins/gitlab/src/tools/glab-exec-guard.ts
@@ -41,7 +41,12 @@ export function effectiveApiMethod(args: string[]): string {
 }
 
 export function findMutation(args: string[]): { blocked: boolean; reason?: string } {
-  const positionals = args.filter((a) => !a.startsWith('-'));
+  // Cobra/pflag consumes the token AFTER a flag token as that flag's value, so a
+  // value-taking flag can shift a command's real verb past positionals[1]. Mirror
+  // cobra by excluding both flag tokens AND the token immediately following one.
+  // This over-excludes tokens after boolean flags (fail-safe: at worst blocks a
+  // read; never allows a mutation) and realigns the verb with what glab dispatches.
+  const positionals = args.filter((a, i) => !a.startsWith('-') && !(i > 0 && args[i - 1].startsWith('-')));
   if (positionals.length === 0) return { blocked: true, reason: 'no glab command provided' };
   const top = positionals[0];
 

--- a/plugins/gitlab/src/tools/glab-exec-guard.ts
+++ b/plugins/gitlab/src/tools/glab-exec-guard.ts
@@ -7,7 +7,7 @@
 
 // Leaf read verbs — the token immediately after the command group in `glab <group> <verb>`.
 // glab uses `view`/`show` (NOT gh's `checks`/`watch`/`download`).
-export const READ_VERBS: ReadonlySet<string> = new Set(['list', 'view', 'diff', 'show', 'get', 'status']);
+export const READ_VERBS: ReadonlySet<string> = new Set(['list', 'view', 'diff', 'show', 'get', 'status', 'trace']);
 
 // Top-level read commands that do not follow the group+verb shape.
 const READ_TOP: ReadonlySet<string> = new Set(['search', 'version', 'help']);
@@ -16,7 +16,7 @@ const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH
 
 // Resolve the HTTP method `glab api` will actually use:
 // explicit --method/-X (any form) wins; otherwise glab sends POST when any body
-// flag (-F/--field, -f/--raw-field, --input) is present, else GET.
+// flag (-F/--field, -f/--raw-field, --input, --form) is present, else GET.
 export function effectiveApiMethod(args: string[]): string {
   let explicit: string | null = null;
   for (let i = 0; i < args.length; i++) {
@@ -33,7 +33,8 @@ export function effectiveApiMethod(args: string[]): string {
       a === '--field' ||
       a === '--raw-field' ||
       a === '--input' ||
-      /^--(field|raw-field|input)=/.test(a) ||
+      a === '--form' ||
+      /^--(field|raw-field|input|form)=/.test(a) ||
       /^-[fF]./.test(a),
   );
   return hasBody ? 'POST' : 'GET';

--- a/plugins/gitlab/src/tools/glab-exec-guard.ts
+++ b/plugins/gitlab/src/tools/glab-exec-guard.ts
@@ -1,0 +1,65 @@
+// Pure guardrail helpers for the glab_exec passthrough tool.
+// Keeps argv hygiene and read-only enforcement free of I/O so they are trivially testable.
+// Fail-safe allowlist design: unknown commands are blocked.
+//
+// `hasControlChars` lives in ./shared (added in Task 3) — imported by the tool,
+// re-exported here is deliberately avoided so there is a single source of truth.
+
+// Leaf read verbs — the token immediately after the command group in `glab <group> <verb>`.
+// glab uses `view`/`show` (NOT gh's `checks`/`watch`/`download`).
+export const READ_VERBS: ReadonlySet<string> = new Set(['list', 'view', 'diff', 'show', 'get', 'status']);
+
+// Top-level read commands that do not follow the group+verb shape.
+const READ_TOP: ReadonlySet<string> = new Set(['search', 'version', 'help']);
+
+const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+// Resolve the HTTP method `glab api` will actually use:
+// explicit --method/-X (any form) wins; otherwise glab sends POST when any body
+// flag (-F/--field, -f/--raw-field, --input) is present, else GET.
+export function effectiveApiMethod(args: string[]): string {
+  let explicit: string | null = null;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '-X' || a === '--method') explicit = (args[i + 1] ?? '').toUpperCase() || explicit;
+    else if (a.startsWith('--method=')) explicit = a.slice('--method='.length).toUpperCase() || explicit;
+    else if (a.startsWith('-X') && a.length > 2) explicit = a.slice(2).replace(/^=/, '').toUpperCase() || explicit;
+  }
+  if (explicit) return explicit;
+  const hasBody = args.some(
+    (a) =>
+      a === '-f' ||
+      a === '-F' ||
+      a === '--field' ||
+      a === '--raw-field' ||
+      a === '--input' ||
+      /^--(field|raw-field|input)=/.test(a) ||
+      /^-[fF]./.test(a),
+  );
+  return hasBody ? 'POST' : 'GET';
+}
+
+export function findMutation(args: string[]): { blocked: boolean; reason?: string } {
+  const positionals = args.filter((a) => !a.startsWith('-'));
+  if (positionals.length === 0) return { blocked: true, reason: 'no glab command provided' };
+  const top = positionals[0];
+
+  if (top === 'api') {
+    const method = effectiveApiMethod(args);
+    if (API_MUTATING_METHODS.has(method)) {
+      return { blocked: true, reason: `glab api resolves to a ${method} request (mutating)` };
+    }
+    return { blocked: false };
+  }
+
+  if (READ_TOP.has(top)) return { blocked: false };
+
+  const verb = positionals[1];
+  if (verb && READ_VERBS.has(verb)) return { blocked: false };
+  return {
+    blocked: true,
+    reason: verb
+      ? `"${top} ${verb}" is not a recognized read-only glab command; run writes through a confirmed path`
+      : `"${top}" is not a recognized read-only glab command; run writes through a confirmed path`,
+  };
+}

--- a/plugins/gitlab/src/tools/glab-exec.ts
+++ b/plugins/gitlab/src/tools/glab-exec.ts
@@ -1,0 +1,49 @@
+import { execGlab } from '../glab/exec';
+import glabExecDescription from '../prompts/glab-exec.md' with { type: 'text' };
+import { findMutation } from './glab-exec-guard';
+import { errorResult, hasControlChars, makeExecApi, textResult } from './shared';
+
+const GLAB_EXEC_MAX_OUTPUT = 50000;
+
+export function createGlabExecTool(pi: any) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    args: Type.Array(Type.String({ description: 'Individual argument (do NOT include "glab")' }), {
+      description: 'glab subcommand and flags as an array, e.g. ["issue", "list", "--output", "json"]',
+    }),
+  });
+
+  return {
+    name: 'glab_exec',
+    label: 'GitLab CLI Execute',
+    description: glabExecDescription,
+    parameters,
+    async execute(_toolCallId: string, params: { args: string[] }, signal: any, _onUpdate: any, ctx: { cwd: string }) {
+      const args = params.args ?? [];
+      if (args.length === 0) {
+        return errorResult('Error: args array must not be empty.', { tool: 'glab_exec' });
+      }
+      for (const a of args) {
+        if (hasControlChars(a)) {
+          return errorResult(`Error: argument contains a control character: "${a}"`, { tool: 'glab_exec' });
+        }
+      }
+      const mutation = findMutation(args);
+      if (mutation.blocked) {
+        return errorResult(
+          `Error: ${mutation.reason}. glab_exec is read-only by default. Run write operations through an explicitly confirmed path, not glab_exec.`,
+          { tool: 'glab_exec' },
+        );
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const result = await execGlab(api, args, signal);
+      let out = result.stdout;
+      if (out.length > GLAB_EXEC_MAX_OUTPUT) {
+        out = `${out.slice(0, GLAB_EXEC_MAX_OUTPUT)}\n\n[Output truncated]`;
+      }
+      return textResult(out, { tool: 'glab_exec' });
+    },
+  };
+}

--- a/plugins/gitlab/src/tools/glab-help.ts
+++ b/plugins/gitlab/src/tools/glab-help.ts
@@ -1,0 +1,57 @@
+import { execGlab, GlabAuthError } from '../glab/exec';
+import glabHelpDescription from '../prompts/glab-help.md' with { type: 'text' };
+import { errorResult, makeExecApi, textResult } from './shared';
+
+// Lowercase letters, spaces, and hyphens only. This blocks shell metacharacters
+// and flag smuggling at the top level; the per-part `-` guard below then rejects
+// any space-split segment that would still reach glab as a flag.
+const HELP_PATH_PATTERN = /^[a-z][a-z -]*$/;
+
+export function createGlabHelpTool(pi: any) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    command_path: Type.Optional(
+      Type.String({
+        description: 'Command path without the "glab" prefix, e.g. "issue list" or "mr". Empty for top-level help.',
+      }),
+    ),
+  });
+
+  return {
+    name: 'glab_help',
+    label: 'GitLab CLI Help',
+    description: glabHelpDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { command_path?: string },
+      signal: any,
+      _onUpdate: any,
+      ctx: { cwd: string },
+    ) {
+      const commandPath = params.command_path?.trim() ?? '';
+      if (commandPath.length > 0 && !HELP_PATH_PATTERN.test(commandPath)) {
+        return errorResult(
+          `Error: invalid command path "${commandPath}". Only lowercase letters, hyphens, and spaces are allowed.`,
+          { tool: 'glab_help' },
+        );
+      }
+
+      const parts = commandPath.length > 0 ? commandPath.split(' ').filter(Boolean) : [];
+      if (parts.some((p) => p.startsWith('-'))) {
+        return errorResult("Error: command path parts must not start with '-'.", { tool: 'glab_help' });
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      try {
+        const result = await execGlab(api, [...parts, '--help'], signal);
+        const output = result.stdout || result.stderr;
+        return textResult(output || `No help output for "glab ${commandPath}".`, { tool: 'glab_help' });
+      } catch (err) {
+        if (err instanceof GlabAuthError) return textResult((err as Error).message);
+        throw err;
+      }
+    },
+  };
+}

--- a/plugins/gitlab/src/tools/shared.ts
+++ b/plugins/gitlab/src/tools/shared.ts
@@ -9,7 +9,7 @@ import type { GlabIssue, GlabProject } from '../glab/types';
 export type GlabErrorType = 'auth_required' | 'not_found' | 'rate_limited' | 'exec_error';
 
 export interface GlabToolDetails {
-  tool?: 'glab_setup' | 'glab_issue_list' | 'glab_issue_view' | 'glab_search' | 'glab_help';
+  tool?: 'glab_setup' | 'glab_issue_list' | 'glab_issue_view' | 'glab_search' | 'glab_help' | 'glab_exec';
   items?: GlabIssue[];
   issue?: GlabIssue;
   projects?: GlabProject[];

--- a/plugins/gitlab/src/tools/shared.ts
+++ b/plugins/gitlab/src/tools/shared.ts
@@ -38,6 +38,10 @@ export function detectErrorType(err: unknown): GlabErrorType {
   return 'exec_error';
 }
 
+export function renderError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 // ---------------------------------------------------------------------------
 // Exec API factory
 // ---------------------------------------------------------------------------

--- a/plugins/gitlab/src/tools/shared.ts
+++ b/plugins/gitlab/src/tools/shared.ts
@@ -9,7 +9,7 @@ import type { GlabIssue, GlabProject } from '../glab/types';
 export type GlabErrorType = 'auth_required' | 'not_found' | 'rate_limited' | 'exec_error';
 
 export interface GlabToolDetails {
-  tool?: 'glab_setup' | 'glab_issue_list' | 'glab_issue_view' | 'glab_search';
+  tool?: 'glab_setup' | 'glab_issue_list' | 'glab_issue_view' | 'glab_search' | 'glab_help';
   items?: GlabIssue[];
   issue?: GlabIssue;
   projects?: GlabProject[];

--- a/plugins/gitlab/src/tools/shared.ts
+++ b/plugins/gitlab/src/tools/shared.ts
@@ -1,12 +1,12 @@
 import type { GlabExecApi } from '../glab/exec';
-import { GlabAuthError } from '../glab/exec';
+import { GlabAuthError, GlabNotFoundError, GlabRateLimitError } from '../glab/exec';
 import type { GlabIssue, GlabProject } from '../glab/types';
 
 // ---------------------------------------------------------------------------
 // Shared types
 // ---------------------------------------------------------------------------
 
-export type GlabErrorType = 'auth_required' | 'not_found' | 'exec_error';
+export type GlabErrorType = 'auth_required' | 'not_found' | 'rate_limited' | 'exec_error';
 
 export interface GlabToolDetails {
   tool?: 'glab_setup' | 'glab_issue_list' | 'glab_issue_view' | 'glab_search';
@@ -33,6 +33,8 @@ export function errorResult(text: string, details?: GlabToolDetails) {
 
 export function detectErrorType(err: unknown): GlabErrorType {
   if (err instanceof GlabAuthError) return 'auth_required';
+  if (err instanceof GlabNotFoundError) return 'not_found';
+  if (err instanceof GlabRateLimitError) return 'rate_limited';
   return 'exec_error';
 }
 

--- a/plugins/gitlab/src/tools/shared.ts
+++ b/plugins/gitlab/src/tools/shared.ts
@@ -48,11 +48,14 @@ export function renderError(err: unknown): string {
 
 // Blocks ASCII C0 control characters and DEL (0x7f), but allows tab (0x09),
 // LF (0x0A), and CR (0x0D) so multi-line `--jq`/field expressions survive intact.
-// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional argv hygiene (allow tab/LF/CR)
-const CONTROL_CHAR_PATTERN = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/;
-
+// Uses a charCode scan (not a regex) so no control-char literal appears in source
+// and no lint suppression is needed.
 export function hasControlChars(arg: string): boolean {
-  return CONTROL_CHAR_PATTERN.test(arg);
+  for (let i = 0; i < arg.length; i++) {
+    const c = arg.charCodeAt(i);
+    if (c <= 8 || c === 11 || c === 12 || (c >= 14 && c <= 31) || c === 127) return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/gitlab/src/tools/shared.ts
+++ b/plugins/gitlab/src/tools/shared.ts
@@ -43,6 +43,19 @@ export function renderError(err: unknown): string {
 }
 
 // ---------------------------------------------------------------------------
+// Argv hygiene (shared with the glab_exec guard — Task 5)
+// ---------------------------------------------------------------------------
+
+// Blocks ASCII C0 control characters and DEL (0x7f), but allows tab (0x09),
+// LF (0x0A), and CR (0x0D) so multi-line `--jq`/field expressions survive intact.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional argv hygiene (allow tab/LF/CR)
+const CONTROL_CHAR_PATTERN = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/;
+
+export function hasControlChars(arg: string): boolean {
+  return CONTROL_CHAR_PATTERN.test(arg);
+}
+
+// ---------------------------------------------------------------------------
 // Exec API factory
 // ---------------------------------------------------------------------------
 
@@ -50,15 +63,26 @@ export function makeExecApi(cwd: string): GlabExecApi {
   return {
     cwd,
     async exec(command: string, args: string[], options?: { signal?: AbortSignal; cwd?: string }) {
-      // Never pass signal to Bun.spawn and never pre-check signal.aborted.
-      // glab commands finish in 1-3s. Passing the signal or pre-checking causes
-      // false cancellations when xcsh's AbortSignal fires between multi-turn
-      // tool calls (the signal is stale from a prior turn).
+      // Thread the AbortSignal so a genuine in-flight cancellation actually
+      // terminates the child: Bun kills the process, leaving empty stdout + a
+      // non-zero exit, which execGlab recognizes as a real cancellation.
+      //
+      // We must NOT reintroduce the stale-signal false-cancel this call site
+      // used to guard against: xcsh can hand us an AbortSignal that already
+      // fired in a PRIOR multi-turn tool call, and a stale abort must never
+      // cancel a fresh command. So we never pre-check signal.aborted to throw a
+      // "cancelled" before running, and we only wire the signal into Bun.spawn
+      // while it is still live at spawn time — handing an already-aborted
+      // (stale) signal to Bun.spawn would kill the fresh process immediately,
+      // resurrecting exactly that false cancel. A signal that aborts *during*
+      // the run is still honored and cancels for real.
+      const signal = options?.signal;
       const child = Bun.spawn([command, ...args], {
         cwd: options?.cwd ?? cwd,
         stdin: 'ignore',
         stdout: 'pipe',
         stderr: 'pipe',
+        ...(signal && !signal.aborted ? { signal } : {}),
       });
       if (!child.stdout || !child.stderr) {
         return { stdout: '', stderr: 'Failed to capture output', code: 1, killed: false };

--- a/plugins/gitlab/test/extension.test.ts
+++ b/plugins/gitlab/test/extension.test.ts
@@ -39,11 +39,18 @@ describe('GitLab extension', () => {
 
     await factory(mockPi);
 
-    // If glab CLI is installed, should register 5 tools; if not, should skip gracefully
+    // If glab CLI is installed, should register 6 tools; if not, should skip gracefully
     if (mockPi._tools.length > 0) {
-      expect(mockPi._tools.length).toBe(5);
+      expect(mockPi._tools.length).toBe(6);
       const names = mockPi._tools.map((t) => t.name).sort();
-      expect(names).toEqual(['glab_help', 'glab_issue_list', 'glab_issue_view', 'glab_search', 'glab_setup']);
+      expect(names).toEqual([
+        'glab_exec',
+        'glab_help',
+        'glab_issue_list',
+        'glab_issue_view',
+        'glab_search',
+        'glab_setup',
+      ]);
     }
   });
 
@@ -115,6 +122,15 @@ describe('Tool factories', () => {
     const tool = createGlabHelpTool(mockPi);
     expect(tool.name).toBe('glab_help');
     expect(tool.label).toBe('GitLab CLI Help');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('createGlabExecTool returns correct name and label', async () => {
+    const { createGlabExecTool } = await import('../src/tools/glab-exec');
+    const tool = createGlabExecTool(mockPi);
+    expect(tool.name).toBe('glab_exec');
+    expect(tool.label).toBe('GitLab CLI Execute');
     expect(typeof tool.description).toBe('string');
     expect(tool.description.length).toBeGreaterThan(20);
   });

--- a/plugins/gitlab/test/extension.test.ts
+++ b/plugins/gitlab/test/extension.test.ts
@@ -39,11 +39,11 @@ describe('GitLab extension', () => {
 
     await factory(mockPi);
 
-    // If glab CLI is installed, should register 4 tools; if not, should skip gracefully
+    // If glab CLI is installed, should register 5 tools; if not, should skip gracefully
     if (mockPi._tools.length > 0) {
-      expect(mockPi._tools.length).toBe(4);
+      expect(mockPi._tools.length).toBe(5);
       const names = mockPi._tools.map((t) => t.name).sort();
-      expect(names).toEqual(['glab_issue_list', 'glab_issue_view', 'glab_search', 'glab_setup']);
+      expect(names).toEqual(['glab_help', 'glab_issue_list', 'glab_issue_view', 'glab_search', 'glab_setup']);
     }
   });
 
@@ -106,6 +106,15 @@ describe('Tool factories', () => {
     const tool = createGlabSearchTool(mockPi);
     expect(tool.name).toBe('glab_search');
     expect(tool.label).toBe('GitLab Search');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('createGlabHelpTool returns correct name and label', async () => {
+    const { createGlabHelpTool } = await import('../src/tools/glab-help');
+    const tool = createGlabHelpTool(mockPi);
+    expect(tool.name).toBe('glab_help');
+    expect(tool.label).toBe('GitLab CLI Help');
     expect(typeof tool.description).toBe('string');
     expect(tool.description.length).toBeGreaterThan(20);
   });

--- a/plugins/gitlab/test/glab/exec.test.ts
+++ b/plugins/gitlab/test/glab/exec.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test';
+import { detectGlabError, GlabAuthError, GlabExecError, GlabNotFoundError, GlabRateLimitError } from '../../src/glab/exec';
+import { detectErrorType } from '../../src/tools/shared';
+
+describe('detectGlabError', () => {
+  it('classifies auth failures', () => {
+    expect(detectGlabError('you must be authenticated: auth failed', '', 1)).toBeInstanceOf(GlabAuthError);
+    expect(detectGlabError('not logged in to gitlab.com', '', 1)).toBeInstanceOf(GlabAuthError);
+    expect(detectGlabError('invalid token provided', '', 1)).toBeInstanceOf(GlabAuthError);
+  });
+  it('classifies not-found failures', () => {
+    expect(detectGlabError('GET https://gitlab.com/... 404 Not Found', '', 1)).toBeInstanceOf(GlabNotFoundError);
+    expect(detectGlabError('the resource was not found', '', 1)).toBeInstanceOf(GlabNotFoundError);
+    expect(detectGlabError('could not resolve project', '', 1)).toBeInstanceOf(GlabNotFoundError);
+  });
+  it('classifies rate-limit failures', () => {
+    expect(detectGlabError('HTTP 429 Too Many Requests', '', 1)).toBeInstanceOf(GlabRateLimitError);
+    expect(detectGlabError('api rate limit exceeded', '', 1)).toBeInstanceOf(GlabRateLimitError);
+    expect(detectGlabError('secondary rate limit hit', '', 1)).toBeInstanceOf(GlabRateLimitError);
+  });
+  it('falls back to base GlabExecError and preserves the message', () => {
+    const e = detectGlabError('some other failure', '', 7);
+    expect(e).toBeInstanceOf(GlabExecError);
+    expect(e).not.toBeInstanceOf(GlabAuthError);
+    expect(e).not.toBeInstanceOf(GlabNotFoundError);
+    expect(e).not.toBeInstanceOf(GlabRateLimitError);
+    expect(e.message).toContain('some other failure');
+    expect(e.code).toBe(7);
+  });
+  it('preserves the decorated auth message text', () => {
+    const e = detectGlabError('token expired', '', 1);
+    expect(e.message).toContain('GitLab auth error');
+    expect(e.message).toContain('glab_setup');
+  });
+  it('preserves the decorated not-found message text', () => {
+    const e = detectGlabError('404 not found', '', 1);
+    expect(e.message).toContain('not found (404/403)');
+  });
+  it('uses stdout when stderr is empty', () => {
+    const e = detectGlabError('', 'could not resolve project', 1);
+    expect(e).toBeInstanceOf(GlabNotFoundError);
+  });
+  it('prefers auth over other classifications when multiple signals present', () => {
+    const e = detectGlabError('invalid token; 404 not found; rate limit', '', 1);
+    expect(e).toBeInstanceOf(GlabAuthError);
+  });
+  it('prefers rate-limit over not-found when both signals present', () => {
+    const e = detectGlabError('HTTP 404 - rate limit exceeded', '', 1);
+    expect(e).toBeInstanceOf(GlabRateLimitError);
+  });
+});
+
+describe('detectErrorType', () => {
+  it('maps each class to its enum', () => {
+    expect(detectErrorType(new GlabAuthError('x'))).toBe('auth_required');
+    expect(detectErrorType(new GlabNotFoundError('x'))).toBe('not_found');
+    expect(detectErrorType(new GlabRateLimitError('x'))).toBe('rate_limited');
+    expect(detectErrorType(new GlabExecError('x'))).toBe('exec_error');
+    expect(detectErrorType(new Error('x'))).toBe('exec_error');
+  });
+});

--- a/plugins/gitlab/test/glab/exec.test.ts
+++ b/plugins/gitlab/test/glab/exec.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test';
-import { detectGlabError, GlabAuthError, GlabExecError, GlabNotFoundError, GlabRateLimitError } from '../../src/glab/exec';
+import {
+  detectGlabError,
+  GlabAuthError,
+  GlabExecError,
+  GlabNotFoundError,
+  GlabRateLimitError,
+} from '../../src/glab/exec';
 import { detectErrorType } from '../../src/tools/shared';
 
 describe('detectGlabError', () => {

--- a/plugins/gitlab/test/index-wrapper.test.ts
+++ b/plugins/gitlab/test/index-wrapper.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { GlabNotFoundError } from '../src/glab/exec';
+import { withErrorType } from '../src/index';
+
+// A minimal fake tool matching the shape withErrorType expects.
+function fakeTool(execute: (...args: never[]) => Promise<unknown>) {
+  return { name: 'fake', execute };
+}
+
+describe('withErrorType wrapper', () => {
+  it('converts a thrown GlabNotFoundError into a structured error result', async () => {
+    const tool = withErrorType(
+      fakeTool(async () => {
+        throw new GlabNotFoundError('missing project');
+      }),
+    );
+
+    const result = (await tool.execute()) as { isError?: boolean; details?: { errorType?: string } };
+    expect(result.isError).toBe(true);
+    expect(result.details?.errorType).toBe('not_found');
+  });
+
+  it('re-throws a cancellation so the agent loop sees it untouched', async () => {
+    const tool = withErrorType(
+      fakeTool(async () => {
+        throw new Error('Command was cancelled');
+      }),
+    );
+
+    await expect(tool.execute()).rejects.toThrow('Command was cancelled');
+  });
+});

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -46,10 +46,13 @@ describe('effectiveApiMethod', () => {
     expect(effectiveApiMethod(['api', 'x', '-fbody=spam'])).toBe('POST');
     expect(effectiveApiMethod(['api', 'x', '--field=k=v'])).toBe('POST');
     expect(effectiveApiMethod(['api', 'x', '--input=body.json'])).toBe('POST');
+    expect(effectiveApiMethod(['api', '--form', 'title=x', 'projects/1/issues'])).toBe('POST');
+    expect(effectiveApiMethod(['api', '--form=title=x', 'x'])).toBe('POST');
   });
 
   it('lets an explicit method win over an inferred body POST', () => {
     expect(effectiveApiMethod(['api', 'x', '--method', 'GET', '-F', 'k=v'])).toBe('GET');
+    expect(effectiveApiMethod(['api', '--method', 'GET', 'x', '--form', 'a=b'])).toBe('GET');
   });
 });
 
@@ -79,12 +82,20 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['api', 'x', '--input', 'f']).blocked).toBe(true);
     expect(findMutation(['api', 'x', '-F', 'k=v']).blocked).toBe(true);
     expect(findMutation(['api', 'x', '-fbody=spam']).blocked).toBe(true);
+    expect(findMutation(['api', '--form', 'title=x', 'projects/1/issues']).blocked).toBe(true);
+    expect(findMutation(['api', '--form=title=x', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', 'projects/1/uploads', '--form', 'file=@-']).blocked).toBe(true);
   });
 
   it('allows glab api GET requests', () => {
     expect(findMutation(['api', '-XGET', 'projects/1']).blocked).toBe(false);
     expect(findMutation(['api', '-X=GET', 'user']).blocked).toBe(false);
     expect(findMutation(['api', 'projects/1']).blocked).toBe(false);
+    expect(findMutation(['api', '--method', 'GET', 'x', '--form', 'a=b']).blocked).toBe(false);
+  });
+
+  it('allows the ci trace streaming read', () => {
+    expect(findMutation(['ci', 'trace', '123']).blocked).toBe(false);
   });
 
   it('does not false-positive on read args that contain a verb word', () => {

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -61,6 +61,23 @@ describe('effectiveApiMethod', () => {
     expect(effectiveApiMethod(['api', 'x', '--method', 'GET', '-F', 'k=v'])).toBe('GET');
     expect(effectiveApiMethod(['api', '--method', 'GET', 'x', '--form', 'a=b'])).toBe('GET');
   });
+
+  it('parses short-flag clusters (boolean flag ahead of a value flag)', () => {
+    // -iF = -i (include) + -F (field, value from next arg) → body → POST.
+    expect(effectiveApiMethod(['api', 'projects/1/issues', '-iF', 'title=x'])).toBe('POST');
+    // -iX = -i + -X (method, value from next arg).
+    expect(effectiveApiMethod(['api', 'x', '-iX', 'POST'])).toBe('POST');
+    // Method value attached inside the same token.
+    expect(effectiveApiMethod(['api', 'x', '-iXPUT'])).toBe('PUT');
+    // `=` cluster form: field letter still detected → POST.
+    expect(effectiveApiMethod(['api', 'x', '-iF=title=y'])).toBe('POST');
+    // Field letter before the boolean.
+    expect(effectiveApiMethod(['api', 'x', '-Fi', 'title=x'])).toBe('POST');
+    // Explicit GET inside a cluster still wins → read.
+    expect(effectiveApiMethod(['api', 'x', '-iX', 'GET'])).toBe('GET');
+    // Include-only boolean cluster → no body, no method → GET.
+    expect(effectiveApiMethod(['api', 'x', '-i'])).toBe('GET');
+  });
 });
 
 describe('findMutation allowlist', () => {
@@ -94,11 +111,21 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['api', 'projects/1/uploads', '--form', 'file=@-']).blocked).toBe(true);
   });
 
+  it('blocks glab api short-flag-cluster mutations (pflag clustering bypass)', () => {
+    expect(findMutation(['api', 'projects/1/issues', '-iF', 'title=x']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-iX', 'POST']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-iXPUT']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-iF=title=y']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-Fi', 'title=x']).blocked).toBe(true);
+  });
+
   it('allows glab api GET requests', () => {
     expect(findMutation(['api', '-XGET', 'projects/1']).blocked).toBe(false);
     expect(findMutation(['api', '-X=GET', 'user']).blocked).toBe(false);
     expect(findMutation(['api', 'projects/1']).blocked).toBe(false);
     expect(findMutation(['api', '--method', 'GET', 'x', '--form', 'a=b']).blocked).toBe(false);
+    expect(findMutation(['api', 'x', '-iX', 'GET']).blocked).toBe(false);
+    expect(findMutation(['api', 'x', '-i']).blocked).toBe(false);
   });
 
   it('allows the ci trace streaming read', () => {

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createGlabExecTool } from '../../src/tools/glab-exec';
+import { effectiveApiMethod, findMutation } from '../../src/tools/glab-exec-guard';
+import { hasControlChars } from '../../src/tools/shared';
+
+const NUL = String.fromCharCode(0);
+const TAB = String.fromCharCode(9);
+
+const mockPi = { typebox: { Type } };
+
+function makeTool() {
+  return createGlabExecTool(mockPi);
+}
+
+describe('hasControlChars', () => {
+  it('rejects NUL/control bytes but allows tab and normal args', () => {
+    expect(hasControlChars(`a${NUL}b`)).toBe(true);
+    expect(hasControlChars(`a${TAB}b`)).toBe(false);
+    expect(hasControlChars("issue list --output json")).toBe(false);
+  });
+});
+
+describe('effectiveApiMethod', () => {
+  it('defaults to GET with no method or body flags', () => {
+    expect(effectiveApiMethod(['api', 'projects/1'])).toBe('GET');
+  });
+
+  it('honors explicit --method / -X in every form (incl attached/equals/lowercase)', () => {
+    expect(effectiveApiMethod(['api', 'x', '--method', 'POST'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '--method=DELETE'])).toBe('DELETE');
+    expect(effectiveApiMethod(['api', 'x', '-X', 'PUT'])).toBe('PUT');
+    expect(effectiveApiMethod(['api', 'x', '-XPATCH'])).toBe('PATCH');
+    expect(effectiveApiMethod(['api', 'x', '-X=POST'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '-X=patch'])).toBe('PATCH');
+    expect(effectiveApiMethod(['api', 'x', '--method', 'get'])).toBe('GET');
+  });
+
+  it('infers POST when a body flag is present (attached, equals, or separate)', () => {
+    expect(effectiveApiMethod(['api', 'x', '-F', 'k=v'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '--field', 'k=v'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '-f', 'k=v'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '--raw-field', 'k=v'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '--input', 'body.json'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '-Fkey=val'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '-fbody=spam'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '--field=k=v'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '--input=body.json'])).toBe('POST');
+  });
+
+  it('lets an explicit method win over an inferred body POST', () => {
+    expect(effectiveApiMethod(['api', 'x', '--method', 'GET', '-F', 'k=v'])).toBe('GET');
+  });
+});
+
+describe('findMutation allowlist', () => {
+  it('allows recognized read-only commands', () => {
+    expect(findMutation(['issue', 'list']).blocked).toBe(false);
+    expect(findMutation(['mr', 'view', '5']).blocked).toBe(false);
+    expect(findMutation(['mr', 'diff', '5']).blocked).toBe(false);
+    expect(findMutation(['ci', 'status']).blocked).toBe(false);
+    expect(findMutation(['api', 'projects/1']).blocked).toBe(false);
+    expect(findMutation(['search', 'issues', 'x']).blocked).toBe(false);
+    expect(findMutation(['version']).blocked).toBe(false);
+  });
+
+  it('blocks writes and unrecognized commands (fail-safe)', () => {
+    expect(findMutation(['mr', 'merge', '5']).blocked).toBe(true);
+    expect(findMutation(['issue', 'create', '--title', 'x']).blocked).toBe(true);
+    expect(findMutation(['repo', 'delete', 'o/r']).blocked).toBe(true);
+    expect(findMutation(['issue', 'close', '5']).blocked).toBe(true);
+    expect(findMutation(['auth', 'login']).blocked).toBe(true);
+  });
+
+  it('blocks glab api mutating requests in every flag form', () => {
+    expect(findMutation(['api', '-XPOST', 'projects/1/issues']).blocked).toBe(true);
+    expect(findMutation(['api', '-X=POST', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', '--method=PUT', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '--input', 'f']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-F', 'k=v']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-fbody=spam']).blocked).toBe(true);
+  });
+
+  it('allows glab api GET requests', () => {
+    expect(findMutation(['api', '-XGET', 'projects/1']).blocked).toBe(false);
+    expect(findMutation(['api', '-X=GET', 'user']).blocked).toBe(false);
+    expect(findMutation(['api', 'projects/1']).blocked).toBe(false);
+  });
+
+  it('does not false-positive on read args that contain a verb word', () => {
+    expect(findMutation(['mr', 'view', 'merge']).blocked).toBe(false);
+  });
+});
+
+describe('glab_exec execute', () => {
+  it('returns correct name and label', () => {
+    const tool = makeTool();
+    expect(tool.name).toBe('glab_exec');
+    expect(tool.label).toBe('GitLab CLI Execute');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('rejects empty args', async () => {
+    const tool = makeTool();
+    const r = await tool.execute('id', { args: [] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+  });
+
+  it('rejects control chars', async () => {
+    const tool = makeTool();
+    const r = await tool.execute('id', { args: [`issue${NUL}list`] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('control character');
+  });
+
+  it('blocks a mutating verb before spawning', async () => {
+    const tool = makeTool();
+    const r = await tool.execute('id', { args: ['mr', 'merge', '5'] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('read-only');
+  });
+
+  it('blocks a mutating glab api request before spawning', async () => {
+    const tool = makeTool();
+    const r = await tool.execute('id', { args: ['api', '-X=POST', 'x'] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('read-only');
+  });
+});

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -6,6 +6,7 @@ import { hasControlChars } from '../../src/tools/shared';
 
 const NUL = String.fromCharCode(0);
 const TAB = String.fromCharCode(9);
+const SOH = String.fromCharCode(1);
 
 const mockPi = { typebox: { Type } };
 
@@ -18,6 +19,12 @@ describe('hasControlChars', () => {
     expect(hasControlChars(`a${NUL}b`)).toBe(true);
     expect(hasControlChars(`a${TAB}b`)).toBe(false);
     expect(hasControlChars('issue list --output json')).toBe(false);
+  });
+
+  it('allows tab, rejects C0 controls, allows normal text (charCode scan)', () => {
+    expect(hasControlChars(`a${TAB}b`)).toBe(false);
+    expect(hasControlChars(`a${SOH}b`)).toBe(true);
+    expect(hasControlChars('normal text here')).toBe(false);
   });
 });
 
@@ -100,6 +107,21 @@ describe('findMutation allowlist', () => {
 
   it('does not false-positive on read args that contain a verb word', () => {
     expect(findMutation(['mr', 'view', 'merge']).blocked).toBe(false);
+  });
+
+  it('blocks the flag-value-shift bypass (cobra consumes the token after a value flag)', () => {
+    // `--title`'s value `list` is consumed by glab; real verb `create` is a mutation.
+    expect(findMutation(['issue', '--title', 'list', 'create']).blocked).toBe(true);
+    // `--reviewer`'s value `view` is consumed; real verb `merge` is a mutation.
+    expect(findMutation(['mr', '--reviewer', 'view', 'merge', '5']).blocked).toBe(true);
+  });
+
+  it('still allows legit reads whose flag values look like verbs', () => {
+    // `create` is the --search term, not the verb; verb is still `list`.
+    expect(findMutation(['issue', 'list', '--search', 'create']).blocked).toBe(false);
+    // Global value-flag before the group; verb is still `list`.
+    expect(findMutation(['-R', 'owner/repo', 'issue', 'list']).blocked).toBe(false);
+    expect(findMutation(['mr', 'view', '5']).blocked).toBe(false);
   });
 });
 

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -17,7 +17,7 @@ describe('hasControlChars', () => {
   it('rejects NUL/control bytes but allows tab and normal args', () => {
     expect(hasControlChars(`a${NUL}b`)).toBe(true);
     expect(hasControlChars(`a${TAB}b`)).toBe(false);
-    expect(hasControlChars("issue list --output json")).toBe(false);
+    expect(hasControlChars('issue list --output json')).toBe(false);
   });
 });
 

--- a/plugins/gitlab/test/tools/glab-help.test.ts
+++ b/plugins/gitlab/test/tools/glab-help.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createGlabHelpTool } from '../../src/tools/glab-help';
+
+const mockPi = { typebox: { Type } };
+
+function makeTool() {
+  return createGlabHelpTool(mockPi);
+}
+
+describe('createGlabHelpTool', () => {
+  it('returns correct name and label', () => {
+    const tool = makeTool();
+    expect(tool.name).toBe('glab_help');
+    expect(tool.label).toBe('GitLab CLI Help');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('rejects an invalid command path before spawning glab', async () => {
+    const tool = makeTool();
+    const result = await tool.execute('t1', { command_path: 'pr;rm -rf' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.toLowerCase()).toContain('invalid command path');
+  });
+
+  it('rejects a dash-prefixed command path part before spawning glab', async () => {
+    const tool = makeTool();
+    // A leading-dash part smuggles a flag past the pattern guard when split on spaces.
+    const result = await tool.execute('t2', { command_path: 'issue --help' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.toLowerCase()).toContain("must not start with '-'");
+  });
+});

--- a/plugins/gitlab/test/tools/shared.test.ts
+++ b/plugins/gitlab/test/tools/shared.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'bun:test';
+import { execGlab, type GlabExecApi } from '../../src/glab/exec';
+import { hasControlChars, makeExecApi } from '../../src/tools/shared';
+
+const NUL = String.fromCharCode(0);
+const TAB = String.fromCharCode(9);
+const LF = String.fromCharCode(10);
+const CR = String.fromCharCode(13);
+const DEL = String.fromCharCode(127);
+
+describe('hasControlChars', () => {
+  it('rejects NUL/control bytes and DEL but allows tab/LF/CR and normal args', () => {
+    expect(hasControlChars(`a${NUL}b`)).toBe(true);
+    expect(hasControlChars(`a${DEL}b`)).toBe(true);
+    expect(hasControlChars(`a${String.fromCharCode(0x1b)}b`)).toBe(true);
+    expect(hasControlChars(`a${TAB}b`)).toBe(false);
+    expect(hasControlChars(`a${LF}b`)).toBe(false);
+    expect(hasControlChars(`a${CR}b`)).toBe(false);
+    expect(hasControlChars("issue list --output json --jq '.[].title'")).toBe(false);
+    expect(hasControlChars('')).toBe(false);
+  });
+});
+
+// A fake exec API lets us assert execGlab's cancellation guard without a real
+// glab binary. `killed` is intentionally true even on success (Bun sets it on
+// every reaped child), so the guard must key off empty stdout + non-zero code.
+describe('execGlab cancellation guard (no false-cancel)', () => {
+  it('returns output for a successful run even though Bun reports killed=true', async () => {
+    const api: GlabExecApi = {
+      cwd: '/tmp',
+      async exec() {
+        return { stdout: 'ok', stderr: '', code: 0, killed: true };
+      },
+    };
+    const r = await execGlab(api, ['issue', 'list']);
+    expect(r.stdout).toBe('ok');
+    expect(r.code).toBe(0);
+  });
+
+  it('treats an actual kill (empty stdout + non-zero code) as cancelled', async () => {
+    const api: GlabExecApi = {
+      cwd: '/tmp',
+      async exec() {
+        return { stdout: '', stderr: '', code: 143, killed: true };
+      },
+    };
+    await expect(execGlab(api, ['issue', 'list'])).rejects.toThrow('cancelled');
+  });
+});
+
+describe('makeExecApi signal threading', () => {
+  it('a non-aborted signal still returns output (guards the false-cancel regression)', async () => {
+    const api = makeExecApi(process.cwd());
+    const controller = new AbortController();
+    const r = await api.exec('sh', ['-c', 'echo hello-live'], { signal: controller.signal });
+    expect(r.stdout).toBe('hello-live');
+    expect(r.code).toBe(0);
+  });
+
+  it('a stale, already-aborted signal does NOT false-cancel a fresh command', async () => {
+    const api = makeExecApi(process.cwd());
+    const controller = new AbortController();
+    controller.abort(); // simulate a signal left aborted by a prior turn
+    const r = await api.exec('sh', ['-c', 'echo still-runs'], { signal: controller.signal });
+    // The documented bug: passing this stale signal to Bun.spawn would kill the
+    // fresh process immediately. Safe threading runs it to completion instead.
+    expect(r.stdout).toBe('still-runs');
+    expect(r.code).toBe(0);
+  });
+
+  // NOTE: real-spawn "abort mid-run" cancellation is verified manually and via
+  // the execGlab guard test above (a killed child -> empty stdout + non-zero
+  // code -> "cancelled"). A live end-to-end sleep+abort test is intentionally
+  // omitted: under `bun test` the runner's child-reaping interacts flakily with
+  // AbortSignal-driven kills (the same code cancels deterministically outside
+  // the test runner). The guard test covers the kill->cancelled contract.
+
+  it('runs without any signal supplied', async () => {
+    const api = makeExecApi(process.cwd());
+    const r = await api.exec('sh', ['-c', 'echo no-signal']);
+    expect(r.stdout).toBe('no-signal');
+    expect(r.code).toBe(0);
+  });
+});

--- a/plugins/gitlab/test/tools/shared.test.ts
+++ b/plugins/gitlab/test/tools/shared.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
 import { execGlab, type GlabExecApi } from '../../src/glab/exec';
 import { hasControlChars, makeExecApi } from '../../src/tools/shared';
 
@@ -80,5 +80,57 @@ describe('makeExecApi signal threading', () => {
     const r = await api.exec('sh', ['-c', 'echo no-signal']);
     expect(r.stdout).toBe('no-signal');
     expect(r.code).toBe(0);
+  });
+});
+
+// Proves the *forwarding* contract deterministically by spying on Bun.spawn:
+// a live signal must reach Bun.spawn, an already-aborted (stale) one must not.
+// No real process, no sleep+abort race — we inspect the options object directly.
+describe('makeExecApi forwards AbortSignal to Bun.spawn only while live', () => {
+  const realSpawn = Bun.spawn;
+
+  // A minimal fake child: empty stdout/stderr streams (truthy, so makeExecApi's
+  // `!child.stdout` guard passes), a resolved `exited`, and killed=false.
+  const emptyStream = () => new ReadableStream<Uint8Array>({ start: (c) => c.close() });
+  const fakeChild = () => ({
+    stdout: emptyStream(),
+    stderr: emptyStream(),
+    exited: Promise.resolve(0),
+    exitCode: 0,
+    killed: false,
+  });
+
+  let recordedOptions: { signal?: AbortSignal } | undefined;
+
+  function installSpawnSpy() {
+    recordedOptions = undefined;
+    Bun.spawn = ((_cmd: string[], options: { signal?: AbortSignal }) => {
+      recordedOptions = options;
+      return fakeChild();
+    }) as unknown as typeof Bun.spawn;
+  }
+
+  afterEach(() => {
+    Bun.spawn = realSpawn;
+  });
+
+  it('hands a live (non-aborted) signal to Bun.spawn', async () => {
+    installSpawnSpy();
+    const controller = new AbortController();
+    await makeExecApi('/tmp').exec('glab', ['issue', 'list'], { signal: controller.signal });
+    expect(recordedOptions).toBeDefined();
+    expect('signal' in (recordedOptions ?? {})).toBe(true);
+    expect(recordedOptions?.signal).toBe(controller.signal);
+  });
+
+  it('withholds an already-aborted (stale) signal from Bun.spawn', async () => {
+    installSpawnSpy();
+    const controller = new AbortController();
+    controller.abort(); // stale abort left over from a prior turn
+    await makeExecApi('/tmp').exec('glab', ['issue', 'list'], { signal: controller.signal });
+    expect(recordedOptions).toBeDefined();
+    // The stale-abort path must build `{}` (no signal), never `{ signal }` —
+    // otherwise Bun would kill the fresh child immediately (false-cancel).
+    expect('signal' in (recordedOptions ?? {})).toBe(false);
   });
 });


### PR DESCRIPTION
Implements **Spec 3** — `gitlab` plugin → CLI-Plugin Capability Contract. (Supersedes #804, which hit a GitHub PR/CI sync stall; identical branch content at the guard-fixed HEAD.)

- Error taxonomy wired (`detectGlabError`, not_found/rate_limited fix, single `GlabToolDetails`, central `withErrorType` wrapper with local `renderError` — no peer-dep runtime import).
- Signal-aware exec (live-only, no false-cancel) + charCode `hasControlChars`.
- `glab_help` (path guard + flag-smuggling reject).
- `glab_exec` read-only passthrough with a fail-safe allowlist guard: leaf-verb allowlist computed with **flag-value exclusion** (closes the cobra flag-value-shift bypass, e.g. `glab issue --title list create`), `glab api` GET-only via `effectiveApiMethod` handling glab `-F/--field`/`-f/--raw-field`/`--input`/`--form` and all `-X/--method` forms.
- `--output json`/`glab api` query docs.
- Benchmark + autoresearch harness (`mock-glab`), real `createGlab*Tool` exports.

Verified: 66 gitlab tests pass; `biome ci plugins/gitlab` exit 0; benchmark composite runs; guard bypass closed with regression tests. Consistency layer + existing tools unchanged.

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)
