### PR TITLE
Spec 6: gcloud plugin → CLI-Plugin Capability Contract (native tool layer from zero)

### DIFF
--- a/.plans/2026-07-23-gcloud-contract-spec6-design.md
+++ b/.plans/2026-07-23-gcloud-contract-spec6-design.md
@@ -1,0 +1,199 @@
+# gcloud Plugin → Capability Contract (Spec 6) — Design
+
+- **Issue:** #809
+- **Status:** design approved (single PR)
+- **Date:** 2026-07-23
+
+## Context
+
+Spec 6 is the final CLI-plugin parity spec. Unlike Specs 2–5, gcloud starts as a
+**status-only** plugin: `src/index.ts` (setup command, service-status registration,
+`before_agent_start` config-context injection, `session_start` notice),
+`src/platform.ts`, `src/wizard.ts`, the consistency layer (`agents/cli-operator.md`,
+`commands/`, `skills/`, `hooks/`), and shell tests under `scripts/tests/`. There is **no
+`src/tools/` directory, no exec layer, no error taxonomy, no formatters, no typed tools,
+no benchmark/autoresearch harness**. So Spec 6 is a from-zero build of the tool layer —
+the heaviest spec on new-file volume, but it has the fullest set of merged references.
+
+The **reference for the tool layer is aws (Spec 5, #812)** for structure (from-zero
+`src/<cli>/` + `src/tools/` split, signal-aware `shared.ts`, charCode `hasControlChars`,
+`withErrorType` wrapper in `index.ts`, typed-tool + formatter + benchmark shape) and
+**azure (Spec 1) for the guard model**: gcloud's grammar is deep
+`gcloud <group> [<subgroup>…] <verb> [args] [--flags]` with a leaf verb and trailing
+positional args — the same shape azure's `az` guard solved, NOT aws's flat 2-level
+`<service> <operation>` prefix model. So the `gcloud_exec` guard ports azure's
+scan-all-positionals fail-safe design, adapted to gcloud verbs, inverted to a **read
+allowlist** (gcloud has too many mutating verbs and dangerous non-`create/delete`
+execution vectors — `get-credentials`, `ssh`, `scp`, `connect`, `call` — to enumerate as a
+denylist safely).
+
+Registration style: gcloud uses the aws/azure `ExtensionFactory` + `createGcloud*Tool(pi)`
+factory idiom reading `pi.typebox.Type` (no `setTypebox` shim).
+
+## Gaps to close (all contract dimensions)
+
+1. **Execution & hygiene** — no exec layer. Add `src/gcloud/exec.ts` (`execGcloudJson`/
+   `execGcloudRaw`) and `src/tools/shared.ts` `makeExecApi` with the aws signal-aware
+   `Bun.spawn` (`...(signal && !signal.aborted ? { signal } : {})`) and charCode
+   `hasControlChars`.
+2. **Discovery** — no `gcloud_help`; no query-grammar docs. Add `gcloud_help` +
+   `gcloud-exec.md`/`gcloud-help.md` documenting `--filter` (server) + `--format` (client
+   projection) + `--project`/`--limit`/`--sort-by`.
+3. **Error taxonomy** — none. Add `Gcloud*Error` classes + `detectGcloudError` +
+   `detectErrorType` → `errorType`.
+4. **Safety** — no read-only guard. Add `gcloud_exec` + `gcloud-exec-guard.ts`
+   (read-allowlist, fail-safe).
+5. **Typed tools + formatters** — none. Add 4 typed reads + `src/gcloud/formatters.ts`.
+6. **Consistency layer** — already ✅ (present). Leave as-is except registering the new
+   tools in `index.ts`.
+7. **Testing & optimization** — only shell tests. Add per-tool `bun test` suites +
+   `benchmarks/` (mock-gcloud + fixtures + scenarios.ts) + autoresearch trio.
+
+## Design decisions
+
+### `gcloud_exec` guard — the hard part (gcloud grammar)
+
+gcloud grammar: `gcloud [alpha|beta] <group> [<subgroup>…] <verb> [positional args] [--flags]`.
+The action **verb is the leaf of the command path, but NOT the last positional** — trailing
+positional args (project IDs, resource names, `gs://` URIs) follow it
+(`gcloud projects describe my-proj` → verb `describe`, arg `my-proj`).
+
+Guard algorithm (`gcloud-exec-guard.ts`), fail-safe **read allowlist**:
+
+- `getPositionals(args)` — every non-flag token (azure's fail-safe model: do NOT try to
+  exclude flag values; a `--filter`/`--format` value that happens to equal a mutating verb
+  is blocked rather than risk a destructive false negative — a rare, safe failure that
+  gcloud filter/format values do not trigger in practice since they are `key=value` /
+  `projection(...)` shaped, not bare verbs).
+- `findVerb(positionals)` — the **leftmost** positional that is a recognized verb (in
+  `READ_EXACT` ∪ `READ_PREFIXES` ∪ `MUTATING_VERBS` ∪ `DANGEROUS_VERBS`). Tokens before it
+  are the group path; tokens after are args. (Leftmost, because the group path is nouns and
+  the first recognized action word is the verb.)
+- Decision:
+  1. If any positional is in `DANGEROUS_VERBS` (execution/credential-exfil vectors) →
+     **block** with a specific message, regardless of position (defense in depth).
+  2. If any positional is in `MUTATING_VERBS` → **block** (defense in depth, azure-style
+     scan-anywhere).
+  3. Else if `findVerb` resolves to a `READ_EXACT` / `READ_PREFIXES` verb → **allow**.
+  4. Else → **block** (fail-safe: unrecognized verb).
+
+Verb sets (grounded in the gcloud surface):
+
+- `READ_EXACT` = `list`, `describe`, `get-iam-policy`, `get-value`, `get-server-config`,
+  `get-ancestors`, `list-grantable-roles`, `print-access-token`, `print-identity-token`,
+  `print-settings`, `version`, `info`.
+- `READ_PREFIXES` = `list-` (e.g. `list-instances`), `describe-`.
+- `READ_TOP` (top-level, no group/verb) = `version`, `info`, `help`, `topic`,
+  `cheat-sheet`. These resolve when positionals[0] is one of them.
+- `DANGEROUS_VERBS` = `ssh`, `scp`, `connect`, `call`, `run` (as a verb, e.g.
+  `functions call`/`run`), `interactive`, `login`, `revoke`, `get-credentials` (writes
+  kubeconfig + grants cluster access — a `get-*` that is NOT a read), `reset-windows-password`,
+  `simulate-maintenance-event`, `enable-service`, `configure-docker`.
+- `MUTATING_VERBS` = `create`, `delete`, `update`, `patch`, `remove`, `add`, `set`,
+  `set-iam-policy`, `add-iam-policy-binding`, `remove-iam-policy-binding`, `deploy`,
+  `import`, `export`, `apply`, `enable`, `disable`, `start`, `stop`, `restart`, `resize`,
+  `suspend`, `resume`, `reset`, `rollback`, `promote`, `migrate`, `undelete`, `restore`,
+  `activate`, `deactivate`, `attach`, `detach`, `bind`, `unbind`, `clear`, `move`,
+  `clone`, `copy`, `wait`, `abandon`, `recreate`, `rotate`, `acknowledge`, `publish`,
+  `seek`, `purge`, `cancel`, `override`, `unset`, `snapshot`, `upgrade`, `downgrade`,
+  `repair`, `drain`, `uncordon`, `cordon`, `add-tags`, `remove-tags`.
+
+Verbs appearing in BOTH `MUTATING_VERBS` and `DANGEROUS_VERBS`: none — `run`/`call` are
+dangerous only; `set-iam-policy` is mutating. `set` covers `config set`, `set-*` covered
+explicitly where the hyphenated form matters.
+
+`buildGcloudArgs(args)` — append `--format=json` only when the caller supplied no
+`--format`; respect a caller `--format=table(...)`/`yaml`/`csv`/`value(...)`. (gcloud uses
+`--format`, not `--output`.)
+
+### The rest (ports of aws Spec 5)
+
+- **`src/tools/shared.ts`**: `GcloudErrorType = auth_required | session_expired |
+  not_found | permission_denied | exec_error`; `GcloudToolDetails` (tool, action, the
+  typed struct arrays, `errorType`); `textResult`/`errorResult`; `detectErrorType`
+  (maps the `Gcloud*Error` subclasses); `renderError`; charCode `hasControlChars`
+  (reject `c<=8`, `11`, `12`, `14–31`, `127`; allow tab/LF/CR); signal-aware `makeExecApi`.
+- **`src/gcloud/exec.ts`**: `GcloudExecError` base + `GcloudAuthError`,
+  `GcloudSessionExpiredError`, `GcloudNotFoundError`, `GcloudPermissionError`.
+  `detectGcloudError(stderr, exitCode)` precedence auth → session-expired → permission →
+  not-found → generic. `parseGcloudJsonOutput`, `execGcloudJson`/`execGcloudRaw` (append
+  `--format=json`, `gcloud` binary).
+  Classification signatures (lowercased stderr):
+  - auth: `do not currently have an active account`, `gcloud auth login`,
+    `does not have any valid credentials`, `no active account`.
+  - session-expired: `reauthentication required`, `reauthentication failed`,
+    `invalid_grant`, `token has been expired or revoked`.
+  - permission: `permission_denied`, `does not have permission`, `permission denied`,
+    `caller does not have permission`, `403`, `forbidden`.
+  - not-found: `not_found`, `was not found`, `does not exist`, `404`.
+- **`index.ts`**: add the aws `withErrorType` wrapper; register the 6 tools guarded by an
+  existing `gcloudAvailable` check (mirror aws — move the availability probe up and gate
+  `registerTool`). Keep the existing service-status + context-injection + session_start
+  blocks unchanged.
+- **`gcloud_help`** (`src/tools/gcloud-help.ts`): `gcloud <path> --help` via the exec
+  layer, `HELP_PATH_PATTERN = /^[a-z][a-z0-9 -]*$/`, reject parts starting with `-`.
+- **Typed reads (4)** mirroring aws/azure, each with a prompt + formatter + validation:
+  1. `gcloud_config_list` — `gcloud config list --format=json` → active project / account
+     / region / zone (context + identity; mirrors `az_account_show`).
+  2. `gcloud_projects_list` — `gcloud projects list --format=json` → projectId / name /
+     projectNumber / lifecycleState.
+  3. `gcloud_compute_instances_list` — `gcloud compute instances list --format=json` →
+     name / zone / machineType / status / internal+external IP.
+  4. `gcloud_storage_buckets_list` — `gcloud storage buckets list --format=json` → name /
+     location / storageClass / created. (Falls back cleanly on empty.)
+- **`src/gcloud/types.ts`**: struct interfaces, `PluginInterface`, `GcloudRawResult`, and
+  validation patterns (`PROJECT_ID_PATTERN = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/`,
+  `ZONE_PATTERN = /^[a-z]+-[a-z]+\d-[a-z]$/`, `HELP_PATH_PATTERN`,
+  `RESOURCE_NAME_PATTERN` first-char-non-dash like aws).
+- **`src/gcloud/formatters.ts`**: normalizers (raw gcloud JSON → structs) + markdown-table
+  formatters with empty states (mirror aws formatters).
+- **query docs** (`src/prompts/gcloud-exec.md`, `gcloud-help.md`, + one per typed tool):
+  document `--filter` (server-side, `key=value`, `AND`/`OR`, `:` substring) and `--format`
+  (client projection: `json`, `value(field)`, `table(...)`, `csv`, `yaml`, `flattened`),
+  `--limit`, `--sort-by`. Explicitly contrast with az `--query` (JMESPath) and note gcloud
+  splits server filter vs client format. State the read-only allowlist and delegation path.
+- **benchmark + autoresearch** (`benchmarks/{mock-gcloud,scenarios.ts,fixtures/*}`,
+  `autoresearch.{md,ideas.md,checks.sh}`): port aws's; real `createGcloud*Tool` exports;
+  fixtures for config-list / projects-list / instances-list; guardrail scenarios incl.
+  `compute instances delete` blocked, `container clusters get-credentials` blocked,
+  `compute ssh` blocked, `sql connect` blocked, and a valid `--filter`/`--format` read
+  allowed.
+
+## Task sequencing (single PR, TDD)
+
+1. `package.json` test script + devDeps; `src/tools/shared.ts` (types, result helpers,
+   `hasControlChars`, signal-aware `makeExecApi`, `detectErrorType`, `renderError`).
+2. `src/gcloud/exec.ts` error taxonomy + `detectGcloudError` + exec helpers (TDD on
+   `detectGcloudError`).
+3. `src/gcloud/types.ts` + `src/gcloud/formatters.ts` (TDD on normalizers/formatters).
+4. `gcloud-exec-guard.ts` (heaviest test surface: leftmost-verb, read allowlist, mutating
+   scan-anywhere, dangerous vectors, `get-credentials` NOT read, `--format` passthrough,
+   control chars) + `gcloud_exec` tool + `gcloud-exec.md`.
+5. `gcloud_help` + path validation + `gcloud-help.md`.
+6. The 4 typed read tools + prompts (TDD on param validation + normalize/format via mock
+   exec).
+7. `index.ts` wiring (`withErrorType` + registration).
+8. benchmark + autoresearch harness.
+9. Verify + PR.
+
+## Verification
+
+- `cd plugins/gcloud && bun test` green (new suites); `npx biome ci plugins/gcloud` exit 0;
+  `bun run benchmarks/scenarios.ts` prints a composite metric; `autoresearch.checks.sh`
+  passes; prose brand-capitalized (Google Cloud / gcloud / Azure / AWS / GitHub / GitLab),
+  no "empty lines" phrasing issues, doc lines < 400; existing `scripts/tests/*.sh`
+  structure/security/hook tests still pass (they assert plugin shape — update
+  `test_structure.sh` only if it enumerates files).
+- Manual smoke (if `gcloud` authed): `gcloud_help` returns help; `gcloud_exec` runs
+  `compute instances list --filter=...` and refuses `compute instances delete`,
+  `container clusters get-credentials`, `compute ssh`, `sql connect`, `config set`;
+  typed tools return structured data.
+- Workflow: issue #809 → branch `feat/gcloud-contract-parity-809` → PR → CI → auto-merge.
+  Keep the implementation plan file UNTRACKED. Verify with `biome ci` (whole plugin)
+  before pushing. Never touch `main`.
+
+## Non-goals
+
+New mutating gcloud tools (writes stay behind the `cli-operator` agent). Touching the
+`platform.ts`/`wizard.ts`/consistency-layer subsystems beyond registering tools. Adding a
+`get-*`-is-read blanket rule (fail-safe allowlist only; `get-credentials` stays blocked).

--- a/.plans/2026-07-23-gcloud-contract-spec6-design.md
+++ b/.plans/2026-07-23-gcloud-contract-spec6-design.md
@@ -86,12 +86,14 @@ Verb sets (grounded in the gcloud surface):
 - `READ_PREFIXES` = `list-` (e.g. `list-instances`), `describe-`.
 - `READ_TOP` (top-level, no group/verb) = `version`, `info`, `help`, `topic`,
   `cheat-sheet`. These resolve when positionals[0] is one of them.
-- `DANGEROUS_VERBS` = `ssh`, `scp`, `connect`, `call`, `run` (as a verb, e.g.
-  `functions call`/`run`), `interactive`, `login`, `revoke`, `get-credentials` (writes
-  kubeconfig + grants cluster access — a `get-*` that is NOT a read), `print-access-token`,
-  `print-identity-token` (mint/print usable bearer credentials to stdout — credential
-  exposure), `reset-windows-password`, `simulate-maintenance-event`, `enable-service`,
-  `configure-docker`.
+- `DANGEROUS_VERBS` = `ssh`, `scp`, `connect`, `call`, `interactive`, `login`, `revoke`,
+  `get-credentials` (writes kubeconfig + grants cluster access — a `get-*` that is NOT a
+  read), `print-access-token`, `print-identity-token` (mint/print usable bearer
+  credentials to stdout — credential exposure), `reset-windows-password`,
+  `simulate-maintenance-event`, `enable-service`, `configure-docker`.
+  (NB: `run` is intentionally excluded — it collides with the Cloud Run group and would
+  block reads like `gcloud run services list`; `functions call` is covered by `call` and
+  `run deploy` by `deploy`.)
 - `MUTATING_VERBS` = `create`, `delete`, `update`, `patch`, `remove`, `add`, `set`,
   `set-iam-policy`, `add-iam-policy-binding`, `remove-iam-policy-binding`, `deploy`,
   `import`, `export`, `apply`, `enable`, `disable`, `start`, `stop`, `restart`, `resize`,
@@ -101,7 +103,7 @@ Verb sets (grounded in the gcloud surface):
   `seek`, `purge`, `cancel`, `override`, `unset`, `snapshot`, `upgrade`, `downgrade`,
   `repair`, `drain`, `uncordon`, `cordon`, `add-tags`, `remove-tags`.
 
-Verbs appearing in BOTH `MUTATING_VERBS` and `DANGEROUS_VERBS`: none — `run`/`call` are
+Verbs appearing in BOTH `MUTATING_VERBS` and `DANGEROUS_VERBS`: none — `call` is
 dangerous only; `set-iam-policy` is mutating. `set` covers `config set`, `set-*` covered
 explicitly where the hyphenated form matters.
 

--- a/.plans/2026-07-23-gcloud-contract-spec6-design.md
+++ b/.plans/2026-07-23-gcloud-contract-spec6-design.md
@@ -86,7 +86,8 @@ Verb sets (grounded in the gcloud surface):
 - `READ_PREFIXES` = `list-` (e.g. `list-instances`), `describe-`.
 - `READ_TOP` (top-level, no group/verb) = `version`, `info`, `help`, `topic`,
   `cheat-sheet`. These resolve when positionals[0] is one of them.
-- `DANGEROUS_VERBS` = `ssh`, `scp`, `connect`, `call`, `interactive`, `login`, `revoke`,
+- `DANGEROUS_VERBS` = `ssh`, `scp`, `connect`, `call`, `execute` (`run jobs execute`,
+  `workflows execute` — code execution), `interactive`, `login`, `revoke`,
   `get-credentials` (writes kubeconfig + grants cluster access — a `get-*` that is NOT a
   read), `print-access-token`, `print-identity-token` (mint/print usable bearer
   credentials to stdout — credential exposure), `reset-windows-password`,

--- a/.plans/2026-07-23-gcloud-contract-spec6-design.md
+++ b/.plans/2026-07-23-gcloud-contract-spec6-design.md
@@ -80,15 +80,18 @@ Guard algorithm (`gcloud-exec-guard.ts`), fail-safe **read allowlist**:
 Verb sets (grounded in the gcloud surface):
 
 - `READ_EXACT` = `list`, `describe`, `get-iam-policy`, `get-value`, `get-server-config`,
-  `get-ancestors`, `list-grantable-roles`, `print-access-token`, `print-identity-token`,
-  `print-settings`, `version`, `info`.
+  `get-ancestors`, `list-grantable-roles`, `print-settings`, `version`, `info`.
+  (`print-access-token` / `print-identity-token` are NOT reads — they mint/print usable
+  bearer credentials to stdout, so they live in `DANGEROUS_VERBS`.)
 - `READ_PREFIXES` = `list-` (e.g. `list-instances`), `describe-`.
 - `READ_TOP` (top-level, no group/verb) = `version`, `info`, `help`, `topic`,
   `cheat-sheet`. These resolve when positionals[0] is one of them.
 - `DANGEROUS_VERBS` = `ssh`, `scp`, `connect`, `call`, `run` (as a verb, e.g.
   `functions call`/`run`), `interactive`, `login`, `revoke`, `get-credentials` (writes
-  kubeconfig + grants cluster access — a `get-*` that is NOT a read), `reset-windows-password`,
-  `simulate-maintenance-event`, `enable-service`, `configure-docker`.
+  kubeconfig + grants cluster access — a `get-*` that is NOT a read), `print-access-token`,
+  `print-identity-token` (mint/print usable bearer credentials to stdout — credential
+  exposure), `reset-windows-password`, `simulate-maintenance-event`, `enable-service`,
+  `configure-docker`.
 - `MUTATING_VERBS` = `create`, `delete`, `update`, `patch`, `remove`, `add`, `set`,
   `set-iam-policy`, `add-iam-policy-binding`, `remove-iam-policy-binding`, `deploy`,
   `import`, `export`, `apply`, `enable`, `disable`, `start`, `stop`, `restart`, `resize`,

--- a/.plans/2026-07-23-gcloud-contract-spec6-design.md
+++ b/.plans/2026-07-23-gcloud-contract-spec6-design.md
@@ -18,16 +18,16 @@ the heaviest spec on new-file volume, but it has the fullest set of merged refer
 The **reference for the tool layer is aws (Spec 5, #812)** for structure (from-zero
 `src/<cli>/` + `src/tools/` split, signal-aware `shared.ts`, charCode `hasControlChars`,
 `withErrorType` wrapper in `index.ts`, typed-tool + formatter + benchmark shape) and
-**azure (Spec 1) for the guard model**: gcloud's grammar is deep
+**Azure (Spec 1) for the guard model**: gcloud's grammar is deep
 `gcloud <group> [<subgroup>…] <verb> [args] [--flags]` with a leaf verb and trailing
-positional args — the same shape azure's `az` guard solved, NOT aws's flat 2-level
-`<service> <operation>` prefix model. So the `gcloud_exec` guard ports azure's
+positional args — the same shape Azure's `az` guard solved, NOT aws's flat 2-level
+`<service> <operation>` prefix model. So the `gcloud_exec` guard ports Azure's
 scan-all-positionals fail-safe design, adapted to gcloud verbs, inverted to a **read
 allowlist** (gcloud has too many mutating verbs and dangerous non-`create/delete`
 execution vectors — `get-credentials`, `ssh`, `scp`, `connect`, `call` — to enumerate as a
 denylist safely).
 
-Registration style: gcloud uses the aws/azure `ExtensionFactory` + `createGcloud*Tool(pi)`
+Registration style: gcloud uses the aws/Azure `ExtensionFactory` + `createGcloud*Tool(pi)`
 factory idiom reading `pi.typebox.Type` (no `setTypebox` shim).
 
 ## Gaps to close (all contract dimensions)
@@ -60,7 +60,7 @@ positional args (project IDs, resource names, `gs://` URIs) follow it
 
 Guard algorithm (`gcloud-exec-guard.ts`), fail-safe **read allowlist**:
 
-- `getPositionals(args)` — every non-flag token (azure's fail-safe model: do NOT try to
+- `getPositionals(args)` — every non-flag token (Azure's fail-safe model: do NOT try to
   exclude flag values; a `--filter`/`--format` value that happens to equal a mutating verb
   is blocked rather than risk a destructive false negative — a rare, safe failure that
   gcloud filter/format values do not trigger in practice since they are `key=value` /
@@ -72,7 +72,7 @@ Guard algorithm (`gcloud-exec-guard.ts`), fail-safe **read allowlist**:
 - Decision:
   1. If any positional is in `DANGEROUS_VERBS` (execution/credential-exfil vectors) →
      **block** with a specific message, regardless of position (defense in depth).
-  2. If any positional is in `MUTATING_VERBS` → **block** (defense in depth, azure-style
+  2. If any positional is in `MUTATING_VERBS` → **block** (defense in depth, Azure-style
      scan-anywhere).
   3. Else if `findVerb` resolves to a `READ_EXACT` / `READ_PREFIXES` verb → **allow**.
   4. Else → **block** (fail-safe: unrecognized verb).
@@ -138,7 +138,7 @@ explicitly where the hyphenated form matters.
   blocks unchanged.
 - **`gcloud_help`** (`src/tools/gcloud-help.ts`): `gcloud <path> --help` via the exec
   layer, `HELP_PATH_PATTERN = /^[a-z][a-z0-9 -]*$/`, reject parts starting with `-`.
-- **Typed reads (4)** mirroring aws/azure, each with a prompt + formatter + validation:
+- **Typed reads (4)** mirroring aws/Azure, each with a prompt + formatter + validation:
   1. `gcloud_config_list` — `gcloud config list --format=json` → active project / account
      / region / zone (context + identity; mirrors `az_account_show`).
   2. `gcloud_projects_list` — `gcloud projects list --format=json` → projectId / name /

--- a/.plans/cli-plugin-contract.md
+++ b/.plans/cli-plugin-contract.md
@@ -51,17 +51,17 @@ Legend: ✅ present · ◑ partial · ❌ missing
 
 | Dimension | Azure | aws | gcloud | GitLab | salesforce | GitHub |
 |---|---|---|---|---|---|---|
-| 1 argv/no-shell | ✅ | n/a | n/a | ✅ | ✅ | ✅ |
-| 1 control-char hygiene | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| 1 signal-aware exec | ❌ | n/a | n/a | ❌ | ❌ | ✅ |
-| 2 `<cli>_help` tool | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| 2 query-language docs | ✅ | ❌ | ❌ | ◑ | ✅ | ◑ |
-| 3 error taxonomy | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| 4 read-only guardrail | ✅ | n/a | n/a | n/a | n/a | ❌ |
+| 1 argv/no-shell | ✅ | n/a | ✅ | ✅ | ✅ | ✅ |
+| 1 control-char hygiene | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| 1 signal-aware exec | ❌ | n/a | ✅ | ❌ | ❌ | ✅ |
+| 2 `<cli>_help` tool | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| 2 query-language docs | ✅ | ❌ | ✅ | ◑ | ✅ | ◑ |
+| 3 error taxonomy | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
+| 4 read-only guardrail | ✅ | n/a | ✅ | n/a | n/a | ❌ |
 | 4 confirmed-mutation | n/a | n/a | n/a | n/a | n/a | ◑ (this spec) |
-| 5 typed tools + formatters | ✅ | ❌ | ❌ | ✅ | ✅ | ◑ |
+| 5 typed tools + formatters | ✅ | ❌ | ✅ | ✅ | ✅ | ◑ |
 | 6 consistency layer | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 7 tests + benchmark + autoresearch | ✅ | ◑ | ◑ | ◑ | ◑ | ◑ |
+| 7 tests + benchmark + autoresearch | ✅ | ◑ | ✅ | ◑ | ◑ | ◑ |
 
 Follow-on specs (2 GitHub, 3 GitLab, 4 salesforce, 5 aws, 6 gcloud) drive each
 column to ✅.

--- a/plugins/gcloud/autoresearch.checks.sh
+++ b/plugins/gcloud/autoresearch.checks.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Post-experiment validation gate for the gcloud plugin autoresearch.
+# All checks must pass for a run to be logged as "keep".
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
+ERRORS=0
+
+# ── Check 1: All tests pass ────────────────────────────────────────────────
+echo "=== Check 1: bun test ==="
+if bun test 2>&1 | tail -3; then
+  echo "PASS: all tests passed"
+else
+  echo "FAIL: bun test failed"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Check 2: Biome lint clean ──────────────────────────────────────────────
+echo ""
+echo "=== Check 2: biome check ==="
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BIOME_OUTPUT="$(cd "$REPO_ROOT" && npx biome check plugins/gcloud/src/ 2>&1 || true)"
+BIOME_ERRORS="$(echo "$BIOME_OUTPUT" | grep -c 'error:' || true)"
+if [ "$BIOME_ERRORS" -eq 0 ]; then
+  echo "PASS: biome check clean"
+else
+  echo "FAIL: biome check found $BIOME_ERRORS error(s)"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Check 3: All 6 tool factories in index.ts ──────────────────────────────
+echo ""
+echo "=== Check 3: tool registrations ==="
+TOOL_FACTORIES=(
+  "createGcloudConfigListTool"
+  "createGcloudProjectsListTool"
+  "createGcloudComputeInstancesListTool"
+  "createGcloudStorageBucketsListTool"
+  "createGcloudExecTool"
+  "createGcloudHelpTool"
+)
+ALL_TOOLS_OK=true
+for tool in "${TOOL_FACTORIES[@]}"; do
+  if ! grep -q "$tool" src/index.ts; then
+    echo "FAIL: $tool not found in src/index.ts"
+    ERRORS=$((ERRORS + 1))
+    ALL_TOOLS_OK=false
+  fi
+done
+if [ "$ALL_TOOLS_OK" = true ]; then
+  echo "PASS: all 6 tool factories registered"
+fi
+
+# ── Check 4: Security invariants intact ────────────────────────────────────
+echo ""
+echo "=== Check 4: security invariants ==="
+ALL_PATTERNS_OK=true
+# gcloud_exec guardrail: read-only allowlist (checkGcloud) built from the
+# all-positionals scan (getPositionals) plus the mutating/dangerous finders,
+# and argv hygiene (control-char reject). The argv boundary is the injection
+# control; do NOT reintroduce per-character shell-metacharacter filtering (it
+# breaks valid gcloud --filter/--format expressions).
+for ident in checkGcloud getPositionals findMutating findDangerous; do
+  if ! grep -q "$ident" src/tools/gcloud-exec-guard.ts; then
+    echo "FAIL: guardrail helper ($ident) missing from src/tools/gcloud-exec-guard.ts"
+    ERRORS=$((ERRORS + 1))
+    ALL_PATTERNS_OK=false
+  fi
+done
+if ! grep -q "hasControlChars" src/tools/shared.ts; then
+  echo "FAIL: argv hygiene guard (hasControlChars) missing from src/tools/shared.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+# Error taxonomy classifier for typed error results.
+if ! grep -q "detectGcloudError" src/gcloud/exec.ts; then
+  echo "FAIL: error classifier (detectGcloudError) missing from src/gcloud/exec.ts"
+  ERRORS=$((ERRORS + 1))
+  ALL_PATTERNS_OK=false
+fi
+if [ "$ALL_PATTERNS_OK" = true ]; then
+  echo "PASS: all security invariants intact"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "CHECKS FAILED: $ERRORS error(s)"
+  exit 1
+fi
+echo "ALL CHECKS PASSED"
+exit 0

--- a/plugins/gcloud/autoresearch.ideas.md
+++ b/plugins/gcloud/autoresearch.ideas.md
@@ -1,0 +1,33 @@
+# Autoresearch Ideas — gcloud Plugin
+
+## Prompt Optimization
+
+- [ ] Compress tool descriptions: keep flag names, parameter types, and one-line summaries; drop prose
+- [ ] Add inline `--filter` / `--format` field examples to gcloud_projects_list and gcloud_compute_instances_list prompts (reduces gcloud_help round-trips)
+- [ ] Reinforce the gcloud `--filter` (server-side selection) versus `--format` (client-side projection) split where the model is most likely to conflate them or reach for an Azure-style `--query`
+- [ ] Cross-tool hints: "use gcloud_help to discover flags before gcloud_exec"
+- [ ] Clarify when to prefer typed tools over gcloud_exec so the model does not reach for the passthrough first
+
+## Error Handling
+
+- [ ] Map more gcloud stderr signatures in src/gcloud/exec.ts to typed errors (auth, session-expired, permission-denied, not-found)
+- [ ] Include the fix command in "not authenticated" errors (run: `gcloud auth login`)
+- [ ] Add structured retry hints to error results (e.g. retry_with: gcloud_config_list)
+
+## Formatter Improvements
+
+- [ ] Shorten column labels in the instance summary table without losing meaning
+- [ ] Consistent "no results" messaging across formatProjectTable, formatInstanceTable, and formatBucketTable
+- [ ] Trim redundant whitespace emitted by the config detail formatter
+
+## Token Efficiency
+
+- [ ] Audit the per-file prompt byte budget across the prompts; target the largest first (gcloud_exec)
+- [ ] Merge near-duplicate guidance shared by gcloud_projects_list and gcloud_compute_instances_list prompts
+- [ ] Remove markdown that adds tokens without improving model parsing (horizontal rules, extra headings)
+
+## Guardrail Coverage
+
+- [ ] Extend benchmark scenarios for gcloud_exec: `container clusters get-credentials` block, `--zone`-shifted mutation block
+- [ ] Add a describe-shaped read scenario driven by a `compute instances describe` fixture
+- [ ] Keep the read-only allowlist fail-safe: new read verbs are opt-in, never a blanket allow

--- a/plugins/gcloud/autoresearch.md
+++ b/plugins/gcloud/autoresearch.md
@@ -1,0 +1,46 @@
+# gcloud Plugin — Autoresearch Contract
+
+Optimize the gcloud plugin's intelligence quality: improve prompt accuracy, reduce tool
+invocation turns, and minimize token cost while maintaining all security invariants.
+
+Composite formula: `accuracy * (1 / (1 + avg_turns / 10)) * (1 / (1 + avg_tokens / 10000))`
+
+## Benchmark
+
+- command: bun run benchmarks/scenarios.ts
+- primary metric: composite_score
+- metric unit:
+- direction: higher
+- secondary metrics: accuracy, avg_turns, avg_tokens, live_accuracy
+
+## Files in Scope
+
+- src/prompts/
+- src/tools/
+- src/gcloud/formatters.ts
+- src/gcloud/exec.ts
+
+## Off Limits
+
+- src/index.ts
+- src/wizard.ts
+- src/platform.ts
+- test/
+- benchmarks/
+
+## Constraints
+
+- All existing tests must pass (bun test exit 0)
+- The gcloud_exec guardrail must stay present: `checkGcloud` (read-only allowlist) with its
+  `getPositionals` / `findMutating` / `findDangerous` helpers in src/tools/gcloud-exec-guard.ts,
+  and `hasControlChars` (argv hygiene) in src/tools/shared.ts. gcloud is spawned argv-only (no
+  shell), so the argv boundary is the injection control — do NOT reintroduce per-character
+  shell-metacharacter filtering, which only breaks valid gcloud expressions such as `--filter`
+  and `--format` syntax.
+- Error taxonomy must stay intact: `detectGcloudError` remains exported from src/gcloud/exec.ts and
+  keeps classifying stderr into GcloudAuthError, GcloudSessionExpiredError, GcloudPermissionError,
+  and GcloudNotFoundError.
+- All 6 tool names must remain stable: gcloud_config_list, gcloud_projects_list,
+  gcloud_compute_instances_list, gcloud_storage_buckets_list, gcloud_exec, gcloud_help
+- Tool parameter names and types must not change
+- Biome lint must pass with no new errors

--- a/plugins/gcloud/benchmarks/fixtures/compute-instances-list.json
+++ b/plugins/gcloud/benchmarks/fixtures/compute-instances-list.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "demo-web-1",
+    "zone": "https://www.googleapis.com/compute/v1/projects/demo-project-123/zones/us-central1-a",
+    "machineType": "https://www.googleapis.com/compute/v1/projects/demo-project-123/zones/us-central1-a/machineTypes/e2-medium",
+    "status": "RUNNING",
+    "networkInterfaces": [
+      {
+        "networkIP": "10.128.0.2",
+        "accessConfigs": [{ "natIP": "34.68.1.2" }]
+      }
+    ]
+  },
+  {
+    "name": "demo-db-1",
+    "zone": "https://www.googleapis.com/compute/v1/projects/demo-project-123/zones/us-central1-b",
+    "machineType": "https://www.googleapis.com/compute/v1/projects/demo-project-123/zones/us-central1-b/machineTypes/e2-standard-4",
+    "status": "TERMINATED",
+    "networkInterfaces": [{ "networkIP": "10.128.0.3", "accessConfigs": [] }]
+  }
+]

--- a/plugins/gcloud/benchmarks/fixtures/config-list.json
+++ b/plugins/gcloud/benchmarks/fixtures/config-list.json
@@ -1,0 +1,10 @@
+{
+  "core": {
+    "project": "demo-project-123",
+    "account": "demo-engineer@example.com"
+  },
+  "compute": {
+    "region": "us-central1",
+    "zone": "us-central1-a"
+  }
+}

--- a/plugins/gcloud/benchmarks/fixtures/projects-list.json
+++ b/plugins/gcloud/benchmarks/fixtures/projects-list.json
@@ -1,0 +1,14 @@
+[
+  {
+    "projectId": "demo-project-123",
+    "name": "Demo Project",
+    "projectNumber": "111111111111",
+    "lifecycleState": "ACTIVE"
+  },
+  {
+    "projectId": "demo-staging-456",
+    "name": "Demo Staging",
+    "projectNumber": "222222222222",
+    "lifecycleState": "ACTIVE"
+  }
+]

--- a/plugins/gcloud/benchmarks/mock-gcloud.sh
+++ b/plugins/gcloud/benchmarks/mock-gcloud.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Mock gcloud CLI for benchmark scenarios.
+#
+# Priority 1 (mirrors the mock-gh.sh contract): emit $MOCK_GCLOUD_FIXTURE when set.
+# Priority 2: emit $MOCK_GCLOUD_HELP when set.
+# Priority 3: route by argv to a fixture under $GCLOUD_BENCH_FIXTURES.
+# Priority 4: pass an auth/spot-check path through to the REAL gcloud on the
+#             preserved original PATH ($GCLOUD_BENCH_ORIG_PATH).
+# Otherwise exit non-zero.
+#
+# Argv routing exists because Bun resolves inherited-spawn binaries and env from
+# the PATH/env captured at process startup and does not observe later
+# process.env mutations. The unmodified tool layer spawns `gcloud` with inherited
+# env, so it cannot pass MOCK_GCLOUD_FIXTURE per call; routing on the argv the
+# tool actually sends keeps the mock deterministic.
+if [ -n "$MOCK_GCLOUD_FIXTURE" ] && [ -f "$MOCK_GCLOUD_FIXTURE" ]; then
+  cat "$MOCK_GCLOUD_FIXTURE"
+  exit 0
+fi
+
+if [ -n "$MOCK_GCLOUD_HELP" ]; then
+  echo "$MOCK_GCLOUD_HELP"
+  exit 0
+fi
+
+args="$*"
+
+# The gcloud CLI exposes help via a `--help` flag. Match it first so a help
+# request returns help text rather than a fixture.
+case "$args" in
+*--help*)
+  echo "GCLOUD CLI HELP: gcloud ${args%% --help*}"
+  echo "DESCRIPTION"
+  echo "  Synthetic help output for benchmark scenarios."
+  exit 0
+  ;;
+esac
+
+if [ -n "$GCLOUD_BENCH_FIXTURES" ]; then
+  case "$args" in
+  *config*list*)
+    cat "$GCLOUD_BENCH_FIXTURES/config-list.json"
+    exit 0
+    ;;
+  *projects*list*)
+    cat "$GCLOUD_BENCH_FIXTURES/projects-list.json"
+    exit 0
+    ;;
+  *compute*instances*list*)
+    cat "$GCLOUD_BENCH_FIXTURES/compute-instances-list.json"
+    exit 0
+    ;;
+  esac
+fi
+
+# Auth/spot-check passthrough: reach the real gcloud via the preserved original
+# PATH so the live spot-check in scenarios.ts can exercise a genuine binary
+# without the mock's fixtures shadowing it.
+case "$args" in
+*auth*print-access-token* | *auth*list*)
+  if [ -n "$GCLOUD_BENCH_ORIG_PATH" ]; then
+    real_gcloud="$(PATH="$GCLOUD_BENCH_ORIG_PATH" command -v gcloud)"
+    if [ -n "$real_gcloud" ]; then
+      exec "$real_gcloud" "$@"
+    fi
+  fi
+  ;;
+esac
+
+echo "mock-gcloud: no fixture for args: $args" >&2
+exit 1

--- a/plugins/gcloud/benchmarks/scenarios.ts
+++ b/plugins/gcloud/benchmarks/scenarios.ts
@@ -1,0 +1,317 @@
+import { mkdtempSync, readdirSync, readFileSync, statSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PLUGIN_ROOT = join(import.meta.dir, '..');
+const FIXTURES_DIR = join(import.meta.dir, 'fixtures');
+const MOCK_GCLOUD = join(import.meta.dir, 'mock-gcloud.sh');
+
+// ---------------------------------------------------------------------------
+// PATH-injected mock bootstrap
+//
+// Bun resolves inherited-spawn binaries from the PATH captured at process
+// startup and does not observe later process.env mutations. The unmodified
+// tool layer (src/tools/shared.ts -> makeExecApi) spawns `gcloud` with inherited
+// env, so injecting a mock via a runtime process.env.PATH mutation is invisible
+// to it. Instead we re-exec this benchmark once with the mock symlinked onto
+// PATH *before* the child process starts, so the tools resolve `gcloud` to the
+// mock. The mock routes by argv to fixtures in GCLOUD_BENCH_FIXTURES; the live
+// spot-check still reaches the real gcloud via GCLOUD_BENCH_ORIG_PATH.
+// ---------------------------------------------------------------------------
+
+if (!process.env.GCLOUD_BENCH_CHILD) {
+  const mockBinDir = mkdtempSync(join(tmpdir(), 'gcloud-bench-'));
+  symlinkSync(MOCK_GCLOUD, join(mockBinDir, 'gcloud'));
+  const origPath = process.env.PATH ?? '';
+  const child = Bun.spawn([process.execPath, import.meta.path], {
+    env: {
+      ...process.env,
+      PATH: `${mockBinDir}:${origPath}`,
+      GCLOUD_BENCH_CHILD: '1',
+      GCLOUD_BENCH_ORIG_PATH: origPath,
+      GCLOUD_BENCH_FIXTURES: FIXTURES_DIR,
+    },
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  process.exit(await child.exited);
+}
+
+const Typebox = await import('@sinclair/typebox');
+const { createGcloudConfigListTool } = await import('../src/tools/gcloud-config-list');
+const { createGcloudProjectsListTool } = await import('../src/tools/gcloud-projects-list');
+const { createGcloudComputeInstancesListTool } = await import('../src/tools/gcloud-compute-instances-list');
+const { checkGcloud } = await import('../src/tools/gcloud-exec-guard');
+
+// The gcloud tools are factory-style: createGcloud*Tool(pi) reads pi.typebox to
+// build its parameter schema. Construct the minimal pi stub the factories need.
+const pi = { typebox: { Type: Typebox.Type } };
+
+const gcloudConfigList = createGcloudConfigListTool(pi);
+const gcloudProjectsList = createGcloudProjectsListTool(pi);
+const gcloudComputeInstancesList = createGcloudComputeInstancesListTool(pi);
+
+const SESSION = { cwd: '/tmp' };
+
+// ---------------------------------------------------------------------------
+// Scenario infrastructure
+// ---------------------------------------------------------------------------
+
+interface ScenarioResult {
+  pass: boolean;
+  score: number;
+}
+
+interface Scenario {
+  name: string;
+  run: () => Promise<ScenarioResult>;
+}
+
+function checkResult(
+  result: { content: Array<{ text: string }>; isError?: boolean },
+  expected: { isError?: boolean; contains?: string[]; notContains?: string[] },
+): ScenarioResult {
+  const text = result.content[0]?.text ?? '';
+  const isError = result.isError ?? false;
+
+  if (expected.isError !== undefined && expected.isError !== isError) {
+    return { pass: false, score: 0 };
+  }
+
+  let matched = 0;
+  let total = 0;
+
+  for (const s of expected.contains ?? []) {
+    total++;
+    if (text.includes(s)) matched++;
+  }
+
+  for (const s of expected.notContains ?? []) {
+    total++;
+    if (!text.includes(s)) matched++;
+  }
+
+  if (total === 0) return { pass: !isError || expected.isError === true, score: 1 };
+  const score = matched / total;
+  return { pass: score >= 0.8, score };
+}
+
+// A pure-guardrail scenario asserts checkGcloud's blocked verdict without
+// spawning gcloud. The score is binary: 1 when the verdict matches.
+function checkGuard(args: string[], expectBlocked: boolean): ScenarioResult {
+  const { blocked } = checkGcloud(args);
+  const pass = blocked === expectBlocked;
+  return { pass, score: pass ? 1 : 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario definitions
+// ---------------------------------------------------------------------------
+
+const scenarios: Scenario[] = [
+  // ── Success scenarios (real tools -> mock gcloud -> fixtures) ────────────
+  {
+    name: 'config-list',
+    async run() {
+      const result = await gcloudConfigList.execute('t', {}, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['demo-project-123', 'demo-engineer@example.com', 'us-central1', 'us-central1-a'],
+      });
+    },
+  },
+  {
+    name: 'projects-list',
+    async run() {
+      const result = await gcloudProjectsList.execute('t', {}, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['demo-project-123', 'Demo Project', 'demo-staging-456', 'ACTIVE'],
+      });
+    },
+  },
+  {
+    name: 'compute-instances-list',
+    async run() {
+      const result = await gcloudComputeInstancesList.execute('t', {}, undefined, undefined, SESSION);
+      return checkResult(result, {
+        isError: false,
+        contains: ['demo-web-1', 'us-central1-a', 'e2-medium', 'RUNNING', '10.128.0.2', '34.68.1.2'],
+      });
+    },
+  },
+
+  // ── Guardrail scenarios (pure checkGcloud, no spawn) ─────────────────────
+  {
+    name: 'guard-compute-instances-delete-blocked',
+    async run() {
+      return checkGuard(['compute', 'instances', 'delete', 'x'], true);
+    },
+  },
+  {
+    name: 'guard-get-credentials-blocked',
+    async run() {
+      return checkGuard(['container', 'clusters', 'get-credentials', 'c'], true);
+    },
+  },
+  {
+    name: 'guard-compute-ssh-blocked',
+    async run() {
+      return checkGuard(['compute', 'ssh', 'vm'], true);
+    },
+  },
+  {
+    name: 'guard-sql-connect-blocked',
+    async run() {
+      return checkGuard(['sql', 'connect', 'i'], true);
+    },
+  },
+  {
+    name: 'guard-auth-print-access-token-blocked',
+    async run() {
+      return checkGuard(['auth', 'print-access-token'], true);
+    },
+  },
+  {
+    name: 'guard-filtered-read-allowed',
+    async run() {
+      return checkGuard(['compute', 'instances', 'list', '--filter=status=RUNNING'], false);
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Accuracy scoring
+// ---------------------------------------------------------------------------
+
+interface AccuracyReport {
+  accuracy: number;
+  failures: string[];
+}
+
+async function measureAccuracy(): Promise<AccuracyReport> {
+  let totalScore = 0;
+  const failures: string[] = [];
+  for (const scenario of scenarios) {
+    try {
+      const { pass, score } = await scenario.run();
+      totalScore += score;
+      if (!pass) failures.push(scenario.name);
+    } catch (err) {
+      failures.push(`${scenario.name} (threw: ${err instanceof Error ? err.message : String(err)})`);
+    }
+  }
+  return { accuracy: totalScore / scenarios.length, failures };
+}
+
+// ---------------------------------------------------------------------------
+// Turn efficiency
+// ---------------------------------------------------------------------------
+
+function measureTurnEfficiency(): number {
+  const promptsDir = join(PLUGIN_ROOT, 'src', 'prompts');
+  const promptContent = readdirSync(promptsDir)
+    .filter((f) => f.endsWith('.md'))
+    .map((f) => readFileSync(join(promptsDir, f), 'utf-8'))
+    .join('\n');
+
+  const tasks = [
+    { minTurns: 1, keywords: ['config', 'project', 'account'] },
+    { minTurns: 1, keywords: ['projects', 'lifecycleState', 'filter'] },
+    { minTurns: 1, keywords: ['compute', 'instances', 'zone'] },
+    { minTurns: 1, keywords: ['command_path', 'gcloud_help'] },
+    { minTurns: 1, keywords: ['--format=json', 'gcloud_exec', 'read-only'] },
+  ];
+
+  let totalTurns = 0;
+  for (const task of tasks) {
+    let turns = task.minTurns;
+    const missing = task.keywords.filter((kw) => !promptContent.toLowerCase().includes(kw.toLowerCase()));
+    turns += missing.length;
+    totalTurns += turns;
+  }
+  return totalTurns / tasks.length;
+}
+
+// ---------------------------------------------------------------------------
+// Token efficiency
+// ---------------------------------------------------------------------------
+
+function measureTokenEfficiency(): number {
+  const promptsDir = join(PLUGIN_ROOT, 'src', 'prompts');
+  let totalBytes = 0;
+  for (const f of readdirSync(promptsDir).filter((f) => f.endsWith('.md'))) {
+    totalBytes += statSync(join(promptsDir, f)).size;
+  }
+  return totalBytes;
+}
+
+// ---------------------------------------------------------------------------
+// Live CLI spot-check (real gcloud via the pre-mock PATH)
+// ---------------------------------------------------------------------------
+
+async function measureLiveAccuracy(): Promise<number> {
+  const liveEnv = { ...process.env, PATH: process.env.GCLOUD_BENCH_ORIG_PATH ?? process.env.PATH };
+  try {
+    const check = Bun.spawnSync(['gcloud', 'version'], { env: liveEnv });
+    if (check.exitCode !== 0) return 0;
+  } catch {
+    return 0;
+  }
+
+  const checks = [
+    {
+      cmd: ['gcloud', 'config', 'list', '--format=json'],
+      validate: (s: string) => typeof JSON.parse(s) === 'object',
+    },
+    {
+      cmd: ['gcloud', 'auth', 'list', '--format=json'],
+      validate: (s: string) => Array.isArray(JSON.parse(s)),
+    },
+  ];
+
+  let passed = 0;
+  for (const c of checks) {
+    try {
+      const proc = Bun.spawn(c.cmd, { stdout: 'pipe', stderr: 'pipe', env: liveEnv });
+      const stdout = await new Response(proc.stdout).text();
+      await proc.exited;
+      if (c.validate(stdout)) passed++;
+    } catch {
+      // skip
+    }
+  }
+  return passed / checks.length;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const { accuracy, failures } = await measureAccuracy();
+  const avgTurns = measureTurnEfficiency();
+  const avgTokens = measureTokenEfficiency();
+  const liveAccuracy = await measureLiveAccuracy();
+
+  const composite = accuracy * (1 / (1 + avgTurns / 10)) * (1 / (1 + avgTokens / 10000));
+
+  console.log(`METRIC accuracy=${accuracy.toFixed(4)}`);
+  console.log(`METRIC avg_turns=${avgTurns.toFixed(2)}`);
+  console.log(`METRIC avg_tokens=${avgTokens}`);
+  console.log(`METRIC live_accuracy=${liveAccuracy.toFixed(4)}`);
+  console.log(`METRIC composite_score=${composite.toFixed(6)}`);
+  console.log(`ASI hypothesis=${process.env.AUTORESEARCH_HYPOTHESIS ?? 'baseline'}`);
+
+  // Hard gate: any failing scenario (success or guardrail) is a benchmark
+  // failure. The composite is still reported above for autoresearch logging.
+  if (failures.length > 0) {
+    console.error(`Benchmark FAILED: ${failures.length} scenario(s) failed: ${failures.join(', ')}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('Benchmark failed:', err);
+  process.exit(1);
+});

--- a/plugins/gcloud/package.json
+++ b/plugins/gcloud/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "Google Cloud CLI status for xcsh welcome screen",
   "main": "src/index.ts",
+  "scripts": {
+    "test": "bun test",
+    "test:watch": "bun test --watch"
+  },
   "xcsh": {
     "name": "GCloud",
     "version": "1.0.0",
@@ -12,6 +16,10 @@
   },
   "peerDependencies": {
     "@f5-sales-demo/xcsh": ">=1.0.0"
+  },
+  "devDependencies": {
+    "@sinclair/typebox": "^0.34.0",
+    "bun-types": "latest"
   },
   "license": "Apache-2.0"
 }

--- a/plugins/gcloud/src/gcloud/exec.ts
+++ b/plugins/gcloud/src/gcloud/exec.ts
@@ -1,0 +1,141 @@
+import type { GcloudRawResult } from './types';
+
+// ---------------------------------------------------------------------------
+// Error taxonomy
+// ---------------------------------------------------------------------------
+
+export class GcloudExecError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode = 1,
+  ) {
+    super(message);
+    this.name = 'GcloudExecError';
+  }
+}
+
+export class GcloudAuthError extends GcloudExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'GcloudAuthError';
+  }
+}
+
+export class GcloudSessionExpiredError extends GcloudExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'GcloudSessionExpiredError';
+  }
+}
+
+export class GcloudNotFoundError extends GcloudExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'GcloudNotFoundError';
+  }
+}
+
+export class GcloudPermissionError extends GcloudExecError {
+  constructor(message: string, exitCode = 1) {
+    super(message, exitCode);
+    this.name = 'GcloudPermissionError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a failed `gcloud` invocation into the appropriate GcloudExecError
+ * subclass by inspecting stderr. Precedence:
+ * auth > session-expired > permission > not-found > generic.
+ */
+export function detectGcloudError(stderr: string, exitCode: number): GcloudExecError {
+  const lower = stderr.toLowerCase();
+
+  if (
+    lower.includes('do not currently have an active account') ||
+    lower.includes('gcloud auth login') ||
+    lower.includes('does not have any valid credentials') ||
+    lower.includes('no active account')
+  ) {
+    return new GcloudAuthError(stderr, exitCode);
+  }
+
+  if (
+    lower.includes('reauthentication required') ||
+    lower.includes('reauthentication failed') ||
+    lower.includes('invalid_grant') ||
+    lower.includes('token has been expired or revoked')
+  ) {
+    return new GcloudSessionExpiredError(stderr, exitCode);
+  }
+
+  if (
+    lower.includes('permission_denied') ||
+    lower.includes('does not have permission') ||
+    lower.includes('permission denied') ||
+    lower.includes('caller does not have permission') ||
+    lower.includes('forbidden') ||
+    lower.includes('403')
+  ) {
+    return new GcloudPermissionError(stderr, exitCode);
+  }
+
+  if (
+    lower.includes('not_found') ||
+    lower.includes('was not found') ||
+    lower.includes('does not exist') ||
+    lower.includes('404')
+  ) {
+    return new GcloudNotFoundError(stderr, exitCode);
+  }
+
+  return new GcloudExecError(stderr, exitCode);
+}
+
+// ---------------------------------------------------------------------------
+// Output parsing
+// ---------------------------------------------------------------------------
+
+export function parseGcloudJsonOutput<T>(raw: string): T {
+  try {
+    if (!raw || raw.trim().length === 0) {
+      throw new GcloudExecError('Empty output from gcloud CLI');
+    }
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    if (err instanceof GcloudExecError) throw err;
+    throw new GcloudExecError(`Failed to parse gcloud CLI output: ${(err as Error).message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exec helpers
+// ---------------------------------------------------------------------------
+
+export interface GcloudExecApi {
+  exec(command: string, args: string[], options?: { signal?: AbortSignal }): Promise<GcloudRawResult>;
+}
+
+export async function execGcloudJson<T>(api: GcloudExecApi, args: string[], signal?: AbortSignal): Promise<T> {
+  const fullArgs = [...args, '--format=json'];
+  const result = await api.exec('gcloud', fullArgs, { signal });
+  if (result.exitCode !== 0) {
+    throw detectGcloudError(result.stderr, result.exitCode);
+  }
+  return parseGcloudJsonOutput<T>(result.stdout);
+}
+
+export async function execGcloudRaw(
+  api: GcloudExecApi,
+  args: string[],
+  signal?: AbortSignal,
+): Promise<GcloudRawResult> {
+  const result = await api.exec('gcloud', args, { signal });
+  if (result.exitCode !== 0) {
+    throw detectGcloudError(result.stderr, result.exitCode);
+  }
+  return result;
+}

--- a/plugins/gcloud/src/gcloud/formatters.ts
+++ b/plugins/gcloud/src/gcloud/formatters.ts
@@ -1,0 +1,124 @@
+import type { GcloudBucket, GcloudConfig, GcloudInstance, GcloudProject } from './types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the last `/`-separated segment of a value. gcloud reports resources
+ * such as zones and machine types as fully-qualified selfLink URLs
+ * (e.g. `.../zones/us-central1-a`); this reduces them to their short name.
+ * Returns the input unchanged when it contains no `/`.
+ */
+export function basename(url: string): string {
+  const idx = url.lastIndexOf('/');
+  return idx === -1 ? url : url.slice(idx + 1);
+}
+
+// ---------------------------------------------------------------------------
+// Normalizers (raw gcloud JSON -> typed structs)
+// ---------------------------------------------------------------------------
+
+export function normalizeConfig(raw: Record<string, unknown>): GcloudConfig {
+  const core = (raw.core as Record<string, unknown>) ?? {};
+  const compute = (raw.compute as Record<string, unknown>) ?? {};
+  return {
+    project: String(core.project ?? ''),
+    account: String(core.account ?? ''),
+    region: String(compute.region ?? ''),
+    zone: String(compute.zone ?? ''),
+  };
+}
+
+export function normalizeProject(raw: Record<string, unknown>): GcloudProject {
+  return {
+    projectId: String(raw.projectId ?? ''),
+    name: String(raw.name ?? ''),
+    projectNumber: String(raw.projectNumber ?? ''),
+    lifecycleState: String(raw.lifecycleState ?? ''),
+  };
+}
+
+export function normalizeInstance(raw: Record<string, unknown>): GcloudInstance {
+  const interfaces = (raw.networkInterfaces as Array<Record<string, unknown>>) ?? [];
+  const primary = interfaces[0] ?? {};
+  const accessConfigs = (primary.accessConfigs as Array<Record<string, unknown>>) ?? [];
+  const primaryAccess = accessConfigs[0] ?? {};
+  return {
+    name: String(raw.name ?? ''),
+    zone: basename(String(raw.zone ?? '')),
+    machineType: basename(String(raw.machineType ?? '')),
+    status: String(raw.status ?? ''),
+    internalIp: String(primary.networkIP ?? ''),
+    externalIp: String(primaryAccess.natIP ?? ''),
+  };
+}
+
+export function normalizeBucket(raw: Record<string, unknown>): GcloudBucket {
+  return {
+    name: String(raw.name ?? ''),
+    location: String(raw.location ?? ''),
+    storageClass: String(raw.storageClass ?? raw.storage_class ?? ''),
+    created: String(raw.timeCreated ?? raw.creation_time ?? ''),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// List normalizers (CLI wraps items in a JSON array)
+// ---------------------------------------------------------------------------
+
+export function normalizeProjects(raw: unknown[]): GcloudProject[] {
+  return raw.map((item) => normalizeProject(item as Record<string, unknown>));
+}
+
+export function normalizeInstances(raw: unknown[]): GcloudInstance[] {
+  return raw.map((item) => normalizeInstance(item as Record<string, unknown>));
+}
+
+export function normalizeBuckets(raw: unknown[]): GcloudBucket[] {
+  return raw.map((item) => normalizeBucket(item as Record<string, unknown>));
+}
+
+// ---------------------------------------------------------------------------
+// Formatters (typed structs -> markdown)
+// ---------------------------------------------------------------------------
+
+export function formatConfigDetail(config: GcloudConfig): string {
+  return [
+    `**Project:** ${config.project || '-'}`,
+    `**Account:** ${config.account || '-'}`,
+    `**Region:** ${config.region || '-'}`,
+    `**Zone:** ${config.zone || '-'}`,
+  ].join('\n');
+}
+
+export function formatProjectTable(projects: GcloudProject[]): string {
+  if (projects.length === 0) return 'No projects found.';
+  const header = '| Project ID | Name | Number | State |';
+  const sep = '|------------|------|--------|-------|';
+  const rows = projects.map(
+    (p) => `| ${p.projectId} | ${p.name || '-'} | ${p.projectNumber || '-'} | ${p.lifecycleState || '-'} |`,
+  );
+  return [header, sep, ...rows].join('\n');
+}
+
+export function formatInstanceTable(instances: GcloudInstance[]): string {
+  if (instances.length === 0) return 'No instances found.';
+  const header = '| Name | Zone | Machine Type | Status | Internal IP | External IP |';
+  const sep = '|------|------|--------------|--------|-------------|-------------|';
+  const rows = instances.map(
+    (i) =>
+      `| ${i.name} | ${i.zone} | ${i.machineType} | ${i.status} | ${i.internalIp || '-'} | ${i.externalIp || '-'} |`,
+  );
+  return [header, sep, ...rows].join('\n');
+}
+
+export function formatBucketTable(buckets: GcloudBucket[]): string {
+  if (buckets.length === 0) return 'No buckets found.';
+  const header = '| Name | Location | Storage Class | Created |';
+  const sep = '|------|----------|---------------|---------|';
+  const rows = buckets.map(
+    (b) => `| ${b.name} | ${b.location || '-'} | ${b.storageClass || '-'} | ${b.created || '-'} |`,
+  );
+  return [header, sep, ...rows].join('\n');
+}

--- a/plugins/gcloud/src/gcloud/types.ts
+++ b/plugins/gcloud/src/gcloud/types.ts
@@ -1,0 +1,51 @@
+export interface GcloudConfig {
+  project: string;
+  account: string;
+  region: string;
+  zone: string;
+}
+
+export interface GcloudProject {
+  projectId: string;
+  name: string;
+  projectNumber: string;
+  lifecycleState: string;
+}
+
+export interface GcloudInstance {
+  name: string;
+  zone: string;
+  machineType: string;
+  status: string;
+  internalIp: string;
+  externalIp: string;
+}
+
+export interface GcloudBucket {
+  name: string;
+  location: string;
+  storageClass: string;
+  created: string;
+}
+
+export interface GcloudRawResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface PluginInterface {
+  typebox: { Type: Record<string, (...args: unknown[]) => unknown> };
+  [key: string]: unknown;
+}
+
+export const PROJECT_ID_PATTERN = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
+export const ZONE_PATTERN = /^[a-z]+-[a-z]+\d-[a-z]$/;
+// Allow lowercase command-path segments with spaces and dashes (e.g.
+// `compute instances`, `get-iam-policy`) but never a leading dash so a value
+// like `-foo` cannot be mistaken for a flag.
+export const HELP_PATH_PATTERN = /^[a-z][a-z0-9 -]*$/;
+// Require a non-dash first character so a value like `--project -foo` (which would
+// otherwise pass the charset check) cannot be a leading dash and be mistaken for a
+// flag. Subsequent characters may still include a dash.
+export const RESOURCE_NAME_PATTERN = /^[A-Za-z0-9._:/][A-Za-z0-9._:/-]*$/;

--- a/plugins/gcloud/src/index.ts
+++ b/plugins/gcloud/src/index.ts
@@ -1,8 +1,34 @@
 import type { ExtensionFactory } from '@f5-sales-demo/xcsh';
+import { detectErrorType, errorResult, renderError } from './tools/shared';
 
 function sanitizeHintField(value: unknown, maxLen = 200): string {
   if (typeof value !== 'string') return '';
   return value.replace(/[^\x20-\x7E]/g, '').slice(0, maxLen);
+}
+
+/**
+ * Wrap a factory tool so any error that still propagates out of its execute()
+ * is converted into a structured error result carrying details.errorType.
+ *
+ * The per-tool handlers already catch gcloud errors and return a friendly
+ * errorResult (a normal result); those never reach this wrapper. A genuine
+ * cancellation (AbortError / ToolAbortError) is re-thrown so the agent loop
+ * can distinguish user cancellation from a real tool failure.
+ */
+export function withErrorType<T extends { name: string; execute: (...args: never[]) => Promise<unknown> }>(tool: T): T {
+  const originalExecute = tool.execute.bind(tool) as (...args: unknown[]) => Promise<unknown>;
+  return {
+    ...tool,
+    execute: (async (...args: unknown[]) => {
+      try {
+        return await originalExecute(...args);
+      } catch (err) {
+        const name = (err as { name?: string } | null | undefined)?.name;
+        if (name === 'AbortError' || name === 'ToolAbortError') throw err;
+        return errorResult(renderError(err), { tool: tool.name, errorType: detectErrorType(err) });
+      }
+    }) as T['execute'],
+  };
 }
 
 const factory: ExtensionFactory = async (pi) => {
@@ -26,6 +52,23 @@ const factory: ExtensionFactory = async (pi) => {
     gcloudAvailable = Bun.spawnSync([checker, 'gcloud']).exitCode === 0;
   } catch {
     // gcloud not available
+  }
+
+  // Only register tools when the gcloud CLI is present.
+  if (gcloudAvailable && typeof pi.registerTool === 'function') {
+    const { createGcloudConfigListTool } = await import('./tools/gcloud-config-list');
+    const { createGcloudProjectsListTool } = await import('./tools/gcloud-projects-list');
+    const { createGcloudComputeInstancesListTool } = await import('./tools/gcloud-compute-instances-list');
+    const { createGcloudStorageBucketsListTool } = await import('./tools/gcloud-storage-buckets-list');
+    const { createGcloudExecTool } = await import('./tools/gcloud-exec');
+    const { createGcloudHelpTool } = await import('./tools/gcloud-help');
+
+    pi.registerTool(withErrorType(createGcloudConfigListTool(pi)));
+    pi.registerTool(withErrorType(createGcloudProjectsListTool(pi)));
+    pi.registerTool(withErrorType(createGcloudComputeInstancesListTool(pi)));
+    pi.registerTool(withErrorType(createGcloudStorageBucketsListTool(pi)));
+    pi.registerTool(withErrorType(createGcloudExecTool(pi)));
+    pi.registerTool(withErrorType(createGcloudHelpTool(pi)));
   }
 
   // Always register service status (shows unavailable when CLI missing)

--- a/plugins/gcloud/src/prompts/gcloud-compute-instances-list.md
+++ b/plugins/gcloud/src/prompts/gcloud-compute-instances-list.md
@@ -1,0 +1,13 @@
+List Compute Engine virtual machine instances via `gcloud compute instances list`.
+
+Returns a table of instance name, zone, machine type, status, and internal/external IP.
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `zone`    | Optional zone to restrict results (mapped to gcloud `--zones`), e.g. `"us-central1-a"` |
+| `filter`  | Optional gcloud `--filter` expression, e.g. `"status=RUNNING"` |
+| `limit`   | Optional positive integer capping the number of results |
+
+For richer queries (custom projections, sorting, sub-field selection), run `gcloud_exec` with `compute instances list` and your own `--filter`/`--format` flags.

--- a/plugins/gcloud/src/prompts/gcloud-config-list.md
+++ b/plugins/gcloud/src/prompts/gcloud-config-list.md
@@ -1,0 +1,5 @@
+Show the active Google Cloud CLI configuration via `gcloud config list`.
+
+Returns the resolved project, account, region, and zone for the current `gcloud` configuration. Use this to confirm which project and identity subsequent commands will target.
+
+Takes no parameters. For richer configuration queries (all properties, named configurations), run `gcloud_exec` with `config list --all` and your own `--filter`/`--format` expressions.

--- a/plugins/gcloud/src/prompts/gcloud-exec.md
+++ b/plugins/gcloud/src/prompts/gcloud-exec.md
@@ -16,11 +16,11 @@ Pass the group, verb, and flags as an array of arguments. Do NOT include `gcloud
 
 - Arguments are passed as an array directly to the `gcloud` binary — **no shell** is involved, so shell metacharacters are inert and never filtered. Any valid `gcloud` invocation runs, including full `--filter` and `--format` expressions. Only NUL/control bytes are rejected.
 - **Read-only by default.** Only recognized read verbs run:
-  - Exact reads: `list`, `describe`, `get-iam-policy`, `get-value`, `get-server-config`, `get-ancestors`, `list-grantable-roles`, `print-access-token`, `print-identity-token`, `print-settings`, `version`, `info`.
+  - Exact reads: `list`, `describe`, `get-iam-policy`, `get-value`, `get-server-config`, `get-ancestors`, `list-grantable-roles`, `print-settings`, `version`, `info`.
   - Read prefixes: any verb starting with `list-` or `describe-`.
   - Top-level: `version`, `info`, `help`, `topic`, `cheat-sheet`.
 - **Mutating verbs are blocked** (`create`, `delete`, `update`, `patch`, `set`, `deploy`, `enable`, `disable`, `set-iam-policy`, `add-iam-policy-binding`, …). Run write/destructive operations through an explicitly confirmed path — delegate to the `gcloud:cli-operator` agent, not `gcloud_exec`.
-- **Execution and credential vectors are blocked** even though some look read-shaped: `ssh`, `scp`, `connect`, `call`, `run`, `interactive`, `login`, `revoke`, `get-credentials`, `reset-windows-password`, `simulate-maintenance-event`, `enable-service`, `configure-docker`. These open sessions, run code, or mint/consume credentials — route them through the `gcloud:cli-operator` agent.
+- **Execution and credential vectors are blocked** even though some look read-shaped: `ssh`, `scp`, `connect`, `call`, `interactive`, `login`, `revoke`, `get-credentials`, `print-access-token`, `print-identity-token`, `reset-windows-password`, `simulate-maintenance-event`, `enable-service`, `configure-docker`. These open sessions, run code, or mint/print credentials — route them through the `gcloud:cli-operator` agent.
 - Unrecognized verbs are blocked (fail-safe): provide an explicit read-only verb.
 - Output is capped to prevent context overflow.
 

--- a/plugins/gcloud/src/prompts/gcloud-exec.md
+++ b/plugins/gcloud/src/prompts/gcloud-exec.md
@@ -1,0 +1,56 @@
+Execute any `gcloud` CLI command directly.
+
+This is the general-purpose tool for running Google Cloud CLI commands that are not covered by the typed tools. Use typed tools when available — they validate inputs and return structured data.
+
+## Usage
+
+Pass the group, verb, and flags as an array of arguments. Do NOT include `gcloud` itself — it is prepended automatically.
+
+**Example:** To run `gcloud compute instances list --filter="status=RUNNING"`:
+
+```json
+{ "args": ["compute", "instances", "list", "--filter=status=RUNNING"] }
+```
+
+## Safety
+
+- Arguments are passed as an array directly to the `gcloud` binary — **no shell** is involved, so shell metacharacters are inert and never filtered. Any valid `gcloud` invocation runs, including full `--filter` and `--format` expressions. Only NUL/control bytes are rejected.
+- **Read-only by default.** Only recognized read verbs run:
+  - Exact reads: `list`, `describe`, `get-iam-policy`, `get-value`, `get-server-config`, `get-ancestors`, `list-grantable-roles`, `print-access-token`, `print-identity-token`, `print-settings`, `version`, `info`.
+  - Read prefixes: any verb starting with `list-` or `describe-`.
+  - Top-level: `version`, `info`, `help`, `topic`, `cheat-sheet`.
+- **Mutating verbs are blocked** (`create`, `delete`, `update`, `patch`, `set`, `deploy`, `enable`, `disable`, `set-iam-policy`, `add-iam-policy-binding`, …). Run write/destructive operations through an explicitly confirmed path — delegate to the `gcloud:cli-operator` agent, not `gcloud_exec`.
+- **Execution and credential vectors are blocked** even though some look read-shaped: `ssh`, `scp`, `connect`, `call`, `run`, `interactive`, `login`, `revoke`, `get-credentials`, `reset-windows-password`, `simulate-maintenance-event`, `enable-service`, `configure-docker`. These open sessions, run code, or mint/consume credentials — route them through the `gcloud:cli-operator` agent.
+- Unrecognized verbs are blocked (fail-safe): provide an explicit read-only verb.
+- Output is capped to prevent context overflow.
+
+## Querying: `--filter` vs `--format`
+
+gcloud splits querying into two distinct, complementary flags. This is **not** Azure `--query` (JMESPath): filtering and projection are separate.
+
+### `--filter` — server-side selection (which resources)
+
+Restricts *which* resources are returned, evaluated before results are sent back.
+
+- Equality: `--filter="status=RUNNING"` (`key=value`)
+- Boolean logic: `--filter="status=RUNNING AND zone:us-central1"` (`AND` / `OR`)
+- Substring match: `--filter="name:prod"` (`:` — has-substring)
+- Regex match: `--filter="name~^web-.*"` (`~`)
+
+### `--format` — client-side projection (how to show it)
+
+Shapes *how* the selected resources are rendered locally.
+
+- `--format=json` (default when you pass no `--format`)
+- `--format=value(name)` — bare field value(s), no keys
+- `--format="table(name,status,zone)"` — tabular columns
+- `--format=csv(name,status)` — comma-separated
+- `--format=yaml` — YAML document
+- `--format=flattened` — flat `key: value` lines
+
+## Tips
+
+- `--format=json` is added automatically unless you pass your own `--format` (e.g. `--format="table(name)"`, `--format=yaml`), which is respected.
+- `--limit=N` caps the number of results; `--sort-by=field` orders them.
+- `--project=PROJECT_ID` targets a specific Google Cloud project.
+- Combine freely: `["compute", "instances", "list", "--filter=status=RUNNING", "--sort-by=name", "--format=value(name)"]`.

--- a/plugins/gcloud/src/prompts/gcloud-exec.md
+++ b/plugins/gcloud/src/prompts/gcloud-exec.md
@@ -20,7 +20,8 @@ Pass the group, verb, and flags as an array of arguments. Do NOT include `gcloud
   - Read prefixes: any verb starting with `list-` or `describe-`.
   - Top-level: `version`, `info`, `help`, `topic`, `cheat-sheet`.
 - **Mutating verbs are blocked** (`create`, `delete`, `update`, `patch`, `set`, `deploy`, `enable`, `disable`, `set-iam-policy`, `add-iam-policy-binding`, …). Run write/destructive operations through an explicitly confirmed path — delegate to the `gcloud:cli-operator` agent, not `gcloud_exec`.
-- **Execution and credential vectors are blocked** even though some look read-shaped: `ssh`, `scp`, `connect`, `call`, `interactive`, `login`, `revoke`, `get-credentials`, `print-access-token`, `print-identity-token`, `reset-windows-password`, `simulate-maintenance-event`, `enable-service`, `configure-docker`. These open sessions, run code, or mint/print credentials — route them through the `gcloud:cli-operator` agent.
+- **Execution and credential vectors are blocked** even though some look read-shaped: `ssh`, `scp`, `connect`, `call`, `execute`, `interactive`, `login`, `revoke`, `get-credentials`, `print-access-token`, `print-identity-token`, `reset-windows-password`, `simulate-maintenance-event`, `enable-service`, `configure-docker`.
+  These open sessions, run code, or mint/print credentials — route them through the `gcloud:cli-operator` agent.
 - Unrecognized verbs are blocked (fail-safe): provide an explicit read-only verb.
 - Output is capped to prevent context overflow.
 

--- a/plugins/gcloud/src/prompts/gcloud-help.md
+++ b/plugins/gcloud/src/prompts/gcloud-help.md
@@ -1,0 +1,36 @@
+Fetch help documentation for any `gcloud` CLI group or command.
+
+Use this tool to discover available groups, commands, and flags for Google Cloud CLI operations that are not covered by the embedded typed tools.
+
+## Usage
+
+Pass the command path (without the `gcloud` prefix) to get help. The tool appends `--help` for you.
+
+**Example:** To see help for the `compute instances` group:
+
+```json
+{ "command_path": "compute instances" }
+```
+
+**Example:** To see help for a top-level group:
+
+```json
+{ "command_path": "projects" }
+```
+
+**Example:** To see top-level `gcloud` help:
+
+```json
+{ "command_path": "" }
+```
+
+## When to Use
+
+- Before using `gcloud_exec` with an unfamiliar group or command
+- To discover available commands within a group
+- To find the correct flags for a specific command (e.g. `--filter`, `--format`)
+- To check required versus optional arguments
+
+## Output
+
+Returns the raw `gcloud <command> --help` output as plain text, including available commands, flags, and usage examples. Once you know the command, run the read through `gcloud_exec`.

--- a/plugins/gcloud/src/prompts/gcloud-projects-list.md
+++ b/plugins/gcloud/src/prompts/gcloud-projects-list.md
@@ -1,0 +1,12 @@
+List the Google Cloud projects accessible to the active account via `gcloud projects list`.
+
+Returns a table of project ID, name, number, and lifecycle state.
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `filter`  | Optional gcloud `--filter` expression, e.g. `"lifecycleState=ACTIVE"` |
+| `limit`   | Optional positive integer capping the number of results |
+
+For richer queries (custom projections, sorting, sub-field selection), run `gcloud_exec` with `projects list` and your own `--filter`/`--format` flags.

--- a/plugins/gcloud/src/prompts/gcloud-storage-buckets-list.md
+++ b/plugins/gcloud/src/prompts/gcloud-storage-buckets-list.md
@@ -1,0 +1,12 @@
+List Cloud Storage buckets via `gcloud storage buckets list`.
+
+Returns a table of bucket name, location, storage class, and creation time.
+
+## Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `filter`  | Optional gcloud `--filter` expression, e.g. `"location=US"` |
+| `limit`   | Optional positive integer capping the number of results |
+
+For richer queries (custom projections, sorting, sub-field selection), run `gcloud_exec` with `storage buckets list` and your own `--filter`/`--format` flags.

--- a/plugins/gcloud/src/tools/gcloud-compute-instances-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-compute-instances-list.ts
@@ -1,0 +1,55 @@
+import { execGcloudJson } from '../gcloud/exec';
+import { formatInstanceTable, normalizeInstances } from '../gcloud/formatters';
+import type { PluginInterface } from '../gcloud/types';
+import { ZONE_PATTERN } from '../gcloud/types';
+import gcloudComputeInstancesListDescription from '../prompts/gcloud-compute-instances-list.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
+
+export function createGcloudComputeInstancesListTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    zone: Type.Optional(Type.String({ description: 'Restrict results to a zone, e.g. "us-central1-a"' })),
+    filter: Type.Optional(Type.String({ description: 'gcloud --filter expression, e.g. "status=RUNNING"' })),
+    limit: Type.Optional(Type.Number({ description: 'Maximum number of instances to return (positive integer)' })),
+  });
+
+  return {
+    name: 'gcloud_compute_instances_list',
+    label: 'Google Cloud Compute Instances',
+    description: gcloudComputeInstancesListDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { zone?: string; filter?: string; limit?: number },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'gcloud_compute_instances_list' as const };
+
+      if (params.zone !== undefined && !ZONE_PATTERN.test(params.zone)) {
+        return errorResult(`Error: invalid zone "${params.zone}". Expected a gcloud zone like "us-central1-a".`, base);
+      }
+
+      if (params.limit !== undefined && (!Number.isInteger(params.limit) || params.limit <= 0)) {
+        return errorResult(`Error: limit must be a positive integer, got "${params.limit}".`, base);
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const args = ['compute', 'instances', 'list'];
+      // gcloud filters the instances list by zone with the `--zones` flag.
+      if (params.zone) args.push('--zones', params.zone);
+      if (params.filter) args.push('--filter', params.filter);
+      if (params.limit !== undefined) args.push('--limit', String(params.limit));
+
+      try {
+        const raw = await execGcloudJson<unknown[]>(api, args, signal);
+        const instances = normalizeInstances(raw);
+        return textResult(formatInstanceTable(instances), { ...base, instances });
+      } catch (err) {
+        return errorResult(`Error: ${renderError(err)}`, { ...base, errorType: detectErrorType(err) });
+      }
+    },
+  };
+}

--- a/plugins/gcloud/src/tools/gcloud-compute-instances-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-compute-instances-list.ts
@@ -39,9 +39,11 @@ export function createGcloudComputeInstancesListTool(pi: PluginInterface) {
       const api = makeExecApi(ctx.cwd);
       const args = ['compute', 'instances', 'list'];
       // gcloud filters the instances list by zone with the `--zones` flag.
-      if (params.zone) args.push('--zones', params.zone);
-      if (params.filter) args.push('--filter', params.filter);
-      if (params.limit !== undefined) args.push('--limit', String(params.limit));
+      // Bind value flags with the `=` form so a value beginning with `-` can never be
+      // re-tokenised by gcloud as a separate flag (argv flag-smuggling defense).
+      if (params.zone) args.push(`--zones=${params.zone}`);
+      if (params.filter) args.push(`--filter=${params.filter}`);
+      if (params.limit !== undefined) args.push(`--limit=${String(params.limit)}`);
 
       try {
         const raw = await execGcloudJson<unknown[]>(api, args, signal);

--- a/plugins/gcloud/src/tools/gcloud-config-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-config-list.ts
@@ -1,0 +1,37 @@
+import { execGcloudJson } from '../gcloud/exec';
+import { formatConfigDetail, normalizeConfig } from '../gcloud/formatters';
+import type { PluginInterface } from '../gcloud/types';
+import gcloudConfigListDescription from '../prompts/gcloud-config-list.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
+
+export function createGcloudConfigListTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({});
+
+  return {
+    name: 'gcloud_config_list',
+    label: 'Google Cloud Config',
+    description: gcloudConfigListDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      _params: Record<string, never>,
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'gcloud_config_list' as const };
+      const api = makeExecApi(ctx.cwd);
+      const args = ['config', 'list'];
+
+      try {
+        const raw = await execGcloudJson<Record<string, unknown>>(api, args, signal);
+        const config = normalizeConfig(raw);
+        return textResult(formatConfigDetail(config), { ...base, config });
+      } catch (err) {
+        return errorResult(`Error: ${renderError(err)}`, { ...base, errorType: detectErrorType(err) });
+      }
+    },
+  };
+}

--- a/plugins/gcloud/src/tools/gcloud-exec-guard.ts
+++ b/plugins/gcloud/src/tools/gcloud-exec-guard.ts
@@ -23,8 +23,6 @@ export const READ_EXACT: ReadonlySet<string> = new Set([
   'get-server-config',
   'get-ancestors',
   'list-grantable-roles',
-  'print-access-token',
-  'print-identity-token',
   'print-settings',
   'version',
   'info',
@@ -49,6 +47,12 @@ export const DANGEROUS_VERBS: ReadonlySet<string> = new Set([
   'login',
   'revoke',
   'get-credentials',
+  // print-access-token / print-identity-token mint and print usable bearer credentials
+  // to stdout, which would flow into agent context and logs — a credential-exposure
+  // vector. Route token minting through the confirmed cli-operator path, not the
+  // read-only passthrough.
+  'print-access-token',
+  'print-identity-token',
   'reset-windows-password',
   'simulate-maintenance-event',
   'enable-service',

--- a/plugins/gcloud/src/tools/gcloud-exec-guard.ts
+++ b/plugins/gcloud/src/tools/gcloud-exec-guard.ts
@@ -9,7 +9,7 @@
 // The read/write decision scans ALL non-flag tokens (see getPositionals) — the
 // azure "all-positionals" model — rather than trying to isolate the verb by
 // position. Any flag-value exclusion / "drop the token after a flag" logic
-// over-excludes and is exactly the bug class that broke the github/gitlab/salesforce
+// over-excludes and is exactly the bug class that broke the GitHub/GitLab/Salesforce
 // guards (`-dp create`, `-fX=GET` slipping a write past the guard). Taking every
 // non-flag token is fail-safe: a flag value that happens to equal a verb is blocked
 // (rare, safe) and a write verb can never be hidden by exclusion.
@@ -42,7 +42,10 @@ export const DANGEROUS_VERBS: ReadonlySet<string> = new Set([
   'scp',
   'connect',
   'call',
-  'run',
+  // NB: `run` is deliberately NOT here — it collides with the Cloud Run group, so
+  // blocking it would refuse legitimate reads like `gcloud run services list`. The real
+  // vectors are covered elsewhere: `functions call` by `call`, `run deploy` by `deploy`
+  // (mutating).
   'interactive',
   'login',
   'revoke',

--- a/plugins/gcloud/src/tools/gcloud-exec-guard.ts
+++ b/plugins/gcloud/src/tools/gcloud-exec-guard.ts
@@ -1,0 +1,213 @@
+// Pure guardrail helpers for the gcloud_exec passthrough tool.
+// Keeps argv hygiene and read-only enforcement free of I/O so they are trivially
+// testable. Fail-safe allowlist design: unrecognized verbs are blocked.
+//
+// `hasControlChars` lives in ./shared (Task 1) — the tool imports it from there so
+// there is a single source of truth; it is deliberately NOT re-exported here.
+//
+// gcloud grammar: `gcloud [alpha|beta] <group> [<subgroup>…] <verb> [positional args] [--flags]`.
+// The read/write decision scans ALL non-flag tokens (see getPositionals) — the
+// azure "all-positionals" model — rather than trying to isolate the verb by
+// position. Any flag-value exclusion / "drop the token after a flag" logic
+// over-excludes and is exactly the bug class that broke the github/gitlab/salesforce
+// guards (`-dp create`, `-fX=GET` slipping a write past the guard). Taking every
+// non-flag token is fail-safe: a flag value that happens to equal a verb is blocked
+// (rare, safe) and a write verb can never be hidden by exclusion.
+
+// Exact read-only verbs that do not fit a read prefix.
+export const READ_EXACT: ReadonlySet<string> = new Set([
+  'list',
+  'describe',
+  'get-iam-policy',
+  'get-value',
+  'get-server-config',
+  'get-ancestors',
+  'list-grantable-roles',
+  'print-access-token',
+  'print-identity-token',
+  'print-settings',
+  'version',
+  'info',
+]);
+
+// Verb prefixes that denote a read across gcloud's `<verb>-<noun>` naming.
+export const READ_PREFIXES: readonly string[] = ['list-', 'describe-'];
+
+// Top-level commands that take no group/verb (resolved when positionals[0] is one).
+export const READ_TOP: ReadonlySet<string> = new Set(['version', 'info', 'help', 'topic', 'cheat-sheet']);
+
+// Verbs that execute code, open interactive sessions, or mint/consume credentials.
+// These are neither pure reads nor simple mutations — they are execution/credential
+// vectors and must never run through the passthrough, even read-shaped ones.
+export const DANGEROUS_VERBS: ReadonlySet<string> = new Set([
+  'ssh',
+  'scp',
+  'connect',
+  'call',
+  'run',
+  'interactive',
+  'login',
+  'revoke',
+  'get-credentials',
+  'reset-windows-password',
+  'simulate-maintenance-event',
+  'enable-service',
+  'configure-docker',
+]);
+
+// Verbs that create, change, or destroy state.
+export const MUTATING_VERBS: ReadonlySet<string> = new Set([
+  'create',
+  'delete',
+  'update',
+  'patch',
+  'remove',
+  'add',
+  'set',
+  'set-iam-policy',
+  'add-iam-policy-binding',
+  'remove-iam-policy-binding',
+  'deploy',
+  'import',
+  'export',
+  'apply',
+  'enable',
+  'disable',
+  'start',
+  'stop',
+  'restart',
+  'resize',
+  'suspend',
+  'resume',
+  'reset',
+  'rollback',
+  'promote',
+  'migrate',
+  'undelete',
+  'restore',
+  'activate',
+  'deactivate',
+  'attach',
+  'detach',
+  'bind',
+  'unbind',
+  'clear',
+  'move',
+  'clone',
+  'copy',
+  'wait',
+  'abandon',
+  'recreate',
+  'rotate',
+  'acknowledge',
+  'publish',
+  'seek',
+  'purge',
+  'cancel',
+  'override',
+  'unset',
+  'snapshot',
+  'upgrade',
+  'downgrade',
+  'repair',
+  'drain',
+  'uncordon',
+  'cordon',
+  'add-tags',
+  'remove-tags',
+]);
+
+const WRITE_DELEGATION =
+  'gcloud_exec is read-only by default. Run write/destructive operations through an ' +
+  'explicitly confirmed path (delegate to the gcloud:cli-operator agent), not gcloud_exec.';
+
+// Every argument that is not itself a flag. We deliberately do NOT exclude
+// "flag values" (the `foo` in `--zone foo`): telling value-taking flags apart from
+// boolean switches without the full gcloud grammar is error-prone, and any mistake
+// lets a destructive verb slip through (e.g. `--zone create instances delete`) or a
+// leading global flag hide the real verb. For a read-only *security* guardrail we
+// fail safe and treat every non-flag token as a candidate verb.
+export function getPositionals(args: string[]): string[] {
+  return args.filter((arg) => !arg.startsWith('-'));
+}
+
+function isKnownVerb(tok: string): boolean {
+  return (
+    READ_EXACT.has(tok) ||
+    READ_PREFIXES.some((p) => tok.startsWith(p)) ||
+    DANGEROUS_VERBS.has(tok) ||
+    MUTATING_VERBS.has(tok)
+  );
+}
+
+// The leftmost positional that is a recognized verb (read, dangerous, or mutating);
+// null if none is recognized.
+export function findVerb(positionals: string[]): string | null {
+  return positionals.find((tok) => isKnownVerb(tok)) ?? null;
+}
+
+// First positional that is a dangerous execution/credential verb, else null.
+export function findDangerous(positionals: string[]): string | null {
+  return positionals.find((tok) => DANGEROUS_VERBS.has(tok)) ?? null;
+}
+
+// First positional that is a mutating verb, else null.
+export function findMutating(positionals: string[]): string | null {
+  return positionals.find((tok) => MUTATING_VERBS.has(tok)) ?? null;
+}
+
+export function isRead(verb: string): boolean {
+  return READ_EXACT.has(verb) || READ_PREFIXES.some((p) => verb.startsWith(p));
+}
+
+export function checkGcloud(args: string[]): { blocked: boolean; reason?: string } {
+  const positionals = getPositionals(args);
+
+  // 1. No command at all.
+  if (positionals.length === 0) {
+    return { blocked: true, reason: 'no gcloud command provided' };
+  }
+
+  // 2. Dangerous execution/credential vectors (scan-anywhere, defense-in-depth).
+  const d = findDangerous(positionals);
+  if (d) {
+    return {
+      blocked: true,
+      reason:
+        `"${d}" is an execution/credential vector (opens a session, runs code, or mints/consumes ` +
+        `credentials) and cannot run through gcloud_exec. Run it through the gcloud:cli-operator agent.`,
+    };
+  }
+
+  // 3. Mutating operations (scan-anywhere, defense-in-depth).
+  const m = findMutating(positionals);
+  if (m) {
+    return { blocked: true, reason: `"${m}" is a mutating operation. ${WRITE_DELEGATION}` };
+  }
+
+  // 4. Top-level read commands (`version`, `info`, `help`, `topic`, `cheat-sheet`).
+  if (READ_TOP.has(positionals[0])) {
+    return { blocked: false };
+  }
+
+  // 5. Require an explicit recognized read verb — fail-safe on unknown verbs.
+  const v = findVerb(positionals);
+  if (v && isRead(v)) {
+    return { blocked: false };
+  }
+
+  return {
+    blocked: true,
+    reason:
+      'unrecognized gcloud command; provide a read-only verb ' +
+      `(list/describe/get-iam-policy/…). ${WRITE_DELEGATION}`,
+  };
+}
+
+// Default to JSON for machine-readable output, but respect a caller-supplied
+// --format so `--format=table(...)`, `--format=yaml`, `--format=csv`, and
+// `--format=value(...)` are honored instead of overridden.
+export function buildGcloudArgs(args: string[]): string[] {
+  const hasFormat = args.some((a) => a === '--format' || a.startsWith('--format='));
+  return hasFormat ? [...args] : [...args, '--format=json'];
+}

--- a/plugins/gcloud/src/tools/gcloud-exec-guard.ts
+++ b/plugins/gcloud/src/tools/gcloud-exec-guard.ts
@@ -42,10 +42,13 @@ export const DANGEROUS_VERBS: ReadonlySet<string> = new Set([
   'scp',
   'connect',
   'call',
-  // NB: `run` is deliberately NOT here — it collides with the Cloud Run group, so
-  // blocking it would refuse legitimate reads like `gcloud run services list`. The real
-  // vectors are covered elsewhere: `functions call` by `call`, `run deploy` by `deploy`
-  // (mutating).
+  // `execute` is a genuine execution vector — `gcloud run jobs execute`, `gcloud
+  // workflows execute` run code — so it is named explicitly (rather than left to the
+  // fail-safe unrecognized-verb block) to route through the cli-operator with a clear
+  // reason. NB: `run` is deliberately NOT a dangerous verb — it collides with the Cloud
+  // Run group and would refuse legitimate reads like `gcloud run services list`; its
+  // real vectors are covered by `execute` (run jobs execute) and `deploy` (run deploy).
+  'execute',
   'interactive',
   'login',
   'revoke',

--- a/plugins/gcloud/src/tools/gcloud-exec-guard.ts
+++ b/plugins/gcloud/src/tools/gcloud-exec-guard.ts
@@ -7,7 +7,7 @@
 //
 // gcloud grammar: `gcloud [alpha|beta] <group> [<subgroup>…] <verb> [positional args] [--flags]`.
 // The read/write decision scans ALL non-flag tokens (see getPositionals) — the
-// azure "all-positionals" model — rather than trying to isolate the verb by
+// Azure "all-positionals" model — rather than trying to isolate the verb by
 // position. Any flag-value exclusion / "drop the token after a flag" logic
 // over-excludes and is exactly the bug class that broke the GitHub/GitLab/Salesforce
 // guards (`-dp create`, `-fX=GET` slipping a write past the guard). Taking every

--- a/plugins/gcloud/src/tools/gcloud-exec.ts
+++ b/plugins/gcloud/src/tools/gcloud-exec.ts
@@ -1,0 +1,76 @@
+import type { PluginInterface } from '../gcloud/types';
+import gcloudExecDescription from '../prompts/gcloud-exec.md' with { type: 'text' };
+import { buildGcloudArgs, checkGcloud } from './gcloud-exec-guard';
+import { detectErrorType, errorResult, hasControlChars, makeExecApi, textResult } from './shared';
+
+const MAX_OUTPUT_LENGTH = 50000;
+
+export function createGcloudExecTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    args: Type.Array(Type.String({ description: 'Individual argument (do NOT include "gcloud" itself)' }), {
+      description: 'gcloud group, verb, and flags as an array, e.g. ["compute", "instances", "list", "--format=json"]',
+    }),
+  });
+
+  return {
+    name: 'gcloud_exec',
+    label: 'Google Cloud CLI Execute',
+    description: gcloudExecDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { args: string[] },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'gcloud_exec' as const };
+      const args = params.args ?? [];
+
+      if (args.length === 0) {
+        return errorResult('Error: args array must not be empty. Provide a gcloud group and verb.', base);
+      }
+
+      // `gcloud` is spawned argv-style with NO shell, so shell metacharacters are inert
+      // (the argv boundary is the real injection control). We therefore do NOT strip
+      // metacharacters — doing so would break valid `--filter`/`--format` expressions.
+      // Only NUL/control bytes, which malform an execve argv, are rejected.
+      for (const arg of args) {
+        if (hasControlChars(arg)) {
+          return errorResult(
+            `Error: argument contains a control character and cannot be passed to gcloud: "${arg}"`,
+            base,
+          );
+        }
+      }
+
+      const c = checkGcloud(args);
+      if (c.blocked) {
+        return errorResult(`Error: ${c.reason}`, base);
+      }
+
+      try {
+        const api = makeExecApi(ctx.cwd);
+        const result = await api.exec('gcloud', buildGcloudArgs(args), { signal });
+        if (result.exitCode !== 0) {
+          return errorResult(`gcloud command failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`, {
+            ...base,
+            errorType: 'exec_error',
+          });
+        }
+        let output = result.stdout;
+        if (output.length > MAX_OUTPUT_LENGTH) {
+          output = `${output.slice(0, MAX_OUTPUT_LENGTH)}\n\n[Output truncated at ${MAX_OUTPUT_LENGTH} characters]`;
+        }
+        return textResult(output, base);
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: detectErrorType(err),
+        });
+      }
+    },
+  };
+}

--- a/plugins/gcloud/src/tools/gcloud-exec.ts
+++ b/plugins/gcloud/src/tools/gcloud-exec.ts
@@ -1,3 +1,4 @@
+import { detectGcloudError } from '../gcloud/exec';
 import type { PluginInterface } from '../gcloud/types';
 import gcloudExecDescription from '../prompts/gcloud-exec.md' with { type: 'text' };
 import { buildGcloudArgs, checkGcloud } from './gcloud-exec-guard';
@@ -55,9 +56,12 @@ export function createGcloudExecTool(pi: PluginInterface) {
         const api = makeExecApi(ctx.cwd);
         const result = await api.exec('gcloud', buildGcloudArgs(args), { signal });
         if (result.exitCode !== 0) {
+          // Classify the failure (auth / session-expired / permission / not-found) from
+          // stderr so the agent gets the same errorType the typed tools surface, instead
+          // of a blanket exec_error.
           return errorResult(`gcloud command failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`, {
             ...base,
-            errorType: 'exec_error',
+            errorType: detectErrorType(detectGcloudError(result.stderr, result.exitCode)),
           });
         }
         let output = result.stdout;

--- a/plugins/gcloud/src/tools/gcloud-help.ts
+++ b/plugins/gcloud/src/tools/gcloud-help.ts
@@ -1,0 +1,73 @@
+import type { PluginInterface } from '../gcloud/types';
+import { HELP_PATH_PATTERN } from '../gcloud/types';
+import gcloudHelpDescription from '../prompts/gcloud-help.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, textResult } from './shared';
+
+export function createGcloudHelpTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    command_path: Type.Optional(
+      Type.String({
+        description:
+          'Command path without "gcloud" prefix, e.g. "compute instances" or "projects". Empty for top-level help.',
+      }),
+    ),
+  });
+
+  return {
+    name: 'gcloud_help',
+    label: 'Google Cloud CLI Help',
+    description: gcloudHelpDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { command_path?: string },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'gcloud_help' as const };
+      const commandPath = params.command_path?.trim() ?? '';
+
+      if (commandPath.length > 0 && !HELP_PATH_PATTERN.test(commandPath)) {
+        return errorResult(
+          `Error: invalid command path "${commandPath}". Only lowercase letters, digits, hyphens, and spaces are allowed.`,
+          base,
+        );
+      }
+
+      const parts = commandPath.length > 0 ? commandPath.split(' ').filter(Boolean) : [];
+      // Belt-and-suspenders: the charset regex admits an interior/leading '-'
+      // (e.g. "compute -foo"), so reject any dash-led part that could be read as a flag.
+      if (parts.some((p) => p.startsWith('-'))) {
+        return errorResult(
+          `Error: invalid command path "${commandPath}". Command path parts must not start with "-".`,
+          base,
+        );
+      }
+
+      // Help output is plain text; do NOT append --format=json.
+      const args = [...parts, '--help'];
+      const api = makeExecApi(ctx.cwd);
+
+      try {
+        const result = await api.exec('gcloud', args, { signal });
+        if (result.exitCode !== 0) {
+          const msg = result.stderr || result.stdout || `gcloud ${commandPath} --help failed (exit ${result.exitCode})`;
+          return errorResult(`Error: ${msg}`, { ...base, errorType: 'exec_error' });
+        }
+        const output = result.stdout || result.stderr;
+        if (!output.trim()) {
+          return errorResult(`No help output for "gcloud ${commandPath}".`, { ...base, errorType: 'exec_error' });
+        }
+        return textResult(output, base);
+      } catch (err) {
+        return errorResult(`Error: ${err instanceof Error ? err.message : String(err)}`, {
+          ...base,
+          errorType: detectErrorType(err),
+        });
+      }
+    },
+  };
+}

--- a/plugins/gcloud/src/tools/gcloud-projects-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-projects-list.ts
@@ -1,0 +1,47 @@
+import { execGcloudJson } from '../gcloud/exec';
+import { formatProjectTable, normalizeProjects } from '../gcloud/formatters';
+import type { PluginInterface } from '../gcloud/types';
+import gcloudProjectsListDescription from '../prompts/gcloud-projects-list.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
+
+export function createGcloudProjectsListTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    filter: Type.Optional(Type.String({ description: 'gcloud --filter expression, e.g. "lifecycleState=ACTIVE"' })),
+    limit: Type.Optional(Type.Number({ description: 'Maximum number of projects to return (positive integer)' })),
+  });
+
+  return {
+    name: 'gcloud_projects_list',
+    label: 'Google Cloud Projects',
+    description: gcloudProjectsListDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { filter?: string; limit?: number },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'gcloud_projects_list' as const };
+
+      if (params.limit !== undefined && (!Number.isInteger(params.limit) || params.limit <= 0)) {
+        return errorResult(`Error: limit must be a positive integer, got "${params.limit}".`, base);
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const args = ['projects', 'list'];
+      if (params.filter) args.push('--filter', params.filter);
+      if (params.limit !== undefined) args.push('--limit', String(params.limit));
+
+      try {
+        const raw = await execGcloudJson<unknown[]>(api, args, signal);
+        const projects = normalizeProjects(raw);
+        return textResult(formatProjectTable(projects), { ...base, projects });
+      } catch (err) {
+        return errorResult(`Error: ${renderError(err)}`, { ...base, errorType: detectErrorType(err) });
+      }
+    },
+  };
+}

--- a/plugins/gcloud/src/tools/gcloud-projects-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-projects-list.ts
@@ -32,8 +32,10 @@ export function createGcloudProjectsListTool(pi: PluginInterface) {
 
       const api = makeExecApi(ctx.cwd);
       const args = ['projects', 'list'];
-      if (params.filter) args.push('--filter', params.filter);
-      if (params.limit !== undefined) args.push('--limit', String(params.limit));
+      // Bind value flags with the `=` form so a value beginning with `-` can never be
+      // re-tokenised by gcloud as a separate flag (argv flag-smuggling defense).
+      if (params.filter) args.push(`--filter=${params.filter}`);
+      if (params.limit !== undefined) args.push(`--limit=${String(params.limit)}`);
 
       try {
         const raw = await execGcloudJson<unknown[]>(api, args, signal);

--- a/plugins/gcloud/src/tools/gcloud-storage-buckets-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-storage-buckets-list.ts
@@ -1,0 +1,47 @@
+import { execGcloudJson } from '../gcloud/exec';
+import { formatBucketTable, normalizeBuckets } from '../gcloud/formatters';
+import type { PluginInterface } from '../gcloud/types';
+import gcloudStorageBucketsListDescription from '../prompts/gcloud-storage-buckets-list.md' with { type: 'text' };
+import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
+
+export function createGcloudStorageBucketsListTool(pi: PluginInterface) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    filter: Type.Optional(Type.String({ description: 'gcloud --filter expression, e.g. "location=US"' })),
+    limit: Type.Optional(Type.Number({ description: 'Maximum number of buckets to return (positive integer)' })),
+  });
+
+  return {
+    name: 'gcloud_storage_buckets_list',
+    label: 'Google Cloud Storage Buckets',
+    description: gcloudStorageBucketsListDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { filter?: string; limit?: number },
+      signal: AbortSignal | undefined,
+      _onUpdate: unknown,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'gcloud_storage_buckets_list' as const };
+
+      if (params.limit !== undefined && (!Number.isInteger(params.limit) || params.limit <= 0)) {
+        return errorResult(`Error: limit must be a positive integer, got "${params.limit}".`, base);
+      }
+
+      const api = makeExecApi(ctx.cwd);
+      const args = ['storage', 'buckets', 'list'];
+      if (params.filter) args.push('--filter', params.filter);
+      if (params.limit !== undefined) args.push('--limit', String(params.limit));
+
+      try {
+        const raw = await execGcloudJson<unknown[]>(api, args, signal);
+        const buckets = normalizeBuckets(raw);
+        return textResult(formatBucketTable(buckets), { ...base, buckets });
+      } catch (err) {
+        return errorResult(`Error: ${renderError(err)}`, { ...base, errorType: detectErrorType(err) });
+      }
+    },
+  };
+}

--- a/plugins/gcloud/src/tools/gcloud-storage-buckets-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-storage-buckets-list.ts
@@ -32,8 +32,10 @@ export function createGcloudStorageBucketsListTool(pi: PluginInterface) {
 
       const api = makeExecApi(ctx.cwd);
       const args = ['storage', 'buckets', 'list'];
-      if (params.filter) args.push('--filter', params.filter);
-      if (params.limit !== undefined) args.push('--limit', String(params.limit));
+      // Bind value flags with the `=` form so a value beginning with `-` can never be
+      // re-tokenised by gcloud as a separate flag (argv flag-smuggling defense).
+      if (params.filter) args.push(`--filter=${params.filter}`);
+      if (params.limit !== undefined) args.push(`--limit=${String(params.limit)}`);
 
       try {
         const raw = await execGcloudJson<unknown[]>(api, args, signal);

--- a/plugins/gcloud/src/tools/shared.ts
+++ b/plugins/gcloud/src/tools/shared.ts
@@ -1,0 +1,99 @@
+import {
+  GcloudAuthError,
+  type GcloudExecApi,
+  GcloudNotFoundError,
+  GcloudPermissionError,
+  GcloudSessionExpiredError,
+} from '../gcloud/exec';
+import type { GcloudBucket, GcloudConfig, GcloudInstance, GcloudProject, GcloudRawResult } from '../gcloud/types';
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export type GcloudErrorType = 'auth_required' | 'session_expired' | 'not_found' | 'permission_denied' | 'exec_error';
+
+export interface GcloudToolDetails {
+  tool: string;
+  action?: string;
+  config?: GcloudConfig;
+  projects?: GcloudProject[];
+  instances?: GcloudInstance[];
+  buckets?: GcloudBucket[];
+  errorType?: GcloudErrorType;
+}
+
+// ---------------------------------------------------------------------------
+// Result helpers
+// ---------------------------------------------------------------------------
+
+export function textResult(text: string, details?: GcloudToolDetails) {
+  return { content: [{ type: 'text' as const, text }], details };
+}
+
+export function errorResult(text: string, details?: GcloudToolDetails) {
+  return { content: [{ type: 'text' as const, text }], isError: true, details };
+}
+
+export function detectErrorType(err: unknown): GcloudErrorType {
+  if (err instanceof GcloudAuthError) return 'auth_required';
+  if (err instanceof GcloudSessionExpiredError) return 'session_expired';
+  if (err instanceof GcloudPermissionError) return 'permission_denied';
+  if (err instanceof GcloudNotFoundError) return 'not_found';
+  return 'exec_error';
+}
+
+export function renderError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ---------------------------------------------------------------------------
+// Argv hygiene (shared with the gcloud_exec guard — later task)
+// ---------------------------------------------------------------------------
+
+// Blocks ASCII C0 control characters and DEL (0x7f), but allows tab (0x09),
+// LF (0x0A), and CR (0x0D) so multi-line `--filter`/`--format` expressions
+// survive intact. Uses a charCode scan (not a regex) so no control-char literal
+// appears in source and no lint suppression is needed.
+export function hasControlChars(arg: string): boolean {
+  for (let i = 0; i < arg.length; i++) {
+    const c = arg.charCodeAt(i);
+    if (c <= 8 || c === 11 || c === 12 || (c >= 14 && c <= 31) || c === 127) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Exec API factory
+// ---------------------------------------------------------------------------
+
+export function makeExecApi(cwd: string): GcloudExecApi {
+  return {
+    async exec(command: string, args: string[], options?: { signal?: AbortSignal }): Promise<GcloudRawResult> {
+      // Thread the AbortSignal so a genuine in-flight cancellation actually
+      // terminates the child. We must NOT pre-check signal.aborted to throw a
+      // "cancelled" before running, and we only wire the signal into Bun.spawn
+      // while it is still live at spawn time — handing an already-aborted
+      // (stale) signal to Bun.spawn would kill the fresh process immediately,
+      // resurrecting a false cancel from a prior multi-turn tool call. A signal
+      // that aborts *during* the run is still honored and cancels for real.
+      const signal = options?.signal;
+      const child = Bun.spawn([command, ...args], {
+        cwd,
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'pipe',
+        ...(signal && !signal.aborted ? { signal } : {}),
+      });
+      if (!child.stdout || !child.stderr) {
+        return { stdout: '', stderr: 'Failed to capture output', exitCode: 1 };
+      }
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited,
+      ]);
+      return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode: exitCode ?? 0 };
+    },
+  };
+}

--- a/plugins/gcloud/test/extension.test.ts
+++ b/plugins/gcloud/test/extension.test.ts
@@ -30,6 +30,44 @@ describe('GCloud Status extension', () => {
     }
   });
 
+  it('registers the tool set (wrapped) when gcloud is available', async () => {
+    const tools: { name: string }[] = [];
+    const mockPi = {
+      setLabel() {},
+      logger: { debug() {} },
+      registerCommand() {},
+      registerServiceStatus() {},
+      registerTool(t: { name: string }) {
+        tools.push(t);
+      },
+      typebox: {
+        Type: {
+          Object: (s: Record<string, unknown>) => s,
+          Array: (s: unknown) => ({ type: 'array', items: s }),
+          String: (o?: Record<string, unknown>) => ({ type: 'string', ...o }),
+          Number: (o?: Record<string, unknown>) => ({ type: 'number', ...o }),
+          Optional: (s: unknown) => ({ optional: true, ...((s as object) ?? {}) }),
+        },
+      },
+    };
+    await factory(mockPi);
+
+    // gcloud may be absent on the runner; when present, the full set registers.
+    if (tools.length > 0) {
+      const names = tools.map((t) => t.name).sort();
+      expect(names).toEqual(
+        [
+          'gcloud_compute_instances_list',
+          'gcloud_config_list',
+          'gcloud_exec',
+          'gcloud_help',
+          'gcloud_projects_list',
+          'gcloud_storage_buckets_list',
+        ].sort(),
+      );
+    }
+  });
+
   it('service check returns valid state', async () => {
     let checkFn: (() => Promise<{ state: string }>) | undefined;
     const mockPi = {

--- a/plugins/gcloud/test/gcloud/exec.test.ts
+++ b/plugins/gcloud/test/gcloud/exec.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  detectGcloudError,
+  GcloudAuthError,
+  GcloudExecError,
+  GcloudNotFoundError,
+  GcloudPermissionError,
+  GcloudSessionExpiredError,
+  parseGcloudJsonOutput,
+} from '../../src/gcloud/exec';
+
+// ---------------------------------------------------------------------------
+// detectGcloudError classification
+// ---------------------------------------------------------------------------
+
+describe('detectGcloudError classification', () => {
+  it('classifies auth failures', () => {
+    expect(detectGcloudError('You do not currently have an active account selected', 1)).toBeInstanceOf(
+      GcloudAuthError,
+    );
+    expect(detectGcloudError('Please run: gcloud auth login', 1)).toBeInstanceOf(GcloudAuthError);
+    expect(detectGcloudError('The account does not have any valid credentials', 1)).toBeInstanceOf(GcloudAuthError);
+    expect(detectGcloudError('No active account found', 1)).toBeInstanceOf(GcloudAuthError);
+  });
+
+  it('classifies session-expired failures', () => {
+    expect(detectGcloudError('Reauthentication required', 1)).toBeInstanceOf(GcloudSessionExpiredError);
+    expect(detectGcloudError('Reauthentication failed', 1)).toBeInstanceOf(GcloudSessionExpiredError);
+    expect(detectGcloudError('invalid_grant: Bad Request', 1)).toBeInstanceOf(GcloudSessionExpiredError);
+    expect(detectGcloudError('Token has been expired or revoked.', 1)).toBeInstanceOf(GcloudSessionExpiredError);
+  });
+
+  it('classifies permission failures', () => {
+    expect(detectGcloudError('PERMISSION_DENIED: missing scope', 1)).toBeInstanceOf(GcloudPermissionError);
+    expect(detectGcloudError('The caller does not have permission', 1)).toBeInstanceOf(GcloudPermissionError);
+    expect(detectGcloudError('Permission denied on resource', 1)).toBeInstanceOf(GcloudPermissionError);
+    expect(detectGcloudError('403 Forbidden', 1)).toBeInstanceOf(GcloudPermissionError);
+  });
+
+  it('classifies not-found failures', () => {
+    expect(detectGcloudError('NOT_FOUND: project missing', 1)).toBeInstanceOf(GcloudNotFoundError);
+    expect(detectGcloudError('The resource was not found', 1)).toBeInstanceOf(GcloudNotFoundError);
+    expect(detectGcloudError('Instance does not exist', 1)).toBeInstanceOf(GcloudNotFoundError);
+    expect(detectGcloudError('404 error', 1)).toBeInstanceOf(GcloudNotFoundError);
+  });
+
+  it('falls back to the base exec error for unmatched stderr', () => {
+    const err = detectGcloudError('some unexpected failure', 1);
+    expect(err).toBeInstanceOf(GcloudExecError);
+    expect(err).not.toBeInstanceOf(GcloudAuthError);
+  });
+
+  it('honours precedence: an auth+permission message classifies as auth', () => {
+    const err = detectGcloudError('You do not currently have an active account; permission denied', 1);
+    expect(err).toBeInstanceOf(GcloudAuthError);
+  });
+
+  it('honours precedence: a session-expired+permission message classifies as session-expired', () => {
+    const err = detectGcloudError('Reauthentication required; permission denied', 1);
+    expect(err).toBeInstanceOf(GcloudSessionExpiredError);
+  });
+
+  it('preserves the exit code on the produced error', () => {
+    expect(detectGcloudError('PERMISSION_DENIED', 2).exitCode).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseGcloudJsonOutput
+// ---------------------------------------------------------------------------
+
+describe('parseGcloudJsonOutput', () => {
+  it('parses valid JSON', () => {
+    const parsed = parseGcloudJsonOutput<{ a: number }[]>('[{"a":1}]');
+    expect(parsed).toEqual([{ a: 1 }]);
+  });
+
+  it('throws GcloudExecError on empty output', () => {
+    expect(() => parseGcloudJsonOutput('')).toThrow(GcloudExecError);
+    expect(() => parseGcloudJsonOutput('   ')).toThrow(GcloudExecError);
+  });
+
+  it('throws GcloudExecError on invalid JSON', () => {
+    expect(() => parseGcloudJsonOutput('{not json')).toThrow(GcloudExecError);
+  });
+});

--- a/plugins/gcloud/test/gcloud/formatters.test.ts
+++ b/plugins/gcloud/test/gcloud/formatters.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  basename,
+  formatBucketTable,
+  formatConfigDetail,
+  formatInstanceTable,
+  formatProjectTable,
+  normalizeBucket,
+  normalizeBuckets,
+  normalizeConfig,
+  normalizeInstance,
+  normalizeInstances,
+  normalizeProject,
+  normalizeProjects,
+} from '../../src/gcloud/formatters';
+
+// ---------------------------------------------------------------------------
+// basename helper
+// ---------------------------------------------------------------------------
+
+describe('basename', () => {
+  it('returns the last path segment of a URL', () => {
+    expect(basename('https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a')).toBe('us-central1-a');
+  });
+
+  it('returns the input unchanged when there is no slash', () => {
+    expect(basename('us-central1-a')).toBe('us-central1-a');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(basename('')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Normalizers
+// ---------------------------------------------------------------------------
+
+describe('normalizeConfig', () => {
+  it('maps nested core/compute config into a flat struct', () => {
+    const config = normalizeConfig({
+      core: { project: 'my-project', account: 'me@example.com' },
+      compute: { region: 'us-central1', zone: 'us-central1-a' },
+    });
+    expect(config).toEqual({
+      project: 'my-project',
+      account: 'me@example.com',
+      region: 'us-central1',
+      zone: 'us-central1-a',
+    });
+  });
+
+  it('defaults missing sections to empty strings', () => {
+    expect(normalizeConfig({})).toEqual({ project: '', account: '', region: '', zone: '' });
+  });
+});
+
+describe('normalizeProject', () => {
+  it('maps project fields', () => {
+    expect(
+      normalizeProject({
+        projectId: 'my-project',
+        name: 'My Project',
+        projectNumber: '123456789',
+        lifecycleState: 'ACTIVE',
+      }),
+    ).toEqual({
+      projectId: 'my-project',
+      name: 'My Project',
+      projectNumber: '123456789',
+      lifecycleState: 'ACTIVE',
+    });
+  });
+
+  it('defaults missing fields to empty strings', () => {
+    expect(normalizeProject({})).toEqual({ projectId: '', name: '', projectNumber: '', lifecycleState: '' });
+  });
+});
+
+describe('normalizeInstance', () => {
+  it('takes URL basenames for zone/machineType and extracts nested IPs', () => {
+    const inst = normalizeInstance({
+      name: 'vm-1',
+      zone: 'https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a',
+      machineType: 'https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/machineTypes/e2-medium',
+      status: 'RUNNING',
+      networkInterfaces: [{ networkIP: '10.0.0.2', accessConfigs: [{ natIP: '34.1.2.3' }] }],
+    });
+    expect(inst).toEqual({
+      name: 'vm-1',
+      zone: 'us-central1-a',
+      machineType: 'e2-medium',
+      status: 'RUNNING',
+      internalIp: '10.0.0.2',
+      externalIp: '34.1.2.3',
+    });
+  });
+
+  it('defaults missing network interfaces to empty IPs', () => {
+    const inst = normalizeInstance({ name: 'vm-2', zone: 'us-central1-b', machineType: 'e2-small', status: 'STOPPED' });
+    expect(inst).toEqual({
+      name: 'vm-2',
+      zone: 'us-central1-b',
+      machineType: 'e2-small',
+      status: 'STOPPED',
+      internalIp: '',
+      externalIp: '',
+    });
+  });
+});
+
+describe('normalizeBucket', () => {
+  it('maps camelCase fields', () => {
+    expect(
+      normalizeBucket({
+        name: 'my-bucket',
+        location: 'US',
+        storageClass: 'STANDARD',
+        timeCreated: '2021-01-01T00:00:00Z',
+      }),
+    ).toEqual({ name: 'my-bucket', location: 'US', storageClass: 'STANDARD', created: '2021-01-01T00:00:00Z' });
+  });
+
+  it('falls back to snake_case field variants', () => {
+    expect(
+      normalizeBucket({
+        name: 'my-bucket',
+        location: 'EU',
+        storage_class: 'NEARLINE',
+        creation_time: '2022-02-02T00:00:00Z',
+      }),
+    ).toEqual({ name: 'my-bucket', location: 'EU', storageClass: 'NEARLINE', created: '2022-02-02T00:00:00Z' });
+  });
+});
+
+describe('list normalizers', () => {
+  it('normalizeProjects maps over the array', () => {
+    const projects = normalizeProjects([
+      { projectId: 'a', name: 'A', projectNumber: '1', lifecycleState: 'ACTIVE' },
+      { projectId: 'b', name: 'B', projectNumber: '2', lifecycleState: 'DELETE_REQUESTED' },
+    ]);
+    expect(projects).toHaveLength(2);
+    expect(projects[0].projectId).toBe('a');
+    expect(projects[1].lifecycleState).toBe('DELETE_REQUESTED');
+  });
+
+  it('normalizeInstances maps over the array', () => {
+    const instances = normalizeInstances([
+      { name: 'vm-1', zone: 'z/us-central1-a', machineType: 'm/e2-medium', status: 'RUNNING' },
+    ]);
+    expect(instances).toHaveLength(1);
+    expect(instances[0].zone).toBe('us-central1-a');
+    expect(instances[0].machineType).toBe('e2-medium');
+  });
+
+  it('normalizeBuckets maps over the array', () => {
+    const buckets = normalizeBuckets([{ name: 'b1', location: 'US', storage_class: 'STANDARD', creation_time: 't' }]);
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].storageClass).toBe('STANDARD');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+
+describe('formatConfigDetail', () => {
+  it('renders all fields', () => {
+    const out = formatConfigDetail({
+      project: 'my-project',
+      account: 'me@example.com',
+      region: 'us-central1',
+      zone: 'us-central1-a',
+    });
+    expect(out).toBe(
+      [
+        '**Project:** my-project',
+        '**Account:** me@example.com',
+        '**Region:** us-central1',
+        '**Zone:** us-central1-a',
+      ].join('\n'),
+    );
+  });
+
+  it('renders - for missing fields', () => {
+    const out = formatConfigDetail({ project: '', account: '', region: '', zone: '' });
+    expect(out).toBe(['**Project:** -', '**Account:** -', '**Region:** -', '**Zone:** -'].join('\n'));
+  });
+});
+
+describe('formatProjectTable', () => {
+  it('returns empty state when list is empty', () => {
+    expect(formatProjectTable([])).toBe('No projects found.');
+  });
+
+  it('renders header, separator and rows', () => {
+    const out = formatProjectTable([
+      { projectId: 'a', name: 'A', projectNumber: '1', lifecycleState: 'ACTIVE' },
+      { projectId: 'b', name: '', projectNumber: '2', lifecycleState: 'ACTIVE' },
+    ]);
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('| Project ID | Name | Number | State |');
+    expect(lines[1]).toBe('|------------|------|--------|-------|');
+    expect(lines[2]).toBe('| a | A | 1 | ACTIVE |');
+    expect(lines[3]).toBe('| b | - | 2 | ACTIVE |');
+  });
+});
+
+describe('formatInstanceTable', () => {
+  it('returns empty state when list is empty', () => {
+    expect(formatInstanceTable([])).toBe('No instances found.');
+  });
+
+  it('renders header, separator and rows with - for empty IPs', () => {
+    const out = formatInstanceTable([
+      {
+        name: 'vm-1',
+        zone: 'us-central1-a',
+        machineType: 'e2-medium',
+        status: 'RUNNING',
+        internalIp: '10.0.0.2',
+        externalIp: '34.1.2.3',
+      },
+      {
+        name: 'vm-2',
+        zone: 'us-central1-b',
+        machineType: 'e2-small',
+        status: 'STOPPED',
+        internalIp: '',
+        externalIp: '',
+      },
+    ]);
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('| Name | Zone | Machine Type | Status | Internal IP | External IP |');
+    expect(lines[1]).toBe('|------|------|--------------|--------|-------------|-------------|');
+    expect(lines[2]).toBe('| vm-1 | us-central1-a | e2-medium | RUNNING | 10.0.0.2 | 34.1.2.3 |');
+    expect(lines[3]).toBe('| vm-2 | us-central1-b | e2-small | STOPPED | - | - |');
+  });
+});
+
+describe('formatBucketTable', () => {
+  it('returns empty state when list is empty', () => {
+    expect(formatBucketTable([])).toBe('No buckets found.');
+  });
+
+  it('renders header, separator and rows', () => {
+    const out = formatBucketTable([
+      { name: 'b1', location: 'US', storageClass: 'STANDARD', created: '2021-01-01T00:00:00Z' },
+      { name: 'b2', location: 'EU', storageClass: 'NEARLINE', created: '' },
+    ]);
+    const lines = out.split('\n');
+    expect(lines[0]).toBe('| Name | Location | Storage Class | Created |');
+    expect(lines[1]).toBe('|------|----------|---------------|---------|');
+    expect(lines[2]).toBe('| b1 | US | STANDARD | 2021-01-01T00:00:00Z |');
+    expect(lines[3]).toBe('| b2 | EU | NEARLINE | - |');
+  });
+});

--- a/plugins/gcloud/test/tools/gcloud-compute-instances-list.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-compute-instances-list.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+import { createGcloudComputeInstancesListTool } from '../../src/tools/gcloud-compute-instances-list';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Number: (opts?: Record<string, unknown>) => ({ type: 'number', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createGcloudComputeInstancesListTool metadata', () => {
+  const tool = createGcloudComputeInstancesListTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('gcloud_compute_instances_list');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Google Cloud Compute Instances');
+  });
+
+  it('has a description mentioning gcloud', () => {
+    expect(tool.description).toContain('gcloud');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('gcloud_compute_instances_list input validation', () => {
+  const tool = createGcloudComputeInstancesListTool({ typebox: mockTypebox });
+
+  it('rejects an invalid zone', async () => {
+    const r = await tool.execute('id', { zone: 'Not_A_Zone' }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('zone');
+  });
+
+  it('rejects a zone with shell metacharacters', async () => {
+    const r = await tool.execute('id', { zone: 'us-central1-a; rm' }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('zone');
+  });
+
+  it('rejects a zero limit', async () => {
+    const r = await tool.execute('id', { limit: 0 }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('limit');
+  });
+
+  it('rejects a negative limit', async () => {
+    const r = await tool.execute('id', { limit: -1 }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('limit');
+  });
+
+  it('rejects a non-integer limit', async () => {
+    const r = await tool.execute('id', { limit: 3.14 }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('limit');
+  });
+
+  it('accepts a valid zone (no validation rejection before spawn)', async () => {
+    try {
+      const r = await tool.execute('id', { zone: 'us-central1-a' }, undefined, null, { cwd: '/tmp' });
+      expect(r.content[0].text).not.toContain('invalid zone');
+    } catch {
+      // gcloud CLI may be unavailable; validation passed
+    }
+  });
+});

--- a/plugins/gcloud/test/tools/gcloud-config-list.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-config-list.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test';
+import { createGcloudConfigListTool } from '../../src/tools/gcloud-config-list';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createGcloudConfigListTool metadata', () => {
+  const tool = createGcloudConfigListTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('gcloud_config_list');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Google Cloud Config');
+  });
+
+  it('has a description mentioning gcloud', () => {
+    expect(tool.description).toContain('gcloud');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});

--- a/plugins/gcloud/test/tools/gcloud-exec.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-exec.test.ts
@@ -110,6 +110,9 @@ describe('checkGcloud ALLOW', () => {
     ['list with filter + format', ['compute', 'instances', 'list', '--filter=status=RUNNING', '--format=value(name)']],
     ['leading global value flag', ['--project', 'p', 'compute', 'instances', 'list']],
     ['describe with zone', ['compute', 'instances', 'describe', 'my-vm', '--zone', 'us-central1-a']],
+    // `run` is the Cloud Run group here (not a dangerous verb); the leaf `list` is a read.
+    ['cloud run services list', ['run', 'services', 'list']],
+    ['cloud run revisions describe', ['run', 'revisions', 'describe', 'r1']],
   ];
 
   for (const [name, args] of allow) {
@@ -138,6 +141,7 @@ describe('checkGcloud BLOCK', () => {
     ['auth print-identity-token', ['auth', 'print-identity-token']],
     ['unknown verb', ['compute', 'instances', 'frobnicate', 'x']],
     ['empty', []],
+    // `run deploy` blocks via the mutating `deploy` (run itself is the Cloud Run group).
     ['run deploy', ['run', 'deploy', 'svc']],
   ];
 
@@ -161,9 +165,9 @@ describe('checkGcloud BLOCK', () => {
     expect(checkGcloud(['compute', 'instances', 'delete', 'x']).reason).toContain('delete');
   });
 
-  it('dangerous takes precedence over mutating (run deploy → run)', () => {
-    // `run` is a dangerous execution vector; it must be reported, not `deploy`.
-    expect(checkGcloud(['run', 'deploy', 'svc']).reason).toContain('run');
+  it('dangerous takes precedence over mutating (ssh + delete → ssh)', () => {
+    // A dangerous execution vector must be reported ahead of any mutating verb present.
+    expect(checkGcloud(['compute', 'ssh', 'vm', 'delete']).reason).toContain('ssh');
   });
 });
 

--- a/plugins/gcloud/test/tools/gcloud-exec.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-exec.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'bun:test';
+import { createGcloudExecTool } from '../../src/tools/gcloud-exec';
+import {
+  buildGcloudArgs,
+  checkGcloud,
+  findDangerous,
+  findMutating,
+  findVerb,
+  getPositionals,
+  isRead,
+} from '../../src/tools/gcloud-exec-guard';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Array: (items: unknown, opts?: Record<string, unknown>) => ({ type: 'array', items, ...opts }),
+  },
+};
+
+// ---------------------------------------------------------------------------
+// getPositionals — all-positionals model (NO flag-value exclusion)
+// ---------------------------------------------------------------------------
+
+describe('getPositionals', () => {
+  it('returns every non-flag token', () => {
+    expect(getPositionals(['compute', 'instances', 'list'])).toEqual(['compute', 'instances', 'list']);
+  });
+
+  it('does NOT drop the token after a flag (no flag-value exclusion)', () => {
+    // The critical anti-bug property: `--zone` does NOT consume the next token.
+    expect(getPositionals(['--zone', 'delete', 'instances', 'list'])).toEqual(['delete', 'instances', 'list']);
+  });
+
+  it('drops --flag=value forms and bare -x/--x flags', () => {
+    expect(getPositionals(['compute', 'list', '--filter=status=RUNNING', '-q'])).toEqual(['compute', 'list']);
+  });
+
+  it('keeps a leading global flag value as a positional (fail-safe)', () => {
+    expect(getPositionals(['--project', 'p', 'compute', 'instances', 'list'])).toEqual([
+      'p',
+      'compute',
+      'instances',
+      'list',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findVerb / findDangerous / findMutating / isRead
+// ---------------------------------------------------------------------------
+
+describe('findVerb', () => {
+  it('finds the leftmost recognized verb', () => {
+    expect(findVerb(['compute', 'instances', 'list'])).toBe('list');
+    expect(findVerb(['projects', 'describe', 'my-proj'])).toBe('describe');
+  });
+
+  it('returns null when no positional is a recognized verb', () => {
+    expect(findVerb(['compute', 'instances', 'frobnicate', 'x'])).toBeNull();
+  });
+});
+
+describe('findDangerous', () => {
+  it('finds a dangerous verb anywhere', () => {
+    expect(findDangerous(['compute', 'ssh', 'vm'])).toBe('ssh');
+    expect(findDangerous(['container', 'clusters', 'get-credentials', 'c'])).toBe('get-credentials');
+  });
+  it('returns null when none present', () => {
+    expect(findDangerous(['compute', 'instances', 'list'])).toBeNull();
+  });
+});
+
+describe('findMutating', () => {
+  it('finds a mutating verb anywhere', () => {
+    expect(findMutating(['compute', 'instances', 'delete', 'x'])).toBe('delete');
+    expect(findMutating(['app', 'deploy'])).toBe('deploy');
+  });
+  it('returns null when none present', () => {
+    expect(findMutating(['compute', 'instances', 'list'])).toBeNull();
+  });
+});
+
+describe('isRead', () => {
+  it('accepts exact and prefix read verbs', () => {
+    expect(isRead('list')).toBe(true);
+    expect(isRead('describe')).toBe(true);
+    expect(isRead('get-iam-policy')).toBe(true);
+    expect(isRead('list-instances')).toBe(true);
+    expect(isRead('describe-something')).toBe(true);
+  });
+  it('rejects non-read verbs', () => {
+    expect(isRead('delete')).toBe(false);
+    expect(isRead('ssh')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkGcloud — the security surface
+// ---------------------------------------------------------------------------
+
+describe('checkGcloud ALLOW', () => {
+  const allow: [string, string[]][] = [
+    ['compute instances list', ['compute', 'instances', 'list']],
+    ['projects describe', ['projects', 'describe', 'my-proj']],
+    ['projects get-iam-policy', ['projects', 'get-iam-policy', 'p']],
+    ['config list', ['config', 'list']],
+    ['version', ['version']],
+    ['info', ['info']],
+    ['list with filter + format', ['compute', 'instances', 'list', '--filter=status=RUNNING', '--format=value(name)']],
+    ['leading global value flag', ['--project', 'p', 'compute', 'instances', 'list']],
+    ['describe with zone', ['compute', 'instances', 'describe', 'my-vm', '--zone', 'us-central1-a']],
+  ];
+
+  for (const [name, args] of allow) {
+    it(`allows ${name}`, () => {
+      expect(checkGcloud(args).blocked).toBe(false);
+    });
+  }
+});
+
+describe('checkGcloud BLOCK', () => {
+  const block: [string, string[]][] = [
+    ['delete', ['compute', 'instances', 'delete', 'x']],
+    ['get-credentials', ['container', 'clusters', 'get-credentials', 'c']],
+    ['ssh', ['compute', 'ssh', 'vm']],
+    ['scp', ['compute', 'scp', 'a', 'b']],
+    ['connect', ['sql', 'connect', 'i']],
+    ['call', ['functions', 'call', 'fn']],
+    ['config set', ['config', 'set', 'x', 'y']],
+    ['add-iam-policy-binding', ['projects', 'add-iam-policy-binding', 'p', '--member', 'x', '--role', 'y']],
+    ['app deploy', ['app', 'deploy']],
+    ['auth login', ['auth', 'login']],
+    ['auth revoke', ['auth', 'revoke']],
+    ['unknown verb', ['compute', 'instances', 'frobnicate', 'x']],
+    ['empty', []],
+    ['run deploy', ['run', 'deploy', 'svc']],
+  ];
+
+  for (const [name, args] of block) {
+    it(`blocks ${name}`, () => {
+      const c = checkGcloud(args);
+      expect(c.blocked).toBe(true);
+      expect(c.reason).toBeTruthy();
+    });
+  }
+
+  it('empty gives a no-command reason', () => {
+    expect(checkGcloud([]).reason).toContain('no gcloud command');
+  });
+
+  it('dangerous verb routes to the cli-operator agent', () => {
+    expect(checkGcloud(['compute', 'ssh', 'vm']).reason).toContain('gcloud:cli-operator');
+  });
+
+  it('mutating verb names the verb', () => {
+    expect(checkGcloud(['compute', 'instances', 'delete', 'x']).reason).toContain('delete');
+  });
+
+  it('dangerous takes precedence over mutating (run deploy → run)', () => {
+    // `run` is a dangerous execution vector; it must be reported, not `deploy`.
+    expect(checkGcloud(['run', 'deploy', 'svc']).reason).toContain('run');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGcloudArgs
+// ---------------------------------------------------------------------------
+
+describe('buildGcloudArgs', () => {
+  it('appends --format=json when no --format present', () => {
+    expect(buildGcloudArgs(['compute', 'instances', 'list'])).toEqual([
+      'compute',
+      'instances',
+      'list',
+      '--format=json',
+    ]);
+  });
+
+  it('leaves --format=table(name) untouched', () => {
+    const args = ['compute', 'instances', 'list', '--format=table(name)'];
+    expect(buildGcloudArgs(args)).toEqual(args);
+  });
+
+  it('leaves a separate --format token untouched', () => {
+    const args = ['compute', 'instances', 'list', '--format', 'yaml'];
+    expect(buildGcloudArgs(args)).toEqual(args);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool metadata + execute guards
+// ---------------------------------------------------------------------------
+
+describe('createGcloudExecTool metadata', () => {
+  const tool = createGcloudExecTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('gcloud_exec');
+  });
+  it('has a label', () => {
+    expect(tool.label).toBe('Google Cloud CLI Execute');
+  });
+  it('has a description mentioning gcloud', () => {
+    expect(tool.description).toContain('gcloud');
+  });
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('createGcloudExecTool execute guards', () => {
+  const tool = createGcloudExecTool({ typebox: mockTypebox });
+
+  it('rejects empty args', async () => {
+    const r = await tool.execute('id', { args: [] }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('empty');
+  });
+
+  it('rejects a control character in an argument', async () => {
+    const NUL = String.fromCharCode(0);
+    const r = await tool.execute('id', { args: ['compute', 'instances', `list${NUL}`] }, undefined, null, {
+      cwd: '/tmp',
+    });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('control character');
+  });
+
+  it('blocks a mutating command before spawning', async () => {
+    const r = await tool.execute('id', { args: ['compute', 'instances', 'delete', 'x'] }, undefined, null, {
+      cwd: '/tmp',
+    });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('mutating');
+  });
+
+  it('blocks a dangerous command before spawning', async () => {
+    const r = await tool.execute('id', { args: ['compute', 'ssh', 'vm'] }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('gcloud:cli-operator');
+  });
+});

--- a/plugins/gcloud/test/tools/gcloud-exec.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-exec.test.ts
@@ -132,6 +132,10 @@ describe('checkGcloud BLOCK', () => {
     ['app deploy', ['app', 'deploy']],
     ['auth login', ['auth', 'login']],
     ['auth revoke', ['auth', 'revoke']],
+    // Token-minting reads print usable bearer credentials to stdout → credential
+    // exposure; they must route through the confirmed path, not the passthrough.
+    ['auth print-access-token', ['auth', 'print-access-token']],
+    ['auth print-identity-token', ['auth', 'print-identity-token']],
     ['unknown verb', ['compute', 'instances', 'frobnicate', 'x']],
     ['empty', []],
     ['run deploy', ['run', 'deploy', 'svc']],

--- a/plugins/gcloud/test/tools/gcloud-exec.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-exec.test.ts
@@ -143,6 +143,9 @@ describe('checkGcloud BLOCK', () => {
     ['empty', []],
     // `run deploy` blocks via the mutating `deploy` (run itself is the Cloud Run group).
     ['run deploy', ['run', 'deploy', 'svc']],
+    // Cloud Run Jobs / Workflows execution — `execute` is a dangerous execution vector.
+    ['run jobs execute', ['run', 'jobs', 'execute', 'my-job']],
+    ['workflows execute', ['workflows', 'execute', 'wf']],
   ];
 
   for (const [name, args] of block) {

--- a/plugins/gcloud/test/tools/gcloud-help.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-help.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test';
+import { createGcloudHelpTool } from '../../src/tools/gcloud-help';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createGcloudHelpTool metadata', () => {
+  const tool = createGcloudHelpTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('gcloud_help');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Google Cloud CLI Help');
+  });
+
+  it('has a description mentioning gcloud', () => {
+    expect(tool.description).toContain('gcloud');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('gcloud_help command path validation', () => {
+  const tool = createGcloudHelpTool({ typebox: mockTypebox });
+
+  it('rejects a dash-led command path ("-x")', async () => {
+    const r = await tool.execute('id', { command_path: '-x' }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('invalid command path');
+  });
+
+  it('rejects a path with shell metacharacters ("a; rm")', async () => {
+    const r = await tool.execute('id', { command_path: 'a; rm' }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('invalid command path');
+  });
+
+  it('rejects an uppercase path ("Foo")', async () => {
+    const r = await tool.execute('id', { command_path: 'Foo' }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('invalid command path');
+  });
+
+  it('rejects a dash-led command path part (flag smuggling)', async () => {
+    const r = await tool.execute('id', { command_path: 'compute -foo' }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('must not start with');
+  });
+
+  it('accepts a valid multi-word command path ("compute instances")', async () => {
+    try {
+      const r = await tool.execute('id', { command_path: 'compute instances' }, undefined, null, { cwd: '/tmp' });
+      expect(r.content[0].text).not.toContain('invalid command path');
+    } catch {
+      // gcloud CLI may be unavailable; validation passed
+    }
+  });
+});

--- a/plugins/gcloud/test/tools/gcloud-projects-list.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-projects-list.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test';
+import { createGcloudProjectsListTool } from '../../src/tools/gcloud-projects-list';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Number: (opts?: Record<string, unknown>) => ({ type: 'number', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createGcloudProjectsListTool metadata', () => {
+  const tool = createGcloudProjectsListTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('gcloud_projects_list');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Google Cloud Projects');
+  });
+
+  it('has a description mentioning gcloud', () => {
+    expect(tool.description).toContain('gcloud');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('gcloud_projects_list limit validation', () => {
+  const tool = createGcloudProjectsListTool({ typebox: mockTypebox });
+
+  it('rejects a zero limit', async () => {
+    const r = await tool.execute('id', { limit: 0 }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('limit');
+  });
+
+  it('rejects a negative limit', async () => {
+    const r = await tool.execute('id', { limit: -5 }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('limit');
+  });
+
+  it('rejects a non-integer limit', async () => {
+    const r = await tool.execute('id', { limit: 2.5 }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('limit');
+  });
+
+  it('accepts a valid positive integer limit (no validation rejection before spawn)', async () => {
+    try {
+      const r = await tool.execute('id', { limit: 10 }, undefined, null, { cwd: '/tmp' });
+      expect(r.content[0].text).not.toContain('limit must');
+    } catch {
+      // gcloud CLI may be unavailable; validation passed
+    }
+  });
+});

--- a/plugins/gcloud/test/tools/gcloud-storage-buckets-list.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-storage-buckets-list.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test';
+import { createGcloudStorageBucketsListTool } from '../../src/tools/gcloud-storage-buckets-list';
+
+const mockTypebox = {
+  Type: {
+    Object: (schema: Record<string, unknown>) => schema,
+    String: (opts?: Record<string, unknown>) => ({ type: 'string', ...opts }),
+    Number: (opts?: Record<string, unknown>) => ({ type: 'number', ...opts }),
+    Optional: (schema: unknown) => ({ optional: true, ...((schema as object) ?? {}) }),
+  },
+};
+
+describe('createGcloudStorageBucketsListTool metadata', () => {
+  const tool = createGcloudStorageBucketsListTool({ typebox: mockTypebox });
+
+  it('has correct name', () => {
+    expect(tool.name).toBe('gcloud_storage_buckets_list');
+  });
+
+  it('has a label', () => {
+    expect(tool.label).toBe('Google Cloud Storage Buckets');
+  });
+
+  it('has a description mentioning gcloud', () => {
+    expect(tool.description).toContain('gcloud');
+  });
+
+  it('has an execute function', () => {
+    expect(typeof tool.execute).toBe('function');
+  });
+});
+
+describe('gcloud_storage_buckets_list limit validation', () => {
+  const tool = createGcloudStorageBucketsListTool({ typebox: mockTypebox });
+
+  it('rejects a zero limit', async () => {
+    const r = await tool.execute('id', { limit: 0 }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('limit');
+  });
+
+  it('rejects a non-integer limit', async () => {
+    const r = await tool.execute('id', { limit: 1.1 }, undefined, null, { cwd: '/tmp' });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toContain('limit');
+  });
+});

--- a/plugins/gcloud/test/tools/shared.test.ts
+++ b/plugins/gcloud/test/tools/shared.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  GcloudAuthError,
+  GcloudExecError,
+  GcloudNotFoundError,
+  GcloudPermissionError,
+  GcloudSessionExpiredError,
+} from '../../src/gcloud/exec';
+import { detectErrorType, hasControlChars } from '../../src/tools/shared';
+
+// ---------------------------------------------------------------------------
+// Argv hygiene
+// ---------------------------------------------------------------------------
+
+const NUL = String.fromCharCode(0);
+const BEL = String.fromCharCode(7);
+const VT = String.fromCharCode(11);
+const FF = String.fromCharCode(12);
+const US = String.fromCharCode(31);
+const TAB = String.fromCharCode(9);
+const LF = String.fromCharCode(10);
+const CR = String.fromCharCode(13);
+const DEL = String.fromCharCode(127);
+
+describe('hasControlChars', () => {
+  it('rejects control bytes and DEL', () => {
+    expect(hasControlChars(`a${NUL}b`)).toBe(true);
+    expect(hasControlChars(`a${BEL}b`)).toBe(true);
+    expect(hasControlChars(`a${VT}b`)).toBe(true);
+    expect(hasControlChars(`a${FF}b`)).toBe(true);
+    expect(hasControlChars(`a${US}b`)).toBe(true);
+    expect(hasControlChars(`a${DEL}b`)).toBe(true);
+  });
+
+  it('allows plain text, tab, LF, CR, and a JMESPath-ish string', () => {
+    expect(hasControlChars('plain text')).toBe(false);
+    expect(hasControlChars(`a${TAB}b`)).toBe(false);
+    expect(hasControlChars(`a${LF}b`)).toBe(false);
+    expect(hasControlChars(`a${CR}b`)).toBe(false);
+    expect(hasControlChars("a[?x=='y'] || b")).toBe(false);
+    expect(hasControlChars('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectErrorType mapping (class -> enum)
+// ---------------------------------------------------------------------------
+
+describe('detectErrorType mapping', () => {
+  it('maps each Gcloud error class to its enum', () => {
+    expect(detectErrorType(new GcloudAuthError('x'))).toBe('auth_required');
+    expect(detectErrorType(new GcloudSessionExpiredError('x'))).toBe('session_expired');
+    expect(detectErrorType(new GcloudPermissionError('x'))).toBe('permission_denied');
+    expect(detectErrorType(new GcloudNotFoundError('x'))).toBe('not_found');
+    expect(detectErrorType(new GcloudExecError('x'))).toBe('exec_error');
+  });
+
+  it('maps unknown/non-gcloud errors to exec_error', () => {
+    expect(detectErrorType(new Error('x'))).toBe('exec_error');
+    expect(detectErrorType('not an error')).toBe('exec_error');
+  });
+});


### PR DESCRIPTION
## Summary

Final spec of the CLI-plugin parity program. Builds the gcloud plugin's tool layer from zero (it was status-only) up to the [CLI-Plugin Capability Contract](.plans/cli-plugin-contract.md), using the merged **aws** (Spec 5) plugin for structure and the **azure** (Spec 1) guard for the deep leaf-verb grammar model.

Delivers every contract dimension for gcloud:

- **Execution & hygiene** — `src/gcloud/exec.ts` + signal-aware `makeExecApi` (`Bun.spawn`, no shell) + charCode `hasControlChars` in `src/tools/shared.ts`.
- **Error taxonomy** — `Gcloud{Exec,Auth,SessionExpired,NotFound,Permission}Error` + `detectGcloudError` (precedence auth→session→permission→not-found→generic), surfaced as `details.errorType` via a central `withErrorType` wrapper.
- **`gcloud_exec` read-only guard** (`gcloud-exec-guard.ts`) — **all-positionals, fail-safe** model (immune by construction to the flag-value-exclusion / cluster bypass class): leftmost-verb read allowlist, scan-anywhere dangerous + mutating denylists, `get-credentials` / `print-*-token` / `ssh` / `scp` / `connect` / `call` treated as execution/credential vectors.
- **Discovery** — `gcloud_help` + `--filter` (server) vs `--format` (client) query docs.
- **Typed reads + formatters** — `gcloud_config_list`, `gcloud_projects_list`, `gcloud_compute_instances_list`, `gcloud_storage_buckets_list`; value flags `=`-bound (argv flag-smuggling defense).
- **Benchmark + autoresearch** — mock-gcloud + fixtures + scenarios (composite metric) + the autoresearch trio.

## Verification

- `bun test` — 145 pass / 0 fail (11 files)
- `bun run benchmarks/scenarios.ts` — composite_score ≈ 0.53, live_accuracy 1.0, exit 0
- `bash autoresearch.checks.sh` — all checks + security invariants pass
- `npx biome ci plugins/gcloud` — exit 0

Built via subagent-driven development (implementer + reviewer per task); the guard passed a dedicated adversarial review (no bypass found) and the whole branch passed a final review. Two security findings surfaced by automated review were fixed at source: token-minting verbs reclassified as dangerous (credential exposure), and typed-tool value flags bound with the `=` form.

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)