### PR TITLE
Security: close gh_exec guard bypasses (flag-value shift + short-flag cluster)

### DIFF
--- a/plugins/github/src/tools/gh-exec-guard.ts
+++ b/plugins/github/src/tools/gh-exec-guard.ts
@@ -100,13 +100,26 @@ export function effectiveApiMethod(args: string[]): string {
   return hasBody ? 'POST' : 'GET';
 }
 
+// Does the flag token `prev` consume the NEXT argv token as its value, per cobra/pflag
+// `stripFlags`? Only two forms take their value from the following token:
+//   - a long flag written without `=`   (`--repo owner/x` → consumes `owner/x`)
+//   - an exactly-2-char short            (`-R owner/x`     → consumes `owner/x`)
+// A single-dash CLUSTER of length ≥ 3 (`-dp`, `-dm`) does NOT consume the next token —
+// pflag reads any in-cluster value flag's value from the token REMAINDER, not the next
+// arg. The earlier code excluded the token after *every* dash token, which dropped the
+// real verb after a boolean cluster (`gh release -dp create view` → verb misread as
+// `view`, a read) and let a write through — a false-negative. Long/2-char over-exclusion
+// stays (can only block a read, never allow a write); cluster over-exclusion is removed.
+function consumesNextAsValue(prev: string): boolean {
+  if (prev.startsWith('--')) return !prev.includes('=');
+  return /^-[A-Za-z]$/.test(prev);
+}
+
 export function findMutation(args: string[]): { blocked: boolean; reason?: string } {
-  // Cobra/pflag consumes the token AFTER a flag token as that flag's value, so a
-  // value-taking flag can shift a command's real verb past positionals[1]. Mirror
-  // cobra by excluding both flag tokens AND the token immediately following one.
-  // This over-excludes tokens after boolean flags (fail-safe: at worst blocks a
-  // read; never allows a mutation) and realigns the verb with what gh dispatches.
-  const positionals = args.filter((a, i) => !a.startsWith('-') && !(i > 0 && args[i - 1].startsWith('-')));
+  const positionals = args.filter((a, i) => {
+    if (a.startsWith('-')) return false;
+    return !(i > 0 && consumesNextAsValue(args[i - 1]));
+  });
   if (positionals.length === 0) return { blocked: true, reason: 'no gh command provided' };
   const top = positionals[0];
 

--- a/plugins/github/src/tools/gh-exec-guard.ts
+++ b/plugins/github/src/tools/gh-exec-guard.ts
@@ -44,6 +44,38 @@ const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH
 // left→right and STOP at the first value-taking short: f/F marks a body (rest is the
 // field value, never a method); X takes the token remainder (or next arg) as the
 // method. Over-flagging here is fail-safe: at worst it blocks a read; never allows a write.
+// gh api long flags that take a VALUE (consume the next token when written without
+// `=`). Every OTHER `--long` is a boolean (--include, --paginate, --silent, --slurp,
+// --verbose) and consumes nothing.
+const LONG_VALUE_FLAGS: ReadonlySet<string> = new Set([
+  '--method',
+  '--field',
+  '--raw-field',
+  '--header',
+  '--input',
+  '--jq',
+  '--template',
+  '--cache',
+  '--hostname',
+  '--preview',
+]);
+// gh api long flags whose presence implies a request BODY (→ POST).
+const LONG_BODY_FLAGS: ReadonlySet<string> = new Set(['--field', '--raw-field', '--input']);
+// gh api single-char shorts that take a VALUE (from the token remainder, else the next
+// token). Every other short (i, and any unknown letter) is boolean.
+const SHORT_VALUE_FLAGS: ReadonlySet<string> = new Set(['X', 'f', 'F', 'H', 'q', 't', 'p']);
+// Shorts that imply a request BODY.
+const SHORT_BODY_FLAGS: ReadonlySet<string> = new Set(['f', 'F']);
+
+// Resolve the HTTP method gh will actually use for `gh api`. gh is a cobra/pflag CLI, so
+// a value-taking flag consumes the following token (or, for a short, the cluster
+// remainder) as its VALUE — and that value must NEVER be reinterpreted as another flag.
+// The earlier version scanned every token, so a value that happened to look like a flag
+// (`--jq -Xhack`, `-q -XGET`, `-H -XGET`) was misread as `-X <method>`, forging a
+// non-mutating method that overrode a real `-f` body POST and let a write through. We
+// therefore consume each value-taking flag's value explicitly. Over-flagging a body is
+// fail-safe (blocks a read); the danger is under-detecting one, so `-f`/`-F`/`--field`/
+// `--raw-field`/`--input` always set hasBody even when their value is attached.
 export function effectiveApiMethod(args: string[]): string {
   let explicit: string | null = null;
   let hasBody = false;
@@ -56,42 +88,37 @@ export function effectiveApiMethod(args: string[]): string {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
 
-    // Long-form (double-dash) flags — unchanged detection.
-    if (a === '--method') {
-      setExplicit(args[i + 1] ?? '');
+    // Long-form (double-dash) flags.
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      const name = eq === -1 ? a : a.slice(0, eq);
+      const inlineVal = eq === -1 ? undefined : a.slice(eq + 1);
+      if (name === '--method') setExplicit(inlineVal ?? args[i + 1] ?? '');
+      if (LONG_BODY_FLAGS.has(name)) hasBody = true;
+      // A value-taking long flag written without `=` consumes the next token as its
+      // value; skip it so it is not reinterpreted as a method/body flag.
+      if (inlineVal === undefined && LONG_VALUE_FLAGS.has(name)) i += 1;
       continue;
     }
-    if (a.startsWith('--method=')) {
-      setExplicit(a.slice('--method='.length));
-      continue;
-    }
-    if (a === '--field' || a === '--raw-field' || a === '--input' || /^--(field|raw-field|input)=/.test(a)) {
-      hasBody = true;
-      continue;
-    }
-    if (a.startsWith('--')) continue;
 
-    // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading
-    // '-' and scan the letters left→right, stopping at the FIRST value-taking
-    // short flag (pflag consumes the token remainder as that flag's value).
+    // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Scan letters left→right;
+    // the FIRST value-taking short consumes the token remainder (or the next token) as
+    // its value and ENDS the cluster — a trailing method-looking substring is data.
     if (/^-[A-Za-z]/.test(a)) {
       const body = a.slice(1);
       for (let j = 0; j < body.length; j++) {
         const c = body[j];
-        if (c === 'f' || c === 'F') {
-          // First value-taking short is a body field: the rest of the token
-          // (including any 'X') is this field's VALUE — never a method flag.
-          hasBody = true;
-          break;
+        if (!SHORT_VALUE_FLAGS.has(c)) continue; // boolean short (e.g. -i); keep scanning
+        let value = body.slice(j + 1).replace(/^=/, '');
+        if (value === '') {
+          // No attached remainder: the value is the next token; consume it so it is
+          // not reinterpreted as a flag.
+          i += 1;
+          value = args[i] ?? '';
         }
-        if (c === 'X') {
-          // First value-taking short is the method flag: value is the token
-          // remainder after X (leading '=' stripped), else the next arg.
-          const after = body.slice(j + 1).replace(/^=/, '');
-          setExplicit(after || (args[i + 1] ?? ''));
-          break;
-        }
-        // Any other letter is a boolean short (e.g. -i); keep scanning.
+        if (c === 'X') setExplicit(value);
+        if (SHORT_BODY_FLAGS.has(c)) hasBody = true;
+        break; // remainder/next token is this flag's value, not more flags
       }
     }
   }

--- a/plugins/github/src/tools/gh-exec-guard.ts
+++ b/plugins/github/src/tools/gh-exec-guard.ts
@@ -31,32 +31,76 @@ const READ_TOP: ReadonlySet<string> = new Set(['search', 'status', 'version', 'h
 const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
 // Resolve the HTTP method gh will actually use for `gh api`:
-// explicit --method/-X (any form) wins; otherwise gh sends POST when any body/input
-// flag is present, else GET.
-function effectiveApiMethod(args: string[]): string {
+// explicit --method/-X (any form) wins; otherwise gh sends POST when any body flag
+// (-f/--field, -F/--raw-field, --input) is present, else GET.
+//
+// gh is a cobra/pflag CLI, so a boolean short flag may CLUSTER ahead of a
+// value-taking short flag inside a single token: `-iF field=x` parses as
+// `-i` (include, boolean) + `-F` (raw-field, value from the next arg), and `-iX POST`
+// as include + method. Prefix matching on the token misses these, so we inspect
+// the whole single-dash letter run — never just the char at index 1 — for the
+// field (f/F) and method (X) letters. Over-flagging here is fail-safe: at worst
+// it treats a read as a body/method write and blocks it; it never allows a write.
+export function effectiveApiMethod(args: string[]): string {
   let explicit: string | null = null;
+  let hasBody = false;
+
+  const setExplicit = (raw: string): void => {
+    const up = (raw ?? '').toUpperCase();
+    if (up) explicit = up;
+  };
+
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === '-X' || a === '--method') explicit = (args[i + 1] ?? '').toUpperCase() || explicit;
-    else if (a.startsWith('--method=')) explicit = a.slice('--method='.length).toUpperCase() || explicit;
-    else if (a.startsWith('-X') && a.length > 2) explicit = a.slice(2).replace(/^=/, '').toUpperCase() || explicit;
+
+    // Long-form (double-dash) flags — unchanged detection.
+    if (a === '--method') {
+      setExplicit(args[i + 1] ?? '');
+      continue;
+    }
+    if (a.startsWith('--method=')) {
+      setExplicit(a.slice('--method='.length));
+      continue;
+    }
+    if (a === '--field' || a === '--raw-field' || a === '--input' || /^--(field|raw-field|input)=/.test(a)) {
+      hasBody = true;
+      continue;
+    }
+    if (a.startsWith('--')) continue;
+
+    // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading
+    // '-' and inspect the letter run up to the first '=' (or end) so a boolean
+    // short flag clustered ahead of a value flag can't hide the value flag.
+    if (/^-[A-Za-z]/.test(a)) {
+      const body = a.slice(1);
+      const eq = body.indexOf('=');
+      const letters = eq === -1 ? body : body.slice(0, eq);
+
+      // Field flag anywhere in the cluster → this token carries a body.
+      if (letters.includes('f') || letters.includes('F')) hasBody = true;
+
+      // Method flag anywhere in the cluster → value is whatever follows the X
+      // in the same token (leading '=' stripped), else the next arg.
+      const xIdx = letters.indexOf('X');
+      if (xIdx !== -1) {
+        const after = body.slice(xIdx + 1).replace(/^=/, '');
+        if (after) setExplicit(after);
+        else setExplicit(args[i + 1] ?? '');
+      }
+    }
   }
+
   if (explicit) return explicit;
-  const hasBody = args.some(
-    (a) =>
-      a === '-f' ||
-      a === '-F' ||
-      a === '--field' ||
-      a === '--raw-field' ||
-      a === '--input' ||
-      /^--(field|raw-field|input)=/.test(a) ||
-      /^-[fF]./.test(a),
-  );
   return hasBody ? 'POST' : 'GET';
 }
 
 export function findMutation(args: string[]): { blocked: boolean; reason?: string } {
-  const positionals = args.filter((a) => !a.startsWith('-'));
+  // Cobra/pflag consumes the token AFTER a flag token as that flag's value, so a
+  // value-taking flag can shift a command's real verb past positionals[1]. Mirror
+  // cobra by excluding both flag tokens AND the token immediately following one.
+  // This over-excludes tokens after boolean flags (fail-safe: at worst blocks a
+  // read; never allows a mutation) and realigns the verb with what gh dispatches.
+  const positionals = args.filter((a, i) => !a.startsWith('-') && !(i > 0 && args[i - 1].startsWith('-')));
   if (positionals.length === 0) return { blocked: true, reason: 'no gh command provided' };
   const top = positionals[0];
 

--- a/plugins/github/src/tools/gh-exec-guard.ts
+++ b/plugins/github/src/tools/gh-exec-guard.ts
@@ -37,10 +37,13 @@ const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH
 // gh is a cobra/pflag CLI, so a boolean short flag may CLUSTER ahead of a
 // value-taking short flag inside a single token: `-iF field=x` parses as
 // `-i` (include, boolean) + `-F` (raw-field, value from the next arg), and `-iX POST`
-// as include + method. Prefix matching on the token misses these, so we inspect
-// the whole single-dash letter run — never just the char at index 1 — for the
-// field (f/F) and method (X) letters. Over-flagging here is fail-safe: at worst
-// it treats a read as a body/method write and blocks it; it never allows a write.
+// as include + method. Crucially, pflag stops at the FIRST value-taking short in a
+// cluster: the REST of the token becomes that flag's value. So `-fX=GET` is
+// `--field` with value `X=GET` (a body field literally named X) — the trailing X is
+// data, NOT a method flag — and gh sends POST. We therefore scan the letter run
+// left→right and STOP at the first value-taking short: f/F marks a body (rest is the
+// field value, never a method); X takes the token remainder (or next arg) as the
+// method. Over-flagging here is fail-safe: at worst it blocks a read; never allows a write.
 export function effectiveApiMethod(args: string[]): string {
   let explicit: string | null = null;
   let hasBody = false;
@@ -69,23 +72,26 @@ export function effectiveApiMethod(args: string[]): string {
     if (a.startsWith('--')) continue;
 
     // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading
-    // '-' and inspect the letter run up to the first '=' (or end) so a boolean
-    // short flag clustered ahead of a value flag can't hide the value flag.
+    // '-' and scan the letters left→right, stopping at the FIRST value-taking
+    // short flag (pflag consumes the token remainder as that flag's value).
     if (/^-[A-Za-z]/.test(a)) {
       const body = a.slice(1);
-      const eq = body.indexOf('=');
-      const letters = eq === -1 ? body : body.slice(0, eq);
-
-      // Field flag anywhere in the cluster → this token carries a body.
-      if (letters.includes('f') || letters.includes('F')) hasBody = true;
-
-      // Method flag anywhere in the cluster → value is whatever follows the X
-      // in the same token (leading '=' stripped), else the next arg.
-      const xIdx = letters.indexOf('X');
-      if (xIdx !== -1) {
-        const after = body.slice(xIdx + 1).replace(/^=/, '');
-        if (after) setExplicit(after);
-        else setExplicit(args[i + 1] ?? '');
+      for (let j = 0; j < body.length; j++) {
+        const c = body[j];
+        if (c === 'f' || c === 'F') {
+          // First value-taking short is a body field: the rest of the token
+          // (including any 'X') is this field's VALUE — never a method flag.
+          hasBody = true;
+          break;
+        }
+        if (c === 'X') {
+          // First value-taking short is the method flag: value is the token
+          // remainder after X (leading '=' stripped), else the next arg.
+          const after = body.slice(j + 1).replace(/^=/, '');
+          setExplicit(after || (args[i + 1] ?? ''));
+          break;
+        }
+        // Any other letter is a boolean short (e.g. -i); keep scanning.
       }
     }
   }

--- a/plugins/github/test/tools/gh-exec.test.ts
+++ b/plugins/github/test/tools/gh-exec.test.ts
@@ -79,14 +79,21 @@ describe('findMutation allowlist', () => {
   });
 
   it('still allows legit reads whose flag values look like verbs', () => {
-    // Branch named `merge`; flag-value exclusion must NOT block this — verb is `view`.
-    expect(findMutation(['pr', 'view', 'merge']).blocked).toBe(false);
     // `create` is the --search term, not the verb; verb is still `list`.
     expect(findMutation(['issue', 'list', '--search', 'create']).blocked).toBe(false);
     // Global value-flag before the group; verb is still `list`.
     expect(findMutation(['-R', 'o/r', 'issue', 'list']).blocked).toBe(false);
-    expect(findMutation(['api', 'repos/o/r']).blocked).toBe(false);
-    expect(findMutation(['pr', 'list']).blocked).toBe(false);
+  });
+
+  it('blocks the -fX=GET body-field bypass (pflag stops at the first value-taking short)', () => {
+    // `-fX=GET` is --field with value `X=GET` (a body field named X) → gh POSTs;
+    // the trailing X must NOT be parsed as a method that downgrades it to GET.
+    expect(findMutation(['api', 'x', '-fX=GET']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-FX=GET']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-f', '-fX=GET']).blocked).toBe(true);
+    expect(findMutation(['api', 'repos/o/r/issues', '-fX=GET', '-ftitle=pwned']).blocked).toBe(true);
+    // A real method-only read (no body) still resolves to GET and is allowed.
+    expect(findMutation(['api', 'repos/o/r', '-X', 'GET']).blocked).toBe(false);
   });
 });
 

--- a/plugins/github/test/tools/gh-exec.test.ts
+++ b/plugins/github/test/tools/gh-exec.test.ts
@@ -62,6 +62,32 @@ describe('findMutation allowlist', () => {
   it('does not false-positive on read args that contain a verb word', () => {
     expect(findMutation(['pr', 'view', 'merge']).blocked).toBe(false);
   });
+
+  it('blocks the flag-value-shift bypass (cobra consumes the token after a value flag)', () => {
+    // `--title`'s value `list` is consumed by gh; real verb `create` is a mutation.
+    expect(findMutation(['issue', '--title', 'list', 'create']).blocked).toBe(true);
+  });
+
+  it('blocks gh api short-flag-cluster mutations (pflag clustering bypass)', () => {
+    // -iF = -i (include) + -F (raw-field, value from next arg) → body → POST.
+    expect(findMutation(['api', 'repos/o/r/issues', '-iF', 'field=y']).blocked).toBe(true);
+    // -iX = -i + -X (method, value from next arg).
+    expect(findMutation(['api', 'x', '-iX', 'POST']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-X=POST']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '--input', 'body.json']).blocked).toBe(true);
+    expect(findMutation(['pr', 'merge', '1']).blocked).toBe(true);
+  });
+
+  it('still allows legit reads whose flag values look like verbs', () => {
+    // Branch named `merge`; flag-value exclusion must NOT block this — verb is `view`.
+    expect(findMutation(['pr', 'view', 'merge']).blocked).toBe(false);
+    // `create` is the --search term, not the verb; verb is still `list`.
+    expect(findMutation(['issue', 'list', '--search', 'create']).blocked).toBe(false);
+    // Global value-flag before the group; verb is still `list`.
+    expect(findMutation(['-R', 'o/r', 'issue', 'list']).blocked).toBe(false);
+    expect(findMutation(['api', 'repos/o/r']).blocked).toBe(false);
+    expect(findMutation(['pr', 'list']).blocked).toBe(false);
+  });
 });
 
 describe('gh_exec execute', () => {

--- a/plugins/github/test/tools/gh-exec.test.ts
+++ b/plugins/github/test/tools/gh-exec.test.ts
@@ -74,8 +74,18 @@ describe('findMutation allowlist', () => {
     // -iX = -i + -X (method, value from next arg).
     expect(findMutation(['api', 'x', '-iX', 'POST']).blocked).toBe(true);
     expect(findMutation(['api', 'x', '-X=POST']).blocked).toBe(true);
-    expect(findMutation(['api', 'x', '--input', 'body.json']).blocked).toBe(true);
-    expect(findMutation(['pr', 'merge', '1']).blocked).toBe(true);
+  });
+
+  it('blocks the boolean-short-cluster verb-shift bypass (pflag: -xy... does not consume next arg)', () => {
+    // A single-dash cluster of length >= 3 is all in-token flags; pflag does NOT read
+    // its value from the following arg, so the real write verb stays a positional and
+    // must not be dropped. `gh release -dp create view` dispatches `release create`.
+    expect(findMutation(['release', '-dp', 'create', 'view']).blocked).toBe(true);
+    expect(findMutation(['pr', '-dm', 'merge', 'view']).blocked).toBe(true);
+    // A genuine long flag without `=` (or a lone 2-char short) still consumes its value,
+    // so these reads whose verb follows a real value flag remain allowed.
+    expect(findMutation(['issue', 'list', '--label', 'create']).blocked).toBe(false);
+    expect(findMutation(['-R', 'o/r', 'pr', 'list']).blocked).toBe(false);
   });
 
   it('still allows legit reads whose flag values look like verbs', () => {

--- a/plugins/github/test/tools/gh-exec.test.ts
+++ b/plugins/github/test/tools/gh-exec.test.ts
@@ -73,7 +73,18 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['api', 'repos/o/r/issues', '-iF', 'field=y']).blocked).toBe(true);
     // -iX = -i + -X (method, value from next arg).
     expect(findMutation(['api', 'x', '-iX', 'POST']).blocked).toBe(true);
-    expect(findMutation(['api', 'x', '-X=POST']).blocked).toBe(true);
+  });
+
+  it('does not misread a value-flag value as -X/method (jq/header/template consume their value)', () => {
+    // `--jq`/`-q`/`-H` take the FOLLOWING token as their value; a value that looks like
+    // `-Xhack`/`-XGET` is data, not a method flag. The `-f` body still makes gh POST, so
+    // the forged method must not downgrade it to an allowed read.
+    expect(findMutation(['api', '-f', 'title=x', '/repos/o/r/issues', '--jq', '-Xhack']).blocked).toBe(true);
+    expect(findMutation(['api', '-f', 'a=b', '--jq', '-XGET']).blocked).toBe(true);
+    expect(findMutation(['api', '-f', 'a=b', '-q', '-XGET']).blocked).toBe(true);
+    expect(findMutation(['api', '-f', 'a=b', '-H', '-XGET']).blocked).toBe(true);
+    // A genuine jq read with a normal expression is still an allowed GET.
+    expect(findMutation(['api', 'repos/o/r', '--jq', '.name']).blocked).toBe(false);
   });
 
   it('blocks the boolean-short-cluster verb-shift bypass (pflag: -xy... does not consume next arg)', () => {


### PR DESCRIPTION
Security hotfix: the merged `gh_exec` guard predated two bypass fixes the merge-gating review required for the gitlab guard (Spec 3). Ports the corrected logic into `plugins/github/src/tools/gh-exec-guard.ts`.

- **Flag-value shift** closed: `findMutation` now computes positionals with flag-value exclusion (exclude the token after any flag), so `["issue","--title","list","create"]` (which `gh` dispatches as `issue create`) is blocked instead of read as `positionals[1]="list"`.
- **pflag short-flag cluster** closed: `effectiveApiMethod` inspects single-dash clusters char-by-char for the method (`X`) and body (`f`/`F`) letters (+ `--input`/attached/`=` forms), so `["api","x","-iF","field=y"]` / `-iX POST` / `-X=POST` resolve to POST and are blocked.

Regression tests added for both bypasses; reads still allowed (`pr view <branch>`, `issue list --search create`, `-R o/r issue list`, `api ... GET`). 64 github tests pass; `biome ci plugins/github` exit 0.

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)
