### PR TITLE
release: catch-up version bumps for the six CLI plugins

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "sales-engineer",
-      "description": "Sales Engineer persona framework for F5 XC demo repositories \u2014 demo execution, environment operations, presentation, Q&A, post-session debrief",
+      "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
       "version": "1.0.6",
       "author": {
         "name": "f5-sales-demo"
@@ -42,7 +42,7 @@
     },
     {
       "name": "github-ops",
-      "description": "GitHub operations automation \u2014 issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
+      "description": "GitHub operations automation — issue-driven development, PR lifecycle, CI polling, post-merge monitoring, verification, rate limit management, upstream contribution workflow, and autonomous workflow operations agent",
       "version": "2.3.1",
       "author": {
         "name": "f5-sales-demo"
@@ -57,7 +57,7 @@
     },
     {
       "name": "docs-pipeline",
-      "description": "Documentation pipeline architecture \u2014 config ownership, release dispatch chain, content authoring, managed files, local preview",
+      "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
       "version": "1.0.2",
       "author": {
         "name": "f5-sales-demo"
@@ -72,7 +72,7 @@
     },
     {
       "name": "brand",
-      "description": "F5 corporate branding enforcement \u2014 colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
+      "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
       "version": "1.0.2",
       "author": {
         "name": "f5-sales-demo"
@@ -87,7 +87,7 @@
     },
     {
       "name": "meddpicc",
-      "description": "MEDDPICC sales qualification and deal-execution framework \u2014 evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
+      "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
       "version": "2.1.0",
       "author": {
         "name": "f5-sales-demo"
@@ -112,7 +112,7 @@
     },
     {
       "name": "devcontainer",
-      "description": "Container awareness \u2014 tool catalog, self-identity, self-diagnosis, and maintenance for the f5-sales-demo devcontainer",
+      "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5-sales-demo devcontainer",
       "version": "1.1.6",
       "author": {
         "name": "f5-sales-demo"
@@ -127,7 +127,7 @@
     },
     {
       "name": "platform",
-      "description": "F5 Distributed Cloud platform automation \u2014 web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
+      "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
       "version": "3.1.1",
       "author": {
         "name": "f5-sales-demo"
@@ -156,7 +156,7 @@
     },
     {
       "name": "osint-framework",
-      "description": "OSINT Framework tool catalog and investigation skills \u2014 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
+      "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
       "version": "1.0.1",
       "author": {
         "name": "f5-sales-demo"
@@ -171,7 +171,7 @@
     },
     {
       "name": "firecrawl",
-      "description": "Local self-hosted firecrawl web scraping \u2014 scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
+      "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
       "version": "1.1.0",
       "author": {
         "name": "f5-sales-demo"
@@ -201,8 +201,8 @@
     },
     {
       "name": "salesforce",
-      "description": "Salesforce pipeline intelligence \u2014 native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.2.0",
+      "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
+      "version": "1.3.0",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -239,7 +239,7 @@
     },
     {
       "name": "cloudstatus",
-      "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API \u2014 status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
+      "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
       "version": "1.3.0",
       "author": {
         "name": "f5-sales-demo"
@@ -263,8 +263,8 @@
     },
     {
       "name": "azure",
-      "description": "Azure CLI integration \u2014 native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-      "version": "1.1.0",
+      "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
+      "version": "1.2.0",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -288,8 +288,8 @@
     },
     {
       "name": "aws",
-      "description": "AWS CLI integration \u2014 container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-      "version": "1.1.0",
+      "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
+      "version": "1.2.0",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -313,8 +313,8 @@
     },
     {
       "name": "gcloud",
-      "description": "Google Cloud CLI integration \u2014 container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
-      "version": "1.1.0",
+      "description": "Google Cloud CLI integration — container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
+      "version": "1.2.0",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -338,8 +338,8 @@
     },
     {
       "name": "gitlab",
-      "description": "GitLab CLI integration \u2014 native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via glab CLI",
-      "version": "1.1.0",
+      "description": "GitLab CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via glab CLI",
+      "version": "1.2.0",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -363,8 +363,8 @@
     },
     {
       "name": "github",
-      "description": "GitHub CLI integration \u2014 native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via gh CLI",
-      "version": "1.1.0",
+      "description": "GitHub CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via gh CLI",
+      "version": "1.2.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,31 +10,31 @@ and this project adheres to
 
 ## [Unreleased]
 
-- **azure** bumped to v1.2.0 — `az_exec` now accepts valid JMESPath `--query`
+- **`azure`** bumped to v1.2.0 — `az_exec` now accepts valid JMESPath `--query`
   (dropped the char filter that rejected `||`, backticks, and pipes); read-only guard,
   `az_help`, error taxonomy with `errorType`, and signal-aware exec. CLI-Plugin
   Capability Contract conformant.
 
-- **aws** bumped to v1.2.0 — native tool layer: `aws_exec` read-only guard, `aws_help`,
+- **`aws`** bumped to v1.2.0 — native tool layer: `aws_exec` read-only guard, `aws_help`,
   typed reads (`sts`/`s3`/`ec2`) with formatters, 6-class error taxonomy, JMESPath query
   docs, and a benchmark + autoresearch harness.
 
-- **gcloud** bumped to v1.2.0 — native tool layer built from status-only: `gcloud_exec`
+- **`gcloud`** bumped to v1.2.0 — native tool layer built from status-only: `gcloud_exec`
   read-only guard, `gcloud_help`, typed reads (config/projects/compute/storage) with
   formatters, error taxonomy, `--filter`/`--format` query docs, and a benchmark +
   autoresearch harness.
 
-- **gitlab** bumped to v1.2.0 — `glab_exec` read-only guard + `glab_help`, error taxonomy
+- **`gitlab`** bumped to v1.2.0 — `glab_exec` read-only guard + `glab_help`, error taxonomy
   with a central `errorType` wrapper, `--output json` query docs, signal-aware exec +
   control-char hygiene, adversarial guard hardening (pflag cluster and value-flag
   method-forgery fixes), and per-tool tests.
 
-- **github** bumped to v1.2.0 — `gh_exec` read-only guard plus confirmed-mutation safety
+- **`github`** bumped to v1.2.0 — `gh_exec` read-only guard plus confirmed-mutation safety
   (`gh_pr_checkout`/`gh_pr_push` behind `ctx.ui.confirm` with a headless fail-safe),
   guard hardening (boolean-cluster verb-shift and value-flag method-forgery), and
   control-char hygiene enforced across every gh/git spawn.
 
-- **salesforce** bumped to v1.3.0 — `sf_exec` read-only guard (colon-grammar normalize,
+- **`salesforce`** bumped to v1.3.0 — `sf_exec` read-only guard (colon-grammar normalize,
   `apex run` and api-body blocks) + `sf_help`, 6-class error taxonomy, adversarial guard
   hardening (pflag cluster and value-flag method-forgery fixes), and a `sf_pipeline_report`
   test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **azure** bumped to v1.2.0 — `az_exec` now accepts valid JMESPath `--query`
+  (dropped the char filter that rejected `||`, backticks, and pipes); read-only guard,
+  `az_help`, error taxonomy with `errorType`, and signal-aware exec. CLI-Plugin
+  Capability Contract conformant.
+
+- **aws** bumped to v1.2.0 — native tool layer: `aws_exec` read-only guard, `aws_help`,
+  typed reads (`sts`/`s3`/`ec2`) with formatters, 6-class error taxonomy, JMESPath query
+  docs, and a benchmark + autoresearch harness.
+
+- **gcloud** bumped to v1.2.0 — native tool layer built from status-only: `gcloud_exec`
+  read-only guard, `gcloud_help`, typed reads (config/projects/compute/storage) with
+  formatters, error taxonomy, `--filter`/`--format` query docs, and a benchmark +
+  autoresearch harness.
+
+- **gitlab** bumped to v1.2.0 — `glab_exec` read-only guard + `glab_help`, error taxonomy
+  with a central `errorType` wrapper, `--output json` query docs, signal-aware exec +
+  control-char hygiene, adversarial guard hardening (pflag cluster and value-flag
+  method-forgery fixes), and per-tool tests.
+
+- **github** bumped to v1.2.0 — `gh_exec` read-only guard plus confirmed-mutation safety
+  (`gh_pr_checkout`/`gh_pr_push` behind `ctx.ui.confirm` with a headless fail-safe),
+  guard hardening (boolean-cluster verb-shift and value-flag method-forgery), and
+  control-char hygiene enforced across every gh/git spawn.
+
+- **salesforce** bumped to v1.3.0 — `sf_exec` read-only guard (colon-grammar normalize,
+  `apex run` and api-body blocks) + `sf_help`, 6-class error taxonomy, adversarial guard
+  hardening (pflag cluster and value-flag method-forgery fixes), and a `sf_pipeline_report`
+  test.
+
 - **f5xc-github-ops** bumped to v2.3.1 — rename `local status` to
   `local http_status` in the sourced `gh-poll.sh` and `retry.sh`
   libs so the agent's polling and backoff helpers no longer fail

--- a/plugins/aws/.xcsh-plugin/plugin.json
+++ b/plugins/aws/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws",
-  "description": "AWS CLI integration \u2014 container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-  "version": "1.1.0",
+  "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
+  "version": "1.2.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/aws",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/aws/package.json
+++ b/plugins/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-aws",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "AWS CLI status for xcsh welcome screen",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "AWS",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/azure/.xcsh-plugin/plugin.json
+++ b/plugins/azure/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "azure",
-  "description": "Azure CLI integration \u2014 native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-  "version": "1.1.0",
+  "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
+  "version": "1.2.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/azure",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/azure/package.json
+++ b/plugins/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-azure",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Azure CLI tools for xcsh — native az command execution, subscription/resource/VM management, and welcome screen status",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Azure",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/gcloud/.xcsh-plugin/plugin.json
+++ b/plugins/gcloud/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gcloud",
-  "description": "Google Cloud CLI integration \u2014 container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
-  "version": "1.1.0",
+  "description": "Google Cloud CLI integration — container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
+  "version": "1.2.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/gcloud",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/gcloud/package.json
+++ b/plugins/gcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-gcloud",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Google Cloud CLI status for xcsh welcome screen",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GCloud",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/github/.xcsh-plugin/plugin.json
+++ b/plugins/github/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "description": "GitHub CLI integration — native xcsh tools (gh_repo_view, gh_issue_view, gh_pr_view, gh_pr_diff, gh_pr_checkout, gh_pr_push, gh_run_watch, gh_search_issues, gh_search_prs), profile collection, and service status",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-github",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "GitHub CLI integration for xcsh — native tools for repos, issues, PRs, diffs, Actions, and search",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GitHub",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "description": "GitHub CLI integration",
     "extensions": [
       "src/index.ts"

--- a/plugins/gitlab/.xcsh-plugin/plugin.json
+++ b/plugins/gitlab/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitlab",
   "description": "GitLab CLI integration — native xcsh tools (glab_setup, glab_issue_list, glab_issue_view, glab_search), welcome screen status, and issue management via glab CLI",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-gitlab",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "GitLab CLI integration for xcsh — native tools, welcome screen status, issue management",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GitLab",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "description": "GitLab CLI integration",
     "extensions": [
       "src/index.ts"

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/salesforce/package.json
+++ b/plugins/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-salesforce",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "Salesforce pipeline intelligence for xcsh — native tools, context discovery, pipeline reports",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Salesforce",
-    "version": "1.0.0",
+    "version": "1.3.0",
     "description": "Salesforce pipeline intelligence",
     "extensions": [
       "src/index.ts"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -121,7 +121,10 @@ for name in "${PLUGINS[@]}"; do
   fi
 
   echo "  $name: $OLD_VER → $NEW_VER"
-  CHANGELOG_ENTRIES+=("- **$name** bumped to v$NEW_VER")
+  # Backtick the plugin name (it is a literal identifier) so the CHANGELOG entry does not
+  # trip the Lint Code Base textlint terminology rule for names like azure/github/gitlab
+  # (code spans are exempt). The release-notes grep in release-plugins.yml still matches.
+  CHANGELOG_ENTRIES+=("- **\`$name\`** bumped to v$NEW_VER")
 done
 
 # ── Update CHANGELOG.md ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Effort B of #822. Everything merged since June — Specs 1–6, gcloud built from zero, all guard hardening, the conformance-matrix work — shipped to `main` but was **never released**, because the version-bump automation was broken (fixed in #823, now CI-enforced). This bumps the six CLI plugins so `release-plugins.yml` cuts releases:

- azure / aws / gcloud / gitlab / github **1.1.0 → 1.2.0**
- salesforce **1.2.0 → 1.3.0**

All four manifests per plugin (`marketplace.json`, `.xcsh-plugin/plugin.json`, `package.json` `version` + `xcsh.version`) synced via the fixed `scripts/bump-version.sh`; CHANGELOG entries hand-written. This PR dogfoods the new gate from #823 (content changed → version bumped → passes).

## UAT — real execution against the installed CLIs

`xcsh plugin link plugins/<name>` linked all six local (bumped) plugins successfully; `xcsh plugin doctor` reports healthy. Each bumped plugin's `*_exec` tool was then exercised against the **real** installed CLIs (`az`, `aws`, `gcloud`, `glab`, `sf`, `gh`) via a harness driving the tool `execute()`:

```
gcloud:     read `version` → ran real gcloud ✓ | BLOCK instances delete ✓ | BLOCK get-credentials ✓ | BLOCK control-char ✓
azure:      read `version` → ran real az ✓     | BLOCK group delete ✓
aws:        BLOCK ec2 run-instances ✓          | BLOCK s3 rm ✓
gitlab:     read `version` → glab 1.109.0 ✓     | BLOCK mr merge ✓
salesforce: read `version` → @salesforce/cli/2.144.6 ✓ | BLOCK apex run ✓
github:     read `pr list` → real authenticated results ✓ | BLOCK pr merge ✓ | BLOCK control-char ✓
```

Reads reach the real binaries; mutations, credential/execution vectors, and control-char args are all refused. Full `bun test` suites pass per plugin (automated acceptance of the shipped code); `validate-plugins.sh` and `biome ci` on the changed JSON are clean.

After merge, `release-plugins.yml` should cut six `NAME/vX.Y.Z` releases — I'll confirm via `gh release list`.

Note (follow-up, not blocking): `bump-version.sh` writes JSON via `jq`, whose formatting differs from Biome's; I ran `biome check --write` on the bumped manifests here. A small follow-up could have `bump-version.sh` run `biome format` on the files it writes so the local biome pre-commit hook never trips on an auto-bump commit.

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)