### PR TITLE
Spec 4: salesforce plugin → CLI-Plugin Capability Contract

### DIFF
--- a/.plans/2026-07-23-salesforce-contract-spec4-design.md
+++ b/.plans/2026-07-23-salesforce-contract-spec4-design.md
@@ -1,0 +1,100 @@
+# Salesforce Plugin → Capability Contract (Spec 4) — Design
+
+- **Issue:** #805
+- **Status:** design approved (single PR)
+- **Date:** 2026-07-23
+
+## Context
+
+Spec 4 brings the `salesforce` plugin to the CLI-Plugin Capability Contract. It is the
+strongest plugin already: a 6-class error taxonomy (`detectSfError`), per-tool
+`errorType`, a modularized formatters module, an excellent SOQL prompt (`sf-query.md`),
+a profile collector + pipeline subsystems, and 12 test files. So Spec 4 is mostly two
+new tools plus wiring — the lightest of the CLI specs on volume, but the `sf_exec`
+guard is the hardest single piece because the `sf` CLI grammar is unusual.
+
+The **reference guard is now GitLab's** `src/tools/glab-exec-guard.ts` — it embeds two
+fixes the merge-gating review required (a flag-value-shift bypass and a pflag
+short-flag-cluster bypass) that the earlier GitHub/Azure guards predate. Port from
+GitLab, not GitHub.
+
+## Gaps to close
+
+1. No general `sf_exec` passthrough; no `sf_help` discovery tool.
+2. Exec layer does not thread `AbortSignal` into `Bun.spawn` (documented stale-signal
+   avoidance) and has no control-char hygiene.
+3. No central `index.ts` `withErrorType` wrapper (errorType is set per-tool);
+   `sf-pipeline-report.ts` has a duplicate `detectErrorType`.
+4. No benchmark/autoresearch harness.
+
+## Design decisions
+
+### `sf_exec` guard — the hard part (sf grammar)
+
+`sf` (v2) uses **space- and colon-separated** topic→subtopic→command, up to 3 deep, and
+accepts BOTH `sf org list` and `sf org:list`. Design:
+
+- **Normalize** every arg by splitting on `:` (so `org:list` → `org`, `list`) before
+  analysis, so the colon form cannot evade a space-based check.
+- **Port GitLab's guard core**: `hasControlChars` (charCode-based, no regex/suppression),
+  flag-value exclusion when computing positionals (exclude the token after any flag —
+  closes the flag-value-shift bypass), and `effectiveApiMethod` with **single-dash
+  short-flag-cluster parsing** (inspect each char for value-taking shorts — closes the
+  cluster bypass).
+- **Read-PREFIX allowlist** (not a single leaf verb — sf is 3-deep): allow only known
+  read command prefixes on the normalized positionals: `data query`, `data search`,
+  `data export`, `org list`, `org display`, `org list metadata`/`metadata-types`,
+  `apex list`, `apex get`, `apex tail`, `sobject describe`/`list`, `schema` (read subs),
+  `limits api display`, plus top-level `version`/`help`/`commands`/`info`/`which`. Block
+  everything else fail-safe — critically `apex run` (arbitrary Apex execution),
+  `data create/update/delete/import/upsert`, `project deploy/delete`, `org create/delete`,
+  `config set`, `alias set`, package/agent writes.
+- **`sf api request`**: sf has an api passthrough (`sf api request rest|graphql` with
+  `-X`/`--method` default GET, and `--body`/`--file`). Reuse `effectiveApiMethod`
+  (adapt flag names) and additionally BLOCK when `--file`/`--body` is present with a
+  non-GET/implied-write method (a file can carry the method/body the guard cannot see).
+
+### The rest (direct ports of GitLab Spec 3)
+
+- **signal + hygiene**: adopt GitLab's `...(signal && !signal.aborted ? { signal } : {})`
+  wire in `src/tools/shared.ts`; add the charCode `hasControlChars`.
+- **central `withErrorType`** in `index.ts` (mirror GitLab): wrap each `createSf*Tool`
+  registration; local `renderError`; re-throw the cancellation error untouched; delete
+  the duplicate `detectErrorType` in `sf-pipeline-report.ts` (import from `shared.ts`).
+  (Adding a `not_found` class to `SfErrorType` is optional; sf classifies by SF error
+  codes, no not-found bug.)
+- **`sf_help`**: `sf <path> --help`, path guard allowing the colon form
+  (`/^[a-z][a-z :-]*$/`), reject parts starting with `-`.
+- **query docs** (`sf-exec.md`, `sf-help.md`): sf global `--json` + `--result-format`
+  (`csv|json|human`), the read-only allowlist, the colon/space grammar — distinct from
+  GitHub `--json/--jq` and GitLab `--output json`. Leave the excellent `sf-query.md`
+  as-is.
+- **benchmark + autoresearch harness** (`mock-sf`): port GitLab's; real `createSf*Tool`
+  exports; fixtures for org-list/data-query/org-display; guardrail scenarios incl.
+  `apex run` blocked and `data:create` (colon form) blocked.
+
+## Task sequencing (single PR)
+
+1. signal + `hasControlChars` in shared.ts. 2. central `withErrorType` + delete pipeline
+duplicate. 3. `sf_help`. 4. `sf_exec` + `sf-exec-guard.ts` (colon normalize + GitLab
+guard port + read-prefix allowlist + `apex run` + `sf api request`) + query docs. 5.
+benchmark/autoresearch harness. 6. verify + PR. TDD where logic exists (guard is the
+heaviest test surface: colon evasion, `apex run`, cluster/flag-value, api method/file).
+
+## Verification
+
+- `cd plugins/salesforce && bun test` green; `npx biome ci plugins/salesforce` exit 0;
+  `bun run benchmarks/scenarios.ts` composite; `autoresearch.checks.sh` passes; prose
+  brand-capitalized (Salesforce/GitHub/GitLab/Azure), no "empty lines" phrasing issues,
+  doc lines < 400.
+- Manual smoke (if `sf` authed): `sf_help` returns help; `sf_exec` runs `sf org list
+  --json` and refuses `sf apex run`, `sf data:create`, `sf api request rest --method
+  POST`; existing tools unchanged.
+- Workflow: issue #805 → branch `feat/salesforce-contract-parity-805` → PR → CI →
+  auto-merge. Keep the implementation plan file UNTRACKED. Verify with `biome ci`
+  (whole plugin) before pushing. Never touch `main`.
+
+## Non-goals
+
+Specs 5–6 (aws, gcloud). New typed SObject tools. Touching the profile/pipeline/context
+subsystems beyond removing the duplicate `detectErrorType`.

--- a/plugins/salesforce/autoresearch.checks.sh
+++ b/plugins/salesforce/autoresearch.checks.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Post-experiment validation gate for the Salesforce plugin autoresearch.
+# All checks must pass for a run to be logged as "keep".
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+ERRORS=0
+
+# ── Check 1: Tests pass (tolerating one known pre-existing failure) ─────────
+# test/integration/extension-load.test.ts (session_start hook resolves
+# undefined) fails on a clean tree. Allow at most that single failure so a real
+# regression is still caught.
+echo "=== Check 1: bun test ==="
+TEST_OUTPUT="$(bun test 2>&1 || true)"
+echo "$TEST_OUTPUT" | tail -3
+FAIL_COUNT="$(echo "$TEST_OUTPUT" | grep -Eo '[0-9]+ fail' | grep -Eo '[0-9]+' | tail -1)"
+FAIL_COUNT="${FAIL_COUNT:-0}"
+if [ "$FAIL_COUNT" -le 1 ]; then
+  echo "PASS: $FAIL_COUNT failure(s) (<=1 known pre-existing)"
+else
+  echo "FAIL: $FAIL_COUNT test failures (>1 known)"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Check 2: Biome lint clean ──────────────────────────────────────────────
+echo ""
+echo "=== Check 2: biome check ==="
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BIOME_OUTPUT="$(cd "$REPO_ROOT" && npx biome check plugins/salesforce/src/ 2>&1 || true)"
+BIOME_ERRORS="$(echo "$BIOME_OUTPUT" | grep -c 'error:' || true)"
+if [ "$BIOME_ERRORS" -eq 0 ]; then
+  echo "PASS: biome check clean"
+else
+  echo "FAIL: biome check found $BIOME_ERRORS error(s)"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Check 3: All 6 tool factories in index.ts ──────────────────────────────
+echo ""
+echo "=== Check 3: tool registrations ==="
+TOOL_FACTORIES=(
+  "createSfSetupTool"
+  "createSfQueryTool"
+  "createSfOrgDisplayTool"
+  "createSfPipelineReportTool"
+  "createSfHelpTool"
+  "createSfExecTool"
+)
+ALL_TOOLS_OK=true
+for tool in "${TOOL_FACTORIES[@]}"; do
+  if ! grep -q "$tool" src/index.ts; then
+    echo "FAIL: $tool not found in src/index.ts"
+    ERRORS=$((ERRORS + 1))
+    ALL_TOOLS_OK=false
+  fi
+done
+if [ "$ALL_TOOLS_OK" = true ]; then
+  echo "PASS: all 6 tool factories registered"
+fi
+
+# ── Check 4: Security invariants intact ────────────────────────────────────
+echo ""
+echo "=== Check 4: security invariants ==="
+ALL_PATTERNS_OK=true
+# sf_exec guardrail: argv hygiene (control-char reject) + read-only allowlist.
+# The argv boundary is the injection control; do NOT reintroduce per-character
+# shell-metacharacter filtering (it breaks valid SOQL/field expressions).
+if ! grep -q "hasControlChars" src/tools/shared.ts; then
+  echo "FAIL: argv hygiene guard (hasControlChars) missing from src/tools/shared.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+if ! grep -q "findMutation" src/tools/sf-exec-guard.ts; then
+  echo "FAIL: read-only guardrail (findMutation) missing from src/tools/sf-exec-guard.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+# Error taxonomy classifier for typed error results.
+if ! grep -q "detectSfError" src/sf/exec.ts; then
+  echo "FAIL: error classifier (detectSfError) missing from src/sf/exec.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+if [ "$ALL_PATTERNS_OK" = true ]; then
+  echo "PASS: all security invariants intact"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "CHECKS FAILED: $ERRORS error(s)"
+  exit 1
+fi
+echo "ALL CHECKS PASSED"
+exit 0

--- a/plugins/salesforce/autoresearch.ideas.md
+++ b/plugins/salesforce/autoresearch.ideas.md
@@ -1,0 +1,34 @@
+# Autoresearch Ideas — Salesforce Plugin
+
+## Prompt Optimization
+
+- [ ] Compress tool descriptions: keep flag names, parameter types, and one-line summaries; drop prose
+- [ ] Add inline SOQL examples to sf_query so the model composes valid queries without an sf_help round-trip
+- [ ] Reinforce the sf `topic:command` grammar (spaces and colons both split parts) in sf_help and sf_exec
+- [ ] Cross-tool hints: "use sf_help to discover flags before sf_exec"
+- [ ] Clarify when to prefer typed tools (sf_query, sf_org_display) over sf_exec so the model does not reach for the passthrough first
+- [ ] Steer pipeline requests to sf_pipeline_report instead of hand-rolled sf_query calls
+
+## Error Handling
+
+- [ ] Map more sf stderr/JSON signatures in src/sf/exec.ts to typed errors (session expired, no default org, auth)
+- [ ] Include the fix command in "not authenticated" errors (run: `/salesforce:setup`)
+- [ ] Add structured retry hints to error results (e.g. retry_with: sf_org_display)
+
+## Formatter Improvements
+
+- [ ] Shorten column labels in the org and query tables without losing meaning
+- [ ] Consistent "no results" messaging across formatOrgTable and formatQueryResults
+- [ ] Collapse redundant vertical whitespace emitted by formatOrgDetail
+
+## Token Efficiency
+
+- [ ] Audit the per-file prompt byte budget across the 6 prompts; target the largest first
+- [ ] Merge near-duplicate guidance shared by sf_query and sf_pipeline_report prompts
+- [ ] Remove markdown that adds tokens without improving model parsing (horizontal rules, extra headings)
+
+## Guardrail Coverage
+
+- [ ] Extend sf_exec scenarios: `--method POST` block, `-X PATCH` cluster block, colon-form write block
+- [ ] Add a Tooling-API read scenario driven by a populated metadata fixture
+- [ ] Keep the read-only allowlist fail-safe: new read verbs are opt-in, never a blanket allow

--- a/plugins/salesforce/autoresearch.md
+++ b/plugins/salesforce/autoresearch.md
@@ -1,0 +1,52 @@
+# Salesforce Plugin — Autoresearch Contract
+
+Optimize the Salesforce plugin's intelligence quality: improve prompt accuracy, reduce tool
+invocation turns, and minimize token cost while maintaining all security invariants.
+
+Composite formula: `accuracy * (1 / (1 + avg_turns / 10)) * (1 / (1 + avg_tokens / 10000))`
+
+## Benchmark
+
+- command: bash autoresearch.sh
+- primary metric: composite_score
+- metric unit:
+- direction: higher
+- secondary metrics: accuracy, avg_turns, avg_tokens, live_accuracy
+
+## Files in Scope
+
+- src/prompts/
+- src/tools/
+- src/sf/formatters.ts
+- src/sf/exec.ts
+
+## Off Limits
+
+- src/index.ts
+- src/wizard.ts
+- src/context/
+- src/pipeline-report/
+- test/
+- benchmarks/
+
+## Constraints
+
+- All existing tests must pass (bun test). One pre-existing failure is known and tolerated:
+  test/integration/extension-load.test.ts (session_start hook resolves undefined). The checks
+  gate allows at most that single known failure; any additional failure is a hard fail.
+- sf_exec guardrail must stay present: `findMutation` (read-only allowlist) in
+  src/tools/sf-exec-guard.ts and `hasControlChars` (argv hygiene) in src/tools/shared.ts. sf is
+  spawned argv-only (no shell), so the argv boundary is the injection control — do NOT reintroduce
+  per-character shell-metacharacter filtering, which only breaks valid SOQL and field expressions.
+- Error taxonomy must stay intact: `detectSfError` remains exported from src/sf/exec.ts and keeps
+  classifying messages into SfSessionExpiredError, SfNoDefaultOrgError, SfAuthError, and SfQueryError.
+- All 6 tool names must remain stable: sf_setup, sf_query, sf_org_display, sf_pipeline_report,
+  sf_help, sf_exec
+- Tool parameter names and types must not change
+- Biome lint must pass with no new errors (npx biome check plugins/salesforce/src/)
+
+## Notes
+
+- Prompts under src/prompts/ dominate avg_tokens; trim prose before touching structure.
+- Salesforce is a brand name — keep it capitalized in prose.
+- Formatter output should stay compact: collapse redundant vertical whitespace in detail views.

--- a/plugins/salesforce/autoresearch.sh
+++ b/plugins/salesforce/autoresearch.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Benchmark harness for the Salesforce plugin autoresearch.
+# Outputs METRIC and ASI lines consumed by the xcsh /autoresearch command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== Gate: existing tests ==="
+# One pre-existing failure is known and tolerated (extension-load session_start
+# hook). Require the fail count to be at most 1 so a genuine regression aborts.
+TEST_OUTPUT="$(bun test 2>&1 || true)"
+echo "$TEST_OUTPUT" | tail -3
+FAIL_COUNT="$(echo "$TEST_OUTPUT" | grep -Eo '[0-9]+ fail' | grep -Eo '[0-9]+' | tail -1)"
+FAIL_COUNT="${FAIL_COUNT:-0}"
+if [ "$FAIL_COUNT" -gt 1 ]; then
+  echo "ERROR: $FAIL_COUNT test failures (>1 known). Aborting benchmark." >&2
+  exit 1
+fi
+echo ""
+
+echo "=== Running benchmark scenarios ==="
+bun run benchmarks/scenarios.ts

--- a/plugins/salesforce/benchmarks/fixtures/data-query.json
+++ b/plugins/salesforce/benchmarks/fixtures/data-query.json
@@ -1,0 +1,22 @@
+{
+  "status": 0,
+  "result": {
+    "totalSize": 2,
+    "done": true,
+    "records": [
+      {
+        "attributes": { "type": "Opportunity", "url": "/services/data/v60.0/sobjects/Opportunity/0060000000000001" },
+        "Name": "Acme Renewal",
+        "Amount": 50000,
+        "StageName": "Closed Won"
+      },
+      {
+        "attributes": { "type": "Opportunity", "url": "/services/data/v60.0/sobjects/Opportunity/0060000000000002" },
+        "Name": "Globex Expansion",
+        "Amount": 75000,
+        "StageName": "Negotiation"
+      }
+    ]
+  },
+  "warnings": []
+}

--- a/plugins/salesforce/benchmarks/fixtures/org-display.json
+++ b/plugins/salesforce/benchmarks/fixtures/org-display.json
@@ -1,0 +1,12 @@
+{
+  "status": 0,
+  "result": {
+    "username": "demo@f5.com",
+    "id": "00D000000000001EAA",
+    "instanceUrl": "https://f5--demo.my.salesforce.com",
+    "connectedStatus": "Connected",
+    "alias": "SFDC",
+    "isSandbox": false
+  },
+  "warnings": []
+}

--- a/plugins/salesforce/benchmarks/fixtures/org-list.json
+++ b/plugins/salesforce/benchmarks/fixtures/org-list.json
@@ -1,0 +1,21 @@
+{
+  "status": 0,
+  "result": {
+    "nonScratchOrgs": [
+      {
+        "alias": "SFDC",
+        "username": "demo@f5.com",
+        "orgId": "00D000000000001EAA",
+        "instanceUrl": "https://f5--demo.my.salesforce.com",
+        "connectedStatus": "Connected",
+        "isDefaultUsername": true,
+        "isSandbox": false
+      }
+    ],
+    "scratchOrgs": [],
+    "sandboxes": [],
+    "devHubs": [],
+    "other": []
+  },
+  "warnings": []
+}

--- a/plugins/salesforce/benchmarks/mock-sf.sh
+++ b/plugins/salesforce/benchmarks/mock-sf.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Mock sf CLI for benchmark scenarios.
+#
+# Priority 1 (mirrors the mock-glab.sh contract): emit $MOCK_SF_FIXTURE when set.
+# Priority 2: emit $MOCK_SF_HELP when set.
+# Priority 3: route by argv to a fixture under $SF_BENCH_FIXTURES.
+# Otherwise: exit non-zero.
+#
+# Argv routing exists because Bun resolves inherited-spawn binaries and env from
+# the PATH/env captured at process startup and does not observe later
+# process.env mutations. The unmodified tool layer (src/tools/shared.ts ->
+# makeExecApi) spawns `sf` with inherited env, so it cannot pass MOCK_SF_FIXTURE
+# per call; routing on the argv the tool actually sends keeps the mock
+# deterministic across scenarios.
+if [ -n "$MOCK_SF_FIXTURE" ] && [ -f "$MOCK_SF_FIXTURE" ]; then
+  cat "$MOCK_SF_FIXTURE"
+  exit 0
+fi
+
+if [ -n "$MOCK_SF_HELP" ]; then
+  echo "$MOCK_SF_HELP"
+  exit 0
+fi
+
+args="$*"
+
+case "$args" in
+*--help*)
+  echo "sf $args"
+  exit 0
+  ;;
+esac
+
+if [ -n "$SF_BENCH_FIXTURES" ]; then
+  case "$args" in
+  *"data query"*)
+    cat "$SF_BENCH_FIXTURES/data-query.json"
+    exit 0
+    ;;
+  *"org display"*)
+    cat "$SF_BENCH_FIXTURES/org-display.json"
+    exit 0
+    ;;
+  *"org list"*)
+    cat "$SF_BENCH_FIXTURES/org-list.json"
+    exit 0
+    ;;
+  esac
+fi
+
+echo "mock-sf: no fixture for args: $args" >&2
+exit 1

--- a/plugins/salesforce/benchmarks/scenarios.ts
+++ b/plugins/salesforce/benchmarks/scenarios.ts
@@ -1,0 +1,315 @@
+import { mkdtempSync, readdirSync, readFileSync, statSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PLUGIN_ROOT = join(import.meta.dir, '..');
+const FIXTURES_DIR = join(import.meta.dir, 'fixtures');
+const MOCK_SF = join(import.meta.dir, 'mock-sf.sh');
+
+// ---------------------------------------------------------------------------
+// PATH-injected mock bootstrap
+//
+// Bun resolves inherited-spawn binaries from the PATH captured at process
+// startup and does not observe later process.env mutations. The unmodified
+// tool layer (src/tools/shared.ts -> makeExecApi) spawns `sf` with inherited
+// env, so injecting a mock via a runtime process.env.PATH mutation is invisible
+// to it. Instead we re-exec this benchmark once with the mock symlinked onto
+// PATH *before* the child process starts, so the tools resolve `sf` to the
+// mock. The mock routes by argv to fixtures in SF_BENCH_FIXTURES; the live
+// spot-check still reaches the real sf via SF_BENCH_ORIG_PATH.
+// ---------------------------------------------------------------------------
+
+if (!process.env.SF_BENCH_CHILD) {
+  const mockBinDir = mkdtempSync(join(tmpdir(), 'sf-bench-'));
+  symlinkSync(MOCK_SF, join(mockBinDir, 'sf'));
+  const origPath = process.env.PATH ?? '';
+  const child = Bun.spawn([process.execPath, import.meta.path], {
+    env: {
+      ...process.env,
+      PATH: `${mockBinDir}:${origPath}`,
+      SF_BENCH_CHILD: '1',
+      SF_BENCH_ORIG_PATH: origPath,
+      SF_BENCH_FIXTURES: FIXTURES_DIR,
+    },
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  process.exit(await child.exited);
+}
+
+const Typebox = await import('@sinclair/typebox');
+const { createSfSetupTool } = await import('../src/tools/sf-setup');
+const { createSfQueryTool } = await import('../src/tools/sf-query');
+const { createSfOrgDisplayTool } = await import('../src/tools/sf-org-display');
+const { createSfHelpTool } = await import('../src/tools/sf-help');
+const { createSfExecTool } = await import('../src/tools/sf-exec');
+
+// The Salesforce tools are factory-style: createSf*Tool(pi) reads pi.typebox to
+// build its parameter schema. Construct the minimal pi stub the factories need.
+const pi = { typebox: { Type: Typebox.Type } };
+
+const sfSetup = createSfSetupTool(pi);
+const sfQuery = createSfQueryTool(pi);
+const sfOrgDisplay = createSfOrgDisplayTool(pi);
+const sfHelp = createSfHelpTool(pi);
+const sfExec = createSfExecTool(pi);
+
+const SESSION = { cwd: '/tmp' };
+
+// ---------------------------------------------------------------------------
+// Scenario infrastructure
+// ---------------------------------------------------------------------------
+
+interface ScenarioResult {
+  pass: boolean;
+  score: number;
+}
+
+interface Scenario {
+  name: string;
+  run: () => Promise<ScenarioResult>;
+}
+
+function checkResult(
+  result: { content: Array<{ text: string }>; isError?: boolean },
+  expected: { isError?: boolean; contains?: string[]; notContains?: string[] },
+): ScenarioResult {
+  const text = result.content[0]?.text ?? '';
+  const isError = result.isError ?? false;
+
+  if (expected.isError !== undefined && expected.isError !== isError) {
+    return { pass: false, score: 0 };
+  }
+
+  let matched = 0;
+  let total = 0;
+
+  for (const s of expected.contains ?? []) {
+    total++;
+    if (text.includes(s)) matched++;
+  }
+
+  for (const s of expected.notContains ?? []) {
+    total++;
+    if (!text.includes(s)) matched++;
+  }
+
+  if (total === 0) return { pass: !isError || expected.isError === true, score: 1 };
+  const score = matched / total;
+  return { pass: score >= 0.8, score };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario definitions
+// ---------------------------------------------------------------------------
+
+const scenarios: Scenario[] = [
+  {
+    name: 'setup-status',
+    async run() {
+      const result = await sfSetup.execute('t', { action: 'status' }, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['SFDC', 'demo@f5.com', 'Connected'],
+      });
+    },
+  },
+  {
+    name: 'query',
+    async run() {
+      const result = await sfQuery.execute(
+        't',
+        { query: 'SELECT Name, Amount, StageName FROM Opportunity' },
+        undefined,
+        undefined,
+        SESSION,
+      );
+      return checkResult(result, {
+        isError: false,
+        contains: ['2 records returned', 'Acme Renewal', 'Closed Won'],
+      });
+    },
+  },
+  {
+    name: 'org-display',
+    async run() {
+      const result = await sfOrgDisplay.execute('t', {}, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['SFDC', 'demo@f5.com', 'Connected'],
+      });
+    },
+  },
+  {
+    name: 'help-valid',
+    async run() {
+      const result = await sfHelp.execute('t', { command_path: 'org list' }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: false, contains: ['sf org list'] });
+    },
+  },
+  {
+    name: 'exec-read-org-list',
+    async run() {
+      const result = await sfExec.execute('t', { args: ['org', 'list'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: false, contains: ['SFDC', 'demo@f5.com'] });
+    },
+  },
+  {
+    name: 'exec-control-char-rejected',
+    async run() {
+      // String.fromCharCode(0) yields a real NUL control byte at runtime while
+      // keeping the source pure ASCII; hasControlChars must reject it before spawn.
+      const result = await sfExec.execute(
+        't',
+        { args: ['org', 'list', `bad${String.fromCharCode(0)}arg`] },
+        undefined,
+        undefined,
+        SESSION,
+      );
+      return checkResult(result, { isError: true, contains: ['control character'] });
+    },
+  },
+  {
+    name: 'exec-apex-run-blocked',
+    async run() {
+      const result = await sfExec.execute('t', { args: ['apex', 'run'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: true, contains: ['read-only'] });
+    },
+  },
+  {
+    name: 'exec-colon-form-blocked',
+    async run() {
+      const result = await sfExec.execute('t', { args: ['data:create'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: true, contains: ['read-only'] });
+    },
+  },
+  {
+    name: 'exec-api-body-flag-blocked',
+    async run() {
+      const result = await sfExec.execute(
+        't',
+        { args: ['api', 'request', 'rest', '-f', 'x'] },
+        undefined,
+        undefined,
+        SESSION,
+      );
+      return checkResult(result, { isError: true, contains: ['read-only'] });
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Accuracy scoring
+// ---------------------------------------------------------------------------
+
+async function measureAccuracy(): Promise<number> {
+  let totalScore = 0;
+  for (const scenario of scenarios) {
+    try {
+      const { score } = await scenario.run();
+      totalScore += score;
+    } catch {}
+  }
+  return totalScore / scenarios.length;
+}
+
+// ---------------------------------------------------------------------------
+// Turn efficiency
+// ---------------------------------------------------------------------------
+
+function measureTurnEfficiency(): number {
+  const promptsDir = join(PLUGIN_ROOT, 'src', 'prompts');
+  const promptContent = readdirSync(promptsDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => readFileSync(join(promptsDir, f), 'utf-8'))
+    .join('\n');
+
+  const tasks = [
+    { minTurns: 1, keywords: ['status', 'set_default', 'sf_setup'] },
+    { minTurns: 1, keywords: ['description', 'SOQL', 'sf_query'] },
+    { minTurns: 1, keywords: ['org', 'connectivity', 'sf_org_display'] },
+    { minTurns: 1, keywords: ['command_path', 'sf_help'] },
+    { minTurns: 1, keywords: ['--json', 'read-only', 'sf_exec'] },
+  ];
+
+  let totalTurns = 0;
+  for (const task of tasks) {
+    let turns = task.minTurns;
+    const missing = task.keywords.filter((kw) => !promptContent.toLowerCase().includes(kw.toLowerCase()));
+    turns += missing.length;
+    totalTurns += turns;
+  }
+  return totalTurns / tasks.length;
+}
+
+// ---------------------------------------------------------------------------
+// Token efficiency
+// ---------------------------------------------------------------------------
+
+function measureTokenEfficiency(): number {
+  const promptsDir = join(PLUGIN_ROOT, 'src', 'prompts');
+  let totalBytes = 0;
+  for (const f of readdirSync(promptsDir).filter((f) => f.endsWith('.md'))) {
+    totalBytes += statSync(join(promptsDir, f)).size;
+  }
+  return totalBytes;
+}
+
+// ---------------------------------------------------------------------------
+// Live CLI spot-check (real sf via the pre-mock PATH)
+// ---------------------------------------------------------------------------
+
+async function measureLiveAccuracy(): Promise<number> {
+  const liveEnv = { ...process.env, PATH: process.env.SF_BENCH_ORIG_PATH ?? process.env.PATH };
+  try {
+    const check = Bun.spawnSync(['sf', 'org', 'list', '--json'], { env: liveEnv });
+    if (check.exitCode !== 0) return 0;
+  } catch {
+    return 0;
+  }
+
+  const checks = [
+    {
+      cmd: ['sf', 'org', 'list', '--json'],
+      validate: (s: string) => typeof JSON.parse(s).status === 'number',
+    },
+  ];
+
+  let passed = 0;
+  for (const c of checks) {
+    try {
+      const proc = Bun.spawn(c.cmd, { stdout: 'pipe', stderr: 'pipe', env: liveEnv });
+      const stdout = await new Response(proc.stdout).text();
+      await proc.exited;
+      if (c.validate(stdout)) passed++;
+    } catch {
+      // skip
+    }
+  }
+  return passed / checks.length;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const accuracy = await measureAccuracy();
+  const avgTurns = measureTurnEfficiency();
+  const avgTokens = measureTokenEfficiency();
+  const liveAccuracy = await measureLiveAccuracy();
+
+  const composite = accuracy * (1 / (1 + avgTurns / 10)) * (1 / (1 + avgTokens / 10000));
+
+  console.log(`METRIC accuracy=${accuracy.toFixed(4)}`);
+  console.log(`METRIC avg_turns=${avgTurns.toFixed(2)}`);
+  console.log(`METRIC avg_tokens=${avgTokens}`);
+  console.log(`METRIC live_accuracy=${liveAccuracy.toFixed(4)}`);
+  console.log(`METRIC composite_score=${composite.toFixed(6)}`);
+  console.log(`ASI hypothesis=${process.env.AUTORESEARCH_HYPOTHESIS ?? 'baseline'}`);
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -1,4 +1,35 @@
 import type { ExtensionFactory } from '@f5-sales-demo/xcsh';
+import type { SfToolDetails } from './tools/shared';
+import { detectErrorType, errorResult, renderError } from './tools/shared';
+
+/**
+ * Wrap a factory tool so any error that still propagates out of its execute()
+ * is converted into a structured error result carrying details.errorType.
+ *
+ * The per-tool handlers already catch Sf*Error and return their own
+ * errorResult(message, { ...base, errorType }); those never reach this wrapper.
+ * A genuine cancellation (xcsh's ToolAbortError, or the web-standard AbortError
+ * raised when an AbortSignal fires) is re-thrown untouched so the agent loop can
+ * distinguish user cancellation from a real tool failure. Cancellation is matched
+ * by error name (not instanceof) to avoid a runtime dependency on xcsh internals.
+ */
+export function withErrorType<T extends { name?: string; execute: (...args: never[]) => Promise<unknown> }>(
+  tool: T,
+): T {
+  const originalExecute = tool.execute.bind(tool) as (...args: unknown[]) => Promise<unknown>;
+  const toolName = tool.name as SfToolDetails['tool'];
+  return {
+    ...tool,
+    execute: (async (...args: unknown[]) => {
+      try {
+        return await originalExecute(...args);
+      } catch (err) {
+        if (err instanceof Error && (err.name === 'AbortError' || err.name === 'ToolAbortError')) throw err;
+        return errorResult(renderError(err), { tool: toolName, errorType: detectErrorType(err) });
+      }
+    }) as T['execute'],
+  };
+}
 
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('Salesforce');
@@ -91,10 +122,10 @@ const factory: ExtensionFactory = async (pi) => {
     const { createSfOrgDisplayTool } = await import('./tools/sf-org-display');
     const { createSfPipelineReportTool } = await import('./tools/sf-pipeline-report');
 
-    pi.registerTool(createSfSetupTool(pi));
-    pi.registerTool(createSfQueryTool(pi));
-    pi.registerTool(createSfOrgDisplayTool(pi));
-    pi.registerTool(createSfPipelineReportTool(pi));
+    pi.registerTool(withErrorType(createSfSetupTool(pi)));
+    pi.registerTool(withErrorType(createSfQueryTool(pi)));
+    pi.registerTool(withErrorType(createSfOrgDisplayTool(pi)));
+    pi.registerTool(withErrorType(createSfPipelineReportTool(pi)));
 
     // Context injection (only when sf available)
     pi.on('before_agent_start', async () => {

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -121,11 +121,13 @@ const factory: ExtensionFactory = async (pi) => {
     const { createSfQueryTool } = await import('./tools/sf-query');
     const { createSfOrgDisplayTool } = await import('./tools/sf-org-display');
     const { createSfPipelineReportTool } = await import('./tools/sf-pipeline-report');
+    const { createSfHelpTool } = await import('./tools/sf-help');
 
     pi.registerTool(withErrorType(createSfSetupTool(pi)));
     pi.registerTool(withErrorType(createSfQueryTool(pi)));
     pi.registerTool(withErrorType(createSfOrgDisplayTool(pi)));
     pi.registerTool(withErrorType(createSfPipelineReportTool(pi)));
+    pi.registerTool(withErrorType(createSfHelpTool(pi)));
 
     // Context injection (only when sf available)
     pi.on('before_agent_start', async () => {

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -122,12 +122,14 @@ const factory: ExtensionFactory = async (pi) => {
     const { createSfOrgDisplayTool } = await import('./tools/sf-org-display');
     const { createSfPipelineReportTool } = await import('./tools/sf-pipeline-report');
     const { createSfHelpTool } = await import('./tools/sf-help');
+    const { createSfExecTool } = await import('./tools/sf-exec');
 
     pi.registerTool(withErrorType(createSfSetupTool(pi)));
     pi.registerTool(withErrorType(createSfQueryTool(pi)));
     pi.registerTool(withErrorType(createSfOrgDisplayTool(pi)));
     pi.registerTool(withErrorType(createSfPipelineReportTool(pi)));
     pi.registerTool(withErrorType(createSfHelpTool(pi)));
+    pi.registerTool(withErrorType(createSfExecTool(pi)));
 
     // Context injection (only when sf available)
     pi.on('before_agent_start', async () => {

--- a/plugins/salesforce/src/prompts/sf-exec.md
+++ b/plugins/salesforce/src/prompts/sf-exec.md
@@ -1,0 +1,31 @@
+Run any read-only `sf` (Salesforce CLI) command. Pass arguments as an array without the `sf` prefix, e.g. `["org", "list", "--json"]`.
+
+## Safety
+
+- Arguments are passed argv-style to `sf` with no shell, so shell metacharacters are inert. Control characters are rejected.
+- Read-only by an allowlist (fail-safe: anything unrecognized is blocked). A command is allowed only when its normalized command path starts with a known read prefix:
+  - `data query`, `data search`, `data export`, `data resume`
+  - `org list`, `org display`
+  - `apex list`, `apex get`, `apex tail`
+  - `sobject describe`, `sobject list`, `schema sobject list`, `schema sobject describe`
+  - `limits api display`
+  - the single top-level commands `version`, `help`, `commands`, `which`, `info`
+- `sf api request rest|graphql` is allowed only when it resolves to a GET: no `-X`/`--method` naming a mutating method, and no `--body`/`--file` (a body payload can carry a mutating method the guard cannot inspect). Use it for GET reads only.
+- Everything else is blocked: `apex run`, `data create`/`update`/`delete`/`import`/`upsert`, `project deploy`/`delete`, `org create`/`delete`/`login`/`logout`, `config set`, `alias set`, and all package/agent writes. Run writes through an explicitly confirmed path, not `sf_exec`.
+- Prefer the typed tools (`sf_query`, `sf_org_display`, `sf_help`, ...) when they cover your need — they return structured data.
+
+## Command grammar (colon or space)
+
+Salesforce accepts both the `topic command` (space) and `topic:command` (colon) forms — `org list` and `org:list` are the same command. The guard normalizes the colon form to the space form before the allowlist check, so `org:create` is blocked exactly like `org create`. Pass either form as separate array elements (`["org", "list"]`) or as a single colon token (`["org:list"]`).
+
+## Querying with `--json` and `--result-format`
+
+The Salesforce CLI shapes output with the global `--json` flag (full structured JSON payload) or, on commands that support it, `--result-format` (e.g. `csv`, `human`, `json`). This is NOT the GitHub CLI's `--json <fields>`/`--jq` projection, and NOT the GitLab CLI's `--output json` — `sf` has no built-in field selection or jq projection, so it emits the full payload and you post-process fields yourself:
+
+- Full JSON: `sf org list --json`
+- SOQL as JSON: `sf data query --query "SELECT Id FROM Account" --json`
+- CSV export shape: `sf data query --query "SELECT Id FROM Account" --result-format csv`
+
+## Discovering flags
+
+Use `sf_help` (e.g. `command_path: "data query"` or `"org:list"`) to discover a command's available flags and output options, then run the actual query through `sf_exec`.

--- a/plugins/salesforce/src/prompts/sf-exec.md
+++ b/plugins/salesforce/src/prompts/sf-exec.md
@@ -20,7 +20,11 @@ Salesforce accepts both the `topic command` (space) and `topic:command` (colon) 
 
 ## Querying with `--json` and `--result-format`
 
-The Salesforce CLI shapes output with the global `--json` flag (full structured JSON payload) or, on commands that support it, `--result-format` (e.g. `csv`, `human`, `json`). This is NOT the GitHub CLI's `--json <fields>`/`--jq` projection, and NOT the GitLab CLI's `--output json` — `sf` has no built-in field selection or jq projection, so it emits the full payload and you post-process fields yourself:
+The Salesforce CLI shapes output with the global `--json` flag (full structured JSON
+payload) or, on commands that support it, `--result-format` (e.g. `csv`, `human`,
+`json`). This is NOT the GitHub CLI's `--json <fields>`/`--jq` projection, and NOT the
+GitLab CLI's `--output json` — `sf` has no built-in field selection or jq projection,
+so it emits the full payload and you post-process fields yourself:
 
 - Full JSON: `sf org list --json`
 - SOQL as JSON: `sf data query --query "SELECT Id FROM Account" --json`

--- a/plugins/salesforce/src/prompts/sf-help.md
+++ b/plugins/salesforce/src/prompts/sf-help.md
@@ -3,5 +3,5 @@ Show Salesforce CLI help for a command path. Use this before running a command w
 <instruction>
 Provide `command_path` (optional): the command path without the `sf` prefix. Salesforce uses a `topic:command` grammar, so both spaces and colons separate parts, e.g. `org`, `org list`, `org:display`, `data query`. Omit for top-level help.
 
-Runs `sf <command_path> --help` and returns the help text verbatim. Discover a command's flags and output options here, then run the actual command.
+Runs `sf <command_path> --help` and returns the help text verbatim. Discover a command's flags and output options here, then run the actual read-only command through `sf_exec` (which enforces a read-only allowlist and supports the global `--json` flag and `sf api request` GET reads).
 </instruction>

--- a/plugins/salesforce/src/prompts/sf-help.md
+++ b/plugins/salesforce/src/prompts/sf-help.md
@@ -1,0 +1,7 @@
+Show Salesforce CLI help for a command path. Use this before running a command when unsure of a topic's subcommands or flags.
+
+<instruction>
+Provide `command_path` (optional): the command path without the `sf` prefix. Salesforce uses a `topic:command` grammar, so both spaces and colons separate parts, e.g. `org`, `org list`, `org:display`, `data query`. Omit for top-level help.
+
+Runs `sf <command_path> --help` and returns the help text verbatim. Discover a command's flags and output options here, then run the actual command.
+</instruction>

--- a/plugins/salesforce/src/tools/sf-exec-guard.ts
+++ b/plugins/salesforce/src/tools/sf-exec-guard.ts
@@ -105,7 +105,9 @@ export function effectiveApiMethod(args: string[]): string {
 
     // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading '-' and
     // inspect the letter run up to the first '=' so a boolean short flag clustered
-    // ahead of the method short can't hide it.
+    // ahead of the method short can't hide it. sf's body/file shorts are `-b`/`-f`, so
+    // a `b` or `f` anywhere in the cluster (`-f`, `-b`, `-if`, `-Sf`, `-bX`, attached
+    // `-freq.json`) implies a body/write, mirroring the method-letter `X` detection.
     if (/^-[A-Za-z]/.test(a)) {
       const body = a.slice(1);
       const eq = body.indexOf('=');
@@ -117,6 +119,7 @@ export function effectiveApiMethod(args: string[]): string {
         if (after) setExplicit(after);
         else setExplicit(args[i + 1] ?? '');
       }
+      if (letters.includes('b') || letters.includes('f')) hasBody = true;
     }
   }
 
@@ -124,11 +127,21 @@ export function effectiveApiMethod(args: string[]): string {
   return hasBody ? 'POST' : 'GET';
 }
 
-// Does the api request carry a body payload flag (--body/--file, any form)? Such a flag
-// can smuggle a mutating method/body the method check alone cannot see, so its mere
-// presence blocks the request regardless of the resolved method.
+// Does the api request carry a body payload flag? Such a flag can smuggle a mutating
+// method/body the method check alone cannot see, so its mere presence blocks the request
+// regardless of the resolved method. sf exposes both long forms (--body/--file, any form)
+// and single-dash shorts (`-b`/`-f`), and shorts may cluster or attach a value
+// (`-if`, `-freq.json`, `-b{}`), so any single-dash token whose letter run includes
+// `b` or `f` counts too.
 function hasApiBodyFlag(args: string[]): boolean {
-  return args.some((a) => a === '--body' || a === '--file' || a.startsWith('--body=') || a.startsWith('--file='));
+  return args.some((a) => {
+    if (a === '--body' || a === '--file' || a.startsWith('--body=') || a.startsWith('--file=')) return true;
+    if (a.startsWith('--') || !/^-[A-Za-z]/.test(a)) return false;
+    const body = a.slice(1);
+    const eq = body.indexOf('=');
+    const letters = eq === -1 ? body : body.slice(0, eq);
+    return letters.includes('b') || letters.includes('f');
+  });
 }
 
 export function findMutation(args: string[]): { blocked: boolean; reason?: string } {

--- a/plugins/salesforce/src/tools/sf-exec-guard.ts
+++ b/plugins/salesforce/src/tools/sf-exec-guard.ts
@@ -1,0 +1,165 @@
+// Pure guardrail helpers for the sf_exec passthrough tool.
+// Keeps argv hygiene and read-only enforcement free of I/O so they stay trivially
+// testable. Fail-safe allowlist design: unknown commands are BLOCKED.
+//
+// Ported from the adversarially-hardened gitlab glab_exec guard and adapted for the
+// Salesforce CLI's `topic:command:subcommand` grammar. Two protections are carried
+// over intact:
+//   1. FLAG-VALUE EXCLUSION — the token immediately after any flag token is treated
+//      as that flag's value and excluded from the command path. This closes the
+//      flag-value-shift bypass where a value-taking flag pushes the real verb past
+//      positionals[1] (e.g. `org -s list create` where `create` is the true verb).
+//   2. SINGLE-DASH SHORT-FLAG-CLUSTER parsing in effectiveApiMethod — every letter in
+//      a `-iX` run is inspected, never just the char at index 1, so a boolean short
+//      (`-i`) clustered ahead of the method short (`-X`) cannot hide it.
+//
+// sf-specific hardening: normalizeArgs splits each POSITIONAL token on ':' so the
+// colon form (`org:list`, `data:create`) decomposes to the same path as the space
+// form and cannot evade a space-based allowlist check. Flag tokens keep their form.
+//
+// `hasControlChars` lives in ./shared (Task 1) and is imported by the tool, not here,
+// so there is a single source of truth for argv hygiene.
+
+const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+// Read-only command PREFIXES on the normalized positional path. sf commands are up to
+// three tokens deep, so a path is allowed when it STARTS WITH one of these prefixes.
+// Anything not matched here (or the api-request / single-top rules below) is blocked.
+const READ_PREFIXES: ReadonlyArray<readonly string[]> = [
+  ['data', 'query'],
+  ['data', 'search'],
+  ['data', 'export'],
+  ['data', 'resume'],
+  ['org', 'list'],
+  ['org', 'display'],
+  ['apex', 'list'],
+  ['apex', 'get'],
+  ['apex', 'tail'],
+  ['sobject', 'describe'],
+  ['sobject', 'list'],
+  ['schema', 'sobject', 'list'],
+  ['schema', 'sobject', 'describe'],
+  ['limits', 'api', 'display'],
+];
+
+// Single-token top-level read commands (meta topics with no write subcommands).
+const READ_TOP: ReadonlySet<string> = new Set(['version', 'help', 'commands', 'which', 'info']);
+
+// Compute the command path used for allowlisting: non-flag tokens, EXCLUDING the token
+// immediately after any flag (its value), with each surviving positional split on ':'
+// so the colon grammar is normalized to the space grammar. Flag tokens keep their form
+// and never contribute path parts. Excluding the post-flag token first means a flag
+// value that itself contains a ':' can never leak a path segment.
+export function normalizeArgs(args: string[]): string[] {
+  const positionals = args.filter((a, i) => !a.startsWith('-') && !(i > 0 && args[i - 1].startsWith('-')));
+  const path: string[] = [];
+  for (const token of positionals) {
+    for (const part of token.split(':')) {
+      if (part.length > 0) path.push(part);
+    }
+  }
+  return path;
+}
+
+function startsWith(path: string[], prefix: readonly string[]): boolean {
+  if (path.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (path[i] !== prefix[i]) return false;
+  }
+  return true;
+}
+
+// Resolve the HTTP method `sf api request rest|graphql` will actually use. An explicit
+// --method/-X (any form) wins; sf otherwise defaults to GET. sf is an oclif CLI, so a
+// boolean short flag may CLUSTER ahead of the method short inside one token: `-iX POST`
+// parses as `-i` (include) + `-X` (method, value from the next arg). We inspect the
+// whole single-dash letter run — never just index 1 — for the method letter X.
+// --body/--file are body flags; their presence forces a mutating shape (reported as
+// POST here, and additionally blocked outright by findMutation). Over-flagging is
+// fail-safe: at worst it treats a read as a write and blocks it; it never allows a write.
+export function effectiveApiMethod(args: string[]): string {
+  let explicit: string | null = null;
+  let hasBody = false;
+
+  const setExplicit = (raw: string): void => {
+    const up = (raw ?? '').toUpperCase();
+    if (up) explicit = up;
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+
+    if (a === '--method') {
+      setExplicit(args[i + 1] ?? '');
+      continue;
+    }
+    if (a.startsWith('--method=')) {
+      setExplicit(a.slice('--method='.length));
+      continue;
+    }
+    if (a === '--body' || a === '--file' || /^--(body|file)=/.test(a)) {
+      hasBody = true;
+      continue;
+    }
+    if (a.startsWith('--')) continue;
+
+    // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading '-' and
+    // inspect the letter run up to the first '=' so a boolean short flag clustered
+    // ahead of the method short can't hide it.
+    if (/^-[A-Za-z]/.test(a)) {
+      const body = a.slice(1);
+      const eq = body.indexOf('=');
+      const letters = eq === -1 ? body : body.slice(0, eq);
+
+      const xIdx = letters.indexOf('X');
+      if (xIdx !== -1) {
+        const after = body.slice(xIdx + 1).replace(/^=/, '');
+        if (after) setExplicit(after);
+        else setExplicit(args[i + 1] ?? '');
+      }
+    }
+  }
+
+  if (explicit) return explicit;
+  return hasBody ? 'POST' : 'GET';
+}
+
+// Does the api request carry a body payload flag (--body/--file, any form)? Such a flag
+// can smuggle a mutating method/body the method check alone cannot see, so its mere
+// presence blocks the request regardless of the resolved method.
+function hasApiBodyFlag(args: string[]): boolean {
+  return args.some((a) => a === '--body' || a === '--file' || a.startsWith('--body=') || a.startsWith('--file='));
+}
+
+export function findMutation(args: string[]): { blocked: boolean; reason?: string } {
+  const path = normalizeArgs(args);
+  if (path.length === 0) return { blocked: true, reason: 'no sf command provided' };
+
+  // `sf api request rest|graphql` passthrough: allow only a GET with no body payload.
+  if (startsWith(path, ['api', 'request'])) {
+    if (hasApiBodyFlag(args)) {
+      return {
+        blocked: true,
+        reason: 'sf api request with --body/--file can carry a mutating payload; only bodyless GET reads are allowed',
+      };
+    }
+    const method = effectiveApiMethod(args);
+    if (API_MUTATING_METHODS.has(method)) {
+      return { blocked: true, reason: `sf api request resolves to a ${method} request (mutating)` };
+    }
+    if (method !== 'GET') {
+      return { blocked: true, reason: `sf api request resolves to a non-GET (${method}) request` };
+    }
+    return { blocked: false };
+  }
+
+  for (const prefix of READ_PREFIXES) {
+    if (startsWith(path, prefix)) return { blocked: false };
+  }
+  if (READ_TOP.has(path[0])) return { blocked: false };
+
+  return {
+    blocked: true,
+    reason: `"${path.join(' ')}" is not a recognized read-only sf command; run writes through a confirmed path`,
+  };
+}

--- a/plugins/salesforce/src/tools/sf-exec.ts
+++ b/plugins/salesforce/src/tools/sf-exec.ts
@@ -1,0 +1,50 @@
+import sfExecDescription from '../prompts/sf-exec.md' with { type: 'text' };
+import { execSfRaw } from '../sf/exec';
+import { findMutation } from './sf-exec-guard';
+import { errorResult, hasControlChars, makeExecApi, textResult } from './shared';
+
+const SF_EXEC_MAX_OUTPUT = 50000;
+
+export function createSfExecTool(pi: any) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    args: Type.Array(Type.String({ description: 'Individual argument (do NOT include "sf")' }), {
+      description: 'sf subcommand and flags as an array, e.g. ["org", "list", "--json"]',
+    }),
+  });
+
+  return {
+    name: 'sf_exec',
+    label: 'Salesforce CLI Execute',
+    description: sfExecDescription,
+    parameters,
+    async execute(_toolCallId: string, params: { args: string[] }, signal: any, _onUpdate: any, ctx: { cwd: string }) {
+      const base = { tool: 'sf_exec' as const };
+      const args = params.args ?? [];
+      if (args.length === 0) {
+        return errorResult('Error: args array must not be empty.', base);
+      }
+      for (const a of args) {
+        if (hasControlChars(a)) {
+          return errorResult(`Error: argument contains a control character: "${a}"`, base);
+        }
+      }
+      const mutation = findMutation(args);
+      if (mutation.blocked) {
+        return errorResult(
+          `Error: ${mutation.reason}. sf_exec is read-only by default and only runs commands on its confirmed allowlist. Run write operations through an explicitly confirmed path, not sf_exec.`,
+          base,
+        );
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const result = await execSfRaw(api, args, signal);
+      let out = result.stdout;
+      if (out.length > SF_EXEC_MAX_OUTPUT) {
+        out = `${out.slice(0, SF_EXEC_MAX_OUTPUT)}\n\n[Output truncated]`;
+      }
+      return textResult(out, base);
+    },
+  };
+}

--- a/plugins/salesforce/src/tools/sf-help.ts
+++ b/plugins/salesforce/src/tools/sf-help.ts
@@ -1,0 +1,56 @@
+import sfHelpDescription from '../prompts/sf-help.md' with { type: 'text' };
+import { errorResult, makeExecApi, textResult } from './shared';
+
+// Lowercase letters, spaces, colons, and hyphens only. The colon supports sf's
+// `topic:command` grammar. This blocks shell metacharacters and flag smuggling at
+// the top level; the per-part `-` guard below then rejects any segment (split on
+// space AND ':') that would still reach sf as a flag.
+const HELP_PATH_PATTERN = /^[a-z][a-z :-]*$/;
+
+export function createSfHelpTool(pi: any) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    command_path: Type.Optional(
+      Type.String({
+        description:
+          'Command path without the "sf" prefix, e.g. "org list", "org:display", or "org". Empty for top-level help.',
+      }),
+    ),
+  });
+
+  return {
+    name: 'sf_help',
+    label: 'Salesforce CLI Help',
+    description: sfHelpDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { command_path?: string },
+      signal: any,
+      _onUpdate: any,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'sf_help' as const };
+      const commandPath = params.command_path?.trim() ?? '';
+      if (commandPath.length > 0 && !HELP_PATH_PATTERN.test(commandPath)) {
+        return errorResult(
+          `Error: invalid command path "${commandPath}". Only lowercase letters, colons, hyphens, and spaces are allowed.`,
+          base,
+        );
+      }
+
+      // Split on both space and colon so sf's `topic:command` form is decomposed
+      // into individual argv parts before the flag-smuggling guard runs.
+      const parts = commandPath.length > 0 ? commandPath.split(/[ :]/).filter(Boolean) : [];
+      if (parts.some((p) => p.startsWith('-'))) {
+        return errorResult("Error: command path parts must not start with '-'.", base);
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const result = await api.exec('sf', [...parts, '--help'], { signal });
+      const output = result.stdout || result.stderr;
+      return textResult(output || `No help output for "sf ${commandPath}".`, base);
+    },
+  };
+}

--- a/plugins/salesforce/src/tools/sf-pipeline-report.ts
+++ b/plugins/salesforce/src/tools/sf-pipeline-report.ts
@@ -3,10 +3,10 @@ import { generatePipelineReport, type SfQueryFn } from '../pipeline-report/gener
 import { renderPipelineReport } from '../pipeline-report/renderer';
 import type { PipelineReportData, PipelineReportOptions } from '../pipeline-report/types';
 import sfPipelineReportDescription from '../prompts/sf-pipeline-report.md' with { type: 'text' };
-import { execSfJson, SfAuthError, SfNoDefaultOrgError, SfSessionExpiredError } from '../sf/exec';
+import { execSfJson } from '../sf/exec';
 import { ORG_ALIAS_PATTERN } from '../sf/types';
 import type { SfErrorType, SfToolDetails } from './shared';
-import { makeExecApi } from './shared';
+import { detectErrorType, makeExecApi } from './shared';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -55,13 +55,6 @@ function buildQueryFn(cwd: string, orgAlias?: string): SfQueryFn {
       return [];
     }
   };
-}
-
-function detectErrorType(err: unknown): SfErrorType {
-  if (err instanceof SfAuthError) return 'auth_required';
-  if (err instanceof SfSessionExpiredError) return 'session_expired';
-  if (err instanceof SfNoDefaultOrgError) return 'no_default_org';
-  return 'exec_error';
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/salesforce/src/tools/shared.ts
+++ b/plugins/salesforce/src/tools/shared.ts
@@ -9,7 +9,7 @@ import type { SfOrg, SfQueryResult, SfRawResult } from '../sf/types';
 export type SfErrorType = 'auth_required' | 'session_expired' | 'no_default_org' | 'invalid_query' | 'exec_error';
 
 export interface SfToolDetails {
-  tool: 'sf_setup' | 'sf_query' | 'sf_org_display' | 'sf_pipeline_report' | 'sf_help';
+  tool: 'sf_setup' | 'sf_query' | 'sf_org_display' | 'sf_pipeline_report' | 'sf_help' | 'sf_exec';
   action?: string;
   orgs?: SfOrg[];
   queryResult?: SfQueryResult;

--- a/plugins/salesforce/src/tools/shared.ts
+++ b/plugins/salesforce/src/tools/shared.ts
@@ -9,7 +9,7 @@ import type { SfOrg, SfQueryResult, SfRawResult } from '../sf/types';
 export type SfErrorType = 'auth_required' | 'session_expired' | 'no_default_org' | 'invalid_query' | 'exec_error';
 
 export interface SfToolDetails {
-  tool: 'sf_setup' | 'sf_query' | 'sf_org_display' | 'sf_pipeline_report';
+  tool: 'sf_setup' | 'sf_query' | 'sf_org_display' | 'sf_pipeline_report' | 'sf_help';
   action?: string;
   orgs?: SfOrg[];
   queryResult?: SfQueryResult;

--- a/plugins/salesforce/src/tools/shared.ts
+++ b/plugins/salesforce/src/tools/shared.ts
@@ -39,21 +39,49 @@ export function detectErrorType(err: unknown): SfErrorType {
 }
 
 // ---------------------------------------------------------------------------
+// Argv hygiene (shared with the sf_exec guard)
+// ---------------------------------------------------------------------------
+
+// Blocks ASCII C0 control characters and DEL (0x7f), but allows tab (0x09),
+// LF (0x0A), and CR (0x0D) so multi-line SOQL/field expressions survive intact.
+// Uses a charCode scan (not a regex) so no control-char literal appears in source
+// and no lint suppression is needed.
+export function hasControlChars(arg: string): boolean {
+  for (let i = 0; i < arg.length; i++) {
+    const c = arg.charCodeAt(i);
+    if (c <= 8 || c === 11 || c === 12 || (c >= 14 && c <= 31) || c === 127) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // Exec API factory
 // ---------------------------------------------------------------------------
 
 export function makeExecApi(cwd: string): SfExecApi {
   return {
-    async exec(command: string, args: string[], _options?: { signal?: AbortSignal }): Promise<SfRawResult> {
-      // Never pass signal to Bun.spawn and never pre-check signal.aborted.
-      // sf commands finish in 1-5s. Passing the signal or pre-checking causes
-      // false cancellations when xcsh's AbortSignal fires between multi-turn
-      // tool calls (the signal is stale from a prior turn).
+    async exec(command: string, args: string[], options?: { signal?: AbortSignal }): Promise<SfRawResult> {
+      // Thread the AbortSignal so a genuine in-flight cancellation actually
+      // terminates the child: Bun kills the process, which surfaces as a
+      // non-zero exit that execSf* treats as a real failure/cancellation.
+      //
+      // We must NOT reintroduce the stale-signal false-cancel this call site
+      // previously guarded against by refusing the signal entirely: xcsh can
+      // hand us an AbortSignal that already fired in a PRIOR multi-turn tool
+      // call, and a stale abort must never cancel a fresh sf command (they
+      // finish in 1-5s). So we never pre-check signal.aborted to throw a
+      // "cancelled" before running, and we only wire the signal into Bun.spawn
+      // while it is still live at spawn time — handing an already-aborted
+      // (stale) signal to Bun.spawn would kill the fresh process immediately,
+      // resurrecting exactly that false cancel. A signal that aborts *during*
+      // the run is still honored and cancels for real.
+      const signal = options?.signal;
       const child = Bun.spawn([command, ...args], {
         cwd,
         stdin: 'ignore',
         stdout: 'pipe',
         stderr: 'pipe',
+        ...(signal && !signal.aborted ? { signal } : {}),
       });
       if (!child.stdout || !child.stderr) {
         return { stdout: '', stderr: 'Failed to capture output', exitCode: 1 };

--- a/plugins/salesforce/src/tools/shared.ts
+++ b/plugins/salesforce/src/tools/shared.ts
@@ -38,6 +38,12 @@ export function detectErrorType(err: unknown): SfErrorType {
   return 'exec_error';
 }
 
+// Local renderer for the central withErrorType wrapper. Kept LOCAL (not imported
+// from @f5-sales-demo/xcsh) because that import fails in the compiled plugin.
+export function renderError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 // ---------------------------------------------------------------------------
 // Argv hygiene (shared with the sf_exec guard)
 // ---------------------------------------------------------------------------

--- a/plugins/salesforce/test/index-wrapper.test.ts
+++ b/plugins/salesforce/test/index-wrapper.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test';
+import { withErrorType } from '../src/index';
+import { SfNotFoundError, SfQueryError, SfSessionExpiredError } from '../src/sf/exec';
+
+// A minimal fake tool matching the shape withErrorType expects: a name plus an
+// execute() that throws whatever we hand it.
+function fakeTool(name: string, thrown: unknown) {
+  return {
+    name,
+    async execute(): Promise<unknown> {
+      throw thrown;
+    },
+  };
+}
+
+describe('withErrorType', () => {
+  it('maps a thrown SfSessionExpiredError to a structured errorResult', async () => {
+    const wrapped = withErrorType(fakeTool('sf_query', new SfSessionExpiredError()));
+    const result = (await wrapped.execute()) as {
+      isError?: boolean;
+      details?: { tool?: string; errorType?: string };
+      content: { type: string; text: string }[];
+    };
+    expect(result.isError).toBe(true);
+    expect(result.details?.errorType).toBe('session_expired');
+    expect(result.details?.tool).toBe('sf_query');
+    expect(result.content[0]?.text).toContain('session expired');
+  });
+
+  it('maps a thrown SfQueryError to errorType invalid_query', async () => {
+    const wrapped = withErrorType(fakeTool('sf_query', new SfQueryError('bad soql', 'SELECT x')));
+    const result = (await wrapped.execute()) as { isError?: boolean; details?: { errorType?: string } };
+    expect(result.isError).toBe(true);
+    expect(result.details?.errorType).toBe('invalid_query');
+  });
+
+  it('maps a generic/unknown Sf error to errorType exec_error', async () => {
+    const wrapped = withErrorType(fakeTool('sf_setup', new SfNotFoundError()));
+    const result = (await wrapped.execute()) as { isError?: boolean; details?: { errorType?: string } };
+    expect(result.isError).toBe(true);
+    expect(result.details?.errorType).toBe('exec_error');
+  });
+
+  it('re-throws a web-standard AbortError untouched (does not swallow cancellation)', async () => {
+    const abort = new Error('The operation was aborted');
+    abort.name = 'AbortError';
+    const wrapped = withErrorType(fakeTool('sf_query', abort));
+    expect(wrapped.execute()).rejects.toBe(abort);
+  });
+
+  it("re-throws xcsh's ToolAbortError untouched", async () => {
+    const abort = new Error('Operation aborted');
+    abort.name = 'ToolAbortError';
+    const wrapped = withErrorType(fakeTool('sf_org_display', abort));
+    expect(wrapped.execute()).rejects.toBe(abort);
+  });
+
+  it('passes through a successful (non-throwing) result unchanged', async () => {
+    const ok = { content: [{ type: 'text' as const, text: 'ok' }], details: { tool: 'sf_setup' as const } };
+    const tool = {
+      name: 'sf_setup',
+      async execute(): Promise<unknown> {
+        return ok;
+      },
+    };
+    const wrapped = withErrorType(tool);
+    expect(await wrapped.execute()).toBe(ok);
+  });
+});

--- a/plugins/salesforce/test/integration/extension-load.test.ts
+++ b/plugins/salesforce/test/integration/extension-load.test.ts
@@ -70,10 +70,11 @@ describe('ExtensionFactory integration', () => {
     await factory(pi);
 
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(['sf_org_display', 'sf_pipeline_report', 'sf_query', 'sf_setup']);
+    expect(names).toEqual(['sf_help', 'sf_org_display', 'sf_pipeline_report', 'sf_query', 'sf_setup']);
 
     const labels = tools.map((t) => t.label).sort();
     expect(labels).toEqual([
+      'Salesforce CLI Help',
       'Salesforce Org Display',
       'Salesforce Pipeline Report',
       'Salesforce Query',

--- a/plugins/salesforce/test/integration/extension-load.test.ts
+++ b/plugins/salesforce/test/integration/extension-load.test.ts
@@ -70,10 +70,11 @@ describe('ExtensionFactory integration', () => {
     await factory(pi);
 
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(['sf_help', 'sf_org_display', 'sf_pipeline_report', 'sf_query', 'sf_setup']);
+    expect(names).toEqual(['sf_exec', 'sf_help', 'sf_org_display', 'sf_pipeline_report', 'sf_query', 'sf_setup']);
 
     const labels = tools.map((t) => t.label).sort();
     expect(labels).toEqual([
+      'Salesforce CLI Execute',
       'Salesforce CLI Help',
       'Salesforce Org Display',
       'Salesforce Pipeline Report',

--- a/plugins/salesforce/test/tools/sf-exec.test.ts
+++ b/plugins/salesforce/test/tools/sf-exec.test.ts
@@ -96,6 +96,7 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['api', 'request', 'rest', 'projects']).blocked).toBe(false);
     expect(findMutation(['api', 'request', 'rest', '-X', 'GET', 'projects']).blocked).toBe(false);
     expect(findMutation(['api', 'request', 'rest', '-iX', 'GET', 'projects']).blocked).toBe(false);
+    expect(findMutation(['api', 'request', 'rest', '--method', 'GET', 'projects']).blocked).toBe(false);
   });
 
   it('blocks writes and unrecognized commands (fail-safe)', () => {
@@ -138,6 +139,15 @@ describe('findMutation allowlist', () => {
   it('blocks the sf api request short-flag-cluster method bypass', () => {
     expect(findMutation(['api', 'request', 'rest', '-iX', 'POST', 'x']).blocked).toBe(true);
     expect(findMutation(['api', 'request', 'rest', '-iXPUT', 'x']).blocked).toBe(true);
+  });
+
+  it('blocks the sf api request short body-flag (-b/-f) mutation bypass', () => {
+    expect(findMutation(['api', 'request', 'rest', '-f', 'req.json']).blocked).toBe(true);
+    expect(findMutation(['api', 'request', 'rest', '-b', '{}', 'url']).blocked).toBe(true);
+    // cluster: `-if` = -i (include) + -f (file)
+    expect(findMutation(['api', 'request', 'rest', '-if', 'req.json']).blocked).toBe(true);
+    // attached form: `-freq.json`
+    expect(findMutation(['api', 'request', 'rest', '-freq.json']).blocked).toBe(true);
   });
 
   it('blocks the flag-value-shift bypass (token after a value flag is consumed)', () => {

--- a/plugins/salesforce/test/tools/sf-exec.test.ts
+++ b/plugins/salesforce/test/tools/sf-exec.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createSfExecTool } from '../../src/tools/sf-exec';
+import { effectiveApiMethod, findMutation, normalizeArgs } from '../../src/tools/sf-exec-guard';
+
+const NUL = String.fromCharCode(0);
+const TAB = String.fromCharCode(9);
+
+const mockPi = { typebox: { Type } };
+
+function makeTool() {
+  return createSfExecTool(mockPi);
+}
+
+describe('normalizeArgs', () => {
+  it('splits positional tokens on ":" (colon grammar → space grammar)', () => {
+    expect(normalizeArgs(['org:list'])).toEqual(['org', 'list']);
+    expect(normalizeArgs(['data:create'])).toEqual(['data', 'create']);
+    expect(normalizeArgs(['apex:run'])).toEqual(['apex', 'run']);
+  });
+
+  it('leaves space-form positionals intact', () => {
+    expect(normalizeArgs(['org', 'list'])).toEqual(['org', 'list']);
+    expect(normalizeArgs(['api', 'request', 'rest', 'projects'])).toEqual(['api', 'request', 'rest', 'projects']);
+  });
+
+  it('excludes flag tokens and the token immediately after a flag (flag-value exclusion)', () => {
+    // `-s`'s value `Account` is consumed; path is just `data create`.
+    expect(normalizeArgs(['data', 'create', '-s', 'Account'])).toEqual(['data', 'create']);
+    // `--query`'s value is consumed; path is `data query`.
+    expect(normalizeArgs(['data', 'query', '--query', 'SELECT Id FROM Account'])).toEqual(['data', 'query']);
+    // `--json` is a trailing boolean flag with no value.
+    expect(normalizeArgs(['org', 'list', '--json'])).toEqual(['org', 'list']);
+  });
+
+  it('does not split flag tokens on ":"', () => {
+    // The colon-bearing flag value is excluded (follows a flag); the flag itself is
+    // never split into path parts.
+    expect(normalizeArgs(['data', 'query', '--where', 'Name:foo'])).toEqual(['data', 'query']);
+  });
+});
+
+describe('effectiveApiMethod', () => {
+  it('defaults to GET with no method or body flags', () => {
+    expect(effectiveApiMethod(['api', 'request', 'rest', 'projects'])).toBe('GET');
+  });
+
+  it('honors explicit --method / -X in every form (attached/equals/lowercase)', () => {
+    expect(effectiveApiMethod(['api', 'request', 'rest', '--method', 'POST', 'x'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '--method=DELETE', 'x'])).toBe('DELETE');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-X', 'PUT', 'x'])).toBe('PUT');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-XPATCH', 'x'])).toBe('PATCH');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-X=POST', 'x'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-X=patch', 'x'])).toBe('PATCH');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '--method', 'get', 'x'])).toBe('GET');
+  });
+
+  it('infers POST when a --body/--file flag is present', () => {
+    expect(effectiveApiMethod(['api', 'request', 'rest', '--body', '{}', 'x'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '--file', 'f.json', 'x'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '--body={}', 'x'])).toBe('POST');
+  });
+
+  it('lets an explicit method win over an inferred body POST', () => {
+    expect(effectiveApiMethod(['api', 'request', 'rest', '--method', 'GET', '--body', '{}', 'x'])).toBe('GET');
+  });
+
+  it('parses short-flag clusters (boolean flag ahead of the method short)', () => {
+    // -iX = -i (include) + -X (method, value from next arg).
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-iX', 'POST', 'x'])).toBe('POST');
+    // Method value attached inside the same token.
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-iXPUT', 'x'])).toBe('PUT');
+    // Explicit GET inside a cluster still resolves to a read.
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-iX', 'GET', 'x'])).toBe('GET');
+    // Include-only boolean cluster → no method → GET.
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-i', 'x'])).toBe('GET');
+  });
+});
+
+describe('findMutation allowlist', () => {
+  it('allows recognized read-only commands (space form)', () => {
+    expect(findMutation(['org', 'list']).blocked).toBe(false);
+    expect(findMutation(['org', 'list', '--json']).blocked).toBe(false);
+    expect(findMutation(['org', 'display']).blocked).toBe(false);
+    expect(findMutation(['data', 'query', '--query', 'SELECT Id FROM Account']).blocked).toBe(false);
+    expect(findMutation(['apex', 'tail', 'log']).blocked).toBe(false);
+    expect(findMutation(['apex', 'list', 'log']).blocked).toBe(false);
+    expect(findMutation(['sobject', 'describe', '--sobject', 'Account']).blocked).toBe(false);
+    expect(findMutation(['schema', 'sobject', 'list']).blocked).toBe(false);
+    expect(findMutation(['limits', 'api', 'display']).blocked).toBe(false);
+    expect(findMutation(['version']).blocked).toBe(false);
+    expect(findMutation(['help']).blocked).toBe(false);
+  });
+
+  it('allows sf api request GET reads', () => {
+    expect(findMutation(['api', 'request', 'rest', 'projects']).blocked).toBe(false);
+    expect(findMutation(['api', 'request', 'rest', '-X', 'GET', 'projects']).blocked).toBe(false);
+    expect(findMutation(['api', 'request', 'rest', '-iX', 'GET', 'projects']).blocked).toBe(false);
+  });
+
+  it('blocks writes and unrecognized commands (fail-safe)', () => {
+    expect(findMutation(['apex', 'run']).blocked).toBe(true);
+    expect(findMutation(['data', 'create', '-s', 'Account']).blocked).toBe(true);
+    expect(findMutation(['data', 'delete']).blocked).toBe(true);
+    expect(findMutation(['project', 'deploy', 'start']).blocked).toBe(true);
+    expect(findMutation(['org', 'create', 'scratch']).blocked).toBe(true);
+    expect(findMutation(['org', 'login', 'web']).blocked).toBe(true);
+    expect(findMutation(['config', 'set', 'x=y']).blocked).toBe(true);
+    expect(findMutation(['alias', 'set']).blocked).toBe(true);
+    expect(findMutation(['package', 'create']).blocked).toBe(true);
+    expect(findMutation(['bogus']).blocked).toBe(true);
+  });
+
+  it('blocks the colon grammar identically to the space grammar', () => {
+    expect(findMutation(['apex:run']).blocked).toBe(true);
+    expect(findMutation(['org:create']).blocked).toBe(true);
+    expect(findMutation(['data:create']).blocked).toBe(true);
+    expect(findMutation(['data:delete']).blocked).toBe(true);
+    // colon read forms are still allowed
+    expect(findMutation(['org:list']).blocked).toBe(false);
+    expect(findMutation(['org:display']).blocked).toBe(false);
+  });
+
+  it('blocks sf api request non-GET methods in every flag form', () => {
+    expect(findMutation(['api', 'request', 'rest', '--method', 'POST', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', 'request', 'rest', '--method=PUT', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', 'request', 'rest', '-XDELETE', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', 'request', 'rest', '-X=PATCH', 'x']).blocked).toBe(true);
+  });
+
+  it('blocks sf api request with --file/--body (can smuggle a mutating payload)', () => {
+    expect(findMutation(['api', 'request', 'rest', '--file', 'f', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', 'request', 'rest', '--body', '{}', 'x']).blocked).toBe(true);
+    // even paired with an explicit GET, the body flag alone blocks
+    expect(findMutation(['api', 'request', 'rest', '--method', 'GET', '--body', '{}', 'x']).blocked).toBe(true);
+  });
+
+  it('blocks the sf api request short-flag-cluster method bypass', () => {
+    expect(findMutation(['api', 'request', 'rest', '-iX', 'POST', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', 'request', 'rest', '-iXPUT', 'x']).blocked).toBe(true);
+  });
+
+  it('blocks the flag-value-shift bypass (token after a value flag is consumed)', () => {
+    // `-s`'s value `list` is consumed; real verb `create` follows → mutation.
+    expect(findMutation(['org', '-s', 'list', 'create']).blocked).toBe(true);
+  });
+
+  it('does not false-positive on read args that contain a verb-like word', () => {
+    // `create` is the --query text, not the command verb.
+    expect(findMutation(['data', 'query', '--query', 'SELECT Id FROM create']).blocked).toBe(false);
+  });
+
+  it('blocks empty command', () => {
+    expect(findMutation([]).blocked).toBe(true);
+  });
+});
+
+describe('sf_exec execute', () => {
+  it('returns correct name and label', () => {
+    const tool = makeTool();
+    expect(tool.name).toBe('sf_exec');
+    expect(tool.label).toBe('Salesforce CLI Execute');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('rejects empty args', async () => {
+    const tool = makeTool();
+    const r = await tool.execute('id', { args: [] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.details.tool).toBe('sf_exec');
+  });
+
+  it('rejects control chars before spawning', async () => {
+    const tool = makeTool();
+    const r = await tool.execute('id', { args: [`org${NUL}list`] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('control character');
+  });
+
+  it('allows a tab inside an argument (not a control char)', () => {
+    // Sanity: tab must not be flagged so multi-line SOQL survives.
+    const tool = makeTool();
+    expect(tool.name).toBe('sf_exec');
+    expect(`a${TAB}b`.length).toBe(3);
+  });
+
+  it('blocks a mutating verb before spawning', async () => {
+    const tool = makeTool();
+    const r = await tool.execute('id', { args: ['apex', 'run'] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('read-only');
+  });
+
+  it('blocks the colon-form mutating verb before spawning', async () => {
+    const tool = makeTool();
+    const r = await tool.execute('id', { args: ['org:create'] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('read-only');
+  });
+
+  it('blocks a mutating sf api request before spawning', async () => {
+    const tool = makeTool();
+    const r = await tool.execute(
+      'id',
+      { args: ['api', 'request', 'rest', '--method', 'POST', 'x'] },
+      undefined,
+      undefined,
+      { cwd: '/tmp' },
+    );
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('read-only');
+  });
+});

--- a/plugins/salesforce/test/tools/sf-help.test.ts
+++ b/plugins/salesforce/test/tools/sf-help.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createSfHelpTool } from '../../src/tools/sf-help';
+
+const mockPi = { typebox: { Type } };
+
+function makeTool() {
+  return createSfHelpTool(mockPi);
+}
+
+describe('createSfHelpTool', () => {
+  it('returns correct name and label', () => {
+    const tool = makeTool();
+    expect(tool.name).toBe('sf_help');
+    expect(tool.label).toBe('Salesforce CLI Help');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('rejects an invalid command path before spawning sf', async () => {
+    const tool = makeTool();
+    const result = await tool.execute('t1', { command_path: 'org;rm -rf' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.toLowerCase()).toContain('invalid command path');
+    expect(result.details.tool).toBe('sf_help');
+  });
+
+  it('rejects a dash-prefixed command path part before spawning sf', async () => {
+    const tool = makeTool();
+    // A leading-dash part smuggles a flag past the pattern guard when split on spaces/colons.
+    const result = await tool.execute('t2', { command_path: 'org --help' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text.toLowerCase()).toContain("must not start with '-'");
+    expect(result.details.tool).toBe('sf_help');
+  });
+
+  it('accepts a colon-form command path via the validator (no dash-part rejection)', async () => {
+    const tool = makeTool();
+    // The colon `topic:command` form must pass the validator and per-part guard.
+    // A guard rejection is RETURNED (isError result); reaching the exec layer means
+    // the path was accepted. We tolerate an exec throw (e.g. sf not installed) since
+    // that proves the guard let the call through rather than rejecting it.
+    let result: { isError?: boolean; content: { text: string }[]; details: { tool: string } } | undefined;
+    try {
+      result = await tool.execute('t3', { command_path: 'org:list' }, undefined, undefined, { cwd: '/tmp' });
+    } catch {
+      // Spawn-layer error: the guard accepted the colon path and let it reach exec.
+      return;
+    }
+    if (result.isError) {
+      // If an error surfaces it must come from exec, never from the path guard.
+      expect(result.content[0].text.toLowerCase()).not.toContain('invalid command path');
+      expect(result.content[0].text.toLowerCase()).not.toContain("must not start with '-'");
+    }
+    expect(result.details.tool).toBe('sf_help');
+  });
+});

--- a/plugins/salesforce/test/tools/shared.test.ts
+++ b/plugins/salesforce/test/tools/shared.test.ts
@@ -1,6 +1,113 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
 import { SfAuthError, SfExecError, SfNoDefaultOrgError, SfQueryError, SfSessionExpiredError } from '../../src/sf/exec';
-import { collectAllOrgs, detectErrorType, errorResult, normalizeOrg, textResult } from '../../src/tools/shared';
+import {
+  collectAllOrgs,
+  detectErrorType,
+  errorResult,
+  hasControlChars,
+  makeExecApi,
+  normalizeOrg,
+  textResult,
+} from '../../src/tools/shared';
+
+const NUL = String.fromCharCode(0);
+const TAB = String.fromCharCode(9);
+const LF = String.fromCharCode(10);
+const CR = String.fromCharCode(13);
+const DEL = String.fromCharCode(127);
+
+describe('hasControlChars', () => {
+  it('rejects NUL/control bytes and DEL but allows tab/LF/CR and normal args', () => {
+    expect(hasControlChars(`a${NUL}b`)).toBe(true);
+    expect(hasControlChars(`a${DEL}b`)).toBe(true);
+    expect(hasControlChars(`a${String.fromCharCode(0x1b)}b`)).toBe(true);
+    expect(hasControlChars(`a${TAB}b`)).toBe(false);
+    expect(hasControlChars(`a${LF}b`)).toBe(false);
+    expect(hasControlChars(`a${CR}b`)).toBe(false);
+    expect(hasControlChars("data query -q 'SELECT Id FROM Account'")).toBe(false);
+    expect(hasControlChars('')).toBe(false);
+  });
+});
+
+describe('makeExecApi signal threading', () => {
+  it('a non-aborted signal still returns output (guards the false-cancel regression)', async () => {
+    const api = makeExecApi(process.cwd());
+    const controller = new AbortController();
+    const r = await api.exec('sh', ['-c', 'echo hello-live'], { signal: controller.signal });
+    expect(r.stdout).toBe('hello-live');
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('a stale, already-aborted signal does NOT false-cancel a fresh command', async () => {
+    const api = makeExecApi(process.cwd());
+    const controller = new AbortController();
+    controller.abort(); // simulate a signal left aborted by a prior turn
+    const r = await api.exec('sh', ['-c', 'echo still-runs'], { signal: controller.signal });
+    // The documented bug: passing this stale signal to Bun.spawn would kill the
+    // fresh process immediately. Safe threading runs it to completion instead.
+    expect(r.stdout).toBe('still-runs');
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('runs without any signal supplied', async () => {
+    const api = makeExecApi(process.cwd());
+    const r = await api.exec('sh', ['-c', 'echo no-signal']);
+    expect(r.stdout).toBe('no-signal');
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+// Proves the *forwarding* contract deterministically by spying on Bun.spawn:
+// a live signal must reach Bun.spawn, an already-aborted (stale) one must not.
+// No real process, no sleep+abort race — we inspect the options object directly.
+describe('makeExecApi forwards AbortSignal to Bun.spawn only while live', () => {
+  const realSpawn = Bun.spawn;
+
+  // A minimal fake child: empty stdout/stderr streams (truthy, so makeExecApi's
+  // `!child.stdout` guard passes), a resolved `exited`, and killed=false.
+  const emptyStream = () => new ReadableStream<Uint8Array>({ start: (c) => c.close() });
+  const fakeChild = () => ({
+    stdout: emptyStream(),
+    stderr: emptyStream(),
+    exited: Promise.resolve(0),
+    exitCode: 0,
+    killed: false,
+  });
+
+  let recordedOptions: { signal?: AbortSignal } | undefined;
+
+  function installSpawnSpy() {
+    recordedOptions = undefined;
+    Bun.spawn = ((_cmd: string[], options: { signal?: AbortSignal }) => {
+      recordedOptions = options;
+      return fakeChild();
+    }) as unknown as typeof Bun.spawn;
+  }
+
+  afterEach(() => {
+    Bun.spawn = realSpawn;
+  });
+
+  it('hands a live (non-aborted) signal to Bun.spawn', async () => {
+    installSpawnSpy();
+    const controller = new AbortController();
+    await makeExecApi('/tmp').exec('sf', ['org', 'list'], { signal: controller.signal });
+    expect(recordedOptions).toBeDefined();
+    expect('signal' in (recordedOptions ?? {})).toBe(true);
+    expect(recordedOptions?.signal).toBe(controller.signal);
+  });
+
+  it('withholds an already-aborted (stale) signal from Bun.spawn', async () => {
+    installSpawnSpy();
+    const controller = new AbortController();
+    controller.abort(); // stale abort left over from a prior turn
+    await makeExecApi('/tmp').exec('sf', ['org', 'list'], { signal: controller.signal });
+    expect(recordedOptions).toBeDefined();
+    // The stale-abort path must build `{}` (no signal), never `{ signal }` —
+    // otherwise Bun would kill the fresh child immediately (false-cancel).
+    expect('signal' in (recordedOptions ?? {})).toBe(false);
+  });
+});
 
 describe('textResult', () => {
   it('returns text content with details', () => {


### PR DESCRIPTION
Implements **Spec 4** — `salesforce` plugin → CLI-Plugin Capability Contract. Salesforce was already the strongest plugin (6-class taxonomy, formatters, SOQL prompt, profile/pipeline subsystems), so this is wiring + two new tools.

- **signal-aware exec** (live-only, no false-cancel; deterministic forwarding test) + charCode `hasControlChars`.
- **central `withErrorType` wrapper** (local `renderError`, no peer-dep runtime import) + removed the duplicate `detectErrorType` in `sf-pipeline-report.ts`.
- **`sf_help`** — colon-aware path guard (`topic:command`) + dash-part reject.
- **`sf_exec`** — read-only passthrough with a fail-safe guard built from the adversarially-hardened GitLab guard, adapted for `sf`: colon-normalization (`org:list`→`org list`), a read-PREFIX allowlist (sf is 3-deep), an `apex run` block, `sf api request` GET-only (blocks `--method` non-GET, `--body`/`--file` incl. the `-b`/`-f` short forms and clusters), plus the ported flag-value-exclusion + short-flag-cluster protections.
- **`--json`/`--result-format` query docs**.
- **benchmark + autoresearch harness** (`mock-sf`), real `createSf*Tool` exports.

Verified: 203 salesforce tests pass (the 1 failing `extension-load.test.ts:211` is pre-existing/unrelated); `biome ci plugins/salesforce` exit 0; benchmark composite runs; guard passed an adversarial review after fixing the sf-specific `-f`/`-b` body-flag bypass. Consistency layer + profile/pipeline/context subsystems unchanged.

Note: a pre-existing test failure in `test/integration/extension-load.test.ts` (session_start hook, unrelated to this PR) remains and is not a CI gate.

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)
