### PR TITLE
fix(ci): repair + enforce plugin version auto-increment

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -9,12 +9,14 @@ on:
       - "plugins/**"
       - ".xcsh-plugin/**"
       - "scripts/validate-plugins.sh"
+      - "scripts/check-version-bumps.sh"
   push:
     branches: [main]
     paths:
       - "plugins/**"
       - ".xcsh-plugin/**"
       - "scripts/validate-plugins.sh"
+      - "scripts/check-version-bumps.sh"
 
 permissions:
   contents: read
@@ -32,6 +34,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # Full history so check-version-bumps.sh can diff against the PR base sha.
+          fetch-depth: 0
 
       - name: Install jq
         run: |
@@ -41,3 +46,9 @@ jobs:
 
       - name: Run plugin validation
         run: ./scripts/validate-plugins.sh
+
+      - name: Enforce plugin version bumps
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: ./scripts/check-version-bumps.sh "$BASE_SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,6 +299,13 @@ apply what fits.
 
 ### Local checks vs CI
 
+- Install the hooks once per clone: `pre-commit install`. Until you do, the local hooks
+  (including the plugin version auto-bump — `scripts/pre-commit-local.sh` →
+  `scripts/auto-bump-version.sh`, which patch-bumps any plugin whose content you staged)
+  do not run. The bump requirement is enforced regardless by CI
+  (`scripts/check-version-bumps.sh` in the `Validate Plugins` workflow): a PR that changes
+  a plugin's content without bumping its version fails. For a `minor`/`major` bump, or to
+  bump without the hook, run `scripts/bump-version.sh <plugin> <major|minor|patch>`.
 - The authoritative lint gate is CI's `Lint Code Base` (Super-Linter). It runs more
   validators than the local `pre-commit` hooks — notably textlint (`NATURAL_LANGUAGE`)
   prose and terminology, which `pre-commit` does not run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,13 +299,6 @@ apply what fits.
 
 ### Local checks vs CI
 
-- Install the hooks once per clone: `pre-commit install`. Until you do, the local hooks
-  (including the plugin version auto-bump — `scripts/pre-commit-local.sh` →
-  `scripts/auto-bump-version.sh`, which patch-bumps any plugin whose content you staged)
-  do not run. The bump requirement is enforced regardless by CI
-  (`scripts/check-version-bumps.sh` in the `Validate Plugins` workflow): a PR that changes
-  a plugin's content without bumping its version fails. For a `minor`/`major` bump, or to
-  bump without the hook, run `scripts/bump-version.sh <plugin> <major|minor|patch>`.
 - The authoritative lint gate is CI's `Lint Code Base` (Super-Linter). It runs more
   validators than the local `pre-commit` hooks — notably textlint (`NATURAL_LANGUAGE`)
   prose and terminology, which `pre-commit` does not run.

--- a/scripts/auto-bump-version.sh
+++ b/scripts/auto-bump-version.sh
@@ -80,11 +80,16 @@ for plugin_name in "${STAGED_PLUGINS[@]}"; do
   echo "auto-bump: bumping '$plugin_name' patch ($head_version → patch)"
   "$REPO_ROOT/scripts/bump-version.sh" "$plugin_name" patch
 
-  # Stage the version file changes produced by bump-version.sh.
+  # Stage the version file changes produced by bump-version.sh. bump-version.sh also
+  # rewrites the plugin's package.json (version + xcsh.version) when present, so stage
+  # it too — otherwise the auto-bump commit would leave package.json dirty/unstaged,
+  # reintroducing the very drift this prevents.
+  pkg_json_abs="$REPO_ROOT/plugins/${plugin_name}/package.json"
   git -C "$REPO_ROOT" add \
     "$plugin_json_abs" \
     "$MARKETPLACE" \
     "$REPO_ROOT/CHANGELOG.md"
+  [[ -f "$pkg_json_abs" ]] && git -C "$REPO_ROOT" add "$pkg_json_abs"
 
   echo "auto-bump: staged version files for '$plugin_name'"
 done

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -110,6 +110,16 @@ for name in "${PLUGINS[@]}"; do
   jq --arg v "$NEW_VER" '.version = $v' \
     "$PLUGIN_JSON" >"$PLUGIN_JSON.tmp" && command mv "$PLUGIN_JSON.tmp" "$PLUGIN_JSON"
 
+  # Keep package.json in lockstep when present (TS plugins carry a separate `version`
+  # and `xcsh.version`). package.json is not release-authoritative — marketplace.json +
+  # plugin.json are — but syncing it prevents the manifests from drifting.
+  PKG_JSON="$REPO_ROOT/plugins/$name/package.json"
+  if [[ -f "$PKG_JSON" ]]; then
+    jq --arg v "$NEW_VER" \
+      '.version = $v | (if .xcsh then .xcsh.version = $v else . end)' \
+      "$PKG_JSON" >"$PKG_JSON.tmp" && command mv "$PKG_JSON.tmp" "$PKG_JSON"
+  fi
+
   echo "  $name: $OLD_VER → $NEW_VER"
   CHANGELOG_ENTRIES+=("- **$name** bumped to v$NEW_VER")
 done
@@ -118,14 +128,28 @@ done
 
 CHANGELOG="$REPO_ROOT/CHANGELOG.md"
 if [[ -f "$CHANGELOG" ]]; then
-  # Build the insertion block
-  INSERT=""
+  # Build the insertion block: a leading blank line, entries separated by blank lines
+  # (matching the loose-list style under "## [Unreleased]"), and a trailing newline.
+  INSERT=$'\n'
+  first=true
   for entry in "${CHANGELOG_ENTRIES[@]}"; do
-    INSERT="${INSERT}\n${entry}"
+    if $first; then
+      INSERT+="$entry"
+      first=false
+    else
+      INSERT+=$'\n\n'"$entry"
+    fi
   done
+  INSERT+=$'\n'
 
-  # Insert after the ## [Unreleased] line
-  sed -i "s/^## \[Unreleased\]$/\0\n${INSERT}/" "$CHANGELOG"
+  # Insert immediately after the "## [Unreleased]" line. Portable in-place edit
+  # (awk + temp file via ENVIRON, preserving real newlines) — avoids the GNU-only
+  # `sed -i` that breaks on BSD/macOS.
+  export INSERT
+  awk '
+    { print }
+    !inserted && /^## \[Unreleased\]$/ { printf "%s", ENVIRON["INSERT"]; inserted = 1 }
+  ' "$CHANGELOG" >"$CHANGELOG.tmp" && command mv "$CHANGELOG.tmp" "$CHANGELOG"
   echo ""
   echo "Updated CHANGELOG.md — edit the entries before committing."
 fi

--- a/scripts/check-version-bumps.sh
+++ b/scripts/check-version-bumps.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# check-version-bumps.sh — CI gate.
+#
+# Fails when a plugin's CONTENT changed versus BASE_REF but its version was not bumped,
+# so plugin changes can never merge unreleased (release-plugins.yml only tags a plugin
+# whose marketplace.json version changed). Enforcement is here in CI, independent of
+# whether a contributor installed the local auto-bump pre-commit hook.
+#
+# Mirrors the bump-eligibility logic in scripts/auto-bump-version.sh: version/metadata
+# files do not count as content, and brand-new plugins (no version at BASE) are skipped.
+#
+# Usage: check-version-bumps.sh <base-ref>
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASE_REF="${1:-}"
+[[ -n "$BASE_REF" ]] || {
+  echo "usage: $(basename "$0") <base-ref>" >&2
+  exit 2
+}
+
+# Files that do NOT count as "content" for bump-eligibility (they ARE the bump, or are
+# repo-level release bookkeeping).
+is_version_file() {
+  case "$1" in
+  plugins/*/.xcsh-plugin/plugin.json) return 0 ;;
+  .xcsh-plugin/marketplace.json) return 0 ;;
+  CHANGELOG.md) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+# Collect plugins that have non-version content changes vs the base.
+declare -a CHANGED_PLUGINS=()
+SEEN=""
+while IFS= read -r f; do
+  [[ "$f" =~ ^plugins/([^/]+)/ ]] || continue
+  is_version_file "$f" && continue
+  p="${BASH_REMATCH[1]}"
+  [[ " $SEEN " == *" $p "* ]] && continue
+  CHANGED_PLUGINS+=("$p")
+  SEEN="$SEEN $p"
+done < <(git -C "$REPO_ROOT" diff --name-only "$BASE_REF" HEAD)
+
+if [[ ${#CHANGED_PLUGINS[@]} -eq 0 ]]; then
+  echo "check-version-bumps: no plugin content changes — OK"
+  exit 0
+fi
+
+FAILED=0
+for p in "${CHANGED_PLUGINS[@]}"; do
+  rel="plugins/$p/.xcsh-plugin/plugin.json"
+
+  # New plugin (no version at base) — initial version is set manually; skip.
+  base_ver=$(git -C "$REPO_ROOT" show "$BASE_REF:$rel" 2>/dev/null | jq -r '.version // empty') || base_ver=""
+  if [[ -z "$base_ver" ]]; then
+    echo "check-version-bumps: '$p' is new (no version at base) — skipping"
+    continue
+  fi
+
+  head_ver=$(jq -r '.version // empty' "$REPO_ROOT/$rel" 2>/dev/null) || head_ver=""
+  if [[ -z "$head_ver" ]]; then
+    echo "::error::Plugin '$p' is missing $rel .version"
+    FAILED=1
+    continue
+  fi
+
+  if [[ "$head_ver" == "$base_ver" ]]; then
+    echo "::error::Plugin '$p' changed content but its version was not bumped (still $base_ver). Run: scripts/bump-version.sh $p <patch|minor|major>"
+    FAILED=1
+  else
+    echo "check-version-bumps: '$p' bumped $base_ver → $head_ver ✓"
+  fi
+done
+
+if [[ $FAILED -ne 0 ]]; then
+  exit 1
+fi
+echo "check-version-bumps: OK"

--- a/scripts/check-version-bumps.sh
+++ b/scripts/check-version-bumps.sh
@@ -58,6 +58,13 @@ for p in "${CHANGED_PLUGINS[@]}"; do
     continue
   fi
 
+  # Removed/renamed plugin — plugin.json is gone at HEAD; nothing to bump. Skip so
+  # legitimate deletion/rename PRs are not blocked by an unsatisfiable version check.
+  if [[ ! -f "$REPO_ROOT/$rel" ]]; then
+    echo "check-version-bumps: '$p' removed at HEAD — skipping"
+    continue
+  fi
+
   head_ver=$(jq -r '.version // empty' "$REPO_ROOT/$rel" 2>/dev/null) || head_ver=""
   if [[ -z "$head_ver" ]]; then
     echo "::error::Plugin '$p' is missing $rel .version"

--- a/scripts/pre-commit-local.sh
+++ b/scripts/pre-commit-local.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# pre-commit-local.sh — repository-specific pre-commit hooks.
+#
+# Dispatched by the `local-hooks` entry in .pre-commit-config.yaml, which runs this
+# file only when it exists and is executable (`if [ -x scripts/pre-commit-local.sh ]`).
+# Add repo-local hook invocations here.
+#
+# NOTE: the pre-commit framework must be installed for this to run on commit —
+# `pre-commit install` (see CONTRIBUTING.md). The authoritative enforcement is the
+# CI gate (scripts/check-version-bumps.sh, run by .github/workflows/validate-plugins.yml);
+# this hook is the local convenience that patch-bumps automatically so you rarely hit it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Auto patch-bump any plugin whose content files are staged (unless already bumped).
+"$REPO_ROOT/scripts/auto-bump-version.sh"


### PR DESCRIPTION
## Summary

Effort A of #822. Plugin version auto-increment was non-functional and unenforced, so plugin changes merged without a bump and `release-plugins.yml` (release-on-version-change) skipped them — the entire July parity program shipped to `main` but was never released.

- **A1 — restore the orphaned auto-bump hook.** `scripts/auto-bump-version.sh` was referenced by nothing. `.pre-commit-config.yaml`'s `local-hooks` entry runs `scripts/pre-commit-local.sh` *if present* — and that dispatcher was never committed. This adds it (invoking auto-bump) + a `pre-commit install` note in CONTRIBUTING.
- **A2 — CI enforcement.** New `scripts/check-version-bumps.sh` + wired into the `Validate Plugins` workflow (`fetch-depth: 0` + a PR-base diff step): a PR that changes a plugin's content without bumping its `plugin.json` version now **fails CI**, independent of whether a contributor installed the local hook. Mirrors the eligibility logic in `auto-bump-version.sh` (excludes version files, skips brand-new plugins).
- **A3 — fix `bump-version.sh`.** Also sync `plugins/<name>/package.json` `version` + `xcsh.version` (was drifting 1.0.0 vs plugin.json 1.1.0), and replace the GNU-only `sed -i` CHANGELOG edit with a portable awk insertion (BSD/macOS-safe).

No plugin content is touched here, so the new gate does not fire on this PR; the catch-up bumps + releases are Effort B (#822, follow-up PR).

## Verification (local)

- **Gate red/green:** on a scratch branch, a committed gcloud content change with no bump → `check-version-bumps.sh origin/main` exits 1 with an actionable `::error::`; after `bump-version.sh gcloud patch` → exits 0.
- **Dispatcher:** staging a gcloud content change and running `scripts/pre-commit-local.sh` auto-patch-bumps gcloud 1.1.0→1.1.1 and stages the version files.
- **bump-version.sh:** on macOS, a scratch bump synced `marketplace.json` + `plugin.json` + `package.json` (`version` + `xcsh.version`) + `CHANGELOG.md` cleanly (portable awk). Reverted.
- **Lint:** `shellcheck`, `yamllint`, `actionlint`, `markdownlint`, `textlint` all clean on the changed files.

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)