### PR TITLE
Drive the CLI-Plugin Capability Contract matrix to legitimately all-green

### DIFF
--- a/.plans/cli-plugin-contract.md
+++ b/.plans/cli-plugin-contract.md
@@ -65,5 +65,5 @@ Legend: ✅ present · ◑ partial · ❌ missing
 
 The parity program (Specs 1–6, plus the follow-on hardening) is complete: every plugin
 conforms on every dimension. `confirmed-mutation` is `n/a` where a plugin exposes only
-read tools (azure, aws, gcloud, GitLab, salesforce) and `✅` for GitHub, the one plugin
+read tools (Azure, aws, gcloud, GitLab, salesforce) and `✅` for GitHub, the one plugin
 with purpose-built mutating tools (`gh_pr_checkout`/`gh_pr_push`) behind `ctx.ui.confirm`.

--- a/.plans/cli-plugin-contract.md
+++ b/.plans/cli-plugin-contract.md
@@ -51,17 +51,19 @@ Legend: ✅ present · ◑ partial · ❌ missing
 
 | Dimension | Azure | aws | gcloud | GitLab | salesforce | GitHub |
 |---|---|---|---|---|---|---|
-| 1 argv/no-shell | ✅ | n/a | ✅ | ✅ | ✅ | ✅ |
-| 1 control-char hygiene | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| 1 signal-aware exec | ❌ | n/a | ✅ | ❌ | ❌ | ✅ |
-| 2 `<cli>_help` tool | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| 2 query-language docs | ✅ | ❌ | ✅ | ◑ | ✅ | ◑ |
-| 3 error taxonomy | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ |
-| 4 read-only guardrail | ✅ | n/a | ✅ | n/a | n/a | ❌ |
-| 4 confirmed-mutation | n/a | n/a | n/a | n/a | n/a | ◑ (this spec) |
-| 5 typed tools + formatters | ✅ | ❌ | ✅ | ✅ | ✅ | ◑ |
+| 1 argv/no-shell | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 1 control-char hygiene | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 1 signal-aware exec | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 2 `<cli>_help` tool | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 2 query-language docs | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 3 error taxonomy | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 4 read-only guardrail | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 4 confirmed-mutation | n/a | n/a | n/a | n/a | n/a | ✅ |
+| 5 typed tools + formatters | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 6 consistency layer | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 7 tests + benchmark + autoresearch | ✅ | ◑ | ✅ | ◑ | ◑ | ◑ |
+| 7 tests + benchmark + autoresearch | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-Follow-on specs (2 GitHub, 3 GitLab, 4 salesforce, 5 aws, 6 gcloud) drive each
-column to ✅.
+The parity program (Specs 1–6, plus the follow-on hardening) is complete: every plugin
+conforms on every dimension. `confirmed-mutation` is `n/a` where a plugin exposes only
+read tools (azure, aws, gcloud, GitLab, salesforce) and `✅` for GitHub, the one plugin
+with purpose-built mutating tools (`gh_pr_checkout`/`gh_pr_push`) behind `ctx.ui.confirm`.

--- a/plugins/azure/src/tools/az-account-show.ts
+++ b/plugins/azure/src/tools/az-account-show.ts
@@ -23,7 +23,7 @@ export function createAzAccountShowTool(pi: PluginInterface) {
     async execute(
       _toolCallId: string,
       params: { action?: string; subscription?: string },
-      _signal: unknown,
+      signal: AbortSignal | undefined,
       _onUpdate: unknown,
       ctx: { cwd: string },
     ) {
@@ -44,7 +44,7 @@ export function createAzAccountShowTool(pi: PluginInterface) {
 
       try {
         if (params.action === 'list') {
-          const raw = await execAzJson<Record<string, unknown>[]>(api, ['account', 'list']);
+          const raw = await execAzJson<Record<string, unknown>[]>(api, ['account', 'list'], signal);
           let subs = raw.map(normalizeSubscription);
           if (params.subscription) {
             const filter = params.subscription.toLowerCase();
@@ -55,7 +55,7 @@ export function createAzAccountShowTool(pi: PluginInterface) {
 
         const args = ['account', 'show'];
         if (params.subscription) args.push('--subscription', params.subscription);
-        const raw = await execAzJson<Record<string, unknown>>(api, args);
+        const raw = await execAzJson<Record<string, unknown>>(api, args, signal);
         const sub = normalizeSubscription(raw);
         return textResult(formatSubscriptionDetail(sub), { ...base, subscriptions: [sub] });
       } catch (err) {

--- a/plugins/azure/src/tools/az-exec.ts
+++ b/plugins/azure/src/tools/az-exec.ts
@@ -133,7 +133,7 @@ export function createAzExecTool(pi: PluginInterface) {
     async execute(
       _toolCallId: string,
       params: { args: string[] },
-      _signal: unknown,
+      signal: AbortSignal | undefined,
       _onUpdate: unknown,
       ctx: { cwd: string },
     ) {
@@ -163,7 +163,7 @@ export function createAzExecTool(pi: PluginInterface) {
       const args = buildAzArgs(params.args);
 
       try {
-        const result = await api.exec('az', args);
+        const result = await api.exec('az', args, { signal });
         if (result.exitCode !== 0) {
           return errorResult(`az command failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`, {
             ...base,

--- a/plugins/azure/src/tools/az-group-list.ts
+++ b/plugins/azure/src/tools/az-group-list.ts
@@ -25,7 +25,7 @@ export function createAzGroupListTool(pi: PluginInterface) {
     async execute(
       _toolCallId: string,
       params: { action?: string; name?: string; subscription?: string; tag?: string },
-      _signal: unknown,
+      signal: AbortSignal | undefined,
       _onUpdate: unknown,
       ctx: { cwd: string },
     ) {
@@ -62,7 +62,7 @@ export function createAzGroupListTool(pi: PluginInterface) {
           }
           const args = ['group', 'show', '--name', params.name];
           if (params.subscription) args.push('--subscription', params.subscription);
-          const raw = await execAzJson<Record<string, unknown>>(api, args);
+          const raw = await execAzJson<Record<string, unknown>>(api, args, signal);
           const group = normalizeResourceGroup(raw);
           return textResult(formatResourceGroupTable([group]), { ...base, resourceGroups: [group] });
         }
@@ -70,7 +70,7 @@ export function createAzGroupListTool(pi: PluginInterface) {
         const args = ['group', 'list'];
         if (params.subscription) args.push('--subscription', params.subscription);
         if (params.tag) args.push('--tag', params.tag);
-        const raw = await execAzJson<Record<string, unknown>[]>(api, args);
+        const raw = await execAzJson<Record<string, unknown>[]>(api, args, signal);
         const groups = raw.map(normalizeResourceGroup);
         return textResult(formatResourceGroupTable(groups), { ...base, resourceGroups: groups });
       } catch (err) {

--- a/plugins/azure/src/tools/az-resource-list.ts
+++ b/plugins/azure/src/tools/az-resource-list.ts
@@ -29,7 +29,7 @@ export function createAzResourceListTool(pi: PluginInterface) {
     async execute(
       _toolCallId: string,
       params: { resource_group: string; subscription?: string; resource_type?: string },
-      _signal: unknown,
+      signal: AbortSignal | undefined,
       _onUpdate: unknown,
       ctx: { cwd: string },
     ) {
@@ -63,7 +63,7 @@ export function createAzResourceListTool(pi: PluginInterface) {
       if (params.resource_type) args.push('--resource-type', params.resource_type);
 
       try {
-        const raw = await execAzJson<Record<string, unknown>[]>(api, args);
+        const raw = await execAzJson<Record<string, unknown>[]>(api, args, signal);
         const resources = raw.map(normalizeResource);
         return textResult(formatResourceTable(resources), { ...base, resources });
       } catch (err) {

--- a/plugins/azure/src/tools/az-vm-list.ts
+++ b/plugins/azure/src/tools/az-vm-list.ts
@@ -22,7 +22,7 @@ export function createAzVmListTool(pi: PluginInterface) {
     async execute(
       _toolCallId: string,
       params: { resource_group?: string; subscription?: string; show_details?: boolean },
-      _signal: unknown,
+      signal: AbortSignal | undefined,
       _onUpdate: unknown,
       ctx: { cwd: string },
     ) {
@@ -50,7 +50,7 @@ export function createAzVmListTool(pi: PluginInterface) {
       if (params.show_details) args.push('--show-details');
 
       try {
-        const raw = await execAzJson<Record<string, unknown>[]>(api, args);
+        const raw = await execAzJson<Record<string, unknown>[]>(api, args, signal);
         const vms = raw.map(normalizeVm);
         return textResult(formatVmTable(vms), { ...base, vms });
       } catch (err) {

--- a/plugins/azure/src/tools/shared.ts
+++ b/plugins/azure/src/tools/shared.ts
@@ -1,4 +1,4 @@
-import { AzAuthError, AzNotFoundError, AzSessionExpiredError } from '../az/exec';
+import { AzAuthError, type AzExecApi, AzNotFoundError, AzSessionExpiredError } from '../az/exec';
 import type { AzRawResult, AzResource, AzResourceGroup, AzSubscription, AzVm } from '../az/types';
 
 export type AzErrorType = 'auth_required' | 'session_expired' | 'not_found' | 'exec_error';
@@ -30,10 +30,22 @@ export function detectErrorType(err: unknown): AzErrorType {
   return 'exec_error';
 }
 
-export function makeExecApi(cwd: string): { exec: (command: string, args: string[]) => Promise<AzRawResult> } {
+export function makeExecApi(cwd: string): AzExecApi {
   return {
-    async exec(command: string, args: string[]): Promise<AzRawResult> {
-      const proc = Bun.spawn([command, ...args], { cwd, stdout: 'pipe', stderr: 'pipe', env: process.env });
+    async exec(command: string, args: string[], options?: { signal?: AbortSignal }): Promise<AzRawResult> {
+      // Thread the AbortSignal so a genuine in-flight cancellation terminates the child.
+      // Only wire it in while still live at spawn time — handing an already-aborted
+      // (stale) signal to Bun.spawn would kill the fresh process immediately, resurrecting
+      // a false cancel from a prior multi-turn tool call. Do NOT pre-check signal.aborted
+      // to throw. A signal that aborts *during* the run still cancels for real.
+      const signal = options?.signal;
+      const proc = Bun.spawn([command, ...args], {
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: process.env,
+        ...(signal && !signal.aborted ? { signal } : {}),
+      });
       const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
       const exitCode = await proc.exited;
       return { stdout, stderr, exitCode };

--- a/plugins/azure/test/tools/shared.test.ts
+++ b/plugins/azure/test/tools/shared.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
 import { AzAuthError, AzExecError, AzNotFoundError, AzSessionExpiredError } from '../../src/az/exec';
 import {
   detectErrorType,
   errorResult,
+  makeExecApi,
   normalizeResource,
   normalizeResourceGroup,
   normalizeSubscription,
@@ -164,5 +165,76 @@ describe('normalizeVm', () => {
     expect(result.powerState).toBe('');
     expect(result.publicIps).toBe('');
     expect(result.fqdns).toBe('');
+  });
+});
+
+describe('makeExecApi forwards AbortSignal to Bun.spawn only while live', () => {
+  const realSpawn = Bun.spawn;
+
+  const emptyStream = () => new ReadableStream<Uint8Array>({ start: (c) => c.close() });
+  const fakeChild = () => ({
+    stdout: emptyStream(),
+    stderr: emptyStream(),
+    exited: Promise.resolve(0),
+    exitCode: 0,
+    killed: false,
+  });
+
+  let recordedOptions: { signal?: AbortSignal } | undefined;
+
+  function installSpawnSpy() {
+    recordedOptions = undefined;
+    Bun.spawn = ((_cmd: string[], options: { signal?: AbortSignal }) => {
+      recordedOptions = options;
+      return fakeChild();
+    }) as unknown as typeof Bun.spawn;
+  }
+
+  afterEach(() => {
+    Bun.spawn = realSpawn;
+  });
+
+  it('hands a live (non-aborted) signal to Bun.spawn', async () => {
+    installSpawnSpy();
+    const controller = new AbortController();
+    await makeExecApi('/tmp').exec('az', ['account', 'show'], { signal: controller.signal });
+    expect(recordedOptions).toBeDefined();
+    expect('signal' in (recordedOptions ?? {})).toBe(true);
+    expect(recordedOptions?.signal).toBe(controller.signal);
+  });
+
+  it('withholds an already-aborted (stale) signal from Bun.spawn', async () => {
+    installSpawnSpy();
+    const controller = new AbortController();
+    controller.abort(); // stale abort left over from a prior turn
+    await makeExecApi('/tmp').exec('az', ['account', 'show'], { signal: controller.signal });
+    expect(recordedOptions).toBeDefined();
+    expect('signal' in (recordedOptions ?? {})).toBe(false);
+  });
+});
+
+describe('makeExecApi live execution', () => {
+  it('a non-aborted signal still returns output', async () => {
+    const api = makeExecApi(process.cwd());
+    const controller = new AbortController();
+    const r = await api.exec('sh', ['-c', 'echo hello-live'], { signal: controller.signal });
+    expect(r.stdout.trim()).toBe('hello-live');
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('a stale, already-aborted signal does NOT false-cancel a fresh command', async () => {
+    const api = makeExecApi(process.cwd());
+    const controller = new AbortController();
+    controller.abort();
+    const r = await api.exec('sh', ['-c', 'echo still-runs'], { signal: controller.signal });
+    expect(r.stdout.trim()).toBe('still-runs');
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('runs without any signal supplied', async () => {
+    const api = makeExecApi(process.cwd());
+    const r = await api.exec('sh', ['-c', 'echo no-signal']);
+    expect(r.stdout.trim()).toBe('no-signal');
+    expect(r.exitCode).toBe(0);
   });
 });

--- a/plugins/github/src/tools/gh-exec-guard.ts
+++ b/plugins/github/src/tools/gh-exec-guard.ts
@@ -2,14 +2,9 @@
 // Keeps argv hygiene and read-only enforcement free of I/O so they are trivially testable.
 // Fail-safe allowlist design: unknown commands are blocked.
 
-// Blocks ASCII control characters except tab (0x09), LF (0x0A), and CR (0x0D),
-// so multi-line `--jq` expressions survive; plus DEL (0x7F).
-// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional argv hygiene (allow tab/LF/CR)
-const CONTROL_CHAR_PATTERN = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/;
-
-export function hasControlChars(arg: string): boolean {
-  return CONTROL_CHAR_PATTERN.test(arg);
-}
+// Argv control-char hygiene lives in ../utils/git (the single source used by every
+// gh/git spawn wrapper); re-exported here so gh_exec and its tests keep one import site.
+export { hasControlChars } from '../utils/git';
 
 // Leaf read verbs — the token immediately after the command group in `gh <group> <verb>`.
 export const READ_VERBS: ReadonlySet<string> = new Set([

--- a/plugins/github/src/utils/git.ts
+++ b/plugins/github/src/utils/git.ts
@@ -8,6 +8,36 @@ import { detectGhError } from '../gh/exec';
 import { ToolAbortError, ToolError, throwIfAborted } from './tool-errors';
 
 // ---------------------------------------------------------------------------
+// Argv hygiene (shared by every gh/git spawn wrapper below and re-exported by
+// the gh_exec guard, so control-char rejection has a single source of truth)
+// ---------------------------------------------------------------------------
+
+// Blocks ASCII C0 control characters and DEL (0x7f) but allows tab (0x09),
+// LF (0x0A), and CR (0x0D) so multi-line `--jq` expressions survive. charCode scan
+// (not a regex) so no control-char literal appears in source and no lint suppression
+// is needed.
+export function hasControlChars(arg: string): boolean {
+  for (let i = 0; i < arg.length; i++) {
+    const c = arg.charCodeAt(i);
+    if (c <= 8 || c === 11 || c === 12 || (c >= 14 && c <= 31) || c === 127) return true;
+  }
+  return false;
+}
+
+// Reject any argv element carrying a control/NUL byte before it reaches Bun.spawn.
+// A NUL malforms an execve argv; other control bytes have no legitimate place in a
+// gh/git argument. Throws a ToolError naming the offending argument.
+export function assertNoControlChars(args: readonly string[]): void {
+  for (const arg of args) {
+    if (hasControlChars(arg)) {
+      throw new ToolError(
+        `Argument contains a control character and cannot be passed to the CLI: ${JSON.stringify(arg)}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
@@ -28,6 +58,7 @@ function which(binary: string): boolean {
 
 async function runCommand(cwd: string, args: readonly string[], signal?: AbortSignal): Promise<GitCommandResult> {
   throwIfAborted(signal);
+  assertNoControlChars(args);
   const child = Bun.spawn(['git', '--no-optional-locks', ...args], {
     cwd,
     stdin: 'ignore',
@@ -294,6 +325,7 @@ export const github = {
 
   async run(cwd: string, args: string[], signal?: AbortSignal, options?: GhCommandOptions): Promise<GhCommandResult> {
     throwIfAborted(signal);
+    assertNoControlChars(args);
     if (!which('gh')) {
       throw new ToolError('GitHub CLI (gh) is not installed. Install it from https://cli.github.com/.');
     }

--- a/plugins/github/test/utils/git.test.ts
+++ b/plugins/github/test/utils/git.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { assertNoControlChars, github, hasControlChars } from '../../src/utils/git';
+
+const NUL = String.fromCharCode(0);
+const BEL = String.fromCharCode(7);
+const DEL = String.fromCharCode(127);
+
+describe('hasControlChars', () => {
+  it('rejects NUL/control/DEL bytes but allows tab, LF, CR and normal args', () => {
+    expect(hasControlChars(`a${NUL}b`)).toBe(true);
+    expect(hasControlChars(`a${BEL}b`)).toBe(true);
+    expect(hasControlChars(`a${DEL}b`)).toBe(true);
+    expect(hasControlChars('a\tb')).toBe(false);
+    expect(hasControlChars('a\nb')).toBe(false);
+    expect(hasControlChars('a\rb')).toBe(false);
+    expect(hasControlChars("pr list --jq '.[].title'")).toBe(false);
+  });
+});
+
+describe('assertNoControlChars', () => {
+  it('throws a ToolError naming the offending argument', () => {
+    expect(() => assertNoControlChars(['repo', 'view', `a${NUL}b`])).toThrow(/control character/i);
+  });
+
+  it('passes clean argv untouched', () => {
+    expect(() => assertNoControlChars(['repo', 'view', '--json', 'nameWithOwner'])).not.toThrow();
+  });
+});
+
+describe('github.run argv hygiene', () => {
+  it('rejects a control-char arg before spawning (central enforcement, no gh required)', async () => {
+    // assertNoControlChars runs before the which('gh') probe, so this is deterministic
+    // regardless of whether gh is installed — proving typed-tool argv is validated too.
+    await expect(github.run('/tmp', ['repo', 'view', `owner/repo${NUL}`])).rejects.toThrow(/control character/i);
+  });
+});

--- a/plugins/gitlab/src/prompts/glab-exec.md
+++ b/plugins/gitlab/src/prompts/glab-exec.md
@@ -10,10 +10,16 @@ Run any read-only `glab` (GitLab CLI) command. Pass arguments as an array withou
 
 ## Querying with `--output json`
 
-The GitLab CLI shapes output with `--output json` (NOT gh's `--json`/`--jq` — glab has no built-in jq projection). It emits the full JSON payload; pipe or post-process fields yourself:
+The GitLab CLI shapes output with `--output json` (NOT gh's `--json`/`--jq` — glab has no built-in field projection or jq). It emits the full JSON payload; select fields client-side yourself (the tool result is JSON you can read directly):
 
 - Full JSON: `glab issue list --output json`
 - Single resource: `glab mr view 5 --output json`
+
+Because there is no projection grammar, narrow results with glab's **server-side filter flags** (they are the query surface), then read the JSON:
+
+- Issues: `--assignee`, `--author`, `--label`, `--milestone`, `--state` (`opened`/`closed`/`all`), `--search`, `--per-page`, `--page` — e.g. `glab issue list --assignee @me --label bug --state opened --output json`
+- MRs: `--reviewer`, `--assignee`, `--label`, `--milestone`, `--state`, `--source-branch`, `--target-branch` — e.g. `glab mr list --reviewer @me --state opened --output json`
+- Pagination: `--per-page N` (default 30, max 100) plus `--page N`; there is no cursor.
 
 Note the flag differences from the GitHub CLI: glab uses `--output json` where gh uses `--json <fields>`, and glab's `glab api` body flags are `-F`/`--field` (typed field) and `-f`/`--raw-field` (raw string field) — the opposite letters carry different typing semantics than you might expect, so both trigger a POST and are blocked here.
 

--- a/plugins/gitlab/test/tools/glab-issue-list.test.ts
+++ b/plugins/gitlab/test/tools/glab-issue-list.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createGlabIssueListTool } from '../../src/tools/glab-issue-list';
+
+const mockPi = { typebox: { Type } };
+
+describe('createGlabIssueListTool', () => {
+  const tool = createGlabIssueListTool(mockPi);
+
+  it('exposes the expected tool metadata', () => {
+    expect(tool.name).toBe('glab_issue_list');
+    expect(tool.label).toBe('GitLab Issues');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('declares parameters and an execute function', () => {
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.execute).toBe('function');
+  });
+});

--- a/plugins/gitlab/test/tools/glab-issue-view.test.ts
+++ b/plugins/gitlab/test/tools/glab-issue-view.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createGlabIssueViewTool } from '../../src/tools/glab-issue-view';
+
+const mockPi = { typebox: { Type } };
+
+describe('createGlabIssueViewTool', () => {
+  const tool = createGlabIssueViewTool(mockPi);
+
+  it('exposes the expected tool metadata', () => {
+    expect(tool.name).toBe('glab_issue_view');
+    expect(tool.label).toBe('GitLab Issue');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('declares parameters and an execute function', () => {
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.execute).toBe('function');
+  });
+});

--- a/plugins/gitlab/test/tools/glab-search.test.ts
+++ b/plugins/gitlab/test/tools/glab-search.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createGlabSearchTool } from '../../src/tools/glab-search';
+
+const mockPi = { typebox: { Type } };
+
+describe('createGlabSearchTool', () => {
+  const tool = createGlabSearchTool(mockPi);
+
+  it('exposes the expected tool metadata', () => {
+    expect(tool.name).toBe('glab_search');
+    expect(tool.label).toBe('GitLab Search');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('declares parameters and an execute function', () => {
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.execute).toBe('function');
+  });
+});

--- a/plugins/gitlab/test/tools/glab-setup.test.ts
+++ b/plugins/gitlab/test/tools/glab-setup.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createGlabSetupTool } from '../../src/tools/glab-setup';
+
+const mockPi = { typebox: { Type } };
+
+describe('createGlabSetupTool', () => {
+  const tool = createGlabSetupTool(mockPi);
+
+  it('exposes the expected tool metadata', () => {
+    expect(tool.name).toBe('glab_setup');
+    expect(tool.label).toBe('GitLab Setup');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(20);
+  });
+
+  it('declares parameters and an execute function', () => {
+    expect(tool.parameters).toBeDefined();
+    expect(typeof tool.execute).toBe('function');
+  });
+});

--- a/plugins/salesforce/test/tools/sf-pipeline-report.test.ts
+++ b/plugins/salesforce/test/tools/sf-pipeline-report.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createSfPipelineReportTool } from '../../src/tools/sf-pipeline-report';
+
+const mockPi = { typebox: { Type }, logger: { debug() {} } };
+
+describe('createSfPipelineReportTool', () => {
+  it('returns a tool definition with correct name and label', () => {
+    const tool = createSfPipelineReportTool(mockPi);
+    expect(tool.name).toBe('sf_pipeline_report');
+    expect(tool.label).toBe('Salesforce Pipeline Report');
+  });
+
+  it('has description loaded from prompt template', () => {
+    const tool = createSfPipelineReportTool(mockPi);
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(10);
+  });
+});
+
+describe('sf_pipeline_report execute — validation', () => {
+  it('rejects command-substitution injection in target_org', async () => {
+    const tool = createSfPipelineReportTool(mockPi);
+    const result = await tool.execute('t1', { target_org: 'bad$(id)' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid org alias');
+  });
+
+  it('rejects semicolon injection', async () => {
+    const tool = createSfPipelineReportTool(mockPi);
+    const result = await tool.execute('t1', { target_org: 'org;rm -rf /' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects pipe injection', async () => {
+    const tool = createSfPipelineReportTool(mockPi);
+    const result = await tool.execute('t1', { target_org: 'org|cat /etc/passwd' }, undefined, undefined, {
+      cwd: '/tmp',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('accepts a valid org alias without a validation error', async () => {
+    const tool = createSfPipelineReportTool(mockPi);
+    const result = await tool.execute('t1', { target_org: 'prod-org' }, undefined, undefined, { cwd: '/tmp' });
+    if (result.isError) {
+      expect(result.content[0].text).not.toContain('invalid org alias');
+    }
+  });
+
+  it('proceeds without target_org', async () => {
+    const tool = createSfPipelineReportTool(mockPi);
+    const result = await tool.execute('t1', {}, undefined, undefined, { cwd: '/tmp' });
+    if (result.isError) {
+      expect(result.content[0].text).not.toContain('invalid org alias');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The conformance matrix in `.plans/cli-plugin-contract.md` was written at the start of the parity program and never updated as Specs 1–6 merged, so it understated five of six plugins and mislabeled the read-only-guardrail cells for aws/gitlab/salesforce as `n/a`. Two read-only audits established the true state; this PR makes the matrix **legitimately** all-✅ — updating the doc AND closing the handful of small, genuine code/test gaps so no ✅ is aspirational.

### Code/test gaps closed (audited)
- **azure** — `makeExecApi` now threads `AbortSignal` into `Bun.spawn` (aws pattern: wire only while live, never pre-check `aborted`); signal passed through `az_exec` + the 4 typed tools. Dimension 1 (signal-aware exec). Spawn-spy + live-exec tests added.
- **github** — `hasControlChars` hoisted into `src/utils/git.ts` (single source) + `assertNoControlChars` called in `github.run` and the git `runCommand`, so **every** `gh`/`git` spawn rejects control/NUL bytes (previously only `gh_exec` did). Dimension 1 (control-char hygiene). `test/utils/git.test.ts` added.
- **gitlab** — enriched `glab-exec.md` query docs (server-side filter flags, pagination, client-side projection note); added per-tool tests for `glab_issue_list`, `glab_issue_view`, `glab_search`, `glab_setup`. Dimensions 2 + 7.
- **salesforce** — added `sf_pipeline_report` test (metadata + `target_org` injection validation). Dimension 7.

### Matrix
Updated every column to the verified current state. Every dimension is now ✅; `confirmed-mutation` is `n/a` for the read-only plugins (azure/aws/gcloud/gitlab/salesforce) and ✅ for GitHub (the one plugin with `ctx.ui.confirm`-gated mutating tools).

Note: github was found to be **already** conformant on `gh_help`, error taxonomy, guard, confirmed-mutation, typed tools, and benchmark — these live in the monolithic `gh.ts`/`gh/exec.ts` and an earlier `ls *-help.ts` grep missed them. The only real github gap was the control-char hoist above.

## Verification

- Per touched plugin: `bun test` green, `npx biome ci` exit 0.
  - salesforce shows 1 pre-existing failure (`extension-load.test.ts` session_start hook) unrelated to this change and not a CI gate; the new `sf_pipeline_report` test passes.
- Doc lint parity: no changed `.md` line ≥ 400 chars; brand terminology correct; no "blank lines" phrasing.

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)