### PR TITLE
Spec 5: aws plugin → CLI-Plugin Capability Contract (native tool layer)

### DIFF
--- a/.plans/2026-07-23-aws-contract-spec5-design.md
+++ b/.plans/2026-07-23-aws-contract-spec5-design.md
@@ -1,0 +1,87 @@
+# AWS Plugin → Capability Contract (Spec 5) — Design
+
+- **Issue:** #808
+- **Status:** design approved (single PR); from-zero tool layer
+- **Date:** 2026-07-23
+
+## Context
+
+The `aws` plugin registers zero native tools — an auth-and-status shell (wizard,
+`cli-operator` Bash agent, skills, `aws_hint` context injection, service status). Spec 5
+builds the native tool layer from scratch, mirroring the conformant Azure structure and
+porting the corrected GitLab guard. Everything in the consistency layer is preserved
+untouched; the new tool block slots into a fresh
+`if (awsAvailable && typeof pi.registerTool === 'function')` gate.
+
+`aws` grammar is `aws <service> <operation>` (space-separated, 2-deep). Output: global
+`--output json|text|table` + client-side `--query` (JMESPath — SAME engine as Azure, so
+do NOT strip shell metacharacters) + per-service `--filters`. There is NO `api`
+passthrough subcommand, so NO `effectiveApiMethod` is needed (simpler than gh/glab/sf).
+
+## Build (files to create)
+
+- `src/aws/types.ts` — interfaces + validation regexes (`INSTANCE_ID_PATTERN`,
+  `REGION_PATTERN`, `S3_URI_PATTERN`, `RESOURCE_NAME_PATTERN`, `HELP_PATH_PATTERN`).
+- `src/aws/exec.ts` — `Aws*Error` taxonomy (`AwsExecError` base + `AwsAuthError`,
+  `AwsSessionExpiredError`, `AwsNotFoundError`, `AwsThrottlingError`,
+  `AwsAccessDeniedError`) + `detectAwsError` (stderr precedence: auth → session-expired →
+  throttling → access-denied → not-found → exec) + signal-aware argv exec
+  (`signal && !signal.aborted` wire) + `execAwsJson`/`execAwsRaw`.
+- `src/tools/shared.ts` — `AwsErrorType`, `AwsToolDetails`, `textResult`/`errorResult`,
+  `detectErrorType`, local `renderError`, charCode `hasControlChars`, `makeExecApi`,
+  normalizers.
+- `src/aws/formatters.ts` — `formatIdentityDetail`, `formatBucketTable`,
+  `formatS3ObjectTable`, `formatInstanceTable` (markdown, empty states).
+- Typed reads: `src/tools/aws-sts-whoami.ts` (`aws sts get-caller-identity`),
+  `aws-s3-ls.ts` (`aws s3 ls` / `s3api list-buckets`), `aws-ec2-describe-instances.ts`.
+- `src/tools/aws-exec.ts` + `src/tools/aws-exec-guard.ts` (read-only passthrough).
+- `src/tools/aws-help.ts` (`aws <path> help` — note `help`, not `--help`).
+- `src/prompts/*.md` (aws-exec.md documents JMESPath `--query` + `--filters` + read-only
+  policy).
+- `src/index.ts` — `withErrorType` wrapper + tool gate (preserve all existing blocks).
+- `package.json` scripts + devDeps (`@sinclair/typebox`, `bun-types`); `tsconfig.json`.
+- `benchmarks/{mock-aws.sh, scenarios.ts, fixtures/*}` + `autoresearch.{sh,checks.sh,md,ideas.md}`.
+- Per-tool tests + `test/aws/{exec,formatters}.test.ts`.
+
+## `aws_exec` guard (`aws-exec-guard.ts`)
+
+Fail-safe read-only allowlist on the operation token (`positionals[1]`), with GitLab's
+flag-value exclusion (exclude the token after any flag) and `hasControlChars`:
+
+- `READ_PREFIXES` = `describe- list- get- lookup- search- batch-get- head- estimate-
+  simulate- preview- filter- check- resolve-`; `READ_EXACT` = `ls wait help scan select
+  query`.
+- **s3 special-case** (`service === 's3'`): allow `ls`; BLOCK `cp mv rm sync mb rb`
+  (S3 writes) and anything else fail-safe.
+- Generic services: allow iff `op` is READ_EXACT or starts with a READ_PREFIX; else
+  BLOCK (unknown → blocked). This inherently blocks `create-*/delete-*/put-*/run-*/
+  terminate-*/update-*/modify-*/…` and any unrecognized op.
+- No `effectiveApiMethod` (aws has no api-method passthrough).
+- Tool: reject empty; `hasControlChars` per arg; block per guard with cli-operator
+  delegation message; default `--output json` unless caller set `--output`/`-o`; cap
+  output; classify failures via `detectAwsError`. Do NOT strip shell metacharacters
+  (argv exec; JMESPath needs `|`/backticks).
+
+## Task sequencing (single PR)
+
+1. `types.ts` + `exec.ts` (taxonomy + signal exec) + `shared.ts` (TDD detector/hygiene).
+2. `formatters.ts` + the 3 typed read tools + their prompts (TDD).
+3. `aws-exec-guard.ts` + `aws-exec.ts` + `aws-help.ts` + prompts (TDD, adversarial guard).
+4. `index.ts` wiring (withErrorType + gate) + package.json/tsconfig + extension test.
+5. benchmark + autoresearch harness (`mock-aws`).
+6. verify + PR.
+
+## Verification
+
+`cd plugins/aws && bun test` green; `npx biome ci plugins/aws` exit 0; `bun run
+benchmarks/scenarios.ts` composite; `autoresearch.checks.sh` passes; prose
+brand-capitalized (AWS/Azure/GitHub/GitLab); doc lines < 400. Manual smoke (if `aws`
+authed): `aws_sts_whoami` returns identity; `aws_exec` runs `ec2 describe-instances` and
+refuses `ec2 run-instances`, `s3 rm`, `iam create-user`. Workflow: issue #808 → branch
+`feat/aws-contract-parity-808` → PR → CI → auto-merge. Plan file UNTRACKED; verify with
+`biome ci` before pushing. Never touch `main`.
+
+## Non-goals
+
+Spec 6 (gcloud). Preserve the auth skill / cli-operator agent / wizard / context
+injection / service status unchanged.

--- a/plugins/aws/autoresearch.checks.sh
+++ b/plugins/aws/autoresearch.checks.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Post-experiment validation gate for the AWS plugin autoresearch.
+# All checks must pass for a run to be logged as "keep".
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+ERRORS=0
+
+# ── Check 1: All tests pass ────────────────────────────────────────────────
+echo "=== Check 1: bun test ==="
+if bun test 2>&1 | tail -3; then
+  echo "PASS: all tests passed"
+else
+  echo "FAIL: bun test failed"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Check 2: Biome lint clean ──────────────────────────────────────────────
+echo ""
+echo "=== Check 2: biome check ==="
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BIOME_OUTPUT="$(cd "$REPO_ROOT" && npx biome check plugins/aws/src/ 2>&1 || true)"
+BIOME_ERRORS="$(echo "$BIOME_OUTPUT" | grep -c 'error:' || true)"
+if [ "$BIOME_ERRORS" -eq 0 ]; then
+  echo "PASS: biome check clean"
+else
+  echo "FAIL: biome check found $BIOME_ERRORS error(s)"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Check 3: All 5 tool factories in index.ts ──────────────────────────────
+echo ""
+echo "=== Check 3: tool registrations ==="
+TOOL_FACTORIES=(
+  "createAwsStsWhoamiTool"
+  "createAwsS3LsTool"
+  "createAwsEc2DescribeInstancesTool"
+  "createAwsHelpTool"
+  "createAwsExecTool"
+)
+ALL_TOOLS_OK=true
+for tool in "${TOOL_FACTORIES[@]}"; do
+  if ! grep -q "$tool" src/index.ts; then
+    echo "FAIL: $tool not found in src/index.ts"
+    ERRORS=$((ERRORS + 1))
+    ALL_TOOLS_OK=false
+  fi
+done
+if [ "$ALL_TOOLS_OK" = true ]; then
+  echo "PASS: all 5 tool factories registered"
+fi
+
+# ── Check 4: Security invariants intact ────────────────────────────────────
+echo ""
+echo "=== Check 4: security invariants ==="
+ALL_PATTERNS_OK=true
+# aws_exec guardrail: argv hygiene (control-char reject) + read-only allowlist.
+# The argv boundary is the injection control; do NOT reintroduce per-character
+# shell-metacharacter filtering (it breaks valid aws expressions).
+if ! grep -q "hasControlChars" src/tools/shared.ts; then
+  echo "FAIL: argv hygiene guard (hasControlChars) missing from src/tools/shared.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+if ! grep -q "findMutation" src/tools/aws-exec-guard.ts; then
+  echo "FAIL: read-only guardrail (findMutation) missing from src/tools/aws-exec-guard.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+# Error taxonomy classifier for typed error results.
+if ! grep -q "detectAwsError" src/aws/exec.ts; then
+  echo "FAIL: error classifier (detectAwsError) missing from src/aws/exec.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+if [ "$ALL_PATTERNS_OK" = true ]; then
+  echo "PASS: all security invariants intact"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "CHECKS FAILED: $ERRORS error(s)"
+  exit 1
+fi
+echo "ALL CHECKS PASSED"
+exit 0

--- a/plugins/aws/autoresearch.ideas.md
+++ b/plugins/aws/autoresearch.ideas.md
@@ -1,0 +1,33 @@
+# Autoresearch Ideas — AWS Plugin
+
+## Prompt Optimization
+
+- [ ] Compress tool descriptions: keep flag names, parameter types, and one-line summaries; drop prose
+- [ ] Add inline `--output json` field examples to aws_s3_ls and aws_ec2_describe_instances prompts (reduces aws_help round-trips)
+- [ ] Reinforce the `aws <service> <operation> help` contrast (help subcommand, not a `--help` flag) where the model is most likely to guess wrong
+- [ ] Cross-tool hints: "use aws_help to discover flags before aws_exec"
+- [ ] Clarify when to prefer typed tools over aws_exec so the model does not reach for the passthrough first
+
+## Error Handling
+
+- [ ] Map more aws stderr signatures in src/aws/exec.ts to typed errors (auth, session-expired, throttling, access-denied, not-found)
+- [ ] Include the fix command in "not authenticated" errors (run: `aws sso login` or `aws configure`)
+- [ ] Add structured retry hints to error results (e.g. retry_with: aws_sts_whoami)
+
+## Formatter Improvements
+
+- [ ] Shorten column labels in the instance summary table without losing meaning
+- [ ] Consistent "no results" messaging across formatBucketTable, formatInstanceTable, and formatS3ObjectTable
+- [ ] Trim redundant whitespace emitted by the identity detail formatter
+
+## Token Efficiency
+
+- [ ] Audit the per-file prompt byte budget across the 5 prompts; target the largest first
+- [ ] Merge near-duplicate guidance shared by aws_s3_ls and aws_ec2_describe_instances prompts
+- [ ] Remove markdown that adds tokens without improving model parsing (horizontal rules, extra headings)
+
+## Guardrail Coverage
+
+- [ ] Extend benchmark scenarios for aws_exec: `s3 sync` block, `--region`-shifted operation block
+- [ ] Add an s3 object listing scenario driven by a text `s3 ls s3://bucket/prefix` fixture
+- [ ] Keep the read-only allowlist fail-safe: new read verbs are opt-in, never a blanket allow

--- a/plugins/aws/autoresearch.md
+++ b/plugins/aws/autoresearch.md
@@ -1,0 +1,45 @@
+# AWS Plugin — Autoresearch Contract
+
+Optimize the AWS plugin's intelligence quality: improve prompt accuracy, reduce tool
+invocation turns, and minimize token cost while maintaining all security invariants.
+
+Composite formula: `accuracy * (1 / (1 + avg_turns / 10)) * (1 / (1 + avg_tokens / 10000))`
+
+## Benchmark
+
+- command: bash autoresearch.sh
+- primary metric: composite_score
+- metric unit:
+- direction: higher
+- secondary metrics: accuracy, avg_turns, avg_tokens, live_accuracy
+
+## Files in Scope
+
+- src/prompts/
+- src/tools/
+- src/aws/formatters.ts
+- src/aws/exec.ts
+
+## Off Limits
+
+- src/index.ts
+- src/wizard.ts
+- src/platform.ts
+- test/
+- benchmarks/
+
+## Constraints
+
+- All existing tests must pass (bun test exit 0)
+- The aws_exec guardrail must stay present: `findMutation` (read-only allowlist) in
+  src/tools/aws-exec-guard.ts and `hasControlChars` (argv hygiene) in src/tools/shared.ts.
+  aws is spawned argv-only (no shell), so the argv boundary is the injection control — do
+  NOT reintroduce per-character shell-metacharacter filtering, which only breaks valid
+  aws expressions such as `--query` JMESPath syntax.
+- Error taxonomy must stay intact: `detectAwsError` remains exported from src/aws/exec.ts and
+  keeps classifying stderr into AwsAuthError, AwsSessionExpiredError, AwsThrottlingError,
+  AwsAccessDeniedError, and AwsNotFoundError.
+- All 5 tool names must remain stable: aws_sts_whoami, aws_s3_ls, aws_ec2_describe_instances,
+  aws_help, aws_exec
+- Tool parameter names and types must not change
+- Biome lint must pass with no new errors

--- a/plugins/aws/autoresearch.sh
+++ b/plugins/aws/autoresearch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Benchmark harness for the AWS plugin autoresearch.
+# Outputs METRIC and ASI lines consumed by the xcsh /autoresearch command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=== Gate: existing tests ==="
+if ! bun test 2>&1 | tail -3; then
+  echo "ERROR: Tests failed. Aborting benchmark." >&2
+  exit 1
+fi
+echo ""
+
+echo "=== Running benchmark scenarios ==="
+bun run benchmarks/scenarios.ts

--- a/plugins/aws/benchmarks/fixtures/caller-identity.json
+++ b/plugins/aws/benchmarks/fixtures/caller-identity.json
@@ -1,0 +1,5 @@
+{
+  "UserId": "AIDAEXAMPLEUSERID123",
+  "Account": "123456789012",
+  "Arn": "arn:aws:iam::123456789012:user/demo-engineer"
+}

--- a/plugins/aws/benchmarks/fixtures/describe-instances.json
+++ b/plugins/aws/benchmarks/fixtures/describe-instances.json
@@ -1,0 +1,17 @@
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "InstanceId": "i-0123456789abcdef0",
+          "State": { "Name": "running" },
+          "InstanceType": "t3.medium",
+          "Placement": { "AvailabilityZone": "us-east-1a" },
+          "PrivateIpAddress": "10.0.1.15",
+          "PublicIpAddress": "54.12.34.56",
+          "Tags": [{ "Key": "Name", "Value": "demo-web-1" }]
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/aws/benchmarks/fixtures/list-buckets.json
+++ b/plugins/aws/benchmarks/fixtures/list-buckets.json
@@ -1,0 +1,7 @@
+{
+  "Buckets": [
+    { "Name": "demo-assets", "CreationDate": "2026-01-15T10:00:00Z" },
+    { "Name": "demo-logs", "CreationDate": "2026-02-20T12:30:00Z" }
+  ],
+  "Owner": { "DisplayName": "demo", "ID": "abc123" }
+}

--- a/plugins/aws/benchmarks/mock-aws.sh
+++ b/plugins/aws/benchmarks/mock-aws.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Mock aws CLI for benchmark scenarios.
+#
+# Priority 1 (mirrors the mock-gh.sh contract): emit $MOCK_AWS_FIXTURE when set.
+# Priority 2: emit $MOCK_AWS_HELP when set.
+# Priority 3: route by argv to a fixture under $AWS_BENCH_FIXTURES.
+# Otherwise exit non-zero.
+#
+# Argv routing exists because Bun resolves inherited-spawn binaries and env from
+# the PATH/env captured at process startup and does not observe later
+# process.env mutations. The unmodified tool layer spawns `aws` with inherited
+# env, so it cannot pass MOCK_AWS_FIXTURE per call; routing on the argv the tool
+# actually sends keeps the mock deterministic.
+if [ -n "$MOCK_AWS_FIXTURE" ] && [ -f "$MOCK_AWS_FIXTURE" ]; then
+  cat "$MOCK_AWS_FIXTURE"
+  exit 0
+fi
+
+if [ -n "$MOCK_AWS_HELP" ]; then
+  echo "$MOCK_AWS_HELP"
+  exit 0
+fi
+
+args="$*"
+
+# The aws CLI exposes help via a trailing `help` subcommand (not a `--help`
+# flag). Match it first so `ec2 describe-instances help` returns help text
+# rather than the describe-instances fixture.
+case "$args" in
+*help*)
+  echo "AWS CLI HELP: aws ${args% help}"
+  echo "DESCRIPTION"
+  echo "  Synthetic help output for benchmark scenarios."
+  exit 0
+  ;;
+esac
+
+if [ -n "$AWS_BENCH_FIXTURES" ]; then
+  case "$args" in
+  *get-caller-identity*)
+    cat "$AWS_BENCH_FIXTURES/caller-identity.json"
+    exit 0
+    ;;
+  *list-buckets*)
+    cat "$AWS_BENCH_FIXTURES/list-buckets.json"
+    exit 0
+    ;;
+  *describe-instances*)
+    cat "$AWS_BENCH_FIXTURES/describe-instances.json"
+    exit 0
+    ;;
+  esac
+fi
+
+echo "mock-aws: no fixture for args: $args" >&2
+exit 1

--- a/plugins/aws/benchmarks/scenarios.ts
+++ b/plugins/aws/benchmarks/scenarios.ts
@@ -1,0 +1,298 @@
+import { mkdtempSync, readdirSync, readFileSync, statSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PLUGIN_ROOT = join(import.meta.dir, '..');
+const FIXTURES_DIR = join(import.meta.dir, 'fixtures');
+const MOCK_AWS = join(import.meta.dir, 'mock-aws.sh');
+
+// ---------------------------------------------------------------------------
+// PATH-injected mock bootstrap
+//
+// Bun resolves inherited-spawn binaries from the PATH captured at process
+// startup and does not observe later process.env mutations. The unmodified
+// tool layer (src/tools/shared.ts -> makeExecApi) spawns `aws` with inherited
+// env, so injecting a mock via a runtime process.env.PATH mutation is invisible
+// to it. Instead we re-exec this benchmark once with the mock symlinked onto
+// PATH *before* the child process starts, so the tools resolve `aws` to the
+// mock. The mock routes by argv to fixtures in AWS_BENCH_FIXTURES; the live
+// spot-check still reaches the real aws via AWS_BENCH_ORIG_PATH.
+// ---------------------------------------------------------------------------
+
+if (!process.env.AWS_BENCH_CHILD) {
+  const mockBinDir = mkdtempSync(join(tmpdir(), 'aws-bench-'));
+  symlinkSync(MOCK_AWS, join(mockBinDir, 'aws'));
+  const origPath = process.env.PATH ?? '';
+  const child = Bun.spawn([process.execPath, import.meta.path], {
+    env: {
+      ...process.env,
+      PATH: `${mockBinDir}:${origPath}`,
+      AWS_BENCH_CHILD: '1',
+      AWS_BENCH_ORIG_PATH: origPath,
+      AWS_BENCH_FIXTURES: FIXTURES_DIR,
+    },
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  process.exit(await child.exited);
+}
+
+const Typebox = await import('@sinclair/typebox');
+const { createAwsStsWhoamiTool } = await import('../src/tools/aws-sts-whoami');
+const { createAwsS3LsTool } = await import('../src/tools/aws-s3-ls');
+const { createAwsEc2DescribeInstancesTool } = await import('../src/tools/aws-ec2-describe-instances');
+const { createAwsHelpTool } = await import('../src/tools/aws-help');
+const { createAwsExecTool } = await import('../src/tools/aws-exec');
+
+// The AWS tools are factory-style: createAws*Tool(pi) reads pi.typebox to build
+// its parameter schema. Construct the minimal pi stub the factories need.
+const pi = { typebox: { Type: Typebox.Type } };
+
+const awsStsWhoami = createAwsStsWhoamiTool(pi);
+const awsS3Ls = createAwsS3LsTool(pi);
+const awsEc2DescribeInstances = createAwsEc2DescribeInstancesTool(pi);
+const awsHelp = createAwsHelpTool(pi);
+const awsExec = createAwsExecTool(pi);
+
+const SESSION = { cwd: '/tmp' };
+
+// ---------------------------------------------------------------------------
+// Scenario infrastructure
+// ---------------------------------------------------------------------------
+
+interface ScenarioResult {
+  pass: boolean;
+  score: number;
+}
+
+interface Scenario {
+  name: string;
+  run: () => Promise<ScenarioResult>;
+}
+
+function checkResult(
+  result: { content: Array<{ text: string }>; isError?: boolean },
+  expected: { isError?: boolean; contains?: string[]; notContains?: string[] },
+): ScenarioResult {
+  const text = result.content[0]?.text ?? '';
+  const isError = result.isError ?? false;
+
+  if (expected.isError !== undefined && expected.isError !== isError) {
+    return { pass: false, score: 0 };
+  }
+
+  let matched = 0;
+  let total = 0;
+
+  for (const s of expected.contains ?? []) {
+    total++;
+    if (text.includes(s)) matched++;
+  }
+
+  for (const s of expected.notContains ?? []) {
+    total++;
+    if (!text.includes(s)) matched++;
+  }
+
+  if (total === 0) return { pass: !isError || expected.isError === true, score: 1 };
+  const score = matched / total;
+  return { pass: score >= 0.8, score };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario definitions
+// ---------------------------------------------------------------------------
+
+const scenarios: Scenario[] = [
+  {
+    name: 'sts-whoami',
+    async run() {
+      const result = await awsStsWhoami.execute('t', {}, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['123456789012', 'arn:aws:iam::123456789012:user/demo-engineer', 'AIDAEXAMPLEUSERID123'],
+      });
+    },
+  },
+  {
+    name: 's3-ls-buckets',
+    async run() {
+      const result = await awsS3Ls.execute('t', {}, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['demo-assets', 'demo-logs'],
+      });
+    },
+  },
+  {
+    name: 'ec2-describe-instances',
+    async run() {
+      const result = await awsEc2DescribeInstances.execute('t', {}, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['i-0123456789abcdef0', 'running', 't3.medium', 'us-east-1a', 'demo-web-1'],
+      });
+    },
+  },
+  {
+    name: 'help-valid',
+    async run() {
+      const result = await awsHelp.execute(
+        't',
+        { command_path: 'ec2 describe-instances' },
+        undefined,
+        undefined,
+        SESSION,
+      );
+      return checkResult(result, { isError: false, contains: ['aws ec2 describe-instances'] });
+    },
+  },
+  {
+    name: 'exec-read-describe-instances',
+    async run() {
+      const result = await awsExec.execute('t', { args: ['ec2', 'describe-instances'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: false, contains: ['i-0123456789abcdef0', 'Reservations'] });
+    },
+  },
+  {
+    name: 'exec-control-char-rejected',
+    async run() {
+      const result = await awsExec.execute('t', { args: ['s3', 'ls', 'bad\u0000arg'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: true, contains: ['control character'] });
+    },
+  },
+  {
+    name: 'exec-run-instances-blocked',
+    async run() {
+      const result = await awsExec.execute('t', { args: ['ec2', 'run-instances'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: true, contains: ['read-only'] });
+    },
+  },
+  {
+    name: 'exec-s3-rm-blocked',
+    async run() {
+      const result = await awsExec.execute('t', { args: ['s3', 'rm', 's3://b/k'] }, undefined, undefined, SESSION);
+      return checkResult(result, { isError: true, contains: ['read-only'] });
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Accuracy scoring
+// ---------------------------------------------------------------------------
+
+async function measureAccuracy(): Promise<number> {
+  let totalScore = 0;
+  for (const scenario of scenarios) {
+    try {
+      const { score } = await scenario.run();
+      totalScore += score;
+    } catch {}
+  }
+  return totalScore / scenarios.length;
+}
+
+// ---------------------------------------------------------------------------
+// Turn efficiency
+// ---------------------------------------------------------------------------
+
+function measureTurnEfficiency(): number {
+  const promptsDir = join(PLUGIN_ROOT, 'src', 'prompts');
+  const promptContent = readdirSync(promptsDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => readFileSync(join(promptsDir, f), 'utf-8'))
+    .join('\n');
+
+  const tasks = [
+    { minTurns: 1, keywords: ['sts', 'get-caller-identity', 'profile'] },
+    { minTurns: 1, keywords: ['s3', 'bucket', 'aws_s3_ls'] },
+    { minTurns: 1, keywords: ['ec2', 'describe-instances', 'region'] },
+    { minTurns: 1, keywords: ['command_path', 'aws_help'] },
+    { minTurns: 1, keywords: ['--output json', 'aws_exec', 'read-only'] },
+  ];
+
+  let totalTurns = 0;
+  for (const task of tasks) {
+    let turns = task.minTurns;
+    const missing = task.keywords.filter((kw) => !promptContent.toLowerCase().includes(kw.toLowerCase()));
+    turns += missing.length;
+    totalTurns += turns;
+  }
+  return totalTurns / tasks.length;
+}
+
+// ---------------------------------------------------------------------------
+// Token efficiency
+// ---------------------------------------------------------------------------
+
+function measureTokenEfficiency(): number {
+  const promptsDir = join(PLUGIN_ROOT, 'src', 'prompts');
+  let totalBytes = 0;
+  for (const f of readdirSync(promptsDir).filter((f) => f.endsWith('.md'))) {
+    totalBytes += statSync(join(promptsDir, f)).size;
+  }
+  return totalBytes;
+}
+
+// ---------------------------------------------------------------------------
+// Live CLI spot-check (real aws via the pre-mock PATH)
+// ---------------------------------------------------------------------------
+
+async function measureLiveAccuracy(): Promise<number> {
+  const liveEnv = { ...process.env, PATH: process.env.AWS_BENCH_ORIG_PATH ?? process.env.PATH };
+  try {
+    const check = Bun.spawnSync(['aws', 'sts', 'get-caller-identity', '--output', 'json'], { env: liveEnv });
+    if (check.exitCode !== 0) return 0;
+  } catch {
+    return 0;
+  }
+
+  const checks = [
+    {
+      cmd: ['aws', 'sts', 'get-caller-identity', '--output', 'json'],
+      validate: (s: string) => typeof JSON.parse(s).Account === 'string',
+    },
+    {
+      cmd: ['aws', 's3api', 'list-buckets', '--output', 'json'],
+      validate: (s: string) => Array.isArray(JSON.parse(s).Buckets),
+    },
+  ];
+
+  let passed = 0;
+  for (const c of checks) {
+    try {
+      const proc = Bun.spawn(c.cmd, { stdout: 'pipe', stderr: 'pipe', env: liveEnv });
+      const stdout = await new Response(proc.stdout).text();
+      await proc.exited;
+      if (c.validate(stdout)) passed++;
+    } catch {
+      // skip
+    }
+  }
+  return passed / checks.length;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const accuracy = await measureAccuracy();
+  const avgTurns = measureTurnEfficiency();
+  const avgTokens = measureTokenEfficiency();
+  const liveAccuracy = await measureLiveAccuracy();
+
+  const composite = accuracy * (1 / (1 + avgTurns / 10)) * (1 / (1 + avgTokens / 10000));
+
+  console.log(`METRIC accuracy=${accuracy.toFixed(4)}`);
+  console.log(`METRIC avg_turns=${avgTurns.toFixed(2)}`);
+  console.log(`METRIC avg_tokens=${avgTokens}`);
+  console.log(`METRIC live_accuracy=${liveAccuracy.toFixed(4)}`);
+  console.log(`METRIC composite_score=${composite.toFixed(6)}`);
+  console.log(`ASI hypothesis=${process.env.AUTORESEARCH_HYPOTHESIS ?? 'baseline'}`);
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});

--- a/plugins/aws/bun.lock
+++ b/plugins/aws/bun.lock
@@ -1,0 +1,705 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@f5-sales-demo/xcsh-aws",
+      "devDependencies": {
+        "@sinclair/typebox": "^0.34.0",
+        "bun-types": "latest",
+      },
+      "peerDependencies": {
+        "@f5-sales-demo/xcsh": ">=1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.16.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1093.0", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/credential-provider-node": "^3.972.71", "@aws-sdk/eventstream-handler-node": "^3.972.29", "@aws-sdk/middleware-eventstream": "^3.972.24", "@aws-sdk/middleware-websocket": "^3.972.42", "@aws-sdk/token-providers": "3.1093.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CpXch6f8k+Cwjh/dLXwmoYc44ELmDlXFMPHAZBe6wDN4TDKNskgk9M6LUuizMvN1OHfvQcoGtvy8Oc/G3RNvLg=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.976.0", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.36", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.4", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-0cjRaEdlVoOrsNb9pP5q1Syyc8pXw5xSj2Np2ryReRTr9FppIIRVSdZK4lbnfmc2Hvgux/xBOUU6baB7z8//uA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.60", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BAkxdoe7tpDDqCghGpuOeHQRbm/2znVvOQm0AvpQbA2tbfMN46doN4zx65fv85ImP3KADwc2zQPmbrlI9MPfMg=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-g/0fGqKTb9xpKdd9AtpmV5Eo3DFKbnkpA2+w0peISSlu7NfAoWOuYBFxsu+yWBtxU89ka55ezoZBCbFaS8pjYQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.5", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/credential-provider-env": "^3.972.60", "@aws-sdk/credential-provider-http": "^3.972.62", "@aws-sdk/credential-provider-login": "^3.972.67", "@aws-sdk/credential-provider-process": "^3.972.60", "@aws-sdk/credential-provider-sso": "^3.973.4", "@aws-sdk/credential-provider-web-identity": "^3.972.66", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ylubazcRfq2TVus/qXucSXeC42Qdjp5HQxTu68K/BsdMiZlcSLD1zkpoCgApXZX1Y6YJhtGGs7ZHhO/GuIgBlw=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.67", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CCygIKJ9YbI3n84OClSaSppkgKKHVj2TGT33c6FRORZrYNZQ1POmD+ip0FLYokiJAK7sSdc3YVkOsBm90oxWMQ=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.71", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.60", "@aws-sdk/credential-provider-http": "^3.972.62", "@aws-sdk/credential-provider-ini": "^3.973.5", "@aws-sdk/credential-provider-process": "^3.972.60", "@aws-sdk/credential-provider-sso": "^3.973.4", "@aws-sdk/credential-provider-web-identity": "^3.972.66", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.60", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-YIo3f99hM43QdYG8hDzwGemnR/pU95b0kramqSJUTleCqaB7+HwKf7YZFHqvOgTqZTPx/mRmNIqoDRr3U0Z3Tw=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.4", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/token-providers": "3.1092.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BPdmL8sSBOCv4ngZ+3LHxyc3CNqDCEK37CHioCk7zGrTMY5sUtkH8q+o6qA80nn6w3/fyBPGNE7OIRlmoOxRQA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.66", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-kSAziJboOmZmsR9/MTbiNjowl2BPes1bQuJpne4qAZ62ubi8fjfr/aupJSQje6udBoYxXTQbsL0e0kby2la3ng=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.29", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-t3tKQRTVXsI2QNPE3CaNjHl0wRO9Xi3acZkAyti2RQsiFmZ9Gi0kArX2ighlRJ1BtDVuul413gThAgzyTfgmWA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.24", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.42", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dw+GP8DC7QC2C8tUoK7DI8BnrNAjz8tb+uBHSrD2qJvxkCf58kTtFr98pljSrk+umU4n4HDW4eU2k7C2dWMzsg=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.34", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Y9REVrSwmLM+Qy6sZJ7ofMC2S3Hr3tPP/4CzL5U1olPP7OGoF+6+Px0E49cVQBtSxJtyeLJMf0UaBErfeSahAA=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.41", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1093.0", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-0TOm0RAnnsgV3eaG/xh/PlMxtmpv8hvdAjVReQvmOMhBgIKdYuc3Iz318GvnDNNgf3pUoV5zUaLVeGz4jp3shw=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.36", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.13.0", "", {}, "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g=="],
+
+    "@colors/colors": ["@colors/colors@1.6.0", "", {}, "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="],
+
+    "@dabh/diagnostics": ["@dabh/diagnostics@2.0.8", "", { "dependencies": { "@so-ric/colorspace": "^1.1.6", "enabled": "2.0.x", "kuler": "^2.0.0" } }, "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q=="],
+
+    "@f5-sales-demo/i18n-core": ["@f5-sales-demo/i18n-core@1.0.24", "", {}, "sha512-dhGBldCeik4hkAvloPoQJkkZDJxIe22CMp8FrbiMsMGK+tZTj/6LhuvKkIGH3gyR6jzcP2EP8/cSA7vmmDQQpQ=="],
+
+    "@f5-sales-demo/pi-agent-core": ["@f5-sales-demo/pi-agent-core@19.81.1", "", { "dependencies": { "@f5-sales-demo/pi-ai": "19.81.1", "@f5-sales-demo/pi-utils": "19.81.1" } }, "sha512-Dh+AjoANDeJdXQLU2K0Re8QHdDGPvf1PA3CNCv1Ki+JOLkowdjK18cbFrUN3JjvQP36LutAeQP+QLST/cy0HJA=="],
+
+    "@f5-sales-demo/pi-ai": ["@f5-sales-demo/pi-ai@19.81.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.78", "@aws-sdk/client-bedrock-runtime": "^3", "@bufbuild/protobuf": "^2.11", "@f5-sales-demo/pi-utils": "19.81.1", "@google/genai": "^1.43", "@sinclair/typebox": "^0.34", "@smithy/node-http-handler": "^4.4", "ajv": "^8.20", "ajv-formats": "^3.0", "openai": "^6.25", "partial-json": "^0.1", "zod": "^4.3" }, "bin": { "pi-ai": "src/cli.ts" } }, "sha512-mUqeX3eALOpxBES1LpQM9qZSJIe1voiTcJ7xQPRsTUA9avzFkEmJUunQDfbagQlH2Q7/zXh7h+plUJ8yn6yz9Q=="],
+
+    "@f5-sales-demo/pi-natives": ["@f5-sales-demo/pi-natives@19.81.1", "", { "optionalDependencies": { "@f5-sales-demo/pi-natives-darwin-arm64": "19.81.1", "@f5-sales-demo/pi-natives-darwin-x64": "19.81.1", "@f5-sales-demo/pi-natives-linux-arm64-gnu": "19.81.1", "@f5-sales-demo/pi-natives-linux-x64-gnu": "19.81.1", "@f5-sales-demo/pi-natives-win32-x64-msvc": "19.81.1" } }, "sha512-K35tAaVwlOnZgK+Kc48zl+5ixBr/RkUc44sgB27Ue2h1ywfCEfVPdwX0LtZZbq+sYuaTpj/sNfhDC5SPTXLVcw=="],
+
+    "@f5-sales-demo/pi-natives-darwin-arm64": ["@f5-sales-demo/pi-natives-darwin-arm64@19.81.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iGj0DR4P+4ApG++k4+kEznonE4CUQpe3XyKyHjsLVuGfjZbMkcCky5q30dC5X29ujFnb+Zvvx5xf5keUb6bxsg=="],
+
+    "@f5-sales-demo/pi-natives-darwin-x64": ["@f5-sales-demo/pi-natives-darwin-x64@19.81.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-5CHxdGiHMemAC1eNqSOU4Sxm82hFKkI5jg07HXu3WXUfzh+qQkQmSUTP8a03xie7X9ZnzC52bgYDqlu44hp07Q=="],
+
+    "@f5-sales-demo/pi-natives-linux-arm64-gnu": ["@f5-sales-demo/pi-natives-linux-arm64-gnu@19.81.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-9zFnZ54Bzs8LsFhZVStNg81cBQ/jwrWJCY/zKGFq/xRHpFv+d72XlV8QAQXQZW5xzPL2iV1G9S5IuUq4SVROzQ=="],
+
+    "@f5-sales-demo/pi-natives-linux-x64-gnu": ["@f5-sales-demo/pi-natives-linux-x64-gnu@19.81.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ikQUl14ED+3i0H5gvmoKAfjKB8GCcmnNRRvYyNpDm3jVEwVOvjB403b9Q4CnmGuZ4GFccwbG54CRVURt44vz4A=="],
+
+    "@f5-sales-demo/pi-natives-win32-x64-msvc": ["@f5-sales-demo/pi-natives-win32-x64-msvc@19.81.1", "", { "os": "win32", "cpu": "x64" }, "sha512-8RJ/wOItOci4Hp1bwALG1LTXKN732Q8fcKk1ePU8/E+KyisV9ovCQXOND2caKUfbduhPGfQQg2TRWvFGdS/tcQ=="],
+
+    "@f5-sales-demo/pi-resource-management": ["@f5-sales-demo/pi-resource-management@19.81.1", "", { "dependencies": { "yaml": "2.9.0" } }, "sha512-0OpmCBRb93hLAeZdSi58lR6wvMcMHdsgL9SwHfevXZX3KxP6xbkXAwqNgkN4amxmaF7dxZ5XZFo8hs10QjIuiA=="],
+
+    "@f5-sales-demo/pi-tui": ["@f5-sales-demo/pi-tui@19.81.1", "", { "dependencies": { "@f5-sales-demo/pi-natives": "19.81.1", "@f5-sales-demo/pi-utils": "19.81.1", "marked": "^17.0" } }, "sha512-2HNQg4pfyKoTuL74LgbUxNGUqzpJ3XpN2W61vOgLAG8rKHuWFbMg9P4pwCbbKt71ncJQcIDilhGm0meJTHJAiw=="],
+
+    "@f5-sales-demo/pi-utils": ["@f5-sales-demo/pi-utils@19.81.1", "", { "dependencies": { "@f5-sales-demo/i18n-core": "^1.0.0", "beautiful-mermaid": "^1.1", "handlebars": "^4.7.9", "winston": "^3.19", "winston-daily-rotate-file": "^5.0" } }, "sha512-t6c6OumjloKscfyCc/SDzHXdslnwi8BcsSZJT1GsTKHw7mfoB39x4MW/mNWajZLVMQfRa8AY5i+rbmVJJN5EHQ=="],
+
+    "@f5-sales-demo/xcsh": ["@f5-sales-demo/xcsh@19.81.1", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@f5-sales-demo/pi-agent-core": "19.81.1", "@f5-sales-demo/pi-ai": "19.81.1", "@f5-sales-demo/pi-natives": "19.81.1", "@f5-sales-demo/pi-resource-management": "19.81.1", "@f5-sales-demo/pi-tui": "19.81.1", "@f5-sales-demo/pi-utils": "19.81.1", "@f5-sales-demo/xcsh-stats": "19.81.1", "@mozilla/readability": "^0.6", "@sinclair/typebox": "^0.34", "@xterm/headless": "^6.0", "ajv": "^8.20", "chalk": "^5.6", "diff": "^8.0", "fflate": "0.8.2", "handlebars": "^4.7", "linkedom": "^0.18", "lru-cache": "11.3.1", "markit-ai": "0.5.0", "puppeteer": "^24.37", "yaml": "2.9.0", "zod": "4.3.6" }, "bin": { "xcsh": "src/cli.ts" } }, "sha512-eZYsLiL0jhpLm9IRGHB9k1o7FRJlBY93OX62O7cUjrMEcLcoij5azXE5SYl2mUZylg6ZWIOEvbiaMEO8+DB+VA=="],
+
+    "@f5-sales-demo/xcsh-stats": ["@f5-sales-demo/xcsh-stats@19.81.1", "", { "dependencies": { "@f5-sales-demo/pi-ai": "19.81.1", "@f5-sales-demo/pi-utils": "19.81.1", "@tailwindcss/node": "^4.2", "chart.js": "^4.5", "date-fns": "~4.1.0", "lucide-react": "^0.576", "react": "^19.2", "react-chartjs-2": "^5.3", "react-dom": "^19.2" }, "bin": { "xcsh-stats": "src/index.ts" } }, "sha512-pQrI9xvZQdiwld3Ax1bNhRQ4DzDluN1pqCZpS3nqMExleSTFStmu3vfm1zNHyPalLkkKB4knur1DL7zeGw5DBg=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
+
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+
+    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
+
+    "@smithy/core": ["@smithy/core@3.29.7", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BiEE2bnnGoPKdlGe3L+gOYORDHFGPuYVRLP7iUow/Sflm0B4hC4XY3FC1MRuc7ltzpW2xNnXopKi34TTkULlKQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.12", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ZZPDbl/aRp77aycuoMlo3BTayT4CE2a3uoqETYZU5ySnVbhpl5IJiY7dCZedn+ZusyDLqVv44IvKBiXd2/nK0Q=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.9", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-EJktha5m5MXCwzdXrlWyqb9UCNHNFKlg+PmTpRsdX3dncJPTiqYleM9OKj2mLgdVJHR01d2tU4alG+z2NdH5rQ=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.9", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-xVBZ3hptB99iNO9XyWqEhC7KD9bP9UPXhuy3h5Y2ItCfBv160D9IIC/Fmmp3EbnWwit4C+KVqlSE+E29Nk/pPg=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.8", "", { "dependencies": { "@smithy/core": "^3.29.7", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-iGBm6hIwD2MGvVRSgrjVWa4FXtXDq3akxu0DCpnkmBo0xtEHZ/siMRt7ycfZAefYr2UdywUgmGtoRLaq5u56pg=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@so-ric/colorspace": ["@so-ric/colorspace@1.1.6", "", { "dependencies": { "color": "^5.0.2", "text-hex": "1.0.x" } }, "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/triple-beam": ["@types/triple-beam@1.3.5", "", {}, "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
+    "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
+    "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
+
+    "bare-events": ["bare-events@2.9.1", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg=="],
+
+    "bare-fs": ["bare-fs@4.7.4", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ=="],
+
+    "bare-path": ["bare-path@3.1.1", "", {}, "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ=="],
+
+    "bare-stream": ["bare-stream@2.13.3", "", { "dependencies": { "b4a": "^1.8.1", "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ=="],
+
+    "bare-url": ["bare-url@2.4.6", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
+
+    "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
+
+    "boolbase": ["boolbase@2.0.0", "", {}, "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
+
+    "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
+
+    "color": ["color@5.0.3", "", { "dependencies": { "color-convert": "^3.1.3", "color-string": "^2.1.3" } }, "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA=="],
+
+    "color-convert": ["color-convert@3.1.3", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg=="],
+
+    "color-name": ["color-name@2.1.1", "", {}, "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg=="],
+
+    "color-string": ["color-string@2.1.4", "", { "dependencies": { "color-name": "^2.0.0" } }, "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
+
+    "css-select": ["css-select@7.0.0", "", { "dependencies": { "boolbase": "^2.0.0", "css-what": "^8.0.0", "domhandler": "^6.0.1", "domutils": "^4.0.2", "nth-check": "^3.0.1" } }, "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g=="],
+
+    "css-what": ["css-what@8.0.0", "", {}, "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw=="],
+
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
+
+    "dom-serializer": ["dom-serializer@3.1.1", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "entities": "^8.0.0" } }, "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@6.0.1", "", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
+
+    "domutils": ["domutils@4.0.2", "", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
+
+    "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "enabled": ["enabled@2.0.0", "", {}, "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
+
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
+    "exifr": ["exifr@7.1.3", "", {}, "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
+
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "fecha": ["fecha@4.2.3", "", {}, "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "file-stream-rotator": ["file-stream-rotator@0.6.1", "", { "dependencies": { "moment": "^2.29.1" } }, "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ=="],
+
+    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
+
+    "fn.name": ["fn.name@1.1.0", "", {}, "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.2.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
+    "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
+
+    "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "kuler": ["kuler@2.0.0", "", {}, "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "linkedom": ["linkedom@0.18.13", "", { "dependencies": { "css-select": "^7.0.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.1.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw=="],
+
+    "logform": ["logform@2.7.0", "", { "dependencies": { "@colors/colors": "1.6.0", "@types/triple-beam": "^1.3.2", "fecha": "^4.2.0", "ms": "^2.1.1", "safe-stable-stringify": "^2.3.1", "triple-beam": "^1.3.0" } }, "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
+    "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
+
+    "lru-cache": ["lru-cache@11.3.1", "", {}, "sha512-Y71HWT4hydF1IAG/2OPync4dgQ/J2iWye7eg6CuzJHI+E97tvqFPlADzxiNnjH6WSljg8ecfXMr9k6bfFuqA5w=="],
+
+    "lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
+
+    "markit-ai": ["markit-ai@0.5.0", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.3", "exifr": "^7.1.3", "fast-xml-parser": "^5.5.9", "jszip": "^3.10.1", "mammoth": "^1.9.0", "mupdf": "^1.27.0", "music-metadata": "^11.12.3", "rss-parser": "^3.13.0", "turndown": "^7.2.0", "turndown-plugin-gfm": "^1.0.2" }, "bin": { "markit": "dist/main.js" } }, "sha512-ob3VxICBZe2Ge3Wg0vFOv6jkk/7OaYisQbtMYR7lUh00MkhAJ/sdVFy0GlqjPkXQ+mGygLdioGB+PfBLUJ5B2w=="],
+
+    "media-typer": ["media-typer@2.0.0", "", {}, "sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mupdf": ["mupdf@1.28.0", "", {}, "sha512-ACUnbpECaQ5JLq04pwd89lS+0IGMest5qL5tb08g9TAR7bDtfqflHEkb2Xm3o4rvC/szguLiV+WEbW9kstj8Sg=="],
+
+    "music-metadata": ["music-metadata@11.14.0", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^2.0.0", "debug": "^4.4.3", "file-type": "^21.3.4", "media-typer": "^2.0.0", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
+
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
+
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "one-time": ["one-time@1.0.0", "", { "dependencies": { "fn.name": "1.x.x" } }, "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g=="],
+
+    "openai": ["openai@6.48.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA=="],
+
+    "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "puppeteer": ["puppeteer@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "cosmiconfig": "^9.0.0", "devtools-protocol": "0.0.1608973", "puppeteer-core": "24.43.1", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/cjs/puppeteer/node/cli.js" } }, "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw=="],
+
+    "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.20.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
+
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
+
+    "react-chartjs-2": ["react-chartjs-2@5.3.1", "", { "peerDependencies": { "chart.js": "^4.1.1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A=="],
+
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "rss-parser": ["rss-parser@3.13.0", "", { "dependencies": { "entities": "^2.0.3", "xml2js": "^0.5.0" } }, "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w=="],
+
+    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
+    "streamx": ["streamx@2.28.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tar-fs": ["tar-fs@3.1.3", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ=="],
+
+    "tar-stream": ["tar-stream@3.2.0", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
+
+    "text-hex": ["text-hex@1.0.0", "", {}, "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "triple-beam": ["triple-beam@1.4.1", "", {}, "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "turndown-plugin-gfm": ["turndown-plugin-gfm@1.0.2", "", {}, "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="],
+
+    "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
+
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
+
+    "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
+
+    "winston": ["winston@3.19.0", "", { "dependencies": { "@colors/colors": "^1.6.0", "@dabh/diagnostics": "^2.0.8", "async": "^3.2.3", "is-stream": "^2.0.0", "logform": "^2.7.0", "one-time": "^1.0.0", "readable-stream": "^3.4.0", "safe-stable-stringify": "^2.3.1", "stack-trace": "0.0.x", "triple-beam": "^1.3.0", "winston-transport": "^4.9.0" } }, "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA=="],
+
+    "winston-daily-rotate-file": ["winston-daily-rotate-file@5.0.0", "", { "dependencies": { "file-stream-rotator": "^0.6.1", "object-hash": "^3.0.0", "triple-beam": "^1.4.1", "winston-transport": "^4.7.0" }, "peerDependencies": { "winston": "^3" } }, "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw=="],
+
+    "winston-transport": ["winston-transport@4.9.0", "", { "dependencies": { "logform": "^2.7.0", "readable-stream": "^3.6.2", "triple-beam": "^1.3.0" } }, "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
+
+    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@10.1.1", "", {}, "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1092.0", "", { "dependencies": { "@aws-sdk/core": "^3.976.0", "@aws-sdk/nested-clients": "^3.997.34", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hBYUAr6iBLNFcsiWTgtBb0stdSw39VOUq4Sp4A5caCNf66BAZplWN4FleKrVpJx5li2YgdnK2DqoFSMWC642FQ=="],
+
+    "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "dom-serializer/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "dom-serializer/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "domhandler/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "domutils/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "htmlparser2/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
+    "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "rss-parser/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
+    "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "htmlparser2/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+  }
+}

--- a/plugins/aws/package.json
+++ b/plugins/aws/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "AWS CLI status for xcsh welcome screen",
   "main": "src/index.ts",
+  "scripts": {
+    "test": "bun test",
+    "test:watch": "bun test --watch"
+  },
   "xcsh": {
     "name": "AWS",
     "version": "1.0.0",
@@ -12,6 +16,10 @@
   },
   "peerDependencies": {
     "@f5-sales-demo/xcsh": ">=1.0.0"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.0",
+    "bun-types": "latest"
   },
   "license": "Apache-2.0"
 }

--- a/plugins/aws/src/aws/exec.ts
+++ b/plugins/aws/src/aws/exec.ts
@@ -1,0 +1,150 @@
+import type { AwsRawResult } from './types';
+
+// ---------------------------------------------------------------------------
+// Error taxonomy
+// ---------------------------------------------------------------------------
+
+export class AwsExecError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode = 1,
+  ) {
+    super(message);
+    this.name = 'AwsExecError';
+  }
+}
+
+export class AwsAuthError extends AwsExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'AwsAuthError';
+  }
+}
+
+export class AwsSessionExpiredError extends AwsExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'AwsSessionExpiredError';
+  }
+}
+
+export class AwsNotFoundError extends AwsExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'AwsNotFoundError';
+  }
+}
+
+export class AwsThrottlingError extends AwsExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'AwsThrottlingError';
+  }
+}
+
+export class AwsAccessDeniedError extends AwsExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'AwsAccessDeniedError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a failed `aws` invocation into the appropriate AwsExecError subclass
+ * by inspecting stderr. Precedence:
+ * auth > session-expired > throttling > access-denied > not-found > generic.
+ */
+export function detectAwsError(stderr: string, exitCode: number): AwsExecError {
+  const lower = stderr.toLowerCase();
+
+  if (
+    lower.includes('unable to locate credentials') ||
+    lower.includes('could not be found') ||
+    lower.includes('no credentials')
+  ) {
+    return new AwsAuthError(stderr, exitCode);
+  }
+
+  if (
+    lower.includes('expiredtoken') ||
+    lower.includes('invalidclienttokenid') ||
+    lower.includes('token included in the request is expired') ||
+    lower.includes('sso token') ||
+    (lower.includes('sso') && lower.includes('expired'))
+  ) {
+    return new AwsSessionExpiredError(stderr, exitCode);
+  }
+
+  if (
+    lower.includes('throttling') ||
+    lower.includes('requestlimitexceeded') ||
+    lower.includes('rate exceeded') ||
+    lower.includes('toomanyrequests')
+  ) {
+    return new AwsThrottlingError(stderr, exitCode);
+  }
+
+  if (
+    lower.includes('accessdenied') ||
+    lower.includes('unauthorizedoperation') ||
+    lower.includes('not authorized to perform')
+  ) {
+    return new AwsAccessDeniedError(stderr, exitCode);
+  }
+
+  if (
+    lower.includes('notfound') ||
+    lower.includes('does not exist') ||
+    lower.includes('nosuchentity') ||
+    lower.includes('nosuchbucket')
+  ) {
+    return new AwsNotFoundError(stderr, exitCode);
+  }
+
+  return new AwsExecError(stderr, exitCode);
+}
+
+// ---------------------------------------------------------------------------
+// Output parsing
+// ---------------------------------------------------------------------------
+
+export function parseAwsJsonOutput<T>(raw: string): T {
+  try {
+    if (!raw || raw.trim().length === 0) {
+      throw new AwsExecError('Empty output from aws CLI');
+    }
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    if (err instanceof AwsExecError) throw err;
+    throw new AwsExecError(`Failed to parse aws CLI output: ${(err as Error).message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exec helpers
+// ---------------------------------------------------------------------------
+
+export interface AwsExecApi {
+  exec(command: string, args: string[], options?: { signal?: AbortSignal }): Promise<AwsRawResult>;
+}
+
+export async function execAwsJson<T>(api: AwsExecApi, args: string[], signal?: AbortSignal): Promise<T> {
+  const fullArgs = [...args, '--output', 'json'];
+  const result = await api.exec('aws', fullArgs, { signal });
+  if (result.exitCode !== 0) {
+    throw detectAwsError(result.stderr, result.exitCode);
+  }
+  return parseAwsJsonOutput<T>(result.stdout);
+}
+
+export async function execAwsRaw(api: AwsExecApi, args: string[], signal?: AbortSignal): Promise<AwsRawResult> {
+  const result = await api.exec('aws', args, { signal });
+  if (result.exitCode !== 0) {
+    throw detectAwsError(result.stderr, result.exitCode);
+  }
+  return result;
+}

--- a/plugins/aws/src/aws/formatters.ts
+++ b/plugins/aws/src/aws/formatters.ts
@@ -1,0 +1,113 @@
+import type { AwsBucket, AwsEc2Instance, AwsIdentity, AwsS3Object } from './types';
+
+// ---------------------------------------------------------------------------
+// Normalizers (raw aws JSON -> typed structs)
+// ---------------------------------------------------------------------------
+
+export function normalizeIdentity(raw: Record<string, unknown>): AwsIdentity {
+  return {
+    Account: String(raw.Account ?? ''),
+    Arn: String(raw.Arn ?? ''),
+    UserId: String(raw.UserId ?? ''),
+  };
+}
+
+export function normalizeBucket(raw: Record<string, unknown>): AwsBucket {
+  return {
+    name: String(raw.Name ?? ''),
+    creationDate: String(raw.CreationDate ?? ''),
+  };
+}
+
+export function normalizeInstance(raw: Record<string, unknown>): AwsEc2Instance {
+  const state = (raw.State as Record<string, unknown>) ?? {};
+  const placement = (raw.Placement as Record<string, unknown>) ?? {};
+  const tags = (raw.Tags as Array<Record<string, unknown>>) ?? [];
+  const nameTag = tags.find((t) => String(t.Key ?? '') === 'Name');
+  return {
+    instanceId: String(raw.InstanceId ?? ''),
+    state: String(state.Name ?? ''),
+    type: String(raw.InstanceType ?? ''),
+    az: String(placement.AvailabilityZone ?? ''),
+    privateIp: String(raw.PrivateIpAddress ?? ''),
+    publicIp: String(raw.PublicIpAddress ?? ''),
+    name: nameTag ? String(nameTag.Value ?? '') : '',
+  };
+}
+
+/**
+ * Flatten the `Reservations[].Instances[]` shape returned by
+ * `aws ec2 describe-instances` into a flat list of typed instances.
+ */
+export function normalizeReservations(raw: Record<string, unknown>): AwsEc2Instance[] {
+  const reservations = (raw.Reservations as Array<Record<string, unknown>>) ?? [];
+  const out: AwsEc2Instance[] = [];
+  for (const reservation of reservations) {
+    const instances = (reservation.Instances as Array<Record<string, unknown>>) ?? [];
+    for (const inst of instances) out.push(normalizeInstance(inst));
+  }
+  return out;
+}
+
+/**
+ * Parse the text output of `aws s3 ls s3://bucket/prefix/` into typed objects.
+ * Data lines look like: `2021-01-01 12:00:00       1234 file.txt`
+ * Common-prefix ("directory") lines look like: `                           PRE sub/`
+ */
+export function parseS3LsOutput(raw: string): AwsS3Object[] {
+  const out: AwsS3Object[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+
+    if (trimmed.startsWith('PRE ')) {
+      out.push({ key: trimmed.slice(4).trim(), size: 0, lastModified: '' });
+      continue;
+    }
+
+    const match = trimmed.match(/^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+(\d+)\s+(.+)$/);
+    if (match) {
+      out.push({ key: match[3], size: Number(match[2]), lastModified: match[1] });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Formatters (typed structs -> markdown)
+// ---------------------------------------------------------------------------
+
+export function formatIdentityDetail(identity: AwsIdentity): string {
+  return [
+    `**Account:** ${identity.Account || '-'}`,
+    `**ARN:** ${identity.Arn || '-'}`,
+    `**User ID:** ${identity.UserId || '-'}`,
+  ].join('\n');
+}
+
+export function formatBucketTable(buckets: AwsBucket[]): string {
+  if (buckets.length === 0) return 'No buckets found.';
+  const header = '| Name | Creation Date |';
+  const sep = '|------|---------------|';
+  const rows = buckets.map((b) => `| ${b.name} | ${b.creationDate || '-'} |`);
+  return [header, sep, ...rows].join('\n');
+}
+
+export function formatS3ObjectTable(objects: AwsS3Object[]): string {
+  if (objects.length === 0) return 'No objects found.';
+  const header = '| Key | Size | Last Modified |';
+  const sep = '|-----|------|---------------|';
+  const rows = objects.map((o) => `| ${o.key} | ${o.size} | ${o.lastModified || '-'} |`);
+  return [header, sep, ...rows].join('\n');
+}
+
+export function formatInstanceTable(instances: AwsEc2Instance[]): string {
+  if (instances.length === 0) return 'No instances found.';
+  const header = '| Instance ID | Name | State | Type | AZ | Private IP | Public IP |';
+  const sep = '|-------------|------|-------|------|-----|------------|-----------|';
+  const rows = instances.map(
+    (i) =>
+      `| ${i.instanceId} | ${i.name || '-'} | ${i.state} | ${i.type} | ${i.az} | ${i.privateIp || '-'} | ${i.publicIp || '-'} |`,
+  );
+  return [header, sep, ...rows].join('\n');
+}

--- a/plugins/aws/src/aws/types.ts
+++ b/plugins/aws/src/aws/types.ts
@@ -1,0 +1,43 @@
+export interface AwsIdentity {
+  Account: string;
+  Arn: string;
+  UserId: string;
+}
+
+export interface AwsBucket {
+  name: string;
+  creationDate: string;
+}
+
+export interface AwsS3Object {
+  key: string;
+  size: number;
+  lastModified: string;
+}
+
+export interface AwsEc2Instance {
+  instanceId: string;
+  state: string;
+  type: string;
+  az: string;
+  privateIp: string;
+  publicIp: string;
+  name: string;
+}
+
+export interface AwsRawResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface PluginInterface {
+  typebox: { Type: Record<string, (...args: unknown[]) => unknown> };
+  [key: string]: unknown;
+}
+
+export const INSTANCE_ID_PATTERN = /^i-[0-9a-f]{8,17}$/;
+export const REGION_PATTERN = /^[a-z]{2}-[a-z]+-\d$/;
+export const S3_URI_PATTERN = /^s3:\/\/[a-z0-9./-]+$/;
+export const RESOURCE_NAME_PATTERN = /^[a-zA-Z0-9._:/-]+$/;
+export const HELP_PATH_PATTERN = /^[a-z][a-z -]*$/;

--- a/plugins/aws/src/aws/types.ts
+++ b/plugins/aws/src/aws/types.ts
@@ -39,7 +39,10 @@ export interface PluginInterface {
 export const INSTANCE_ID_PATTERN = /^i-[0-9a-f]{8,17}$/;
 export const REGION_PATTERN = /^[a-z]{2}-[a-z]+-\d$/;
 export const S3_URI_PATTERN = /^s3:\/\/[a-z0-9./-]+$/;
-export const RESOURCE_NAME_PATTERN = /^[a-zA-Z0-9._:/-]+$/;
+// Require a non-dash first character so a value like `--profile -foo` (which would
+// otherwise pass the charset check) cannot be a leading dash and be mistaken for a
+// flag. Subsequent characters may still include a dash.
+export const RESOURCE_NAME_PATTERN = /^[A-Za-z0-9._:/][A-Za-z0-9._:/-]*$/;
 // Allow digits (ec2, s3, s3api, route53, ec2-instance-connect) but never as the
 // first character, keeping the pattern strict.
 export const HELP_PATH_PATTERN = /^[a-z][a-z0-9 -]*$/;

--- a/plugins/aws/src/aws/types.ts
+++ b/plugins/aws/src/aws/types.ts
@@ -40,4 +40,6 @@ export const INSTANCE_ID_PATTERN = /^i-[0-9a-f]{8,17}$/;
 export const REGION_PATTERN = /^[a-z]{2}-[a-z]+-\d$/;
 export const S3_URI_PATTERN = /^s3:\/\/[a-z0-9./-]+$/;
 export const RESOURCE_NAME_PATTERN = /^[a-zA-Z0-9._:/-]+$/;
-export const HELP_PATH_PATTERN = /^[a-z][a-z -]*$/;
+// Allow digits (ec2, s3, s3api, route53, ec2-instance-connect) but never as the
+// first character, keeping the pattern strict.
+export const HELP_PATH_PATTERN = /^[a-z][a-z0-9 -]*$/;

--- a/plugins/aws/src/index.ts
+++ b/plugins/aws/src/index.ts
@@ -1,8 +1,34 @@
 import type { ExtensionFactory } from '@f5-sales-demo/xcsh';
+import { detectErrorType, errorResult, renderError } from './tools/shared';
 
 function sanitizeHintField(value: unknown, maxLen = 200): string {
   if (typeof value !== 'string') return '';
   return value.replace(/[^\x20-\x7E]/g, '').slice(0, maxLen);
+}
+
+/**
+ * Wrap a factory tool so any error that still propagates out of its execute()
+ * is converted into a structured error result carrying details.errorType.
+ *
+ * The per-tool handlers already catch AWS errors and return a friendly
+ * errorResult (a normal result); those never reach this wrapper. A genuine
+ * cancellation (AbortError / ToolAbortError) is re-thrown so the agent loop
+ * can distinguish user cancellation from a real tool failure.
+ */
+export function withErrorType<T extends { name: string; execute: (...args: never[]) => Promise<unknown> }>(tool: T): T {
+  const originalExecute = tool.execute.bind(tool) as (...args: unknown[]) => Promise<unknown>;
+  return {
+    ...tool,
+    execute: (async (...args: unknown[]) => {
+      try {
+        return await originalExecute(...args);
+      } catch (err) {
+        const name = (err as { name?: string } | null | undefined)?.name;
+        if (name === 'AbortError' || name === 'ToolAbortError') throw err;
+        return errorResult(renderError(err), { tool: tool.name, errorType: detectErrorType(err) });
+      }
+    }) as T['execute'],
+  };
 }
 
 const factory: ExtensionFactory = async (pi) => {
@@ -26,6 +52,21 @@ const factory: ExtensionFactory = async (pi) => {
     awsAvailable = Bun.spawnSync([checker, 'aws']).exitCode === 0;
   } catch {
     // aws not available
+  }
+
+  // Only register tools when aws CLI is present
+  if (awsAvailable && typeof pi.registerTool === 'function') {
+    const { createAwsStsWhoamiTool } = await import('./tools/aws-sts-whoami');
+    const { createAwsS3LsTool } = await import('./tools/aws-s3-ls');
+    const { createAwsEc2DescribeInstancesTool } = await import('./tools/aws-ec2-describe-instances');
+    const { createAwsExecTool } = await import('./tools/aws-exec');
+    const { createAwsHelpTool } = await import('./tools/aws-help');
+
+    pi.registerTool(withErrorType(createAwsStsWhoamiTool(pi)));
+    pi.registerTool(withErrorType(createAwsS3LsTool(pi)));
+    pi.registerTool(withErrorType(createAwsEc2DescribeInstancesTool(pi)));
+    pi.registerTool(withErrorType(createAwsExecTool(pi)));
+    pi.registerTool(withErrorType(createAwsHelpTool(pi)));
   }
 
   // Always register service status (shows unavailable when CLI missing)

--- a/plugins/aws/src/prompts/aws-ec2-describe-instances.md
+++ b/plugins/aws/src/prompts/aws-ec2-describe-instances.md
@@ -1,0 +1,40 @@
+Describe Amazon EC2 instances via `aws ec2 describe-instances`.
+
+## Usage
+
+```
+aws ec2 describe-instances [--region REGION] [--instance-ids ID ...] [--filters ...] --output json
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `region` | Optional AWS region (e.g. `us-east-1`) |
+| `instanceIds` | Optional list of instance IDs (e.g. `i-0123456789abcdef0`) |
+| `filters` | Optional list of `Name=...,Values=...` filter expressions |
+
+## Output Fields (JSON, flattened)
+
+Results arrive as `Reservations[].Instances[]` and are flattened to:
+
+- `instanceId` — Instance ID
+- `name` — Value of the `Name` tag, if present
+- `state` — Lifecycle state (running, stopped, terminated, etc.)
+- `type` — Instance type (e.g. `t3.micro`)
+- `az` — Availability Zone
+- `privateIp` — Private IPv4 address
+- `publicIp` — Public IPv4 address, if assigned
+
+## Notes
+
+Without a region, the CLI's default region is used. Combine `--filters` for
+server-side narrowing, e.g. `Name=instance-state-name,Values=running`.
+
+For advanced field selection, add `--query` with a JMESPath expression, e.g.
+`--query "Reservations[].Instances[].InstanceId"`.
+
+## Related Commands
+
+- `aws ec2 describe-instance-status` — Health and status checks
+- `aws ec2 start-instances --instance-ids ID` — Start a stopped instance

--- a/plugins/aws/src/prompts/aws-exec.md
+++ b/plugins/aws/src/prompts/aws-exec.md
@@ -1,0 +1,57 @@
+Execute any `aws` CLI command directly.
+
+This is the general-purpose tool for running AWS CLI commands that are not covered by the typed tools (aws_sts_whoami, aws_s3_ls, aws_ec2_describe_instances). Prefer the typed tools when available — they validate inputs and return structured data.
+
+## Usage
+
+Pass the service, operation, and flags as an array of arguments. Do NOT include `aws` itself — it is prepended automatically.
+
+**Example:** To run `aws ec2 describe-instances --region us-east-1`:
+
+```json
+{ "args": ["ec2", "describe-instances", "--region", "us-east-1"] }
+```
+
+The AWS CLI grammar is `aws <service> <operation>` (for example `ec2 describe-instances`, `iam list-users`, `s3 ls`).
+
+## Safety
+
+- Arguments are passed as an array directly to the `aws` binary — **no shell** is involved, so shell metacharacters are inert and never filtered. Any valid `aws` invocation runs, including full JMESPath `--query` syntax.
+- **Read-only by default:** only read operations are allowed. Reads are recognized by operation prefix (`describe-`, `list-`, `get-`, `lookup-`, `search-`, `head-`, `check-`, `resolve-`, …) plus a few exact reads (`scan`, `query`, `select`, `wait`, and `s3 ls`).
+- Everything else — including `run-instances`, `terminate-instances`, `create-*`, `update-*`, `delete-*`, and the mutating `s3` verbs (`cp`, `mv`, `rm`, `sync`, `mb`, `rb`) — is blocked. Run write/destructive operations through an explicitly confirmed path (delegate to the `aws:cli-operator` agent), not `aws_exec`.
+- Output is capped to prevent context overflow.
+
+## Output format with `--output`
+
+Control the response format with `--output json|text|table` (JSON is added automatically when you do not supply your own):
+
+- `--output json` — machine-readable JSON (the default)
+- `--output text` — tab-separated, good for piping
+- `--output table` — human-readable ASCII table
+
+## Filtering with `--filters`
+
+Many `describe-*` operations accept server-side `--filters` in `Name=...,Values=...` form, which narrows results before they are returned:
+
+```json
+{ "args": ["ec2", "describe-instances", "--filters", "Name=instance-state-name,Values=running"] }
+```
+
+## Querying with `--query` (JMESPath)
+
+AWS uses the JMESPath grammar for the client-side `--query` flag — pass the expression as a single argument value. This is NOT the GitHub CLI `--json`/`--jq` model; there is no `--jq`. Common patterns:
+
+- Field projection: `--query "Reservations[].Instances[].{id:InstanceId, type:InstanceType}"`
+- Filter: `--query "Reservations[].Instances[?State.Name=='running']"`
+- Substring match: `--query "Buckets[?contains(Name, 'prod')]"`
+- Backtick literals (numbers/booleans/quoted enums): `` --query "Volumes[?Size==`100`]" ``
+- OR / AND / NOT: `--query "[?a=='x' || b=='y']"`, `--query "[?a && b]"`, `--query "[?!Encrypted]"`
+- Pipe to post-process a projection: `--query "Reservations[].Instances[].InstanceId | [0]"`
+
+All of the above — including `||`, `|`, and backticks — are accepted verbatim, because arguments bypass the shell.
+
+## Tips
+
+- `--output json` is added automatically unless you pass your own `--output`/`-o` (for example `-o table`, `-o text`), which is respected.
+- Use `--region NAME` to target a specific region and `--profile NAME` to select credentials.
+- Use the `aws_help` tool first if you are unsure about a service's available operations or flags.

--- a/plugins/aws/src/prompts/aws-help.md
+++ b/plugins/aws/src/prompts/aws-help.md
@@ -1,0 +1,43 @@
+Fetch help documentation for any `aws` CLI service or operation.
+
+Use this tool to discover available services, operations, and flags for AWS CLI commands that are not covered by the embedded tool documentation.
+
+## Usage
+
+Pass the command path (without the `aws` prefix) to get help:
+
+**Example:** To see help for the `ec2` service:
+
+```json
+{ "command_path": "ec2" }
+```
+
+**Example:** To see help for a specific operation:
+
+```json
+{ "command_path": "ec2 describe-instances" }
+```
+
+**Example:** To see top-level `aws` help:
+
+```json
+{ "command_path": "" }
+```
+
+Note that the AWS CLI exposes help through the `help` subcommand (for example `aws ec2 help`), not a `--help` flag — this tool appends `help` for you.
+
+## When to Use
+
+- Before using `aws_exec` with an unfamiliar service
+- To discover available operations within a service
+- To find the correct flags for a specific operation
+- To check required versus optional parameters
+
+## Output
+
+Returns the raw `aws <command> help` output, which includes:
+
+- Available services and operations
+- Command arguments with descriptions
+- Required versus optional parameters
+- Usage examples

--- a/plugins/aws/src/prompts/aws-s3-ls.md
+++ b/plugins/aws/src/prompts/aws-s3-ls.md
@@ -1,0 +1,41 @@
+List Amazon S3 buckets, or the contents of a bucket or prefix, via the AWS CLI.
+
+## Usage
+
+```
+aws s3api list-buckets --output json      # no target: list all buckets
+aws s3 ls s3://bucket/prefix/             # with target: list objects/prefixes
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `target` | Optional `s3://bucket[/prefix]` URI. Omit to list all buckets in the account. |
+
+## Output Fields
+
+Bucket listing (JSON):
+
+- `Name` — Bucket name
+- `CreationDate` — When the bucket was created
+
+Object listing (text, parsed):
+
+- `key` — Object key or common prefix (directory)
+- `size` — Object size in bytes (0 for prefixes)
+- `lastModified` — Last modified timestamp
+
+## Notes
+
+Without a target, buckets are listed globally for the account (bucket names are
+not region-scoped). With a target, a trailing slash lists the contents of that
+prefix; `PRE` entries are common prefixes ("folders").
+
+For advanced filtering on the JSON bucket list, add `--query` with a JMESPath
+expression, e.g. `--query "Buckets[?starts_with(Name, 'log')].Name"`.
+
+## Related Commands
+
+- `aws s3 ls s3://bucket --recursive` — List all objects under a bucket
+- `aws s3api head-object --bucket B --key K` — Object metadata

--- a/plugins/aws/src/prompts/aws-sts-whoami.md
+++ b/plugins/aws/src/prompts/aws-sts-whoami.md
@@ -1,0 +1,33 @@
+Show the caller identity for the active AWS credentials via `aws sts get-caller-identity`.
+
+## Usage
+
+```
+aws sts get-caller-identity [--profile NAME] --output json
+```
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `profile` | Optional named profile from `~/.aws/config` / `~/.aws/credentials` |
+
+## Output Fields (JSON)
+
+- `Account` — 12-digit AWS account ID
+- `Arn` — ARN of the calling principal (IAM user, assumed role, etc.)
+- `UserId` — Unique identifier of the principal
+
+## Notes
+
+Use this to confirm which account and identity your credentials resolve to before
+running privileged operations. It requires no IAM permissions and is the quickest
+way to verify that a profile or SSO session is active.
+
+For advanced field selection, add `--query` with a JMESPath expression, e.g.
+`--query Account`.
+
+## Related Commands
+
+- `aws configure list` — Show the resolved credential/config sources
+- `aws sso login --profile NAME` — Refresh an expired SSO session

--- a/plugins/aws/src/tools/aws-ec2-describe-instances.ts
+++ b/plugins/aws/src/tools/aws-ec2-describe-instances.ts
@@ -5,6 +5,11 @@ import { INSTANCE_ID_PATTERN, REGION_PATTERN } from '../aws/types';
 import awsEc2DescribeDescription from '../prompts/aws-ec2-describe-instances.md' with { type: 'text' };
 import { detectErrorType, errorResult, hasControlChars, makeExecApi, renderError, textResult } from './shared';
 
+// Strict shape for an EC2 `--filters` element. Anchored so a value cannot start
+// with a dash (which the aws CLI would read as a flag → argument injection) and
+// so only known-safe characters appear on either side of the Name/Values pair.
+const EC2_FILTER_PATTERN = /^Name=[A-Za-z0-9:._/-]+,Values=[A-Za-z0-9:._/,*-]+$/;
+
 export function createAwsEc2DescribeInstancesTool(pi: PluginInterface) {
   const { Type } = pi.typebox;
 
@@ -46,6 +51,16 @@ export function createAwsEc2DescribeInstancesTool(pi: PluginInterface) {
         for (const filter of params.filters) {
           if (hasControlChars(filter)) {
             return errorResult(`Error: invalid filter "${filter}". Control characters are not allowed.`, base);
+          }
+          // A leading dash would be interpreted by the aws CLI as a flag
+          // (argument injection); the pattern also rejects it, but guard first
+          // so the intent is explicit. Otherwise require the strict
+          // Name=…,Values=… shape.
+          if (filter.startsWith('-') || !EC2_FILTER_PATTERN.test(filter)) {
+            return errorResult(
+              `Error: invalid filter "${filter}". Expected the form "Name=<name>,Values=<v1,v2,...>", e.g. "Name=instance-state-name,Values=running".`,
+              base,
+            );
           }
         }
       }

--- a/plugins/aws/src/tools/aws-ec2-describe-instances.ts
+++ b/plugins/aws/src/tools/aws-ec2-describe-instances.ts
@@ -1,0 +1,68 @@
+import { execAwsJson } from '../aws/exec';
+import { formatInstanceTable, normalizeReservations } from '../aws/formatters';
+import type { PluginInterface } from '../aws/types';
+import { INSTANCE_ID_PATTERN, REGION_PATTERN } from '../aws/types';
+import awsEc2DescribeDescription from '../prompts/aws-ec2-describe-instances.md' with { type: 'text' };
+import { detectErrorType, errorResult, hasControlChars, makeExecApi, renderError, textResult } from './shared';
+
+export function createAwsEc2DescribeInstancesTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    region: Type.Optional(Type.String({ description: 'AWS region, e.g. us-east-1' })),
+    instanceIds: Type.Optional(Type.Array(Type.String(), { description: 'Instance IDs, e.g. i-0123456789abcdef0' })),
+    filters: Type.Optional(
+      Type.Array(Type.String(), { description: 'Filters, e.g. Name=instance-state-name,Values=running' }),
+    ),
+  });
+
+  return {
+    name: 'aws_ec2_describe_instances',
+    label: 'AWS EC2 Instances',
+    description: awsEc2DescribeDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { region?: string; instanceIds?: string[]; filters?: string[] },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'aws_ec2_describe_instances' as const };
+
+      if (params.region !== undefined && !REGION_PATTERN.test(params.region)) {
+        return errorResult(`Error: invalid region "${params.region}". Expected a form like "us-east-1".`, base);
+      }
+
+      if (params.instanceIds) {
+        for (const id of params.instanceIds) {
+          if (!INSTANCE_ID_PATTERN.test(id)) {
+            return errorResult(`Error: invalid instance ID "${id}". Expected a form like "i-0123456789abcdef0".`, base);
+          }
+        }
+      }
+
+      if (params.filters) {
+        for (const filter of params.filters) {
+          if (hasControlChars(filter)) {
+            return errorResult(`Error: invalid filter "${filter}". Control characters are not allowed.`, base);
+          }
+        }
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const args = ['ec2', 'describe-instances'];
+      if (params.region) args.push('--region', params.region);
+      if (params.instanceIds && params.instanceIds.length > 0) args.push('--instance-ids', ...params.instanceIds);
+      if (params.filters && params.filters.length > 0) args.push('--filters', ...params.filters);
+
+      try {
+        const raw = await execAwsJson<Record<string, unknown>>(api, args, signal);
+        const instances = normalizeReservations(raw);
+        return textResult(formatInstanceTable(instances), { ...base, instances });
+      } catch (err) {
+        return errorResult(`Error: ${renderError(err)}`, { ...base, errorType: detectErrorType(err) });
+      }
+    },
+  };
+}

--- a/plugins/aws/src/tools/aws-exec-guard.ts
+++ b/plugins/aws/src/tools/aws-exec-guard.ts
@@ -40,14 +40,44 @@ export const READ_PREFIXES: readonly string[] = [
 // Exact read operations that do not fit the prefix convention.
 export const READ_EXACT: ReadonlySet<string> = new Set(['ls', 'wait', 'help', 'scan', 'select', 'query']);
 
-// Port of the gitlab guard's positional extraction with FLAG-VALUE EXCLUSION: drop
-// every flag token AND the token immediately following a flag. This prevents a
-// value-taking global flag (e.g. `--region us-east-1`) from shifting the real
-// operation out of positionals[1] (which would let `--region us-east-1 ec2
-// run-instances` masquerade as a read). Over-excluding the token after a boolean
-// flag is fail-safe: at worst it blocks a read; it never allows a write.
+// Global value-taking flags whose NEXT token (in space form) is a value, not a
+// positional. These can precede or interleave the service+operation, so their
+// value must be excluded from positional extraction — otherwise a value-taking
+// flag (e.g. `--region us-east-1`) would shift the real operation out of
+// positionals[1] and let `--region us-east-1 ec2 run-instances` masquerade as a
+// read.
+const VALUE_FLAGS: ReadonlySet<string> = new Set([
+  '--region',
+  '--profile',
+  '--output',
+  '--query',
+  '--endpoint-url',
+  '--color',
+  '--ca-bundle',
+  '--cli-read-timeout',
+  '--cli-connect-timeout',
+  '--page-size',
+  '--max-items',
+  '--starting-token',
+]);
+
+// Positional extraction with FLAG-VALUE EXCLUSION restricted to KNOWN value-taking
+// flags. A token is a positional iff it does NOT start with `-` AND its preceding
+// token is not a value-taking flag in space form. Boolean flags (e.g.
+// `--no-cli-pager`, `--debug`) take no value, so the token after them is NOT
+// dropped — this closes the bypass where a boolean placed before the operation
+// dropped the real (write) verb and promoted a later read-prefixed bare positional
+// into the operation slot. `--flag=value` forms consume no separate token, so
+// nothing extra is dropped for them.
 export function getPositionals(args: string[]): string[] {
-  return args.filter((a, i) => !a.startsWith('-') && !(i > 0 && args[i - 1].startsWith('-')));
+  return args.filter((a, i) => {
+    if (a.startsWith('-')) return false;
+    if (i > 0) {
+      const prev = args[i - 1];
+      if (VALUE_FLAGS.has(prev) && !prev.includes('=')) return false;
+    }
+    return true;
+  });
 }
 
 const WRITE_DELEGATION =

--- a/plugins/aws/src/tools/aws-exec-guard.ts
+++ b/plugins/aws/src/tools/aws-exec-guard.ts
@@ -1,0 +1,105 @@
+// Pure guardrail helpers for the aws_exec passthrough tool.
+// Keeps argv hygiene and read-only enforcement free of I/O so they are trivially
+// testable. Fail-safe allowlist design: unknown operations are blocked.
+//
+// `hasControlChars` lives in ./shared (Task 1) — the tool imports it from there so
+// there is a single source of truth; it is deliberately NOT re-exported here.
+//
+// aws grammar is `aws <service> <operation>` (space-separated, 2-deep). There is
+// NO `api`/HTTP passthrough, so — unlike gitlab/glab — there is no effectiveApiMethod
+// or HTTP-method inference. The read/write decision is made purely on the operation
+// token (positionals[1]), with an s3 special-case for its non-`<verb>-<noun>` verbs.
+
+// Top-level read commands that take no service/operation (e.g. `aws help`).
+export const READ_TOP: ReadonlySet<string> = new Set(['help']);
+
+// `aws s3` (the high-level transfer command, distinct from `aws s3api`) uses bare
+// verbs rather than the `<verb>-<noun>` convention, so it needs an explicit table.
+// `ls` is the only read; the rest move/delete objects or buckets.
+export const S3_READ_OPS: ReadonlySet<string> = new Set(['ls']);
+export const S3_WRITE_OPS: ReadonlySet<string> = new Set(['cp', 'mv', 'rm', 'sync', 'mb', 'rb']);
+
+// Operation-name prefixes that denote a read across the AWS CLI's `<verb>-<noun>`
+// naming convention. Anything not matched here (or in READ_EXACT) is blocked.
+export const READ_PREFIXES: readonly string[] = [
+  'describe-',
+  'list-',
+  'get-',
+  'lookup-',
+  'search-',
+  'batch-get-',
+  'head-',
+  'estimate-',
+  'simulate-',
+  'preview-',
+  'filter-',
+  'check-',
+  'resolve-',
+];
+
+// Exact read operations that do not fit the prefix convention.
+export const READ_EXACT: ReadonlySet<string> = new Set(['ls', 'wait', 'help', 'scan', 'select', 'query']);
+
+// Port of the gitlab guard's positional extraction with FLAG-VALUE EXCLUSION: drop
+// every flag token AND the token immediately following a flag. This prevents a
+// value-taking global flag (e.g. `--region us-east-1`) from shifting the real
+// operation out of positionals[1] (which would let `--region us-east-1 ec2
+// run-instances` masquerade as a read). Over-excluding the token after a boolean
+// flag is fail-safe: at worst it blocks a read; it never allows a write.
+export function getPositionals(args: string[]): string[] {
+  return args.filter((a, i) => !a.startsWith('-') && !(i > 0 && args[i - 1].startsWith('-')));
+}
+
+const WRITE_DELEGATION =
+  'aws_exec is read-only by default. Run write/destructive operations through an ' +
+  'explicitly confirmed path (delegate to the aws:cli-operator agent), not aws_exec.';
+
+export function findMutation(args: string[]): { blocked: boolean; reason?: string } {
+  const positionals = getPositionals(args);
+  if (positionals.length === 0) {
+    return { blocked: true, reason: 'no aws command provided' };
+  }
+
+  const service = positionals[0];
+  const op = positionals[1];
+
+  // Top-level reads (`aws help`) take no operation.
+  if (READ_TOP.has(service)) return { blocked: false };
+
+  // s3 high-level command: explicit allow/deny table, fail-safe on anything else.
+  if (service === 's3') {
+    if (op && S3_READ_OPS.has(op)) return { blocked: false };
+    if (op && S3_WRITE_OPS.has(op)) {
+      return { blocked: true, reason: `"s3 ${op}" writes to S3. ${WRITE_DELEGATION}` };
+    }
+    return {
+      blocked: true,
+      reason: op
+        ? `"s3 ${op}" is not a recognized read-only S3 command. ${WRITE_DELEGATION}`
+        : `"s3" requires a subcommand; only "s3 ls" is allowed as read-only. ${WRITE_DELEGATION}`,
+    };
+  }
+
+  // Generic services: read iff the operation matches the allowlist.
+  if (!op) {
+    return {
+      blocked: true,
+      reason: `"${service}" has no operation; provide a read-only operation. ${WRITE_DELEGATION}`,
+    };
+  }
+
+  const isRead = READ_EXACT.has(op) || READ_PREFIXES.some((p) => op.startsWith(p));
+  if (isRead) return { blocked: false };
+
+  return {
+    blocked: true,
+    reason: `"${service} ${op}" is not a recognized read-only aws operation. ${WRITE_DELEGATION}`,
+  };
+}
+
+// Default to JSON for machine-readable output, but respect a caller-supplied
+// --output / -o so `-o table` and `-o text` are honored instead of overridden.
+export function buildAwsArgs(args: string[]): string[] {
+  const hasOutput = args.some((a) => a === '--output' || a === '-o');
+  return hasOutput ? [...args] : [...args, '--output', 'json'];
+}

--- a/plugins/aws/src/tools/aws-exec.ts
+++ b/plugins/aws/src/tools/aws-exec.ts
@@ -1,0 +1,71 @@
+import { detectAwsError } from '../aws/exec';
+import type { PluginInterface } from '../aws/types';
+import awsExecDescription from '../prompts/aws-exec.md' with { type: 'text' };
+import { buildAwsArgs, findMutation } from './aws-exec-guard';
+import { errorResult, hasControlChars, makeExecApi, textResult } from './shared';
+
+const MAX_OUTPUT_LENGTH = 50000;
+
+export function createAwsExecTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    args: Type.Array(Type.String({ description: 'Individual argument (do NOT include "aws" itself)' }), {
+      description:
+        'aws service, operation, and flags as an array, e.g. ["ec2", "describe-instances", "--output", "json"]',
+    }),
+  });
+
+  return {
+    name: 'aws_exec',
+    label: 'AWS CLI Execute',
+    description: awsExecDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { args: string[] },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'aws_exec' as const };
+      const args = params.args ?? [];
+
+      if (args.length === 0) {
+        return errorResult('Error: args array must not be empty. Provide an aws service and operation.', base);
+      }
+
+      // `aws` is spawned argv-style with NO shell, so shell metacharacters are inert
+      // (the argv boundary is the real injection control). We therefore do NOT strip
+      // metacharacters — doing so would break valid `--query` (JMESPath) syntax such
+      // as `||`, backtick literals, and pipes. Only NUL/control bytes, which malform
+      // an execve argv, are rejected.
+      for (const arg of args) {
+        if (hasControlChars(arg)) {
+          return errorResult(
+            `Error: argument contains a control character and cannot be passed to aws: "${arg}"`,
+            base,
+          );
+        }
+      }
+
+      const mutation = findMutation(args);
+      if (mutation.blocked) {
+        return errorResult(`Error: ${mutation.reason}`, base);
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const builtArgs = buildAwsArgs(args);
+      const result = await api.exec('aws', builtArgs, { signal });
+      if (result.exitCode !== 0) {
+        throw detectAwsError(result.stderr, result.exitCode);
+      }
+
+      let output = result.stdout;
+      if (output.length > MAX_OUTPUT_LENGTH) {
+        output = `${output.slice(0, MAX_OUTPUT_LENGTH)}\n\n[Output truncated at ${MAX_OUTPUT_LENGTH} characters]`;
+      }
+      return textResult(output, base);
+    },
+  };
+}

--- a/plugins/aws/src/tools/aws-help.ts
+++ b/plugins/aws/src/tools/aws-help.ts
@@ -1,0 +1,68 @@
+import type { PluginInterface } from '../aws/types';
+import { HELP_PATH_PATTERN } from '../aws/types';
+import awsHelpDescription from '../prompts/aws-help.md' with { type: 'text' };
+import { errorResult, makeExecApi, textResult } from './shared';
+
+export function createAwsHelpTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    command_path: Type.Optional(
+      Type.String({
+        description: 'Command path without "aws" prefix, e.g. "ec2 describe-instances". Empty for top-level help.',
+      }),
+    ),
+  });
+
+  return {
+    name: 'aws_help',
+    label: 'AWS CLI Help',
+    description: awsHelpDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { command_path?: string },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'aws_help' as const };
+      const commandPath = params.command_path?.trim() ?? '';
+
+      if (commandPath.length > 0 && !HELP_PATH_PATTERN.test(commandPath)) {
+        return errorResult(
+          `Error: invalid command path "${commandPath}". Only lowercase letters, hyphens, and spaces are allowed.`,
+          base,
+        );
+      }
+
+      const parts = commandPath.length > 0 ? commandPath.split(' ').filter(Boolean) : [];
+      // Belt-and-suspenders: the charset regex admits an interior/leading '-'
+      // (e.g. "iam -foo"), so reject any dash-led part that could be read as a flag.
+      if (parts.some((p) => p.startsWith('-'))) {
+        return errorResult(
+          `Error: invalid command path "${commandPath}". Command path parts must not start with "-".`,
+          base,
+        );
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      // NOTE: aws uses the `help` subcommand, NOT a `--help` flag.
+      const args = [...parts, 'help'];
+
+      try {
+        const result = await api.exec('aws', args, { signal });
+        const output = result.stdout || result.stderr;
+        if (!output.trim()) {
+          return errorResult(`No help output for "aws ${commandPath}".`, { ...base, errorType: 'exec_error' });
+        }
+        return textResult(output, base);
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: 'exec_error',
+        });
+      }
+    },
+  };
+}

--- a/plugins/aws/src/tools/aws-s3-ls.ts
+++ b/plugins/aws/src/tools/aws-s3-ls.ts
@@ -1,0 +1,53 @@
+import { execAwsJson, execAwsRaw } from '../aws/exec';
+import { formatBucketTable, formatS3ObjectTable, normalizeBucket, parseS3LsOutput } from '../aws/formatters';
+import type { PluginInterface } from '../aws/types';
+import { S3_URI_PATTERN } from '../aws/types';
+import awsS3LsDescription from '../prompts/aws-s3-ls.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
+
+export function createAwsS3LsTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    target: Type.Optional(Type.String({ description: 'Optional s3://bucket[/prefix] URI. Omit to list all buckets.' })),
+  });
+
+  return {
+    name: 'aws_s3_ls',
+    label: 'AWS S3 List',
+    description: awsS3LsDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { target?: string },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'aws_s3_ls' as const };
+
+      if (params.target !== undefined && !S3_URI_PATTERN.test(params.target)) {
+        return errorResult(
+          `Error: invalid S3 target "${params.target}". Must be an s3:// URI using lowercase letters, digits, dots, slashes, and hyphens.`,
+          base,
+        );
+      }
+
+      const api = makeExecApi(ctx.cwd);
+
+      try {
+        if (params.target) {
+          const result = await execAwsRaw(api, ['s3', 'ls', params.target], signal);
+          const objects = parseS3LsOutput(result.stdout);
+          return textResult(formatS3ObjectTable(objects), { ...base, objects });
+        }
+
+        const raw = await execAwsJson<{ Buckets?: Record<string, unknown>[] }>(api, ['s3api', 'list-buckets'], signal);
+        const buckets = (raw.Buckets ?? []).map(normalizeBucket);
+        return textResult(formatBucketTable(buckets), { ...base, buckets });
+      } catch (err) {
+        return errorResult(`Error: ${renderError(err)}`, { ...base, errorType: detectErrorType(err) });
+      }
+    },
+  };
+}

--- a/plugins/aws/src/tools/aws-sts-whoami.ts
+++ b/plugins/aws/src/tools/aws-sts-whoami.ts
@@ -1,0 +1,49 @@
+import { execAwsJson } from '../aws/exec';
+import { formatIdentityDetail, normalizeIdentity } from '../aws/formatters';
+import type { PluginInterface } from '../aws/types';
+import { RESOURCE_NAME_PATTERN } from '../aws/types';
+import awsStsWhoamiDescription from '../prompts/aws-sts-whoami.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
+
+export function createAwsStsWhoamiTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    profile: Type.Optional(Type.String({ description: 'Named AWS profile to use' })),
+  });
+
+  return {
+    name: 'aws_sts_whoami',
+    label: 'AWS Caller Identity',
+    description: awsStsWhoamiDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { profile?: string },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'aws_sts_whoami' as const };
+
+      if (params.profile !== undefined && !RESOURCE_NAME_PATTERN.test(params.profile)) {
+        return errorResult(
+          `Error: invalid profile "${params.profile}". Only alphanumeric characters, dots, underscores, colons, slashes, and hyphens are allowed.`,
+          base,
+        );
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const args = ['sts', 'get-caller-identity'];
+      if (params.profile) args.push('--profile', params.profile);
+
+      try {
+        const raw = await execAwsJson<Record<string, unknown>>(api, args, signal);
+        const identity = normalizeIdentity(raw);
+        return textResult(formatIdentityDetail(identity), { ...base, identity });
+      } catch (err) {
+        return errorResult(`Error: ${renderError(err)}`, { ...base, errorType: detectErrorType(err) });
+      }
+    },
+  };
+}

--- a/plugins/aws/src/tools/shared.ts
+++ b/plugins/aws/src/tools/shared.ts
@@ -1,0 +1,107 @@
+import {
+  AwsAccessDeniedError,
+  AwsAuthError,
+  type AwsExecApi,
+  AwsNotFoundError,
+  AwsSessionExpiredError,
+  AwsThrottlingError,
+} from '../aws/exec';
+import type { AwsBucket, AwsEc2Instance, AwsIdentity, AwsRawResult, AwsS3Object } from '../aws/types';
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export type AwsErrorType =
+  | 'auth_required'
+  | 'session_expired'
+  | 'not_found'
+  | 'throttled'
+  | 'access_denied'
+  | 'exec_error';
+
+export interface AwsToolDetails {
+  tool: string;
+  action?: string;
+  identity?: AwsIdentity;
+  buckets?: AwsBucket[];
+  objects?: AwsS3Object[];
+  instances?: AwsEc2Instance[];
+  errorType?: AwsErrorType;
+}
+
+// ---------------------------------------------------------------------------
+// Result helpers
+// ---------------------------------------------------------------------------
+
+export function textResult(text: string, details?: AwsToolDetails) {
+  return { content: [{ type: 'text' as const, text }], details };
+}
+
+export function errorResult(text: string, details?: AwsToolDetails) {
+  return { content: [{ type: 'text' as const, text }], isError: true, details };
+}
+
+export function detectErrorType(err: unknown): AwsErrorType {
+  if (err instanceof AwsAuthError) return 'auth_required';
+  if (err instanceof AwsSessionExpiredError) return 'session_expired';
+  if (err instanceof AwsThrottlingError) return 'throttled';
+  if (err instanceof AwsAccessDeniedError) return 'access_denied';
+  if (err instanceof AwsNotFoundError) return 'not_found';
+  return 'exec_error';
+}
+
+export function renderError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ---------------------------------------------------------------------------
+// Argv hygiene (shared with the aws_exec guard — later task)
+// ---------------------------------------------------------------------------
+
+// Blocks ASCII C0 control characters and DEL (0x7f), but allows tab (0x09),
+// LF (0x0A), and CR (0x0D) so multi-line `--query`/filter expressions survive
+// intact. Uses a charCode scan (not a regex) so no control-char literal appears
+// in source and no lint suppression is needed.
+export function hasControlChars(arg: string): boolean {
+  for (let i = 0; i < arg.length; i++) {
+    const c = arg.charCodeAt(i);
+    if (c <= 8 || c === 11 || c === 12 || (c >= 14 && c <= 31) || c === 127) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Exec API factory
+// ---------------------------------------------------------------------------
+
+export function makeExecApi(cwd: string): AwsExecApi {
+  return {
+    async exec(command: string, args: string[], options?: { signal?: AbortSignal }): Promise<AwsRawResult> {
+      // Thread the AbortSignal so a genuine in-flight cancellation actually
+      // terminates the child. We must NOT pre-check signal.aborted to throw a
+      // "cancelled" before running, and we only wire the signal into Bun.spawn
+      // while it is still live at spawn time — handing an already-aborted
+      // (stale) signal to Bun.spawn would kill the fresh process immediately,
+      // resurrecting a false cancel from a prior multi-turn tool call. A signal
+      // that aborts *during* the run is still honored and cancels for real.
+      const signal = options?.signal;
+      const child = Bun.spawn([command, ...args], {
+        cwd,
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        ...(signal && !signal.aborted ? { signal } : {}),
+      });
+      if (!child.stdout || !child.stderr) {
+        return { stdout: '', stderr: 'Failed to capture output', exitCode: 1 };
+      }
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode: exitCode ?? 0 };
+    },
+  };
+}

--- a/plugins/aws/test/aws/exec.test.ts
+++ b/plugins/aws/test/aws/exec.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  AwsAccessDeniedError,
+  AwsAuthError,
+  AwsExecError,
+  AwsNotFoundError,
+  AwsSessionExpiredError,
+  AwsThrottlingError,
+  detectAwsError,
+} from '../../src/aws/exec';
+import { detectErrorType, hasControlChars, makeExecApi } from '../../src/tools/shared';
+
+// ---------------------------------------------------------------------------
+// detectAwsError classification
+// ---------------------------------------------------------------------------
+
+describe('detectAwsError classification', () => {
+  it('classifies auth failures', () => {
+    expect(detectAwsError('Unable to locate credentials', 255)).toBeInstanceOf(AwsAuthError);
+    expect(detectAwsError('The config profile could not be found', 255)).toBeInstanceOf(AwsAuthError);
+    expect(detectAwsError('You must specify a region. No credentials.', 255)).toBeInstanceOf(AwsAuthError);
+  });
+
+  it('classifies session-expired failures', () => {
+    expect(detectAwsError('ExpiredToken: the token has expired', 255)).toBeInstanceOf(AwsSessionExpiredError);
+    expect(detectAwsError('InvalidClientTokenId', 255)).toBeInstanceOf(AwsSessionExpiredError);
+    expect(detectAwsError('The security token included in the request is expired', 255)).toBeInstanceOf(
+      AwsSessionExpiredError,
+    );
+    expect(detectAwsError('Error loading SSO Token: token expired', 255)).toBeInstanceOf(AwsSessionExpiredError);
+    expect(detectAwsError('Your SSO session associated has expired', 255)).toBeInstanceOf(AwsSessionExpiredError);
+  });
+
+  it('classifies throttling failures', () => {
+    expect(detectAwsError('Throttling: Rate exceeded', 255)).toBeInstanceOf(AwsThrottlingError);
+    expect(detectAwsError('RequestLimitExceeded', 255)).toBeInstanceOf(AwsThrottlingError);
+    expect(detectAwsError('TooManyRequestsException', 255)).toBeInstanceOf(AwsThrottlingError);
+  });
+
+  it('classifies access-denied failures', () => {
+    expect(detectAwsError('AccessDenied: not allowed', 255)).toBeInstanceOf(AwsAccessDeniedError);
+    expect(detectAwsError('UnauthorizedOperation', 255)).toBeInstanceOf(AwsAccessDeniedError);
+    expect(detectAwsError('User is not authorized to perform: s3:ListBucket', 255)).toBeInstanceOf(
+      AwsAccessDeniedError,
+    );
+  });
+
+  it('classifies not-found failures', () => {
+    expect(detectAwsError('ResourceNotFoundException', 255)).toBeInstanceOf(AwsNotFoundError);
+    expect(detectAwsError('The bucket does not exist', 255)).toBeInstanceOf(AwsNotFoundError);
+    expect(detectAwsError('NoSuchEntity', 255)).toBeInstanceOf(AwsNotFoundError);
+    expect(detectAwsError('NoSuchBucket', 255)).toBeInstanceOf(AwsNotFoundError);
+  });
+
+  it('falls back to the base exec error', () => {
+    const err = detectAwsError('some unexpected failure', 1);
+    expect(err).toBeInstanceOf(AwsExecError);
+    expect(err).not.toBeInstanceOf(AwsAuthError);
+  });
+
+  it('honours precedence: an auth+throttling message classifies as auth', () => {
+    const err = detectAwsError('Unable to locate credentials; also Throttling: Rate exceeded', 255);
+    expect(err).toBeInstanceOf(AwsAuthError);
+  });
+
+  it('honours precedence: a session-expired+access-denied message classifies as session-expired', () => {
+    const err = detectAwsError('ExpiredToken and AccessDenied', 255);
+    expect(err).toBeInstanceOf(AwsSessionExpiredError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectErrorType mapping (class -> enum)
+// ---------------------------------------------------------------------------
+
+describe('detectErrorType mapping', () => {
+  it('maps each error class to its enum', () => {
+    expect(detectErrorType(new AwsAuthError('x'))).toBe('auth_required');
+    expect(detectErrorType(new AwsSessionExpiredError('x'))).toBe('session_expired');
+    expect(detectErrorType(new AwsThrottlingError('x'))).toBe('throttled');
+    expect(detectErrorType(new AwsAccessDeniedError('x'))).toBe('access_denied');
+    expect(detectErrorType(new AwsNotFoundError('x'))).toBe('not_found');
+    expect(detectErrorType(new AwsExecError('x'))).toBe('exec_error');
+    expect(detectErrorType(new Error('x'))).toBe('exec_error');
+    expect(detectErrorType('not an error')).toBe('exec_error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Argv hygiene
+// ---------------------------------------------------------------------------
+
+const NUL = String.fromCharCode(0);
+const TAB = String.fromCharCode(9);
+const LF = String.fromCharCode(10);
+const CR = String.fromCharCode(13);
+const DEL = String.fromCharCode(127);
+
+describe('hasControlChars', () => {
+  it('rejects NUL/control bytes and DEL but allows tab/LF/CR and normal args', () => {
+    expect(hasControlChars(`a${NUL}b`)).toBe(true);
+    expect(hasControlChars(`a${DEL}b`)).toBe(true);
+    expect(hasControlChars(`a${String.fromCharCode(0x1b)}b`)).toBe(true);
+    expect(hasControlChars(`a${TAB}b`)).toBe(false);
+    expect(hasControlChars(`a${LF}b`)).toBe(false);
+    expect(hasControlChars(`a${CR}b`)).toBe(false);
+    expect(hasControlChars("s3 ls --query 'Contents[].Key'")).toBe(false);
+    expect(hasControlChars('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeExecApi signal threading (spy on Bun.spawn)
+// ---------------------------------------------------------------------------
+
+describe('makeExecApi forwards AbortSignal to Bun.spawn only while live', () => {
+  const realSpawn = Bun.spawn;
+
+  const emptyStream = () => new ReadableStream<Uint8Array>({ start: (c) => c.close() });
+  const fakeChild = () => ({
+    stdout: emptyStream(),
+    stderr: emptyStream(),
+    exited: Promise.resolve(0),
+    exitCode: 0,
+    killed: false,
+  });
+
+  let recordedOptions: { signal?: AbortSignal } | undefined;
+
+  function installSpawnSpy() {
+    recordedOptions = undefined;
+    Bun.spawn = ((_cmd: string[], options: { signal?: AbortSignal }) => {
+      recordedOptions = options;
+      return fakeChild();
+    }) as unknown as typeof Bun.spawn;
+  }
+
+  afterEach(() => {
+    Bun.spawn = realSpawn;
+  });
+
+  it('hands a live (non-aborted) signal to Bun.spawn', async () => {
+    installSpawnSpy();
+    const controller = new AbortController();
+    await makeExecApi('/tmp').exec('aws', ['sts', 'get-caller-identity'], { signal: controller.signal });
+    expect(recordedOptions).toBeDefined();
+    expect('signal' in (recordedOptions ?? {})).toBe(true);
+    expect(recordedOptions?.signal).toBe(controller.signal);
+  });
+
+  it('withholds an already-aborted (stale) signal from Bun.spawn', async () => {
+    installSpawnSpy();
+    const controller = new AbortController();
+    controller.abort(); // stale abort left over from a prior turn
+    await makeExecApi('/tmp').exec('aws', ['sts', 'get-caller-identity'], { signal: controller.signal });
+    expect(recordedOptions).toBeDefined();
+    expect('signal' in (recordedOptions ?? {})).toBe(false);
+  });
+});
+
+describe('makeExecApi live execution', () => {
+  it('a non-aborted signal still returns output', async () => {
+    const api = makeExecApi(process.cwd());
+    const controller = new AbortController();
+    const r = await api.exec('sh', ['-c', 'echo hello-live'], { signal: controller.signal });
+    expect(r.stdout).toBe('hello-live');
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('a stale, already-aborted signal does NOT false-cancel a fresh command', async () => {
+    const api = makeExecApi(process.cwd());
+    const controller = new AbortController();
+    controller.abort();
+    const r = await api.exec('sh', ['-c', 'echo still-runs'], { signal: controller.signal });
+    expect(r.stdout).toBe('still-runs');
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('runs without any signal supplied', async () => {
+    const api = makeExecApi(process.cwd());
+    const r = await api.exec('sh', ['-c', 'echo no-signal']);
+    expect(r.stdout).toBe('no-signal');
+    expect(r.exitCode).toBe(0);
+  });
+});

--- a/plugins/aws/test/aws/formatters.test.ts
+++ b/plugins/aws/test/aws/formatters.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  formatBucketTable,
+  formatIdentityDetail,
+  formatInstanceTable,
+  formatS3ObjectTable,
+  normalizeBucket,
+  normalizeIdentity,
+  normalizeInstance,
+  normalizeReservations,
+  parseS3LsOutput,
+} from '../../src/aws/formatters';
+import type { AwsBucket, AwsEc2Instance, AwsS3Object } from '../../src/aws/types';
+
+describe('normalizeIdentity', () => {
+  it('maps sts get-caller-identity JSON', () => {
+    const id = normalizeIdentity({
+      Account: '123456789012',
+      Arn: 'arn:aws:iam::123456789012:user/alice',
+      UserId: 'AIDAEXAMPLE',
+    });
+    expect(id).toEqual({
+      Account: '123456789012',
+      Arn: 'arn:aws:iam::123456789012:user/alice',
+      UserId: 'AIDAEXAMPLE',
+    });
+  });
+
+  it('defaults missing fields to empty strings', () => {
+    expect(normalizeIdentity({})).toEqual({ Account: '', Arn: '', UserId: '' });
+  });
+});
+
+describe('normalizeBucket', () => {
+  it('maps s3api list-buckets entry', () => {
+    expect(normalizeBucket({ Name: 'my-bucket', CreationDate: '2021-01-01T00:00:00Z' })).toEqual({
+      name: 'my-bucket',
+      creationDate: '2021-01-01T00:00:00Z',
+    });
+  });
+});
+
+describe('normalizeInstance', () => {
+  it('extracts name tag, state, placement and IPs', () => {
+    const inst = normalizeInstance({
+      InstanceId: 'i-0123456789abcdef0',
+      InstanceType: 't3.micro',
+      State: { Name: 'running' },
+      Placement: { AvailabilityZone: 'us-east-1a' },
+      PrivateIpAddress: '10.0.0.5',
+      PublicIpAddress: '54.1.2.3',
+      Tags: [
+        { Key: 'Name', Value: 'web-1' },
+        { Key: 'env', Value: 'prod' },
+      ],
+    });
+    expect(inst).toEqual({
+      instanceId: 'i-0123456789abcdef0',
+      state: 'running',
+      type: 't3.micro',
+      az: 'us-east-1a',
+      privateIp: '10.0.0.5',
+      publicIp: '54.1.2.3',
+      name: 'web-1',
+    });
+  });
+
+  it('handles missing tags and public IP', () => {
+    const inst = normalizeInstance({
+      InstanceId: 'i-000',
+      InstanceType: 't2.nano',
+      State: { Name: 'stopped' },
+      Placement: { AvailabilityZone: 'eu-west-1b' },
+      PrivateIpAddress: '10.0.0.9',
+    });
+    expect(inst.name).toBe('');
+    expect(inst.publicIp).toBe('');
+    expect(inst.state).toBe('stopped');
+  });
+});
+
+describe('normalizeReservations', () => {
+  it('flattens Reservations[].Instances[]', () => {
+    const instances = normalizeReservations({
+      Reservations: [
+        { Instances: [{ InstanceId: 'i-1', State: { Name: 'running' } }] },
+        { Instances: [{ InstanceId: 'i-2', State: { Name: 'stopped' } }, { InstanceId: 'i-3' }] },
+      ],
+    });
+    expect(instances.map((i) => i.instanceId)).toEqual(['i-1', 'i-2', 'i-3']);
+  });
+
+  it('returns empty array when no reservations', () => {
+    expect(normalizeReservations({})).toEqual([]);
+  });
+});
+
+describe('parseS3LsOutput', () => {
+  it('parses object and prefix lines', () => {
+    const raw = [
+      '                           PRE logs/',
+      '2021-01-01 12:00:00       1234 file.txt',
+      '2021-06-15 08:30:59         42 dir/nested.json',
+      '',
+    ].join('\n');
+    const objects = parseS3LsOutput(raw);
+    expect(objects).toEqual([
+      { key: 'logs/', size: 0, lastModified: '' },
+      { key: 'file.txt', size: 1234, lastModified: '2021-01-01 12:00:00' },
+      { key: 'dir/nested.json', size: 42, lastModified: '2021-06-15 08:30:59' },
+    ]);
+  });
+
+  it('returns empty array for empty output', () => {
+    expect(parseS3LsOutput('')).toEqual([]);
+  });
+});
+
+describe('formatIdentityDetail', () => {
+  it('renders account, arn and user id', () => {
+    const out = formatIdentityDetail({
+      Account: '123456789012',
+      Arn: 'arn:aws:iam::123456789012:user/alice',
+      UserId: 'AIDAEXAMPLE',
+    });
+    expect(out).toContain('123456789012');
+    expect(out).toContain('arn:aws:iam::123456789012:user/alice');
+    expect(out).toContain('AIDAEXAMPLE');
+  });
+});
+
+describe('formatBucketTable', () => {
+  it('returns empty state for no buckets', () => {
+    expect(formatBucketTable([])).toBe('No buckets found.');
+  });
+
+  it('renders a markdown table', () => {
+    const buckets: AwsBucket[] = [
+      { name: 'alpha', creationDate: '2021-01-01T00:00:00Z' },
+      { name: 'beta', creationDate: '2022-02-02T00:00:00Z' },
+    ];
+    const out = formatBucketTable(buckets);
+    expect(out).toContain('| Name | Creation Date |');
+    expect(out).toContain('alpha');
+    expect(out).toContain('beta');
+  });
+});
+
+describe('formatS3ObjectTable', () => {
+  it('returns empty state for no objects', () => {
+    expect(formatS3ObjectTable([])).toBe('No objects found.');
+  });
+
+  it('renders object rows', () => {
+    const objects: AwsS3Object[] = [{ key: 'file.txt', size: 1234, lastModified: '2021-01-01 12:00:00' }];
+    const out = formatS3ObjectTable(objects);
+    expect(out).toContain('| Key | Size | Last Modified |');
+    expect(out).toContain('file.txt');
+    expect(out).toContain('1234');
+  });
+});
+
+describe('formatInstanceTable', () => {
+  it('returns empty state for no instances', () => {
+    expect(formatInstanceTable([])).toBe('No instances found.');
+  });
+
+  it('renders instance rows with name fallback', () => {
+    const instances: AwsEc2Instance[] = [
+      {
+        instanceId: 'i-1',
+        state: 'running',
+        type: 't3.micro',
+        az: 'us-east-1a',
+        privateIp: '10.0.0.5',
+        publicIp: '',
+        name: '',
+      },
+    ];
+    const out = formatInstanceTable(instances);
+    expect(out).toContain('| Instance ID | Name | State | Type | AZ | Private IP | Public IP |');
+    expect(out).toContain('i-1');
+    expect(out).toContain('running');
+    // empty name and public IP render as '-'
+    expect(out).toContain('| i-1 | - | running |');
+  });
+});

--- a/plugins/aws/test/extension.test.ts
+++ b/plugins/aws/test/extension.test.ts
@@ -1,5 +1,30 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 
+const mockTypebox = {
+  Type: {
+    Object: (s: unknown) => s,
+    String: (o?: unknown) => ({ type: 'string', ...((o as object) ?? {}) }),
+    Boolean: (o?: unknown) => ({ type: 'boolean', ...((o as object) ?? {}) }),
+    Optional: (s: unknown) => ({ optional: true, ...((s as object) ?? {}) }),
+    Array: (i: unknown, o?: unknown) => ({ type: 'array', items: i, ...((o as object) ?? {}) }),
+    Union: (s: unknown[]) => ({ union: s }),
+    Literal: (v: string) => ({ const: v }),
+  },
+};
+
+function baseMockPi(overrides?: Record<string, unknown>) {
+  return {
+    setLabel() {},
+    logger: { debug() {} },
+    registerCommand() {},
+    registerServiceStatus() {},
+    registerTool() {},
+    on() {},
+    typebox: mockTypebox,
+    ...overrides,
+  };
+}
+
 describe('AWS Status extension', () => {
   let factory: (pi: unknown) => Promise<void>;
 
@@ -14,14 +39,11 @@ describe('AWS Status extension', () => {
 
   it('registers service status when aws is available', async () => {
     const registered: { name: string }[] = [];
-    const mockPi = {
-      setLabel() {},
-      logger: { debug() {} },
-      registerCommand() {},
+    const mockPi = baseMockPi({
       registerServiceStatus(c: { name: string }) {
         registered.push(c);
       },
-    };
+    });
     await factory(mockPi);
 
     // If aws CLI is installed, should register; if not, should skip gracefully
@@ -32,19 +54,50 @@ describe('AWS Status extension', () => {
 
   it('service check returns valid state', async () => {
     let checkFn: (() => Promise<{ state: string }>) | undefined;
-    const mockPi = {
-      setLabel() {},
-      logger: { debug() {} },
-      registerCommand() {},
+    const mockPi = baseMockPi({
       registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
         checkFn = c.check;
       },
-    };
+    });
     await factory(mockPi);
 
     if (checkFn) {
       const result = await checkFn();
       expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+    }
+  });
+
+  it('registers 5 tools when aws CLI is available', async () => {
+    const tools: Array<{ name: string }> = [];
+    const mockPi = baseMockPi({
+      registerTool(tool: { name: string }) {
+        tools.push(tool);
+      },
+    });
+    await factory(mockPi);
+
+    // If aws CLI is installed, should register all 5; if not, should skip gracefully
+    if (tools.length > 0) {
+      const toolNames = tools.map((t) => t.name).sort();
+      expect(toolNames).toEqual(['aws_ec2_describe_instances', 'aws_exec', 'aws_help', 'aws_s3_ls', 'aws_sts_whoami']);
+    }
+  });
+
+  it('each registered tool has required fields', async () => {
+    const tools: Array<Record<string, unknown>> = [];
+    const mockPi = baseMockPi({
+      registerTool(tool: Record<string, unknown>) {
+        tools.push(tool);
+      },
+    });
+    await factory(mockPi);
+
+    for (const tool of tools) {
+      expect(tool.name).toBeDefined();
+      expect(tool.label).toBeDefined();
+      expect(tool.description).toBeDefined();
+      expect(tool.parameters).toBeDefined();
+      expect(typeof tool.execute).toBe('function');
     }
   });
 });

--- a/plugins/aws/test/tools/aws-ec2-describe-instances.test.ts
+++ b/plugins/aws/test/tools/aws-ec2-describe-instances.test.ts
@@ -61,6 +61,35 @@ describe('aws_ec2_describe_instances input validation', () => {
     expect(result.isError).toBe(true);
   });
 
+  it('rejects a dash-prefixed filter (flag smuggling)', async () => {
+    const result = await tool.execute('id', { filters: ['--force'] }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid filter');
+  });
+
+  it('rejects a malformed filter that is not Name=...,Values=...', async () => {
+    const result = await tool.execute('id', { filters: ['badfilter'] }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid filter');
+  });
+
+  it('accepts a valid Name=...,Values=... filter (no validation rejection before spawn)', async () => {
+    try {
+      const result = await tool.execute(
+        'id',
+        { filters: ['Name=instance-state-name,Values=running'] },
+        undefined,
+        null,
+        { cwd: '/tmp' },
+      );
+      // If the aws CLI is present the call may resolve; either way validation
+      // must not have flagged the filter as invalid.
+      expect(result.content[0].text).not.toContain('invalid filter');
+    } catch {
+      // aws CLI may be unavailable; validation passed
+    }
+  });
+
   it('accepts valid region + instance IDs + filters (no validation rejection before spawn)', async () => {
     try {
       await tool.execute(

--- a/plugins/aws/test/tools/aws-ec2-describe-instances.test.ts
+++ b/plugins/aws/test/tools/aws-ec2-describe-instances.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'bun:test';
+import { createAwsEc2DescribeInstancesTool } from '../../src/tools/aws-ec2-describe-instances';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Array: (item: unknown, opts?: Record<string, unknown>) => ({ type: 'array', items: item, ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createAwsEc2DescribeInstancesTool', () => {
+  const tool = createAwsEc2DescribeInstancesTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('aws_ec2_describe_instances');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('AWS EC2 Instances');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('describe-instances');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('aws_ec2_describe_instances input validation', () => {
+  const tool = createAwsEc2DescribeInstancesTool({ typebox: mockTypebox });
+
+  it('rejects an invalid region', async () => {
+    const result = await tool.execute('id', { region: 'us_east_1' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid region');
+  });
+
+  it('rejects a region with shell injection', async () => {
+    const result = await tool.execute('id', { region: 'us-east-1; rm -rf /' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects an invalid instance ID', async () => {
+    const result = await tool.execute('id', { instanceIds: ['not-an-id'] }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid instance ID');
+  });
+
+  it('rejects an instance ID with injection', async () => {
+    const result = await tool.execute('id', { instanceIds: ['i-0123; whoami'] }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects a filter with control characters', async () => {
+    const dirty = `Name=tag,Values=x${String.fromCharCode(1)}`;
+    const result = await tool.execute('id', { filters: [dirty] }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts valid region + instance IDs + filters (no validation rejection before spawn)', async () => {
+    try {
+      await tool.execute(
+        'id',
+        {
+          region: 'us-east-1',
+          instanceIds: ['i-0123456789abcdef0'],
+          filters: ['Name=instance-state-name,Values=running'],
+        },
+        undefined,
+        null,
+        { cwd: '/tmp' },
+      );
+    } catch {
+      // aws CLI may be unavailable; validation passed
+    }
+  });
+});

--- a/plugins/aws/test/tools/aws-exec.test.ts
+++ b/plugins/aws/test/tools/aws-exec.test.ts
@@ -80,10 +80,39 @@ describe('findMutation — flag-value-shift bypass (port gitlab exclusion)', () 
     expect(r.blocked).toBe(false);
   });
 
-  it('does not let a value flag between service and op break a read', () => {
-    // --table-name X excluded → positionals = [dynamodb, query].
-    expect(findMutation(['dynamodb', '--table-name', 'X', 'query']).blocked).toBe(false);
+  it('does not let a global value flag between service and op break a read', () => {
+    // --region's value us-east-1 excluded → positionals = [ec2, describe-instances].
+    expect(findMutation(['ec2', '--region', 'us-east-1', 'describe-instances']).blocked).toBe(false);
   });
+});
+
+describe('findMutation — boolean-flag guard bypass (value-taking exclusion only)', () => {
+  const block: string[][] = [
+    // A boolean flag before the op must NOT drop the write verb.
+    ['lambda', '--no-cli-pager', 'invoke', '--function-name', 'x', 'get-out.json'],
+    ['ec2', '--debug', 'run-instances'],
+    // synthesize-speech is a write; it matches no read prefix.
+    ['polly', 'synthesize-speech', 'out.mp3'],
+    ['--no-paginate', 'iam', 'create-user', '--user-name', 'x'],
+  ];
+  for (const args of block) {
+    it(`blocks ${JSON.stringify(args)}`, () => {
+      expect(findMutation(args).blocked).toBe(true);
+    });
+  }
+
+  const allow: string[][] = [
+    // --debug is boolean → s3 kept → positionals [s3, ls] → allowed.
+    ['--debug', 's3', 'ls'],
+    ['--region', 'us-east-1', 'ec2', 'describe-instances'],
+    ['ec2', 'describe-instances', '--query', 'Reservations[].Instances[]'],
+    ['sts', 'get-caller-identity'],
+  ];
+  for (const args of allow) {
+    it(`allows ${JSON.stringify(args)}`, () => {
+      expect(findMutation(args).blocked).toBe(false);
+    });
+  }
 });
 
 describe('findMutation — s3 special-case', () => {

--- a/plugins/aws/test/tools/aws-exec.test.ts
+++ b/plugins/aws/test/tools/aws-exec.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createAwsExecTool } from '../../src/tools/aws-exec';
+import { buildAwsArgs, findMutation } from '../../src/tools/aws-exec-guard';
+import { createAwsHelpTool } from '../../src/tools/aws-help';
+import { hasControlChars } from '../../src/tools/shared';
+
+const NUL = String.fromCharCode(0);
+const TAB = String.fromCharCode(9);
+const SOH = String.fromCharCode(1);
+
+const mockPi = { typebox: { Type } };
+
+function makeExec() {
+  return createAwsExecTool(mockPi);
+}
+function makeHelp() {
+  return createAwsHelpTool(mockPi);
+}
+
+describe('findMutation — ALLOW read-only aws commands', () => {
+  const allow: string[][] = [
+    ['sts', 'get-caller-identity'],
+    ['ec2', 'describe-instances'],
+    ['s3', 'ls'],
+    ['iam', 'list-users'],
+    ['dynamodb', 'query', '--table-name', 'X'],
+    [
+      'ec2',
+      'describe-instances',
+      '--query',
+      'Reservations[].Instances[]',
+      '--filters',
+      'Name=instance-state-name,Values=running',
+    ],
+    ['cloudformation', 'describe-stacks'],
+    ['help'],
+  ];
+
+  for (const args of allow) {
+    it(`allows ${JSON.stringify(args)}`, () => {
+      expect(findMutation(args).blocked).toBe(false);
+    });
+  }
+});
+
+describe('findMutation — BLOCK writes and unknown ops (fail-safe)', () => {
+  const block: string[][] = [
+    ['ec2', 'run-instances'],
+    ['ec2', 'terminate-instances', '--instance-ids', 'i-x'],
+    ['iam', 'create-user', '--user-name', 'x'],
+    ['s3', 'rm', 's3://b/k'],
+    ['s3', 'sync', '.', 's3://b'],
+    ['s3', 'cp', 'a', 's3://b'],
+    ['s3api', 'put-object', '--bucket', 'b', '--key', 'k'],
+    ['lambda', 'update-function-code', '--function-name', 'f'],
+    [],
+  ];
+
+  for (const args of block) {
+    it(`blocks ${JSON.stringify(args)}`, () => {
+      expect(findMutation(args).blocked).toBe(true);
+    });
+  }
+
+  it('blocks an empty command with a helpful reason', () => {
+    expect(findMutation([]).reason).toContain('no aws command');
+  });
+});
+
+describe('findMutation — flag-value-shift bypass (port gitlab exclusion)', () => {
+  it('blocks when a leading value flag would otherwise shift the operation', () => {
+    // `--region`'s value `us-east-1` is excluded; positionals = [ec2, run-instances].
+    const r = findMutation(['--region', 'us-east-1', 'ec2', 'run-instances']);
+    expect(r.blocked).toBe(true);
+  });
+
+  it('still allows a real read when a leading value flag precedes it', () => {
+    const r = findMutation(['--region', 'us-east-1', 'ec2', 'describe-instances']);
+    expect(r.blocked).toBe(false);
+  });
+
+  it('does not let a value flag between service and op break a read', () => {
+    // --table-name X excluded → positionals = [dynamodb, query].
+    expect(findMutation(['dynamodb', '--table-name', 'X', 'query']).blocked).toBe(false);
+  });
+});
+
+describe('findMutation — s3 special-case', () => {
+  it('allows s3 ls', () => {
+    expect(findMutation(['s3', 'ls']).blocked).toBe(false);
+    expect(findMutation(['s3', 'ls', 's3://bucket/prefix/']).blocked).toBe(false);
+  });
+
+  it('blocks s3 write subcommands with a "writes to S3" reason', () => {
+    for (const op of ['cp', 'mv', 'rm', 'sync', 'mb', 'rb']) {
+      const r = findMutation(['s3', op, 'a', 'b']);
+      expect(r.blocked).toBe(true);
+      expect(r.reason).toContain('S3');
+    }
+  });
+
+  it('blocks an unknown s3 subcommand fail-safe', () => {
+    expect(findMutation(['s3', 'presign', 's3://b/k']).blocked).toBe(true);
+  });
+
+  it('blocks bare s3 with no subcommand', () => {
+    expect(findMutation(['s3']).blocked).toBe(true);
+  });
+});
+
+describe('findMutation — generic allowlist', () => {
+  it('allows every READ_PREFIX family', () => {
+    expect(findMutation(['ec2', 'describe-vpcs']).blocked).toBe(false);
+    expect(findMutation(['iam', 'list-roles']).blocked).toBe(false);
+    expect(findMutation(['ssm', 'get-parameter', '--name', 'x']).blocked).toBe(false);
+    expect(findMutation(['cloudtrail', 'lookup-events']).blocked).toBe(false);
+    expect(findMutation(['ec2', 'search-transit-gateway-routes']).blocked).toBe(false);
+    expect(findMutation(['s3api', 'head-bucket', '--bucket', 'b']).blocked).toBe(false);
+  });
+
+  it('allows READ_EXACT ops', () => {
+    expect(findMutation(['dynamodb', 'scan', '--table-name', 't']).blocked).toBe(false);
+    expect(findMutation(['dynamodb', 'query', '--table-name', 't']).blocked).toBe(false);
+    expect(findMutation(['ec2', 'wait', 'instance-running']).blocked).toBe(false);
+  });
+
+  it('blocks a service with no operation', () => {
+    expect(findMutation(['ec2']).blocked).toBe(true);
+  });
+
+  it('names the cli-operator delegation path in the block reason for a write', () => {
+    const r = findMutation(['ec2', 'run-instances']);
+    expect(r.reason?.toLowerCase()).toContain('cli-operator');
+  });
+});
+
+describe('buildAwsArgs — default --output json unless caller set output', () => {
+  it('appends --output json by default', () => {
+    expect(buildAwsArgs(['ec2', 'describe-instances'])).toEqual(['ec2', 'describe-instances', '--output', 'json']);
+  });
+
+  it('respects a caller-supplied --output', () => {
+    expect(buildAwsArgs(['ec2', 'describe-instances', '--output', 'table'])).toEqual([
+      'ec2',
+      'describe-instances',
+      '--output',
+      'table',
+    ]);
+  });
+
+  it('respects a caller-supplied -o', () => {
+    expect(buildAwsArgs(['s3', 'ls', '-o', 'text'])).toEqual(['s3', 'ls', '-o', 'text']);
+  });
+});
+
+describe('hasControlChars', () => {
+  it('rejects NUL/C0 controls but allows tab and normal args', () => {
+    expect(hasControlChars(`a${NUL}b`)).toBe(true);
+    expect(hasControlChars(`a${SOH}b`)).toBe(true);
+    expect(hasControlChars(`a${TAB}b`)).toBe(false);
+    expect(hasControlChars('ec2 describe-instances --query Reservations[]')).toBe(false);
+  });
+});
+
+describe('aws_exec execute', () => {
+  it('returns correct name and label', () => {
+    const tool = makeExec();
+    expect(tool.name).toBe('aws_exec');
+    expect(tool.label).toBe('AWS CLI Execute');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('rejects empty args', async () => {
+    const r = await makeExec().execute('id', { args: [] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+  });
+
+  it('rejects a control character before spawning', async () => {
+    const r = await makeExec().execute('id', { args: [`ec2${NUL}describe`] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('control character');
+  });
+
+  it('blocks a mutating operation before spawning (read-only + cli-operator)', async () => {
+    const r = await makeExec().execute('id', { args: ['ec2', 'run-instances'] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    const text = r.content[0].text.toLowerCase();
+    expect(text).toContain('read-only');
+    expect(text).toContain('cli-operator');
+  });
+
+  it('blocks an s3 write before spawning', async () => {
+    const r = await makeExec().execute('id', { args: ['s3', 'rm', 's3://b/k'] }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+  });
+
+  it('blocks the leading-flag operation shift before spawning', async () => {
+    const r = await makeExec().execute(
+      'id',
+      { args: ['--region', 'us-east-1', 'ec2', 'run-instances'] },
+      undefined,
+      undefined,
+      { cwd: '/tmp' },
+    );
+    expect(r.isError).toBe(true);
+  });
+
+  it('tags results with the aws_exec tool detail', () => {
+    const tool = makeExec();
+    expect(tool.name).toBe('aws_exec');
+  });
+});
+
+describe('aws_help execute', () => {
+  it('returns correct name and label', () => {
+    const tool = makeHelp();
+    expect(tool.name).toBe('aws_help');
+    expect(tool.label).toBe('AWS CLI Help');
+    expect(typeof tool.description).toBe('string');
+  });
+
+  it('rejects a command path with invalid characters', async () => {
+    const r = await makeHelp().execute('id', { command_path: 'ec2; rm -rf /' }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text.toLowerCase()).toContain('invalid');
+  });
+
+  it('rejects a command path part starting with a dash (charset-valid but dash-led)', async () => {
+    // `iam -foo` passes the [a-z -] charset regex but the second part is a dash flag.
+    const r = await makeHelp().execute('id', { command_path: 'iam -foo' }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+  });
+
+  it('rejects uppercase / command substitution', async () => {
+    const r = await makeHelp().execute('id', { command_path: 'ec2 $(whoami)' }, undefined, undefined, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+  });
+});

--- a/plugins/aws/test/tools/aws-help.test.ts
+++ b/plugins/aws/test/tools/aws-help.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test';
+import { createAwsHelpTool } from '../../src/tools/aws-help';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createAwsHelpTool', () => {
+  const tool = createAwsHelpTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('aws_help');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('AWS CLI Help');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('aws_help command path validation', () => {
+  const tool = createAwsHelpTool({ typebox: mockTypebox });
+
+  it('accepts a service with digits ("ec2")', async () => {
+    try {
+      const result = await tool.execute('id', { command_path: 'ec2' }, undefined, null, { cwd: '/tmp' });
+      expect(result.content[0].text).not.toContain('invalid command path');
+    } catch {
+      // aws CLI may be unavailable; validation passed
+    }
+  });
+
+  it('accepts a service with digits and letters ("s3api")', async () => {
+    try {
+      const result = await tool.execute('id', { command_path: 's3api' }, undefined, null, { cwd: '/tmp' });
+      expect(result.content[0].text).not.toContain('invalid command path');
+    } catch {
+      // aws CLI may be unavailable; validation passed
+    }
+  });
+
+  it('rejects a path with shell metacharacters', async () => {
+    const result = await tool.execute('id', { command_path: 'pr; rm' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid command path');
+  });
+
+  it('rejects an uppercase path', async () => {
+    const result = await tool.execute('id', { command_path: 'EC2' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid command path');
+  });
+
+  it('rejects a dash-led command path part (flag smuggling)', async () => {
+    const result = await tool.execute('id', { command_path: 'iam -foo' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('must not start with');
+  });
+});

--- a/plugins/aws/test/tools/aws-s3-ls.test.ts
+++ b/plugins/aws/test/tools/aws-s3-ls.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test';
+import { createAwsS3LsTool } from '../../src/tools/aws-s3-ls';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createAwsS3LsTool', () => {
+  const tool = createAwsS3LsTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('aws_s3_ls');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('AWS S3 List');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('S3');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('aws_s3_ls input validation', () => {
+  const tool = createAwsS3LsTool({ typebox: mockTypebox });
+
+  it('rejects a target that is not an s3:// URI', async () => {
+    const result = await tool.execute('id', { target: '/etc/passwd' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid');
+  });
+
+  it('rejects a target with shell injection', async () => {
+    const result = await tool.execute('id', { target: 's3://bucket; rm -rf /' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects a target with command substitution', async () => {
+    const result = await tool.execute('id', { target: 's3://$(whoami)' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts a valid s3:// target (no validation rejection before spawn)', async () => {
+    try {
+      await tool.execute('id', { target: 's3://my-bucket/prefix/' }, undefined, null, { cwd: '/tmp' });
+    } catch {
+      // aws CLI may be unavailable; validation passed
+    }
+  });
+});

--- a/plugins/aws/test/tools/aws-sts-whoami.test.ts
+++ b/plugins/aws/test/tools/aws-sts-whoami.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test';
+import { createAwsStsWhoamiTool } from '../../src/tools/aws-sts-whoami';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createAwsStsWhoamiTool', () => {
+  const tool = createAwsStsWhoamiTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('aws_sts_whoami');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('AWS Caller Identity');
+  });
+
+  it('has a description from markdown', () => {
+    expect(tool.description).toContain('aws sts get-caller-identity');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('aws_sts_whoami input validation', () => {
+  const tool = createAwsStsWhoamiTool({ typebox: mockTypebox });
+
+  it('rejects profile with shell injection', async () => {
+    const result = await tool.execute('id', { profile: '$(whoami)' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid');
+  });
+
+  it('rejects profile with pipe', async () => {
+    const result = await tool.execute('id', { profile: 'a|b' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects profile with semicolon', async () => {
+    const result = await tool.execute('id', { profile: 'a;rm -rf /' }, undefined, null, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts a valid profile (no validation rejection before spawn)', async () => {
+    try {
+      await tool.execute('id', { profile: 'my-sso-profile' }, undefined, null, { cwd: '/tmp' });
+    } catch {
+      // aws CLI may be unavailable; validation passed
+    }
+  });
+});

--- a/plugins/aws/tsconfig.json
+++ b/plugins/aws/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Implements **Spec 5** — builds the `aws` plugin's native tool layer from ZERO (it was an auth-and-status shell), mirroring the Azure structure and porting the corrected GitLab guard.

- **Core**: `src/aws/exec.ts` (6-class `Aws*Error` taxonomy + `detectAwsError` + signal-aware argv exec), `src/aws/types.ts`, `src/tools/shared.ts` (result builders, `detectErrorType`, local `renderError`, charCode `hasControlChars`, `makeExecApi`).
- **Typed reads**: `aws_sts_whoami`, `aws_s3_ls`, `aws_ec2_describe_instances` (+ formatters with empty states; strict input validation — region/instance-id/s3-uri/`--filters` all reject injection/dash-prefix).
- **`aws_exec`**: read-only passthrough with a fail-safe guard — read-prefix allowlist (`describe-`/`list-`/`get-`/…) + `READ_EXACT` + s3 special-case (blocks `cp/mv/rm/sync/mb/rb`); flag-value exclusion restricted to known value-taking flags (closes a boolean-flag verb-hiding bypass found in review); no api-method logic (aws has none); shell metacharacters preserved for JMESPath `--query`.
- **`aws_help`**, **`--query`/`--filters`/`--output` docs**, **`withErrorType` wiring**, **benchmark + autoresearch harness** (`mock-aws`).
- Preserved untouched: auth skill, `cli-operator` agent, wizard, `aws_hint` context injection, service status.

Verified: 138 aws tests pass; `biome ci plugins/aws` exit 0; benchmark composite runs; guard passed an adversarial final review after fixing an ec2 `--filters` injection, a help-path digit bug, and the boolean-flag bypass. No runtime `@f5-sales-demo/xcsh` value import.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
