### PR TITLE
fix(gitlab,salesforce): correct pflag cluster parsing (-fX=GET body-field bypass)

### DIFF
--- a/plugins/gitlab/src/tools/glab-exec-guard.ts
+++ b/plugins/gitlab/src/tools/glab-exec-guard.ts
@@ -21,10 +21,13 @@ const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH
 // glab is a cobra/pflag CLI, so a boolean short flag may CLUSTER ahead of a
 // value-taking short flag inside a single token: `-iF title=x` parses as
 // `-i` (include, boolean) + `-F` (field, value from the next arg), and `-iX POST`
-// as include + method. Prefix matching on the token misses these, so we inspect
-// the whole single-dash letter run — never just the char at index 1 — for the
-// field (f/F) and method (X) letters. Over-flagging here is fail-safe: at worst
-// it treats a read as a body/method write and blocks it; it never allows a write.
+// as include + method. Crucially, pflag stops at the FIRST value-taking short in a
+// cluster: the REST of the token becomes that flag's value. So `-fX=GET` is
+// `--raw-field` with value `X=GET` (a body field literally named X) — the trailing
+// X is data, NOT a method flag — and glab sends POST. We therefore scan the letter
+// run left→right and STOP at the first value-taking short: f/F marks a body (rest is
+// the field value, never a method); X takes the token remainder (or next arg) as the
+// method. Over-flagging here is fail-safe: at worst it blocks a read; never allows a write.
 export function effectiveApiMethod(args: string[]): string {
   let explicit: string | null = null;
   let hasBody = false;
@@ -59,23 +62,26 @@ export function effectiveApiMethod(args: string[]): string {
     if (a.startsWith('--')) continue;
 
     // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading
-    // '-' and inspect the letter run up to the first '=' (or end) so a boolean
-    // short flag clustered ahead of a value flag can't hide the value flag.
+    // '-' and scan the letters left→right, stopping at the FIRST value-taking
+    // short flag (pflag consumes the token remainder as that flag's value).
     if (/^-[A-Za-z]/.test(a)) {
       const body = a.slice(1);
-      const eq = body.indexOf('=');
-      const letters = eq === -1 ? body : body.slice(0, eq);
-
-      // Field flag anywhere in the cluster → this token carries a body.
-      if (letters.includes('f') || letters.includes('F')) hasBody = true;
-
-      // Method flag anywhere in the cluster → value is whatever follows the X
-      // in the same token (leading '=' stripped), else the next arg.
-      const xIdx = letters.indexOf('X');
-      if (xIdx !== -1) {
-        const after = body.slice(xIdx + 1).replace(/^=/, '');
-        if (after) setExplicit(after);
-        else setExplicit(args[i + 1] ?? '');
+      for (let j = 0; j < body.length; j++) {
+        const c = body[j];
+        if (c === 'f' || c === 'F') {
+          // First value-taking short is a body field: the rest of the token
+          // (including any 'X') is this field's VALUE — never a method flag.
+          hasBody = true;
+          break;
+        }
+        if (c === 'X') {
+          // First value-taking short is the method flag: value is the token
+          // remainder after X (leading '=' stripped), else the next arg.
+          const after = body.slice(j + 1).replace(/^=/, '');
+          setExplicit(after || (args[i + 1] ?? ''));
+          break;
+        }
+        // Any other letter is a boolean short (e.g. -i); keep scanning.
       }
     }
   }

--- a/plugins/gitlab/src/tools/glab-exec-guard.ts
+++ b/plugins/gitlab/src/tools/glab-exec-guard.ts
@@ -90,13 +90,24 @@ export function effectiveApiMethod(args: string[]): string {
   return hasBody ? 'POST' : 'GET';
 }
 
+// Does the flag token `prev` consume the NEXT argv token as its value, per cobra/pflag
+// `stripFlags`? Only a long flag without `=` (`--repo x` → consumes `x`) or an
+// exactly-2-char short (`-R x` → consumes `x`) take their value from the following
+// token. A single-dash CLUSTER of length >= 3 (`-dp`, `-dm`) does NOT — pflag reads any
+// in-cluster value flag's value from the token REMAINDER, not the next arg. Excluding
+// the token after every dash token (the earlier code) dropped the real verb after a
+// boolean cluster and let a write through; long/2-char over-exclusion is retained
+// (it can only block a read, never allow a write), cluster over-exclusion is removed.
+function consumesNextAsValue(prev: string): boolean {
+  if (prev.startsWith('--')) return !prev.includes('=');
+  return /^-[A-Za-z]$/.test(prev);
+}
+
 export function findMutation(args: string[]): { blocked: boolean; reason?: string } {
-  // Cobra/pflag consumes the token AFTER a flag token as that flag's value, so a
-  // value-taking flag can shift a command's real verb past positionals[1]. Mirror
-  // cobra by excluding both flag tokens AND the token immediately following one.
-  // This over-excludes tokens after boolean flags (fail-safe: at worst blocks a
-  // read; never allows a mutation) and realigns the verb with what glab dispatches.
-  const positionals = args.filter((a, i) => !a.startsWith('-') && !(i > 0 && args[i - 1].startsWith('-')));
+  const positionals = args.filter((a, i) => {
+    if (a.startsWith('-')) return false;
+    return !(i > 0 && consumesNextAsValue(args[i - 1]));
+  });
   if (positionals.length === 0) return { blocked: true, reason: 'no glab command provided' };
   const top = positionals[0];
 

--- a/plugins/gitlab/src/tools/glab-exec-guard.ts
+++ b/plugins/gitlab/src/tools/glab-exec-guard.ts
@@ -28,6 +28,35 @@ const API_MUTATING_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH
 // run left→right and STOP at the first value-taking short: f/F marks a body (rest is
 // the field value, never a method); X takes the token remainder (or next arg) as the
 // method. Over-flagging here is fail-safe: at worst it blocks a read; never allows a write.
+// glab api long flags that take a VALUE (consume the next token when written without
+// `=`). Every OTHER `--long` is a boolean (--include, --silent, --paginate) and
+// consumes nothing.
+const LONG_VALUE_FLAGS: ReadonlySet<string> = new Set([
+  '--method',
+  '--field',
+  '--raw-field',
+  '--input',
+  '--form',
+  '--header',
+  '--hostname',
+]);
+// glab api long flags whose presence implies a request BODY (→ POST).
+const LONG_BODY_FLAGS: ReadonlySet<string> = new Set(['--field', '--raw-field', '--input', '--form']);
+// glab api single-char shorts that take a VALUE (from the token remainder, else the
+// next token). glab swaps gh's convention: -F = --field, -f = --raw-field, -H =
+// --header, -X = --method. Every other short (i, and any unknown letter) is boolean.
+const SHORT_VALUE_FLAGS: ReadonlySet<string> = new Set(['X', 'F', 'f', 'H']);
+// Shorts that imply a request BODY.
+const SHORT_BODY_FLAGS: ReadonlySet<string> = new Set(['F', 'f']);
+
+// Resolve the HTTP method glab will actually use for `glab api`. glab is a cobra/pflag
+// CLI, so a value-taking flag consumes the following token (or, for a short, the cluster
+// remainder) as its VALUE — that value must NEVER be reinterpreted as another flag.
+// Scanning every token let a value consumed by another flag (`-H -XGET`, `--header
+// -XGET`) be misread as `-X <method>`, forging a non-mutating method that overrode a
+// real body POST. We therefore consume each value-taking flag's value explicitly. Body
+// shorts/longs always set hasBody even when their value is attached; over-flagging a
+// body is fail-safe (blocks a read), under-detecting one is the danger.
 export function effectiveApiMethod(args: string[]): string {
   let explicit: string | null = null;
   let hasBody = false;
@@ -40,48 +69,32 @@ export function effectiveApiMethod(args: string[]): string {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
 
-    // Long-form (double-dash) flags — unchanged detection.
-    if (a === '--method') {
-      setExplicit(args[i + 1] ?? '');
+    // Long-form (double-dash) flags.
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      const name = eq === -1 ? a : a.slice(0, eq);
+      const inlineVal = eq === -1 ? undefined : a.slice(eq + 1);
+      if (name === '--method') setExplicit(inlineVal ?? args[i + 1] ?? '');
+      if (LONG_BODY_FLAGS.has(name)) hasBody = true;
+      if (inlineVal === undefined && LONG_VALUE_FLAGS.has(name)) i += 1; // consume value token
       continue;
     }
-    if (a.startsWith('--method=')) {
-      setExplicit(a.slice('--method='.length));
-      continue;
-    }
-    if (
-      a === '--field' ||
-      a === '--raw-field' ||
-      a === '--input' ||
-      a === '--form' ||
-      /^--(field|raw-field|input|form)=/.test(a)
-    ) {
-      hasBody = true;
-      continue;
-    }
-    if (a.startsWith('--')) continue;
 
-    // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading
-    // '-' and scan the letters left→right, stopping at the FIRST value-taking
-    // short flag (pflag consumes the token remainder as that flag's value).
+    // Single-dash cluster token: scan letters left→right; the FIRST value-taking short
+    // consumes the token remainder (or the next token) as its value and ENDS the cluster.
     if (/^-[A-Za-z]/.test(a)) {
       const body = a.slice(1);
       for (let j = 0; j < body.length; j++) {
         const c = body[j];
-        if (c === 'f' || c === 'F') {
-          // First value-taking short is a body field: the rest of the token
-          // (including any 'X') is this field's VALUE — never a method flag.
-          hasBody = true;
-          break;
+        if (!SHORT_VALUE_FLAGS.has(c)) continue; // boolean short (e.g. -i); keep scanning
+        let value = body.slice(j + 1).replace(/^=/, '');
+        if (value === '') {
+          i += 1;
+          value = args[i] ?? '';
         }
-        if (c === 'X') {
-          // First value-taking short is the method flag: value is the token
-          // remainder after X (leading '=' stripped), else the next arg.
-          const after = body.slice(j + 1).replace(/^=/, '');
-          setExplicit(after || (args[i + 1] ?? ''));
-          break;
-        }
-        // Any other letter is a boolean short (e.g. -i); keep scanning.
+        if (c === 'X') setExplicit(value);
+        if (SHORT_BODY_FLAGS.has(c)) hasBody = true;
+        break; // remainder/next token is this flag's value, not more flags
       }
     }
   }

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -146,6 +146,16 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['api', 'x', '-X', 'GET']).blocked).toBe(false);
   });
 
+  it('does not misread a value-flag value as -X/method (header consumes its value)', () => {
+    // `-H`/`--header` take the FOLLOWING token as their value; a value like `-XGET` is
+    // data, not a method flag. The `-F`/`--form` body still makes glab POST, so the
+    // forged method must not downgrade it to an allowed read.
+    expect(findMutation(['api', 'projects/1/issues', '-F', 'title=x', '-H', '-XGET']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '--form', 'a=b', '--header', '-XGET']).blocked).toBe(true);
+    // A genuine header read (no body/method) is still an allowed GET.
+    expect(findMutation(['api', 'projects/1', '-H', 'Accept: application/json']).blocked).toBe(false);
+  });
+
   it('allows glab api GET requests', () => {
     expect(findMutation(['api', '-XGET', 'projects/1']).blocked).toBe(false);
     expect(findMutation(['api', '-X=GET', 'user']).blocked).toBe(false);

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -77,6 +77,10 @@ describe('effectiveApiMethod', () => {
     expect(effectiveApiMethod(['api', 'x', '-iX', 'GET'])).toBe('GET');
     // Include-only boolean cluster → no body, no method → GET.
     expect(effectiveApiMethod(['api', 'x', '-i'])).toBe('GET');
+    // pflag stops at the first value-taking short: `-fX=GET` / `-FX=GET` are a body
+    // field whose value contains `X=GET` → POST; the trailing X is data, not a method.
+    expect(effectiveApiMethod(['api', 'x', '-fX=GET'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'x', '-FX=GET'])).toBe('POST');
   });
 });
 
@@ -117,6 +121,16 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['api', 'x', '-iXPUT']).blocked).toBe(true);
     expect(findMutation(['api', 'x', '-iF=title=y']).blocked).toBe(true);
     expect(findMutation(['api', 'x', '-Fi', 'title=x']).blocked).toBe(true);
+  });
+
+  it('blocks the -fX=GET / -FX=GET body-field cluster bypass (#813)', () => {
+    // pflag stops at the first value-taking short: `-fX=GET` is `-f`/--raw-field with
+    // value `X=GET` (a field literally named X) → body → POST, NOT `-X GET`. The
+    // trailing `X` must not be mis-read as an explicit GET that allows the write.
+    expect(findMutation(['api', 'x', '-fX=GET']).blocked).toBe(true);
+    expect(findMutation(['api', 'x', '-FX=GET']).blocked).toBe(true);
+    // A genuine bodyless `-X GET` remains an allowed read.
+    expect(findMutation(['api', 'x', '-X', 'GET']).blocked).toBe(false);
   });
 
   it('allows glab api GET requests', () => {

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -103,6 +103,19 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['auth', 'login']).blocked).toBe(true);
   });
 
+  it('blocks the boolean-short-cluster verb-shift bypass (-xy… does not consume the next arg)', () => {
+    // A single-dash cluster of length >= 3 is all in-token flags; pflag does NOT read
+    // its value from the following arg, so the real write verb stays a positional and
+    // must not be dropped. Previously the token after any dash was excluded, misreading
+    // the verb as a later read and allowing the write.
+    expect(findMutation(['mr', '-dm', 'merge', 'view']).blocked).toBe(true);
+    expect(findMutation(['release', '-dp', 'create', 'view']).blocked).toBe(true);
+    // A genuine long flag without `=` (or a lone 2-char short) still consumes its value,
+    // so these reads whose verb follows a real value flag remain allowed.
+    expect(findMutation(['issue', 'list', '--label', 'create']).blocked).toBe(false);
+    expect(findMutation(['-R', 'o/r', 'mr', 'list']).blocked).toBe(false);
+  });
+
   it('blocks glab api mutating requests in every flag form', () => {
     expect(findMutation(['api', '-XPOST', 'projects/1/issues']).blocked).toBe(true);
     expect(findMutation(['api', '-X=POST', 'x']).blocked).toBe(true);

--- a/plugins/salesforce/src/tools/sf-exec-guard.ts
+++ b/plugins/salesforce/src/tools/sf-exec-guard.ts
@@ -45,13 +45,29 @@ const READ_PREFIXES: ReadonlyArray<readonly string[]> = [
 // Single-token top-level read commands (meta topics with no write subcommands).
 const READ_TOP: ReadonlySet<string> = new Set(['version', 'help', 'commands', 'which', 'info']);
 
-// Compute the command path used for allowlisting: non-flag tokens, EXCLUDING the token
-// immediately after any flag (its value), with each surviving positional split on ':'
+// Does the flag token `prev` consume the NEXT argv token as its value? Only a long flag
+// without `=` (`--target-org x` → consumes `x`) or an exactly-2-char short (`-o x` →
+// consumes `x`) take their value from the following token. A single-dash CLUSTER of
+// length >= 3 (`-fp`, combined booleans) does NOT — its value, if any, is the token
+// remainder, not the next arg. Excluding the token after every dash token (the earlier
+// code) dropped the real subcommand after a boolean cluster and could let a write path
+// resolve to a read prefix; long/2-char over-exclusion is retained (it can only block a
+// read, never allow a write), cluster over-exclusion is removed.
+function consumesNextAsValue(prev: string): boolean {
+  if (prev.startsWith('--')) return !prev.includes('=');
+  return /^-[A-Za-z]$/.test(prev);
+}
+
+// Compute the command path used for allowlisting: non-flag tokens, EXCLUDING a flag's
+// value token (per consumesNextAsValue), with each surviving positional split on ':'
 // so the colon grammar is normalized to the space grammar. Flag tokens keep their form
-// and never contribute path parts. Excluding the post-flag token first means a flag
+// and never contribute path parts. Excluding the post-flag value first means a flag
 // value that itself contains a ':' can never leak a path segment.
 export function normalizeArgs(args: string[]): string[] {
-  const positionals = args.filter((a, i) => !a.startsWith('-') && !(i > 0 && args[i - 1].startsWith('-')));
+  const positionals = args.filter((a, i) => {
+    if (a.startsWith('-')) return false;
+    return !(i > 0 && consumesNextAsValue(args[i - 1]));
+  });
   const path: string[] = [];
   for (const token of positionals) {
     for (const part of token.split(':')) {

--- a/plugins/salesforce/src/tools/sf-exec-guard.ts
+++ b/plugins/salesforce/src/tools/sf-exec-guard.ts
@@ -71,10 +71,14 @@ function startsWith(path: string[], prefix: readonly string[]): boolean {
 
 // Resolve the HTTP method `sf api request rest|graphql` will actually use. An explicit
 // --method/-X (any form) wins; sf otherwise defaults to GET. sf is an oclif CLI, so a
-// boolean short flag may CLUSTER ahead of the method short inside one token: `-iX POST`
-// parses as `-i` (include) + `-X` (method, value from the next arg). We inspect the
-// whole single-dash letter run — never just index 1 — for the method letter X.
-// --body/--file are body flags; their presence forces a mutating shape (reported as
+// boolean short flag may CLUSTER ahead of a value-taking short inside one token: `-iX POST`
+// parses as `-i` (include) + `-X` (method, value from the next arg). Crucially, the
+// parser stops at the FIRST value-taking short in a cluster: the REST of the token
+// becomes that flag's value. So `-fX=GET` is `--file` with value `X=GET` (the trailing
+// X is data, NOT a method flag) — a body → POST. We therefore scan the letter run
+// left→right and STOP at the first value-taking short: b/f marks a body (rest is that
+// flag's value, never a method); X takes the token remainder (or next arg) as the method.
+// --body/--file are body flags too; their presence forces a mutating shape (reported as
 // POST here, and additionally blocked outright by findMutation). Over-flagging is
 // fail-safe: at worst it treats a read as a write and blocks it; it never allows a write.
 export function effectiveApiMethod(args: string[]): string {
@@ -104,22 +108,30 @@ export function effectiveApiMethod(args: string[]): string {
     if (a.startsWith('--')) continue;
 
     // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading '-' and
-    // inspect the letter run up to the first '=' so a boolean short flag clustered
-    // ahead of the method short can't hide it. sf's body/file shorts are `-b`/`-f`, so
-    // a `b` or `f` anywhere in the cluster (`-f`, `-b`, `-if`, `-Sf`, `-bX`, attached
-    // `-freq.json`) implies a body/write, mirroring the method-letter `X` detection.
+    // scan the letters left→right, stopping at the FIRST value-taking short flag (the
+    // parser consumes the token remainder as that flag's value). sf's body/file shorts
+    // are `-b`/`-f`, so a leading `b`/`f` (`-f`, `-b`, `-if`, `-bX`, attached
+    // `-freq.json`) marks a body — the rest of the token, including any `X`, is that
+    // flag's value and is never parsed as a method.
     if (/^-[A-Za-z]/.test(a)) {
       const body = a.slice(1);
-      const eq = body.indexOf('=');
-      const letters = eq === -1 ? body : body.slice(0, eq);
-
-      const xIdx = letters.indexOf('X');
-      if (xIdx !== -1) {
-        const after = body.slice(xIdx + 1).replace(/^=/, '');
-        if (after) setExplicit(after);
-        else setExplicit(args[i + 1] ?? '');
+      for (let j = 0; j < body.length; j++) {
+        const c = body[j];
+        if (c === 'b' || c === 'f') {
+          // First value-taking short is a body/file field: the rest of the token
+          // (including any 'X') is this flag's VALUE — never a method flag.
+          hasBody = true;
+          break;
+        }
+        if (c === 'X') {
+          // First value-taking short is the method flag: value is the token
+          // remainder after X (leading '=' stripped), else the next arg.
+          const after = body.slice(j + 1).replace(/^=/, '');
+          setExplicit(after || (args[i + 1] ?? ''));
+          break;
+        }
+        // Any other letter is a boolean short (e.g. -i); keep scanning.
       }
-      if (letters.includes('b') || letters.includes('f')) hasBody = true;
     }
   }
 

--- a/plugins/salesforce/src/tools/sf-exec-guard.ts
+++ b/plugins/salesforce/src/tools/sf-exec-guard.ts
@@ -97,6 +97,26 @@ function startsWith(path: string[], prefix: readonly string[]): boolean {
 // --body/--file are body flags too; their presence forces a mutating shape (reported as
 // POST here, and additionally blocked outright by findMutation). Over-flagging is
 // fail-safe: at worst it treats a read as a write and blocks it; it never allows a write.
+// sf api request long flags that take a VALUE (consume the next token when written
+// without `=`). Every OTHER `--long` is a boolean (--include, --stream-to-file) and
+// consumes nothing.
+const LONG_VALUE_FLAGS: ReadonlySet<string> = new Set(['--method', '--body', '--file', '--header']);
+// Long flags whose presence implies a request BODY (→ POST).
+const LONG_BODY_FLAGS: ReadonlySet<string> = new Set(['--body', '--file']);
+// sf api request single-char shorts that take a VALUE (from the token remainder, else
+// the next token): X = --method, b = --body, f = --file, h = --header. Every other short
+// (i, S, and any unknown letter) is boolean.
+const SHORT_VALUE_FLAGS: ReadonlySet<string> = new Set(['X', 'b', 'f', 'h']);
+// Shorts that imply a request BODY.
+const SHORT_BODY_FLAGS: ReadonlySet<string> = new Set(['b', 'f']);
+
+// Resolve the HTTP method `sf api request rest|graphql` will actually use. A value-taking
+// flag consumes the following token (or, for a short, the cluster remainder) as its
+// VALUE — that value must NEVER be reinterpreted as another flag. Scanning every token
+// let a value consumed by another flag (`--header -XGET`, `-h -XGET`) be misread as
+// `-X <method>`, forging a method that overrode a real `--method`/body. We consume each
+// value-taking flag's value explicitly. (hasApiBodyFlag below is an independent
+// belt-and-suspenders that blocks any api request carrying a body flag at all.)
 export function effectiveApiMethod(args: string[]): string {
   let explicit: string | null = null;
   let hasBody = false;
@@ -109,44 +129,32 @@ export function effectiveApiMethod(args: string[]): string {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
 
-    if (a === '--method') {
-      setExplicit(args[i + 1] ?? '');
+    // Long-form (double-dash) flags.
+    if (a.startsWith('--')) {
+      const eq = a.indexOf('=');
+      const name = eq === -1 ? a : a.slice(0, eq);
+      const inlineVal = eq === -1 ? undefined : a.slice(eq + 1);
+      if (name === '--method') setExplicit(inlineVal ?? args[i + 1] ?? '');
+      if (LONG_BODY_FLAGS.has(name)) hasBody = true;
+      if (inlineVal === undefined && LONG_VALUE_FLAGS.has(name)) i += 1; // consume value token
       continue;
     }
-    if (a.startsWith('--method=')) {
-      setExplicit(a.slice('--method='.length));
-      continue;
-    }
-    if (a === '--body' || a === '--file' || /^--(body|file)=/.test(a)) {
-      hasBody = true;
-      continue;
-    }
-    if (a.startsWith('--')) continue;
 
-    // Single-dash cluster token: /^-[A-Za-z]/ and NOT '--'. Strip the leading '-' and
-    // scan the letters left→right, stopping at the FIRST value-taking short flag (the
-    // parser consumes the token remainder as that flag's value). sf's body/file shorts
-    // are `-b`/`-f`, so a leading `b`/`f` (`-f`, `-b`, `-if`, `-bX`, attached
-    // `-freq.json`) marks a body — the rest of the token, including any `X`, is that
-    // flag's value and is never parsed as a method.
+    // Single-dash cluster token: scan letters left→right; the FIRST value-taking short
+    // consumes the token remainder (or the next token) as its value and ENDS the cluster.
     if (/^-[A-Za-z]/.test(a)) {
       const body = a.slice(1);
       for (let j = 0; j < body.length; j++) {
         const c = body[j];
-        if (c === 'b' || c === 'f') {
-          // First value-taking short is a body/file field: the rest of the token
-          // (including any 'X') is this flag's VALUE — never a method flag.
-          hasBody = true;
-          break;
+        if (!SHORT_VALUE_FLAGS.has(c)) continue; // boolean short (e.g. -i); keep scanning
+        let value = body.slice(j + 1).replace(/^=/, '');
+        if (value === '') {
+          i += 1;
+          value = args[i] ?? '';
         }
-        if (c === 'X') {
-          // First value-taking short is the method flag: value is the token
-          // remainder after X (leading '=' stripped), else the next arg.
-          const after = body.slice(j + 1).replace(/^=/, '');
-          setExplicit(after || (args[i + 1] ?? ''));
-          break;
-        }
-        // Any other letter is a boolean short (e.g. -i); keep scanning.
+        if (c === 'X') setExplicit(value);
+        if (SHORT_BODY_FLAGS.has(c)) hasBody = true;
+        break; // remainder/next token is this flag's value, not more flags
       }
     }
   }

--- a/plugins/salesforce/test/tools/sf-exec.test.ts
+++ b/plugins/salesforce/test/tools/sf-exec.test.ts
@@ -74,6 +74,10 @@ describe('effectiveApiMethod', () => {
     expect(effectiveApiMethod(['api', 'request', 'rest', '-iX', 'GET', 'x'])).toBe('GET');
     // Include-only boolean cluster → no method → GET.
     expect(effectiveApiMethod(['api', 'request', 'rest', '-i', 'x'])).toBe('GET');
+    // Parser stops at the first value-taking short: `-fX=GET` / `-bX=GET` are a
+    // body/file flag whose value contains `X=GET` → POST; the trailing X is data.
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-fX=GET', 'x'])).toBe('POST');
+    expect(effectiveApiMethod(['api', 'request', 'rest', '-bX=GET', 'x'])).toBe('POST');
   });
 });
 
@@ -148,6 +152,16 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['api', 'request', 'rest', '-if', 'req.json']).blocked).toBe(true);
     // attached form: `-freq.json`
     expect(findMutation(['api', 'request', 'rest', '-freq.json']).blocked).toBe(true);
+  });
+
+  it('blocks the -fX=GET / -bX=GET body-field cluster bypass (#813)', () => {
+    // The parser stops at the first value-taking short: `-fX=GET` is `-f`/--file with
+    // value `X=GET` (data, incl. a trailing X) → body → POST, NOT `-X GET`. The
+    // trailing `X` must not be mis-read as an explicit GET that allows the write.
+    expect(findMutation(['api', 'request', 'rest', '-fX=GET', 'proj']).blocked).toBe(true);
+    expect(findMutation(['api', 'request', 'rest', '-bX=GET', 'proj']).blocked).toBe(true);
+    // A genuine bodyless `-X GET` remains an allowed read.
+    expect(findMutation(['api', 'request', 'rest', '-X', 'GET', 'proj']).blocked).toBe(false);
   });
 
   it('blocks the flag-value-shift bypass (token after a value flag is consumed)', () => {

--- a/plugins/salesforce/test/tools/sf-exec.test.ts
+++ b/plugins/salesforce/test/tools/sf-exec.test.ts
@@ -116,6 +116,19 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['bogus']).blocked).toBe(true);
   });
 
+  it('blocks the boolean-short-cluster path-shift bypass (-xy… does not consume the next arg)', () => {
+    // A single-dash cluster of length >= 3 is all in-token flags; its value (if any) is
+    // the token remainder, never the next arg. Previously the token after any dash was
+    // excluded, which dropped a write subcommand and shifted a read prefix into place.
+    // `data -fp create query` must stay `data create …`, not collapse to `data query`.
+    expect(findMutation(['data', '-fp', 'create', 'query']).blocked).toBe(true);
+    expect(findMutation(['org', '-fp', 'create', 'list']).blocked).toBe(true);
+    // A genuine long flag without `=` (or a lone 2-char short) still consumes its value,
+    // so these reads whose verb follows a real value flag remain allowed.
+    expect(findMutation(['org', 'list', '--target-org', 'create']).blocked).toBe(false);
+    expect(findMutation(['org', 'list', '-o', 'create']).blocked).toBe(false);
+  });
+
   it('blocks the colon grammar identically to the space grammar', () => {
     expect(findMutation(['apex:run']).blocked).toBe(true);
     expect(findMutation(['org:create']).blocked).toBe(true);

--- a/plugins/salesforce/test/tools/sf-exec.test.ts
+++ b/plugins/salesforce/test/tools/sf-exec.test.ts
@@ -177,6 +177,15 @@ describe('findMutation allowlist', () => {
     expect(findMutation(['api', 'request', 'rest', '-X', 'GET', 'proj']).blocked).toBe(false);
   });
 
+  it('does not let a value-flag value forge a GET over a real method (header consumes its value)', () => {
+    // `--header`/`-h` take the FOLLOWING token as their value; a value like `-XGET` is
+    // data, not a method flag, so it must not overwrite a real `--method POST`.
+    expect(findMutation(['api', 'request', 'rest', '--method', 'POST', '--header', '-XGET', 'x']).blocked).toBe(true);
+    expect(findMutation(['api', 'request', 'rest', '-XPOST', '-h', '-XGET', 'x']).blocked).toBe(true);
+    // A genuine header read (no body/method) is still an allowed GET.
+    expect(findMutation(['api', 'request', 'rest', '-h', 'Accept: application/json', 'projects']).blocked).toBe(false);
+  });
+
   it('blocks the flag-value-shift bypass (token after a value flag is consumed)', () => {
     // `-s`'s value `list` is consumed; real verb `create` follows → mutation.
     expect(findMutation(['org', '-s', 'list', 'create']).blocked).toBe(true);


### PR DESCRIPTION
## Summary

Backports the pflag cluster-parsing fix from the github guard hardening (branch `fix/github-guard-hardening-810`) to the merged gitlab and salesforce `*-exec-guard.ts` guards.

**Bug:** a value-taking short flag consumes the REST of its single-dash token as its value, so `-fX=GET` is `--field X=GET` (a body → POST), NOT `-f` + `-X GET`. The previous `effectiveApiMethod` inspected each cluster letter independently and mis-read the embedded `X` as `--method GET`, resolving to GET and letting a POST past the read-only guard.

**Fix:** scan the single-dash cluster left→right and STOP at the first value-taking short flag — a body short (`-f`/`-F` for gitlab; `-f`/`-b` for salesforce) sets `hasBody` and stops; a method short (`-X`) takes the remainder as its value and stops. An `X` embedded in a body-flag value can no longer poison the method.

- **gitlab:** genuine live bypass (`-fX=GET` was allowed while `glab` would POST) — now blocked.
- **salesforce:** same mis-parse, but no live bypass (the api-request path's separate `hasApiBodyFlag()` already blocked it); fix is correctness / defense-in-depth so the resolver agrees with the CLI.

## Verification

- gitlab `bun test`: 69 pass / 0 fail
- salesforce `bun test`: 204 pass / 1 fail (only the pre-existing `extension-load.test.ts:211` session_start hook failure, identical on clean HEAD)
- `npx biome ci plugins/gitlab` exit 0; `npx biome ci plugins/salesforce` exit 0
- Regression tests added for `-fX=GET`/`-FX=GET`/`-bX=GET` (blocked) and `-X GET` (allowed) in both plugins

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)