### PR TITLE
feat(meddpicc): render a deal sheet deterministically; expose the template

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework \u2014 evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/.xcsh-plugin/resources.json
+++ b/plugins/meddpicc/.xcsh-plugin/resources.json
@@ -1,13 +1,12 @@
 {
   "schema": "schema/meddpicc-schema.json",
   "example": "schema/example-deal.json",
+  "template": "skills/deal-qualification/references/meddpicc-template.xlsx",
+  "cellMapping": "skills/deal-qualification/references/cell-mapping.json",
+  "sfdcMapping": "skills/deal-qualification/references/sfdc-field-mapping.json",
   "engine": {
     "runtime": "bun",
     "entry": "engine/cli.ts",
-    "commands": ["validate", "next", "score", "check-mappings", "hint"]
-  },
-  "mappings": {
-    "cell": "skills/deal-qualification/references/cell-mapping.json",
-    "sfdc": "skills/deal-qualification/references/sfdc-field-mapping.json"
+    "commands": ["validate", "next", "score", "hint", "render", "check-mappings"]
   }
 }

--- a/plugins/meddpicc/commands/qualify-deal.md
+++ b/plugins/meddpicc/commands/qualify-deal.md
@@ -6,6 +6,12 @@ argument-hint: "[deal name or account] [--import] [--sfdc <opportunity-id>]"
 Invoke the `meddpicc:deal-qualification` skill to produce a
 MEDDPICC scorecard for the deal "$ARGUMENTS".
 
+Start by inventorying the current workspace: list the files, read
+any `*.json` conforming to the MEDDPICC schema, and treat call
+notes, briefings and transcripts alongside them as evidence. If a
+deal file for "$ARGUMENTS" already exists, resume from it rather
+than re-interviewing.
+
 **Modes:**
 
 - Default: guided interview — walks through each MEDDPICC element,
@@ -16,4 +22,7 @@ MEDDPICC scorecard for the deal "$ARGUMENTS".
   before starting the guided interview
 
 **Output:** JSON deal file (source of truth) + Markdown scorecard.
-Add "render" or "export" to also generate an XLS spreadsheet.
+Add "render" or "export" for a spreadsheet too — in an Excel task
+pane that means a deal sheet built in the open workbook from the
+engine's `render` plan; in the terminal, a populated copy of the
+shipped template.

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { computeCompletion } from './completion';
 import { computeElementHint, computeHintOverview } from './hint';
 import { checkMappings } from './mappings';
+import { renderSheet } from './render';
 import { computeScore } from './score';
 import { QUALIFICATION_ELEMENTS } from './sections';
 import { validateDeal } from './validate';
@@ -87,6 +88,18 @@ async function main(): Promise<number> {
     }
   }
 
+  if (command === 'render') {
+    const dealPath = rest[0];
+    if (!dealPath) {
+      process.stderr.write('Usage: cli.ts render <deal.json> [--cell <cell-mapping.json>]\n');
+      return 1;
+    }
+    const deal = await readJson(dealPath);
+    const cell = await readJson(flag(rest, '--cell') ?? CELL_PATH);
+    print(renderSheet(deal, cell as Parameters<typeof renderSheet>[1]));
+    return 0;
+  }
+
   if (command === 'check-mappings') {
     const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
     const cell = await readJson(flag(rest, '--cell') ?? CELL_PATH);
@@ -97,7 +110,7 @@ async function main(): Promise<number> {
   }
 
   process.stderr.write(
-    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, check-mappings\n`,
+    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, render, check-mappings\n`,
   );
   return 1;
 }

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/render.test.ts
+++ b/plugins/meddpicc/engine/render.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import { renderSheet } from './render';
+
+const cellMapping = {
+  sheetName: 'MEDDPICC Deal Review Sheet',
+  staticFields: [
+    { jsonPath: 'metadata.accountName', cell: 'B4' },
+    { jsonPath: 'metadata.winProbability', cell: 'G5', format: 'percentage' },
+    { jsonPath: 'metadata.revenue.acv', cell: 'N7', format: 'currency' },
+    { jsonPath: 'qualification.metrics.responses[0]', cell: 'C14' },
+    { jsonPath: 'threeWhys.f5.whyNow', cell: 'B36' },
+  ],
+  dynamicSections: [
+    {
+      jsonPath: 'stakeholders',
+      startRow: 41,
+      maxRows: 2,
+      columns: { name: 'B', mustSayYes: 'H' },
+      booleanFormat: { true: 'Yes', false: 'No' },
+    },
+  ],
+};
+
+const deal = {
+  metadata: {
+    accountName: 'Visa, Inc.',
+    winProbability: 0.6,
+    revenue: { acv: 473687 },
+  },
+  qualification: { metrics: { responses: ['Uptime and latency during intrusion'] } },
+  threeWhys: { f5: { whyNow: 'Cloudflare outage forced a multi-vendor strategy' } },
+  stakeholders: [
+    { name: 'Matthew Davy', mustSayYes: true },
+    { name: 'Gary Slater', mustSayYes: false },
+  ],
+  scoring: { elementScores: { metrics: 4, champion: 3 } },
+};
+
+/** Every value the plan writes, flattened — order-independent content assertions. */
+function allValues(plan: ReturnType<typeof renderSheet>): unknown[] {
+  return plan.writes.flatMap((w) => w.values.flat());
+}
+
+describe('renderSheet', () => {
+  test('names the sheet after the account, not the template', () => {
+    // The template's own sheet name is generic; a from-scratch sheet is per-deal so
+    // two reviews in one workbook do not collide.
+    const plan = renderSheet(deal, cellMapping);
+    expect(plan.sheetName).toBe('MEDDPICC — Visa, Inc.');
+  });
+
+  test('falls back to a stable sheet name when the account is missing', () => {
+    const plan = renderSheet({}, cellMapping);
+    expect(plan.sheetName).toBe('MEDDPICC Deal Review');
+  });
+
+  test('labels every mapped field from its json path', () => {
+    const values = allValues(renderSheet(deal, cellMapping));
+    expect(values).toContain('Account Name');
+    expect(values).toContain('F5 — Why Now');
+  });
+
+  test('disambiguates repeated leaf keys with their parent', () => {
+    // `threeWhys.f5.whyNow` and `threeWhys.partner.whyNow` are different questions.
+    const mapping = {
+      ...cellMapping,
+      staticFields: [
+        { jsonPath: 'threeWhys.f5.whyNow', cell: 'B36' },
+        { jsonPath: 'threeWhys.partner.whyNow', cell: 'J36' },
+      ],
+    };
+    const values = allValues(renderSheet({ threeWhys: { f5: { whyNow: 'a' }, partner: { whyNow: 'b' } } }, mapping));
+    expect(values).toContain('F5 — Why Now');
+    expect(values).toContain('Partner — Why Now');
+  });
+
+  test('numbers stay numbers so the sheet can do arithmetic', () => {
+    const values = allValues(renderSheet(deal, cellMapping));
+    // 473687 as a number, not "$473,687" — a formatted string cannot be summed, and
+    // there is no number-format host tool to undo the damage.
+    expect(values).toContain(473687);
+    expect(values).toContain(0.6);
+  });
+
+  test('carries the unit in the label rather than mangling the value', () => {
+    const values = allValues(renderSheet(deal, cellMapping));
+    // "Revenue — ACV", not a bare "ACV": the parent disambiguates it from any other acv.
+    expect(values).toContain('Revenue — ACV (USD)');
+    expect(values).toContain('Win Probability (0-1)');
+  });
+
+  test('names the fields the camelCase rule cannot recover', () => {
+    // "pAndIplusAcvx" would otherwise render as "P And Iplus Acvx".
+    const mapping = { staticFields: [{ jsonPath: 'metadata.revenue.pAndIplusAcvx', cell: 'M4', format: 'currency' }] };
+    const values = allValues(renderSheet({ metadata: { revenue: { pAndIplusAcvx: 12 } } }, mapping));
+    expect(values).toContain('P&I + ACVx (USD)');
+  });
+
+  test('renders indexed responses as numbered rows under their element', () => {
+    const values = allValues(renderSheet(deal, cellMapping));
+    expect(values).toContain('Metrics — Response 1');
+    expect(values).toContain('Uptime and latency during intrusion');
+  });
+
+  test('renders a dynamic section as a header row plus one row per item', () => {
+    const plan = renderSheet(deal, cellMapping);
+    const values = allValues(plan);
+    expect(values).toContain('Stakeholders');
+    expect(values).toContain('Name');
+    expect(values).toContain('Must Say Yes');
+    expect(values).toContain('Matthew Davy');
+    expect(values).toContain('Gary Slater');
+  });
+
+  test('applies the section booleanFormat', () => {
+    const values = allValues(renderSheet(deal, cellMapping));
+    expect(values).toContain('Yes');
+    expect(values).toContain('No');
+    expect(values).not.toContain(true);
+  });
+
+  test('truncates a dynamic section at maxRows', () => {
+    const many = { ...deal, stakeholders: [{ name: 'a' }, { name: 'b' }, { name: 'c' }] };
+    const values = allValues(renderSheet(many, cellMapping));
+    expect(values).toContain('b');
+    expect(values).not.toContain('c');
+  });
+
+  test('includes the MEDDPICC scores from the shared scoring engine', () => {
+    const values = allValues(renderSheet(deal, cellMapping));
+    expect(values).toContain('Metrics');
+    expect(values).toContain(4);
+    // computeScore fills every one of the 8 elements, absent ones as 0.
+    expect(values).toContain('Overall');
+  });
+
+  test('omits fields the deal has not filled in', () => {
+    const values = allValues(renderSheet({ metadata: { accountName: 'Visa, Inc.' } }, cellMapping));
+    expect(values).toContain('Account Name');
+    expect(values).not.toContain('Why Now');
+  });
+
+  test('emits contiguous A:B write blocks whose shape matches the address', () => {
+    const plan = renderSheet(deal, cellMapping);
+    for (const w of plan.writes) {
+      const m = w.address.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
+      expect(m).not.toBeNull();
+      const [, , top, , bottom] = m as RegExpMatchArray;
+      expect(w.values.length).toBe(Number(bottom) - Number(top) + 1);
+      const width = new Set(w.values.map((r) => r.length));
+      expect(width.size).toBe(1);
+    }
+  });
+
+  test('is deterministic — same input, byte-identical plan', () => {
+    expect(JSON.stringify(renderSheet(deal, cellMapping))).toBe(JSON.stringify(renderSheet(deal, cellMapping)));
+  });
+
+  test('never emits a leading =, +, - or @ that Excel would treat as a formula', () => {
+    const hostile = {
+      metadata: { accountName: '=cmd|/c calc' },
+      qualification: { metrics: { responses: ['+SUM(A1)'] } },
+    };
+    for (const v of allValues(renderSheet(hostile, cellMapping))) {
+      if (typeof v === 'string') expect(v.trimStart()[0] ?? '').not.toMatch(/^[=+\-@]$/);
+    }
+  });
+});

--- a/plugins/meddpicc/engine/render.ts
+++ b/plugins/meddpicc/engine/render.ts
@@ -1,0 +1,309 @@
+/**
+ * Render a deal JSON into a self-contained MEDDPICC worksheet plan.
+ *
+ * The plugin ships `meddpicc-template.xlsx`, whose layout `cell-mapping.json`
+ * describes cell by cell. That mapping only works when the template itself is open —
+ * its coordinates assume the template's merged cells, headers and banding. A task pane
+ * usually faces some other workbook, so this renderer treats the mapping as a *field
+ * inventory* (which fields belong on the sheet, in which order, with which units and
+ * which columns per table) and lays them out itself, in a fixed two-column form.
+ *
+ * The content is therefore exactly the official sheet's content; only the arrangement
+ * is ours, and it is fixed in code rather than improvised per run. `renderSheet` is
+ * pure and deterministic: same deal in, byte-identical plan out.
+ *
+ * Output is a list of `write_range`-shaped operations (`address` + 2D `values`), so a
+ * caller can execute the plan without deciding anything.
+ */
+import { computeScore } from './score';
+import { QUALIFICATION_ELEMENTS } from './sections';
+
+export interface SheetWrite {
+  /** A1-style range, e.g. "A1:B1". Bare — the caller qualifies it with the sheet. */
+  address: string;
+  /** Rows of column values; shape always matches `address`. */
+  values: CellValue[][];
+}
+
+export interface SheetPlan {
+  sheetName: string;
+  writes: SheetWrite[];
+  /** Last row used, so a caller can append below the plan. */
+  rowCount: number;
+}
+
+export type CellValue = string | number;
+
+interface StaticField {
+  jsonPath: string;
+  cell?: string;
+  format?: string;
+}
+
+interface DynamicSection {
+  jsonPath: string;
+  maxRows?: number;
+  columns?: Record<string, string>;
+  booleanFormat?: { true?: string; false?: string };
+}
+
+export interface CellMapping {
+  sheetName?: string;
+  staticFields?: StaticField[];
+  dynamicSections?: DynamicSection[];
+}
+
+/** Sheet name when the deal carries no account — stable, never empty. */
+const FALLBACK_SHEET_NAME = 'MEDDPICC Deal Review';
+
+/** Excel sheet names cannot exceed 31 chars or contain these. */
+const SHEET_NAME_FORBIDDEN = /[:\\/?*[\]]/g;
+const SHEET_NAME_MAX = 31;
+
+/**
+ * Units are carried in the LABEL, never folded into the value: `0.6` written as the
+ * string "60%" can no longer be averaged, and there is no number-format host tool to
+ * restore it afterwards. The sheet keeps arithmetic; the reader keeps context.
+ */
+const UNIT_BY_FORMAT: Record<string, string> = {
+  currency: 'USD',
+  percentage: '0-1',
+};
+
+/**
+ * Paths whose schema key does not survive camelCase splitting.
+ *
+ * `pAndIplusAcvx` humanizes to the nonsense "P And Iplus Acvx" — the key encodes an
+ * ampersand and an internal capital the rule cannot recover. Rather than bend the
+ * general rule around one field, name the exception. Renaming the schema key itself
+ * would be the real fix, but it is referenced by every existing deal file and by
+ * `cell-mapping.json`.
+ */
+const LABEL_OVERRIDES: Record<string, string> = {
+  'metadata.revenue.pAndIplusAcvx': 'P&I + ACVx',
+};
+
+/** camelCase / f5-ish key -> "Title Case" words. `whyF5` -> "Why F5". */
+function humanize(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .map((w) => (/^(f5|acv|sfdc|map|poc|usd)$/i.test(w) ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(' ');
+}
+
+/** Split "a.b[0].c" into ["a", "b", 0, "c"]. */
+function tokenize(path: string): Array<string | number> {
+  const tokens: Array<string | number> = [];
+  for (const part of path.split('.')) {
+    const m = part.match(/^([^[\]]*)((?:\[\d+\])*)$/);
+    if (!m) {
+      tokens.push(part);
+      continue;
+    }
+    if (m[1]) tokens.push(m[1]);
+    for (const idx of m[2].match(/\d+/g) ?? []) tokens.push(Number(idx));
+  }
+  return tokens;
+}
+
+function readPath(root: unknown, path: string): unknown {
+  let cur: unknown = root;
+  for (const tok of tokenize(path)) {
+    if (cur === null || cur === undefined) return undefined;
+    if (typeof tok === 'number') {
+      if (!Array.isArray(cur)) return undefined;
+      cur = cur[tok];
+      continue;
+    }
+    if (typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[tok];
+  }
+  return cur;
+}
+
+/**
+ * A human label for a mapped path.
+ *
+ * The leaf key alone is ambiguous — `threeWhys.f5.whyNow` and `threeWhys.partner.whyNow`
+ * are different questions with the same leaf — so a path nested below its top-level
+ * group carries its parent too. An indexed leaf becomes "Parent — Response N", matching
+ * how the template numbers the two answers per element.
+ */
+function labelFor(field: StaticField): string {
+  const override = LABEL_OVERRIDES[field.jsonPath];
+  if (override) {
+    const overrideUnit = field.format ? UNIT_BY_FORMAT[field.format] : undefined;
+    return overrideUnit ? `${override} (${overrideUnit})` : override;
+  }
+
+  const tokens = tokenize(field.jsonPath);
+  const index = typeof tokens[tokens.length - 1] === 'number' ? (tokens.pop() as number) : null;
+  const names = tokens.filter((t): t is string => typeof t === 'string');
+
+  const leaf = names[names.length - 1] ?? field.jsonPath;
+  const parent = names.length > 2 ? names[names.length - 2] : null;
+
+  let label = index === null ? humanize(leaf) : `${humanize(parent ?? leaf)} — Response ${index + 1}`;
+  if (index === null && parent) label = `${humanize(parent)} — ${label}`;
+
+  const unit = field.format ? UNIT_BY_FORMAT[field.format] : undefined;
+  return unit ? `${label} (${unit})` : label;
+}
+
+/** The group heading a path belongs under, e.g. "metadata" -> "Metadata". */
+function groupFor(path: string): string {
+  const first = tokenize(path).find((t): t is string => typeof t === 'string');
+  return humanize(first ?? 'Details');
+}
+
+/**
+ * Neutralise spreadsheet formula injection.
+ *
+ * A deal file is assembled from call notes, emails and OSINT reports — text this plugin
+ * did not author. A cell opening with `=`, `+`, `-` or `@` is executed by Excel on open,
+ * so it is prefixed with an apostrophe (the standard escape) before it can reach a sheet.
+ * The pane's `write_range` sanitises too; doing it here keeps the plan safe to inspect,
+ * diff or hand to any other consumer.
+ */
+function sanitize(value: string): string {
+  return /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+
+/** Coerce a JSON value to something a cell can hold, or null to skip the row. */
+function toCell(value: unknown, booleanFormat?: DynamicSection['booleanFormat']): CellValue | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'boolean') {
+    const text = value ? (booleanFormat?.true ?? 'Yes') : (booleanFormat?.false ?? 'No');
+    return sanitize(text);
+  }
+  if (typeof value === 'string') return value.trim() === '' ? null : sanitize(value);
+  if (Array.isArray(value)) {
+    const parts = value.map((v) => toCell(v, booleanFormat)).filter((v): v is CellValue => v !== null);
+    return parts.length > 0 ? sanitize(parts.join('; ')) : null;
+  }
+  return null;
+}
+
+function sheetNameFor(deal: unknown): string {
+  const account = readPath(deal, 'metadata.accountName');
+  if (typeof account !== 'string' || account.trim() === '') return FALLBACK_SHEET_NAME;
+  const name = `MEDDPICC — ${account.trim()}`.replace(SHEET_NAME_FORBIDDEN, ' ');
+  return name.length > SHEET_NAME_MAX ? name.slice(0, SHEET_NAME_MAX).trimEnd() : name;
+}
+
+/** Accumulates rows and hands back `write_range`-shaped blocks. */
+class SheetBuilder {
+  #rows: CellValue[][] = [];
+
+  /** Add a row, padding to the plan's widest row happens at emit time. */
+  row(...cells: CellValue[]): void {
+    this.#rows.push(cells);
+  }
+
+  blank(): void {
+    // Only between content — never a leading or trailing run of empties.
+    if (this.#rows.length > 0) this.#rows.push([]);
+  }
+
+  get length(): number {
+    return this.#rows.length;
+  }
+
+  /**
+   * One write per contiguous run of same-width rows. Excel rejects a `values` grid whose
+   * shape disagrees with its address, so rows are padded to the run's width rather than
+   * emitted ragged — and blank separators ride along inside their run.
+   */
+  emit(): { writes: SheetWrite[]; rowCount: number } {
+    while (this.#rows.length > 0 && this.#rows[this.#rows.length - 1].length === 0) this.#rows.pop();
+
+    const writes: SheetWrite[] = [];
+    let start = 0;
+    while (start < this.#rows.length) {
+      let end = start;
+      let width = this.#rows[start].length || 1;
+      // Extend the run while the width matches; a blank row (length 0) joins any run.
+      while (end + 1 < this.#rows.length) {
+        const next = this.#rows[end + 1].length;
+        if (next !== 0 && next !== width) break;
+        if (next > width) width = next;
+        end++;
+      }
+      const values = this.#rows.slice(start, end + 1).map((r) => {
+        const padded = r.slice(0, width) as CellValue[];
+        while (padded.length < width) padded.push('');
+        return padded;
+      });
+      writes.push({ address: `A${start + 1}:${columnLetter(width)}${end + 1}`, values });
+      start = end + 1;
+    }
+    return { writes, rowCount: this.#rows.length };
+  }
+}
+
+/** 1 -> "A", 26 -> "Z", 27 -> "AA". */
+export function columnLetter(oneBased: number): string {
+  let n = Math.max(1, oneBased);
+  let out = '';
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    out = String.fromCharCode(65 + rem) + out;
+    n = Math.floor((n - 1) / 26);
+  }
+  return out;
+}
+
+export function renderSheet(deal: unknown, cellMapping: CellMapping): SheetPlan {
+  const b = new SheetBuilder();
+
+  b.row('MEDDPICC Deal Review');
+
+  // ── Static fields, in mapping order, grouped by their top-level section ──────
+  let currentGroup: string | null = null;
+  for (const field of cellMapping.staticFields ?? []) {
+    const value = toCell(readPath(deal, field.jsonPath));
+    if (value === null) continue; // an unanswered field is absent, not an empty row
+    const group = groupFor(field.jsonPath);
+    if (group !== currentGroup) {
+      b.blank();
+      b.row(group);
+      currentGroup = group;
+    }
+    b.row(labelFor(field), value);
+  }
+
+  // ── Scores, from the same engine the CLI's `score` command uses ──────────────
+  const score = computeScore(deal);
+  b.blank();
+  b.row('Scoring (0-4)');
+  for (const element of QUALIFICATION_ELEMENTS) {
+    b.row(humanize(element), score.elementScores[element] ?? 0);
+  }
+  b.row('Overall', score.sum);
+  b.row('Overall %', score.overallScore);
+  b.row('Rating', score.overallRating);
+
+  // ── Dynamic sections as header + one row per item ────────────────────────────
+  for (const section of cellMapping.dynamicSections ?? []) {
+    const items = readPath(deal, section.jsonPath);
+    if (!Array.isArray(items) || items.length === 0) continue;
+    const columns = Object.keys(section.columns ?? {});
+    if (columns.length === 0) continue;
+
+    b.blank();
+    // "closePlan.milestones" -> "Close Plan Milestones": the whole path, because the two
+    // side-by-side sections in the template share a leaf-adjacent name.
+    b.row(humanize(section.jsonPath.replace(/\./g, ' ')));
+    b.row(...columns.map(humanize));
+    for (const item of items.slice(0, section.maxRows ?? items.length)) {
+      b.row(...columns.map((c) => toCell(readPath(item, c), section.booleanFormat) ?? ''));
+    }
+  }
+
+  const { writes, rowCount } = b.emit();
+  return { sheetName: sheetNameFor(deal), writes, rowCount };
+}

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/tests/test_engine.sh
+++ b/plugins/meddpicc/scripts/tests/test_engine.sh
@@ -96,3 +96,38 @@ test_engine_check_mappings_detects_broken() {
   fi
   rm -rf "$tmp"
 }
+
+test_engine_render_produces_a_writable_plan() {
+  _engine_precheck || return 0
+  local out
+  out=$(bun "$PLUGIN_ROOT/engine/cli.ts" render "$PLUGIN_ROOT/schema/example-deal.json")
+  [ "$(jq -r '.sheetName' <<<"$out")" != "null" ] || {
+    echo "render produced no sheetName: $out"
+    return 1
+  }
+  # Every write must be directly executable by the pane's write_range: an A1-style
+  # address whose row span equals the number of value rows.
+  local bad
+  bad=$(jq -r '
+    [ .writes[]
+      | (.address | capture("^[A-Z]+(?<top>[0-9]+):[A-Z]+(?<bottom>[0-9]+)$"))
+        as $a
+      | select((($a.bottom | tonumber) - ($a.top | tonumber) + 1) != (.values | length))
+      | .address
+    ] | join(",")' <<<"$out")
+  [ -z "$bad" ] || {
+    echo "write address/row-count mismatch at: $bad"
+    return 1
+  }
+}
+
+test_engine_render_is_deterministic() {
+  _engine_precheck || return 0
+  local a b
+  a=$(bun "$PLUGIN_ROOT/engine/cli.ts" render "$PLUGIN_ROOT/schema/example-deal.json")
+  b=$(bun "$PLUGIN_ROOT/engine/cli.ts" render "$PLUGIN_ROOT/schema/example-deal.json")
+  [ "$a" = "$b" ] || {
+    echo "render is not deterministic across runs"
+    return 1
+  }
+}

--- a/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
+++ b/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
@@ -7,22 +7,45 @@ test_resources_manifest_paths_exist() {
     echo "resources.json missing"
     return 1
   fi
-  local schema engine_entry
-  schema=$(jq -r '.schema' "$manifest")
+  local engine_entry
   engine_entry=$(jq -r '.engine.entry' "$manifest")
-  [ -f "$PLUGIN_ROOT/$schema" ] || {
-    echo "schema path missing: $schema"
-    return 1
-  }
   [ -f "$PLUGIN_ROOT/$engine_entry" ] || {
     echo "engine.entry missing: $engine_entry"
     return 1
   }
-  # every mappings.* path resolves
-  local p
-  for p in $(jq -r '.mappings // {} | to_entries[] | .value' "$manifest"); do
+  # Every top-level string value is a declared resource path — `xcsh://plugin/<name>/<key>`
+  # resolves exactly those, so each one must exist on disk.
+  local key p
+  while IFS=$'\t' read -r key p; do
     [ -f "$PLUGIN_ROOT/$p" ] || {
-      echo "mapping path missing: $p"
+      echo "resource \"$key\" points at a missing file: $p"
+      return 1
+    }
+  done < <(jq -r 'to_entries[] | select(.value | type == "string") | [.key, .value] | @tsv' "$manifest")
+}
+
+# The pane surfaces the schema and the template through `xcsh://plugin/meddpicc/<key>`,
+# which only resolves TOP-LEVEL string keys. Nesting a path (the old `mappings.cell`)
+# made it unreachable, so pin the shape the resolver actually supports.
+test_resources_manifest_declares_reachable_keys() {
+  local manifest="$PLUGIN_ROOT/.xcsh-plugin/resources.json"
+  local key
+  for key in schema example template cellMapping sfdcMapping; do
+    [ "$(jq -r --arg k "$key" '.[$k] | type' "$manifest")" = "string" ] || {
+      echo "resources.json must declare \"$key\" as a top-level string"
+      return 1
+    }
+  done
+}
+
+# `render` is what the Office pane calls to build the deal sheet; a manifest that does
+# not advertise it leaves the pane guessing at the engine's surface.
+test_resources_manifest_advertises_engine_commands() {
+  local manifest="$PLUGIN_ROOT/.xcsh-plugin/resources.json"
+  local cmd
+  for cmd in validate next score hint render check-mappings; do
+    jq -e --arg c "$cmd" '.engine.commands | index($c)' "$manifest" >/dev/null || {
+      echo "engine.commands does not advertise \"$cmd\""
       return 1
     }
   done

--- a/plugins/meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/meddpicc/skills/deal-qualification/SKILL.md
@@ -319,18 +319,44 @@ After writing the JSON file, display a scorecard summary:
    - **By when:** [timeframe]
 ```
 
-### Optional output: XLS spreadsheet
+### Optional output: spreadsheet
 
-If the user requests XLS output or says "render", "spreadsheet",
-or "export":
+Triggered when the user says "render", "spreadsheet", "export", or
+asks for a report. Which route you take depends on where you are
+running — the JSON file is the source of truth either way, and the
+spreadsheet is disposable.
 
-1. Read the template from
-   [meddpicc-template.xlsx](references/meddpicc-template.xlsx)
-2. Use the cell mapping from
-   [cell-mapping.json](references/cell-mapping.json) to populate
-   the template with data from the deal JSON
+**In an Excel task pane** (you have the `write_range` host tool):
+build the sheet in the OPEN workbook. Never hand-place cells — the
+engine emits the whole plan:
+
+```bash
+bun xcsh://plugin/meddpicc/file/engine/cli.ts render <deal.json>
+```
+
+It returns `{sheetName, writes[], rowCount}`, where each write is
+`{address, values}` shaped exactly for `write_range`. Then:
+
+1. Call `add_sheet` with the plan's `sheetName`. It is idempotent —
+   an existing sheet of that name is reused, so a re-render
+   overwrites rather than duplicating.
+2. For each entry in `writes`, call `write_range` with
+   `"<sheetName>!<address>"` and its `values`, in order.
+3. Report the sheet name and row count. Do not re-read the sheet to
+   "confirm" — `write_range` already did.
+
+The layout comes from `cell-mapping.json` (which fields, in what
+order, with which units and table columns) laid out in a fixed
+two-column form. It is deterministic: the same deal renders the same
+sheet every time.
+
+**In the terminal** (no host tools): the template is the better
+route, because it carries the F5 sheet's formatting.
+
+1. Resolve the template at `xcsh://plugin/meddpicc/template`
+2. Populate it using `xcsh://plugin/meddpicc/cellMapping`, whose
+   coordinates match that template exactly
 3. Save as `{accountName}-{dealName}-{YYYY-MM-DD}.xlsx`
-4. The XLS is disposable — the JSON file is the source of truth
 
 ## Coaching Behavior
 


### PR DESCRIPTION
Closes #858

## Why

The plugin's spreadsheet story only worked in a terminal that could open
`meddpicc-template.xlsx` and rewrite its cells. In an Excel task pane — where an SE
actually reviews a deal — neither half was available:

- **`cell-mapping.json`'s coordinates only fit the template.** `metadata.accountName` →
  `B4`, stakeholders from row 41, milestones and criticalActions side-by-side from row 67
  — all of it assumes the template's merged cells, headers and banding. Written into any
  other workbook it produces a field of unlabelled values.
- **The template was not addressable.** `xcsh://plugin/<name>/<key>` resolves only
  top-level *string* keys, so the nested `mappings.cell` was unreachable by design and
  `template` was never declared. Nothing could ask the plugin where its spreadsheet lives.

## What `render` does

Reads the mapping as a **field inventory** — which fields, in what order, with which units
and which table columns — and lays them out in a fixed two-column form. The content is the
official sheet's content; the arrangement is code, so the same deal renders the same sheet
every time instead of whatever the model improvises this run. Output is a list of
`{address, values}` blocks shaped exactly for the pane's `write_range`, so the caller
decides nothing. Scoring reuses `computeScore` rather than recomputing it.

```
$ bun engine/cli.ts render ~/MEDDPICC/VISA/meddpicc.json
sheetName: MEDDPICC — Visa, Inc.        rowCount: 105   writes: 20
  1 | MEDDPICC Deal Review
  3 | Metadata
  4 | Account Name              | Visa, Inc.
 12 | Revenue — Software (USD)  | 1421060
 20 | Metrics — Response 1      | Visa prioritized control, application uptime…
 49 | Scoring (0-4)
 58 | Overall                   | 25
 60 | Rating                    | Yellow
 62 | Stakeholders
 63 | Name | Title | Role In Deal | Must Say Yes | Can Say No | …
```

## Two choices worth stating plainly

**Numbers stay numbers.** `473687` written as `"$473,687"` can no longer be summed, and
there is no number-format host tool to undo the damage — so units ride in the label
(`Revenue — ACV (USD)`, `Win Probability (0-1)`) and the value is untouched.

**Every string is escaped against formula injection.** A deal file is assembled from call
notes, emails and OSINT reports this plugin did not author, and a cell opening with `=`,
`+`, `-` or `@` is executed by Excel on open. The pane's `write_range` sanitises too;
doing it here keeps the plan safe to inspect, diff, or hand to any other consumer.

One honest wart: `pAndIplusAcvx` humanises to the nonsense "P And Iplus Acvx", so it has a
named override. Renaming the schema key would be the real fix, but it is referenced by
every existing deal file and by `cell-mapping.json`.

## Manifest

`template`, `cellMapping` and `sfdcMapping` are now top-level strings; the unreachable
nested `mappings` is gone (clean break — the only consumer was this repo's own test). The
manifest test now checks **every** top-level string path and pins the shape, so a future
nested key fails loudly rather than going quietly unreachable.

## Verification

- 16 unit tests for `render`, **mutation-checked**: removing the formula escaping fails
  the injection test, removing the row padding fails the write-shape test (both confirmed).
- `bun test engine/`: 47 pass / 0 fail. `scripts/tests/run-tests.sh`: 22 pass / 0 fail,
  including two new end-to-end `render` cases (writable-plan shape, determinism across
  separate process runs).
- The manifest test is mutation-checked too: re-nesting `cellMapping` under `mappings`
  fails `test_resources_manifest_declares_reachable_keys` (confirmed).
- Codex `verified-code-review` (`adversarial-review --base origin/main`): **0 findings**.

## Dependency

`SKILL.md` tells the pane to call `add_sheet`, which lands in **xcsh#2477**. Until that
merges the terminal route works and the pane route has no sheet to write into, so these
two should go together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)