### PR TITLE
MEDDPICC: workbook spec + schema guard, and run the plugin suites in CI

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -10,6 +10,7 @@ on:
       - ".xcsh-plugin/**"
       - "scripts/validate-plugins.sh"
       - "scripts/check-version-bumps.sh"
+      - "scripts/run-plugin-tests.sh"
   push:
     branches: [main]
     paths:
@@ -17,6 +18,7 @@ on:
       - ".xcsh-plugin/**"
       - "scripts/validate-plugins.sh"
       - "scripts/check-version-bumps.sh"
+      - "scripts/run-plugin-tests.sh"
 
 permissions:
   contents: read
@@ -52,3 +54,26 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: ./scripts/check-version-bumps.sh "$BASE_SHA"
+
+  test:
+    name: Run plugin test suites
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install jq
+        run: |
+          if ! command -v jq &> /dev/null; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq jq
+          fi
+
+      # Pinned, not a range: a floating runtime turns an unrelated bun release into a
+      # mystery CI failure.
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Run plugin test suites
+        run: ./scripts/run-plugin-tests.sh

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** bumped to v2.4.0 — foundations for a formula-driven workbook generated
+  from the schema. Adds `engine/xlsx.ts`, an OOXML writer that emits a complete `.xlsx`
+  from scratch with a fixed, named style palette, and `engine/workbook-spec.json`, a
+  declarative description of the workbook that names a `jsonPath` for every input cell and
+  writes formulas as symbolic references (`{{ref:acv}}`, `{{col:elements.score}}`) rather
+  than addresses. `check-spec` validates the two against the deal schema: every input path
+  resolves, all eight scored elements are captured exactly once, no two cells claim one
+  value, every formula reference names something that exists, and side-by-side tables do
+  not overlap. No output changes yet — `fill` is still what produces the report.
+
 - **`meddpicc`** bumped to v2.3.0 — the deal review now fills the shipped F5 Deal
   Review Sheet template instead of a layout of its own: corrected `cell-mapping.json`
   (every scalar coordinate previously named the label cell, not the value cell),

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
-  "description": "MEDDPICC sales qualification and deal-execution framework \u2014 evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "2.3.0",
+  "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
+  "version": "2.4.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/.xcsh-plugin/resources.json
+++ b/plugins/meddpicc/.xcsh-plugin/resources.json
@@ -4,9 +4,10 @@
   "template": "skills/deal-qualification/references/meddpicc-template.xlsx",
   "cellMapping": "skills/deal-qualification/references/cell-mapping.json",
   "sfdcMapping": "skills/deal-qualification/references/sfdc-field-mapping.json",
+  "workbookSpec": "engine/workbook-spec.json",
   "engine": {
     "runtime": "bun",
     "entry": "engine/cli.ts",
-    "commands": ["validate", "next", "score", "hint", "fill", "check-mappings"]
+    "commands": ["validate", "next", "score", "hint", "fill", "check-mappings", "check-spec"]
   }
 }

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -9,6 +9,7 @@ import { computeScore } from './score';
 import { QUALIFICATION_ELEMENTS } from './sections';
 import { readTemplateText } from './template';
 import { validateDeal } from './validate';
+import { checkWorkbookSpec, type WorkbookSpec } from './workbook-spec';
 
 /**
  * Resolve the plugin root by walking up from this file until we find the
@@ -32,6 +33,7 @@ const SCHEMA_PATH = path.join(PLUGIN_ROOT, 'schema', 'meddpicc-schema.json');
 const CELL_PATH = path.join(PLUGIN_ROOT, 'skills', 'deal-qualification', 'references', 'cell-mapping.json');
 const TEMPLATE_RELPATH = 'skills/deal-qualification/references/meddpicc-template.xlsx';
 const SFDC_PATH = path.join(PLUGIN_ROOT, 'skills', 'deal-qualification', 'references', 'sfdc-field-mapping.json');
+const WORKBOOK_SPEC_PATH = path.join(PLUGIN_ROOT, 'engine', 'workbook-spec.json');
 
 async function readJson(p: string): Promise<unknown> {
   return JSON.parse(await Bun.file(p).text());
@@ -130,8 +132,16 @@ async function main(): Promise<number> {
     return result.ok ? 0 : 1;
   }
 
+  if (command === 'check-spec') {
+    const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
+    const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
+    const result = checkWorkbookSpec(schema, spec);
+    print(result);
+    return result.ok ? 0 : 1;
+  }
+
   process.stderr.write(
-    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, fill, check-mappings\n`,
+    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, fill, check-mappings, check-spec\n`,
   );
   return 1;
 }

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -1,0 +1,814 @@
+{
+  "version": 1,
+  "sheets": [
+    {
+      "name": "Deal",
+      "kind": "form",
+      "columns": [{ "min": 1, "max": 1, "width": 34 }, { "min": 2, "max": 2, "width": 78 }],
+      "blocks": [
+        { "kind": "title", "text": "MEDDPICC Deal Review" },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Deal" },
+        { "kind": "field", "id": "dealId", "label": "Deal ID", "jsonPath": "metadata.dealId", "valueType": "string" },
+        {
+          "kind": "field",
+          "id": "accountName",
+          "label": "Account name",
+          "jsonPath": "metadata.accountName",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "dealName",
+          "label": "Deal name",
+          "jsonPath": "metadata.dealName",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "accountTeam",
+          "label": "Account team",
+          "jsonPath": "metadata.accountTeam",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "dealStatus",
+          "label": "Deal status",
+          "jsonPath": "metadata.dealStatus",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "forecastStage",
+          "label": "Forecast stage",
+          "jsonPath": "metadata.forecastStage",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "competition",
+          "label": "Primary competition",
+          "jsonPath": "metadata.competition",
+          "valueType": "text"
+        },
+        {
+          "kind": "field",
+          "id": "closeDate",
+          "label": "Expected close date",
+          "jsonPath": "metadata.closeDate",
+          "valueType": "date"
+        },
+        {
+          "kind": "field",
+          "id": "winProbability",
+          "label": "Win probability",
+          "jsonPath": "metadata.winProbability",
+          "valueType": "percent"
+        },
+        {
+          "kind": "field",
+          "id": "reviewer",
+          "label": "Reviewer",
+          "jsonPath": "metadata.reviewer",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "reviewDate",
+          "label": "Review date",
+          "jsonPath": "metadata.reviewDate",
+          "valueType": "date"
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Revenue" },
+        {
+          "kind": "field",
+          "id": "revenuePandI",
+          "label": "P&I + ACVx",
+          "jsonPath": "metadata.revenue.pAndIplusAcvx",
+          "valueType": "currency"
+        },
+        {
+          "kind": "field",
+          "id": "revenueHardware",
+          "label": "Hardware",
+          "jsonPath": "metadata.revenue.hardware",
+          "valueType": "currency"
+        },
+        {
+          "kind": "field",
+          "id": "revenueSoftware",
+          "label": "Software",
+          "jsonPath": "metadata.revenue.software",
+          "valueType": "currency"
+        },
+        {
+          "kind": "field",
+          "id": "acv",
+          "label": "Annual contract value",
+          "jsonPath": "metadata.revenue.acv",
+          "valueType": "currency"
+        },
+        {
+          "kind": "computed",
+          "id": "revenueTotal",
+          "label": "Total booked value",
+          "formula": "{{ref:revenuePandI}}+{{ref:revenueHardware}}+{{ref:revenueSoftware}}",
+          "valueType": "currency"
+        },
+        {
+          "kind": "computed",
+          "id": "factoredPipeline",
+          "label": "Factored pipeline",
+          "formula": "{{ref:acv}}*{{ref:winProbability}}",
+          "valueType": "currency"
+        },
+        {
+          "kind": "computed",
+          "id": "daysToClose",
+          "label": "Days to close",
+          "formula": "IF({{ref:closeDate}}=\"\",\"\",{{ref:closeDate}}-TODAY())",
+          "valueType": "number"
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Client interaction" },
+        {
+          "kind": "field",
+          "id": "lastInteractionDate",
+          "label": "Last interaction — date",
+          "jsonPath": "metadata.lastClientInteraction.date",
+          "valueType": "date"
+        },
+        {
+          "kind": "field",
+          "id": "lastInteractionOutcome",
+          "label": "Last interaction — outcome",
+          "jsonPath": "metadata.lastClientInteraction.outcome",
+          "valueType": "text"
+        },
+        {
+          "kind": "field",
+          "id": "nextInteractionDate",
+          "label": "Next interaction — date",
+          "jsonPath": "metadata.nextClientInteraction.date",
+          "valueType": "date"
+        },
+        {
+          "kind": "field",
+          "id": "nextInteractionObjective",
+          "label": "Next interaction — objective",
+          "jsonPath": "metadata.nextClientInteraction.objective",
+          "valueType": "text"
+        },
+        {
+          "kind": "computed",
+          "id": "daysSinceLastInteraction",
+          "label": "Days since last interaction",
+          "formula": "IF({{ref:lastInteractionDate}}=\"\",\"\",TODAY()-{{ref:lastInteractionDate}})",
+          "valueType": "number"
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Three Whys — F5" },
+        {
+          "kind": "field",
+          "id": "whyAnything",
+          "label": "Why anything?",
+          "jsonPath": "threeWhys.f5.whyAnything",
+          "valueType": "text",
+          "height": 44
+        },
+        {
+          "kind": "field",
+          "id": "whyF5",
+          "label": "Why F5?",
+          "jsonPath": "threeWhys.f5.whyF5",
+          "valueType": "text",
+          "height": 44
+        },
+        {
+          "kind": "field",
+          "id": "whyNow",
+          "label": "Why now?",
+          "jsonPath": "threeWhys.f5.whyNow",
+          "valueType": "text",
+          "height": 44
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Three Whys — Partner" },
+        {
+          "kind": "field",
+          "id": "partnerName",
+          "label": "Partner",
+          "jsonPath": "threeWhys.partner.name",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "partnerWhyAnything",
+          "label": "Why anything?",
+          "jsonPath": "threeWhys.partner.whyAnything",
+          "valueType": "text",
+          "height": 44
+        },
+        {
+          "kind": "field",
+          "id": "partnerWhyThisPartner",
+          "label": "Why this partner?",
+          "jsonPath": "threeWhys.partner.whyThisPartner",
+          "valueType": "text",
+          "height": 44
+        },
+        {
+          "kind": "field",
+          "id": "partnerWhyNow",
+          "label": "Why now?",
+          "jsonPath": "threeWhys.partner.whyNow",
+          "valueType": "text",
+          "height": 44
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Sales strategy" },
+        {
+          "kind": "field",
+          "id": "differentiatedValueProposition",
+          "label": "Differentiated value proposition",
+          "jsonPath": "salesStrategy.differentiatedValueProposition",
+          "valueType": "text",
+          "height": 60
+        },
+        {
+          "kind": "field",
+          "id": "winStrategy",
+          "label": "Win strategy",
+          "jsonPath": "salesStrategy.winStrategy",
+          "valueType": "text",
+          "height": 60
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Salesforce" },
+        {
+          "kind": "field",
+          "id": "salesforceOpportunityId",
+          "label": "Opportunity ID",
+          "jsonPath": "metadata.salesforce.opportunityId",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "salesforceAccountId",
+          "label": "Account ID",
+          "jsonPath": "metadata.salesforce.accountId",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "salesforceOwnerId",
+          "label": "Owner ID",
+          "jsonPath": "metadata.salesforce.ownerId",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "salesforceStageName",
+          "label": "Stage name",
+          "jsonPath": "metadata.salesforce.stageName",
+          "valueType": "string"
+        },
+        {
+          "kind": "field",
+          "id": "salesforceLastSync",
+          "label": "Last sync",
+          "jsonPath": "metadata.salesforce.lastSyncDate",
+          "valueType": "string"
+        }
+      ]
+    },
+    {
+      "name": "Qualification",
+      "kind": "table",
+      "tables": [
+        {
+          "id": "elements",
+          "source": { "kind": "elements" },
+          "anchorColumn": 1,
+          "headerRow": 1,
+          "columns": [
+            { "id": "element", "header": "Element", "role": "derived", "valueType": "string", "width": 20 },
+            { "id": "definition", "header": "Definition", "role": "derived", "valueType": "text", "width": 56 },
+            {
+              "id": "score",
+              "header": "Score (0-4)",
+              "role": "input",
+              "jsonPath": "qualification.*.score",
+              "valueType": "score",
+              "width": 12
+            },
+            {
+              "id": "previousScore",
+              "header": "Previous",
+              "role": "input",
+              "jsonPath": "scoring.previousElementScores.*",
+              "valueType": "score",
+              "width": 11
+            },
+            {
+              "id": "change",
+              "header": "Change",
+              "role": "computed",
+              "formula": "{{this:score}}-{{this:previousScore}}",
+              "valueType": "number",
+              "width": 10
+            },
+            { "id": "rubric", "header": "What this score means", "role": "derived", "valueType": "text", "width": 56 },
+            {
+              "id": "evidence",
+              "header": "Evidence",
+              "role": "input",
+              "jsonPath": "qualification.*.evidence",
+              "valueType": "text",
+              "width": 52
+            },
+            {
+              "id": "notes",
+              "header": "Notes",
+              "role": "input",
+              "jsonPath": "qualification.*.notes",
+              "valueType": "text",
+              "width": 52
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Questions",
+      "kind": "table",
+      "tables": [
+        {
+          "id": "responses",
+          "source": { "kind": "elementResponses" },
+          "anchorColumn": 1,
+          "headerRow": 1,
+          "columns": [
+            { "id": "element", "header": "Element", "role": "derived", "valueType": "string", "width": 20 },
+            { "id": "position", "header": "#", "role": "derived", "valueType": "integer", "width": 6 },
+            { "id": "question", "header": "Question", "role": "derived", "valueType": "text", "width": 62 },
+            {
+              "id": "response",
+              "header": "Response",
+              "role": "input",
+              "jsonPath": "qualification.*.responses[]",
+              "valueType": "text",
+              "width": 84
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Stakeholders",
+      "kind": "table",
+      "tables": [
+        {
+          "id": "stakeholders",
+          "source": { "kind": "list", "jsonPath": "stakeholders" },
+          "anchorColumn": 1,
+          "headerRow": 1,
+          "minRows": 12,
+          "columns": [
+            { "id": "name", "header": "Name", "role": "input", "jsonPath": "name", "valueType": "string", "width": 24 },
+            {
+              "id": "title",
+              "header": "Title",
+              "role": "input",
+              "jsonPath": "title",
+              "valueType": "string",
+              "width": 30
+            },
+            {
+              "id": "roleInDeal",
+              "header": "Role in deal",
+              "role": "input",
+              "jsonPath": "roleInDeal",
+              "valueType": "string",
+              "width": 18
+            },
+            {
+              "id": "mustSayYes",
+              "header": "Must say yes",
+              "role": "input",
+              "jsonPath": "mustSayYes",
+              "valueType": "boolean",
+              "width": 14
+            },
+            {
+              "id": "canSayNo",
+              "header": "Can say no",
+              "role": "input",
+              "jsonPath": "canSayNo",
+              "valueType": "boolean",
+              "width": 13
+            },
+            {
+              "id": "whatTheyNeedToBelieve",
+              "header": "What they need to believe",
+              "role": "input",
+              "jsonPath": "whatTheyNeedToBelieve",
+              "valueType": "text",
+              "width": 56
+            },
+            {
+              "id": "viewOfF5",
+              "header": "View of F5",
+              "role": "input",
+              "jsonPath": "viewOfF5",
+              "valueType": "string",
+              "width": 14
+            },
+            {
+              "id": "f5Owner",
+              "header": "F5 owner",
+              "role": "input",
+              "jsonPath": "f5Owner",
+              "valueType": "string",
+              "width": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Close Plan",
+      "kind": "table",
+      "tables": [
+        {
+          "id": "milestones",
+          "source": { "kind": "list", "jsonPath": "closePlan.milestones" },
+          "anchorColumn": 1,
+          "headerRow": 1,
+          "minRows": 10,
+          "columns": [
+            {
+              "id": "description",
+              "header": "Milestone",
+              "role": "input",
+              "jsonPath": "description",
+              "valueType": "text",
+              "width": 56
+            },
+            {
+              "id": "targetDate",
+              "header": "Target date",
+              "role": "input",
+              "jsonPath": "targetDate",
+              "valueType": "date",
+              "width": 14
+            },
+            {
+              "id": "status",
+              "header": "Status",
+              "role": "input",
+              "jsonPath": "status",
+              "valueType": "string",
+              "width": 14
+            }
+          ]
+        },
+        {
+          "id": "actions",
+          "source": { "kind": "list", "jsonPath": "closePlan.criticalActions" },
+          "anchorColumn": 5,
+          "headerRow": 1,
+          "minRows": 12,
+          "columns": [
+            {
+              "id": "action",
+              "header": "Critical action",
+              "role": "input",
+              "jsonPath": "action",
+              "valueType": "text",
+              "width": 56
+            },
+            {
+              "id": "owner",
+              "header": "Owner",
+              "role": "input",
+              "jsonPath": "owner",
+              "valueType": "string",
+              "width": 22
+            },
+            {
+              "id": "dueDate",
+              "header": "Due date",
+              "role": "input",
+              "jsonPath": "dueDate",
+              "valueType": "date",
+              "width": 14
+            },
+            {
+              "id": "status",
+              "header": "Status",
+              "role": "input",
+              "jsonPath": "status",
+              "valueType": "string",
+              "width": 14
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Team",
+      "kind": "table",
+      "tables": [
+        {
+          "id": "teamF5",
+          "source": { "kind": "list", "jsonPath": "team.f5" },
+          "anchorColumn": 1,
+          "headerRow": 1,
+          "minRows": 16,
+          "columns": [
+            { "id": "name", "header": "Name", "role": "input", "jsonPath": "name", "valueType": "string", "width": 26 },
+            { "id": "role", "header": "Role", "role": "input", "jsonPath": "role", "valueType": "string", "width": 34 },
+            {
+              "id": "dateRequiredFrom",
+              "header": "Required from",
+              "role": "input",
+              "jsonPath": "dateRequiredFrom",
+              "valueType": "date",
+              "width": 15
+            },
+            {
+              "id": "assignedToDeal",
+              "header": "Assigned",
+              "role": "input",
+              "jsonPath": "assignedToDeal",
+              "valueType": "boolean",
+              "width": 11
+            }
+          ]
+        },
+        {
+          "id": "teamPartner",
+          "source": { "kind": "list", "jsonPath": "team.partner" },
+          "anchorColumn": 6,
+          "headerRow": 1,
+          "minRows": 10,
+          "columns": [
+            { "id": "name", "header": "Name", "role": "input", "jsonPath": "name", "valueType": "string", "width": 26 },
+            { "id": "role", "header": "Role", "role": "input", "jsonPath": "role", "valueType": "string", "width": 34 },
+            {
+              "id": "dateRequiredFrom",
+              "header": "Required from",
+              "role": "input",
+              "jsonPath": "dateRequiredFrom",
+              "valueType": "date",
+              "width": 15
+            },
+            {
+              "id": "assignedToDeal",
+              "header": "Assigned",
+              "role": "input",
+              "jsonPath": "assignedToDeal",
+              "valueType": "boolean",
+              "width": 11
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Completion",
+      "kind": "table",
+      "tables": [
+        {
+          "id": "sections",
+          "source": { "kind": "sections" },
+          "anchorColumn": 1,
+          "headerRow": 1,
+          "columns": [
+            { "id": "section", "header": "Section", "role": "derived", "valueType": "string", "width": 26 },
+            { "id": "status", "header": "Status", "role": "derived", "valueType": "string", "width": 16 }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Scorecard",
+      "kind": "form",
+      "columns": [{ "min": 1, "max": 1, "width": 34 }, { "min": 2, "max": 2, "width": 22 }],
+      "blocks": [
+        { "kind": "title", "text": "Scorecard" },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Qualification" },
+        {
+          "kind": "computed",
+          "id": "scoreTotal",
+          "label": "Total score",
+          "formula": "SUM({{col:elements.score}})",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "scoreMaximum",
+          "label": "Maximum possible",
+          "formula": "COUNT({{col:elements.score}})*4",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "scorePercent",
+          "label": "Overall score",
+          "formula": "IF({{ref:scoreMaximum}}=0,0,{{ref:scoreTotal}}/{{ref:scoreMaximum}})",
+          "valueType": "percent"
+        },
+        {
+          "kind": "computed",
+          "id": "scoreRating",
+          "label": "Rating",
+          "formula": "IF({{ref:scoreTotal}}>=26,\"Green\",IF({{ref:scoreTotal}}>=14,\"Yellow\",\"Red\"))",
+          "valueType": "rating"
+        },
+        {
+          "kind": "computed",
+          "id": "scorePreviousTotal",
+          "label": "Previous total",
+          "formula": "SUM({{col:elements.previousScore}})",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "scoreChange",
+          "label": "Change since last review",
+          "formula": "{{ref:scoreTotal}}-{{ref:scorePreviousTotal}}",
+          "valueType": "number"
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Weakest links" },
+        {
+          "kind": "computed",
+          "id": "lowestElement",
+          "label": "Lowest-scoring element",
+          "formula": "INDEX({{col:elements.element}},MATCH(MIN({{col:elements.score}}),{{col:elements.score}},0))",
+          "valueType": "string"
+        },
+        {
+          "kind": "computed",
+          "id": "elementsAtZero",
+          "label": "Elements still at zero",
+          "formula": "COUNTIF({{col:elements.score}},0)",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "elementsBelowThree",
+          "label": "Elements below 3",
+          "formula": "COUNTIF({{col:elements.score}},\"<3\")",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "economicBuyerScore",
+          "label": "Economic buyer",
+          "formula": "{{row:elements.score@economicBuyer}}",
+          "valueType": "score"
+        },
+        {
+          "kind": "computed",
+          "id": "championScore",
+          "label": "Champion",
+          "formula": "{{row:elements.score@champion}}",
+          "valueType": "score"
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Completion" },
+        {
+          "kind": "computed",
+          "id": "sectionsComplete",
+          "label": "Sections complete",
+          "formula": "COUNTIF({{col:sections.status}},\"complete\")",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "sectionsTracked",
+          "label": "Sections tracked",
+          "formula": "COUNTA({{col:sections.section}})",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "completionPercent",
+          "label": "Completion",
+          "formula": "IF({{ref:sectionsTracked}}=0,0,{{ref:sectionsComplete}}/{{ref:sectionsTracked}})",
+          "valueType": "percent"
+        },
+        {
+          "kind": "computed",
+          "id": "questionsAsked",
+          "label": "Questions asked",
+          "formula": "COUNTA({{col:responses.question}})",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "questionsAnswered",
+          "label": "Questions answered",
+          "formula": "COUNTA({{col:responses.response}})",
+          "valueType": "number"
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Stakeholders" },
+        {
+          "kind": "computed",
+          "id": "stakeholdersMapped",
+          "label": "Stakeholders mapped",
+          "formula": "COUNTA({{col:stakeholders.name}})",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "mustSayYesCount",
+          "label": "Must say yes",
+          "formula": "COUNTIF({{col:stakeholders.mustSayYes}},TRUE)",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "canSayNoCount",
+          "label": "Can say no",
+          "formula": "COUNTIF({{col:stakeholders.canSayNo}},TRUE)",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "sentimentUnknown",
+          "label": "Sentiment unknown",
+          "formula": "COUNTIF({{col:stakeholders.viewOfF5}},\"Unknown\")",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "sentimentNegative",
+          "label": "Sentiment negative",
+          "formula": "COUNTIF({{col:stakeholders.viewOfF5}},\"Negative\")",
+          "valueType": "number"
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Close plan" },
+        {
+          "kind": "computed",
+          "id": "milestonesTotal",
+          "label": "Milestones",
+          "formula": "COUNTA({{col:milestones.description}})",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "milestonesComplete",
+          "label": "Milestones complete",
+          "formula": "COUNTIF({{col:milestones.status}},\"complete\")",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "actionsOpen",
+          "label": "Actions open",
+          "formula": "COUNTA({{col:actions.action}})-COUNTIF({{col:actions.status}},\"complete\")",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "actionsOverdue",
+          "label": "Actions overdue",
+          "formula": "SUMPRODUCT(({{col:actions.dueDate}}<>\"\")*({{col:actions.dueDate}}<TODAY())*({{col:actions.status}}<>\"complete\"))",
+          "valueType": "number"
+        },
+        { "kind": "spacer" },
+        { "kind": "section", "text": "Team" },
+        {
+          "kind": "computed",
+          "id": "teamF5Count",
+          "label": "F5 team members",
+          "formula": "COUNTA({{col:teamF5.name}})",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "teamF5Assigned",
+          "label": "F5 assigned to deal",
+          "formula": "COUNTIF({{col:teamF5.assignedToDeal}},TRUE)",
+          "valueType": "number"
+        },
+        {
+          "kind": "computed",
+          "id": "teamPartnerCount",
+          "label": "Partner team members",
+          "formula": "COUNTA({{col:teamPartner.name}})",
+          "valueType": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/meddpicc/engine/workbook-spec.test.ts
+++ b/plugins/meddpicc/engine/workbook-spec.test.ts
@@ -5,6 +5,7 @@ import { QUALIFICATION_ELEMENTS } from './sections';
 import {
   checkWorkbookSpec,
   expandJsonPath,
+  findMalformedReferences,
   parseReferences,
   type SpecSheet,
   VALUE_TYPE_STYLE,
@@ -163,6 +164,26 @@ describe('parseReferences', () => {
   });
 });
 
+describe('findMalformedReferences', () => {
+  // A placeholder the parser does not recognise is invisible to it, so without this the
+  // guard would pass a formula that reaches Excel with `{{reff:…}}` still in it.
+  test('catches a misspelled reference kind', () => {
+    expect(findMalformedReferences('{{reff:scoreTotal}}')).toEqual(['{{reff:scoreTotal}}']);
+  });
+
+  test('catches a placeholder with no kind at all', () => {
+    expect(findMalformedReferences('SUM({{elements.score}})')).toEqual(['{{elements.score}}']);
+  });
+
+  test('catches an unclosed placeholder', () => {
+    expect(findMalformedReferences('SUM({{col:elements.score)').join()).toMatch(/unbalanced/);
+  });
+
+  test('passes a formula whose placeholders are all well formed', () => {
+    expect(findMalformedReferences('{{ref:acv}}*{{col:elements.score}}')).toEqual([]);
+  });
+});
+
 describe('checkWorkbookSpec — the good spec', () => {
   test('passes every rule', () => {
     const result = checkWorkbookSpec(schema, baseSpec());
@@ -196,6 +217,31 @@ describe('checkWorkbookSpec — schema paths', () => {
     const result = checkWorkbookSpec(schema, spec);
     expect(result.ok).toBe(false);
     expect(result.schemaPaths.failures.join()).toContain('stakeholders.nameTYPO');
+  });
+
+  test('rejects a wildcard in a list column, where it would expand to nothing', () => {
+    // The failure this closes: a list source has no key axis, so a wildcard expanded to an
+    // empty set of paths and the column dropped out of the check entirely — ok, and
+    // writing nowhere.
+    const spec = clone(baseSpec());
+    const sh = sheet(spec, 'Stakeholders');
+    if (sh.kind !== 'table') throw new Error('fixture drift');
+    sh.tables[0].columns[0].jsonPath = '*.nameTYPO';
+
+    const result = checkWorkbookSpec(schema, spec);
+    expect(result.ok).toBe(false);
+    expect(result.schemaPaths.failures.join()).toContain('stakeholders.name');
+  });
+
+  test('rejects an input that expands to no path at all', () => {
+    const spec = clone(baseSpec());
+    const q = sheet(spec, 'Qualification');
+    if (q.kind !== 'table') throw new Error('fixture drift');
+    q.tables[0].source = { kind: 'fixed', keys: [] };
+
+    const result = checkWorkbookSpec(schema, spec);
+    expect(result.ok).toBe(false);
+    expect(result.schemaPaths.failures.join()).toMatch(/no path/);
   });
 
   test('rejects a wildcard in a form field, where there is nothing to expand it over', () => {
@@ -314,6 +360,19 @@ describe('checkWorkbookSpec — references', () => {
     block.formula = '{{row:stakeholders.name@0}}';
 
     expect(checkWorkbookSpec(schema, spec).references.failures.join()).toContain('stakeholders');
+  });
+
+  test('rejects a formula with a placeholder the parser does not recognise', () => {
+    const spec = clone(baseSpec());
+    const sc = sheet(spec, 'Scorecard');
+    if (sc.kind !== 'form') throw new Error('fixture drift');
+    const block = sc.blocks[0];
+    if (block.kind !== 'computed') throw new Error('fixture drift');
+    block.formula = 'SUM({{colm:elements.score}})';
+
+    const result = checkWorkbookSpec(schema, spec);
+    expect(result.ok).toBe(false);
+    expect(result.references.failures.join()).toContain('{{colm:elements.score}}');
   });
 
   test('rejects {{this:…}} outside a table column', () => {

--- a/plugins/meddpicc/engine/workbook-spec.test.ts
+++ b/plugins/meddpicc/engine/workbook-spec.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { QUALIFICATION_ELEMENTS } from './sections';
+import {
+  checkWorkbookSpec,
+  expandJsonPath,
+  parseReferences,
+  type SpecSheet,
+  VALUE_TYPE_STYLE,
+  type WorkbookSpec,
+} from './workbook-spec';
+
+const schema = JSON.parse(fs.readFileSync(path.join(import.meta.dir, '..', 'schema', 'meddpicc-schema.json'), 'utf8'));
+
+/**
+ * A minimal but structurally complete spec: one form sheet, one fixed-row table over the
+ * eight elements, one list table. Each test clones and breaks exactly one thing, so a
+ * failure names the rule that caught it.
+ */
+function baseSpec(): WorkbookSpec {
+  return {
+    version: 1,
+    sheets: [
+      {
+        name: 'Deal',
+        kind: 'form',
+        blocks: [
+          { kind: 'title', text: 'MEDDPICC Deal Review' },
+          { kind: 'field', id: 'acv', label: 'ACV', jsonPath: 'metadata.revenue.acv', valueType: 'currency' },
+          {
+            kind: 'field',
+            id: 'winProbability',
+            label: 'Win probability',
+            jsonPath: 'metadata.winProbability',
+            valueType: 'percent',
+          },
+          {
+            kind: 'computed',
+            id: 'factoredPipe',
+            label: 'Factored pipeline',
+            formula: '{{ref:acv}}*{{ref:winProbability}}',
+            valueType: 'currency',
+          },
+        ],
+      },
+      {
+        name: 'Qualification',
+        kind: 'table',
+        tables: [
+          {
+            id: 'elements',
+            source: { kind: 'elements' },
+            anchorColumn: 1,
+            headerRow: 1,
+            columns: [
+              { id: 'element', header: 'Element', role: 'derived', valueType: 'string' },
+              { id: 'score', header: 'Score', role: 'input', jsonPath: 'qualification.*.score', valueType: 'score' },
+              {
+                id: 'prevScore',
+                header: 'Previous',
+                role: 'input',
+                jsonPath: 'scoring.previousElementScores.*',
+                valueType: 'score',
+              },
+              {
+                id: 'delta',
+                header: 'Delta',
+                role: 'computed',
+                formula: '{{this:score}}-{{this:prevScore}}',
+                valueType: 'number',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'Stakeholders',
+        kind: 'table',
+        tables: [
+          {
+            id: 'stakeholders',
+            source: { kind: 'list', jsonPath: 'stakeholders' },
+            anchorColumn: 1,
+            headerRow: 1,
+            columns: [
+              { id: 'name', header: 'Name', role: 'input', jsonPath: 'name', valueType: 'string' },
+              { id: 'mustSayYes', header: 'Must say yes', role: 'input', jsonPath: 'mustSayYes', valueType: 'boolean' },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'Scorecard',
+        kind: 'form',
+        blocks: [
+          {
+            kind: 'computed',
+            id: 'scoreTotal',
+            label: 'Total',
+            formula: 'SUM({{col:elements.score}})',
+            valueType: 'number',
+          },
+          {
+            kind: 'computed',
+            id: 'metricsScore',
+            label: 'Metrics',
+            formula: '{{row:elements.score@metrics}}',
+            valueType: 'score',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** Deep clone so a mutation in one test cannot leak into the next. */
+const clone = (s: WorkbookSpec): WorkbookSpec => JSON.parse(JSON.stringify(s));
+
+const sheet = (s: WorkbookSpec, name: string): SpecSheet => {
+  const found = s.sheets.find((x) => x.name === name);
+  if (!found) throw new Error(`fixture has no sheet ${name}`);
+  return found;
+};
+
+describe('expandJsonPath', () => {
+  test('leaves a plain path alone', () => {
+    expect(expandJsonPath('metadata.accountName', QUALIFICATION_ELEMENTS)).toEqual(['metadata.accountName']);
+  });
+
+  test('expands a wildcard once per key', () => {
+    expect(expandJsonPath('qualification.*.score', ['metrics', 'champion'])).toEqual([
+      'qualification.metrics.score',
+      'qualification.champion.score',
+    ]);
+  });
+
+  test('resolves an open array index to the first element', () => {
+    // `responses[]` means "one cell per response"; for schema resolution any index does.
+    expect(expandJsonPath('qualification.metrics.responses[]', [])).toEqual(['qualification.metrics.responses[0]']);
+  });
+
+  test('refuses more than one wildcard rather than guessing which to expand', () => {
+    expect(() => expandJsonPath('a.*.b.*', ['x'])).toThrow(/one wildcard/);
+  });
+});
+
+describe('parseReferences', () => {
+  test('finds every reference kind in a formula', () => {
+    const refs = parseReferences(
+      'IF({{ref:acv}}>0,SUM({{col:elements.score}})-{{this:prev}},{{row:elements.score@metrics}})',
+    );
+    expect(refs).toEqual([
+      { kind: 'ref', target: 'acv', raw: '{{ref:acv}}' },
+      { kind: 'col', target: 'elements.score', raw: '{{col:elements.score}}' },
+      { kind: 'this', target: 'prev', raw: '{{this:prev}}' },
+      { kind: 'row', target: 'elements.score@metrics', raw: '{{row:elements.score@metrics}}' },
+    ]);
+  });
+
+  test('returns nothing for a formula with no references', () => {
+    expect(parseReferences('TODAY()')).toEqual([]);
+  });
+});
+
+describe('checkWorkbookSpec — the good spec', () => {
+  test('passes every rule', () => {
+    const result = checkWorkbookSpec(schema, baseSpec());
+    expect(result).toMatchObject({ ok: true });
+    expect(result.schemaPaths.checked).toBeGreaterThan(0);
+    expect(result.references.checked).toBeGreaterThan(0);
+  });
+});
+
+describe('checkWorkbookSpec — schema paths', () => {
+  test('rejects an input whose jsonPath is not in the schema', () => {
+    const spec = clone(baseSpec());
+    const deal = sheet(spec, 'Deal');
+    if (deal.kind !== 'form') throw new Error('fixture drift');
+    const field = deal.blocks[1];
+    if (field.kind !== 'field') throw new Error('fixture drift');
+    field.jsonPath = 'metadata.revenue.acvTYPO';
+
+    const result = checkWorkbookSpec(schema, spec);
+    expect(result.ok).toBe(false);
+    expect(result.schemaPaths.failures.join()).toContain('acvTYPO');
+  });
+
+  test('resolves a list column against its item schema, not the root', () => {
+    // `name` alone is meaningless at the root; it only resolves under `stakeholders`.
+    const spec = clone(baseSpec());
+    const sh = sheet(spec, 'Stakeholders');
+    if (sh.kind !== 'table') throw new Error('fixture drift');
+    sh.tables[0].columns[0].jsonPath = 'nameTYPO';
+
+    const result = checkWorkbookSpec(schema, spec);
+    expect(result.ok).toBe(false);
+    expect(result.schemaPaths.failures.join()).toContain('stakeholders.nameTYPO');
+  });
+
+  test('rejects a wildcard in a form field, where there is nothing to expand it over', () => {
+    const spec = clone(baseSpec());
+    const deal = sheet(spec, 'Deal');
+    if (deal.kind !== 'form') throw new Error('fixture drift');
+    const field = deal.blocks[1];
+    if (field.kind !== 'field') throw new Error('fixture drift');
+    field.jsonPath = 'qualification.*.score';
+
+    expect(checkWorkbookSpec(schema, spec).ok).toBe(false);
+  });
+});
+
+describe('checkWorkbookSpec — the eight scored elements', () => {
+  test('rejects a spec that captures only some element scores', () => {
+    // The bug this guards: replacing the wildcard with explicit rows and dropping one.
+    const spec = clone(baseSpec());
+    const q = sheet(spec, 'Qualification');
+    if (q.kind !== 'table') throw new Error('fixture drift');
+    q.tables[0].source = { kind: 'fixed', keys: ['metrics', 'champion'] };
+
+    const result = checkWorkbookSpec(schema, spec);
+    expect(result.ok).toBe(false);
+    expect(result.elements.failures.join()).toMatch(/economicBuyer/);
+  });
+
+  test('rejects a spec that captures an element score twice', () => {
+    const spec = clone(baseSpec());
+    const q = sheet(spec, 'Qualification');
+    if (q.kind !== 'table') throw new Error('fixture drift');
+    q.tables[0].columns.push({
+      id: 'scoreAgain',
+      header: 'Score (again)',
+      role: 'input',
+      jsonPath: 'qualification.*.score',
+      valueType: 'score',
+    });
+
+    const result = checkWorkbookSpec(schema, spec);
+    expect(result.ok).toBe(false);
+    // Two cells writing one value make the round-trip ambiguous, so it is a duplicate
+    // failure as well as an element-count one.
+    expect(result.duplicates.failures.join()).toContain('qualification.metrics.score');
+  });
+});
+
+describe('checkWorkbookSpec — roles', () => {
+  test('rejects an input with no jsonPath', () => {
+    const spec = clone(baseSpec());
+    const sh = sheet(spec, 'Stakeholders');
+    if (sh.kind !== 'table') throw new Error('fixture drift');
+    sh.tables[0].columns[0].jsonPath = undefined;
+    expect(checkWorkbookSpec(schema, spec).roles.failures.join()).toContain('stakeholders.name');
+  });
+
+  test('rejects a computed column that also claims a jsonPath', () => {
+    // A derived number must never flow back into the deal JSON as if a human typed it.
+    const spec = clone(baseSpec());
+    const q = sheet(spec, 'Qualification');
+    if (q.kind !== 'table') throw new Error('fixture drift');
+    const delta = q.tables[0].columns.find((c) => c.id === 'delta');
+    if (!delta) throw new Error('fixture drift');
+    delta.jsonPath = 'qualification.*.score';
+
+    expect(checkWorkbookSpec(schema, spec).roles.failures.join()).toContain('delta');
+  });
+
+  test('rejects an unknown valueType, which would have no style to render with', () => {
+    const spec = clone(baseSpec());
+    const sh = sheet(spec, 'Stakeholders');
+    if (sh.kind !== 'table') throw new Error('fixture drift');
+    sh.tables[0].columns[0].valueType = 'colour' as never;
+    expect(checkWorkbookSpec(schema, spec).roles.failures.join()).toContain('colour');
+  });
+
+  test('every declared valueType has a style in the palette', () => {
+    for (const [type, style] of Object.entries(VALUE_TYPE_STYLE)) {
+      expect(typeof style, `${type} maps to a style name`).toBe('string');
+    }
+  });
+});
+
+describe('checkWorkbookSpec — references', () => {
+  test('rejects a formula naming a cell that does not exist', () => {
+    const spec = clone(baseSpec());
+    const sc = sheet(spec, 'Scorecard');
+    if (sc.kind !== 'form') throw new Error('fixture drift');
+    const block = sc.blocks[0];
+    if (block.kind !== 'computed') throw new Error('fixture drift');
+    block.formula = 'SUM({{col:elements.scoreTYPO}})';
+
+    const result = checkWorkbookSpec(schema, spec);
+    expect(result.ok).toBe(false);
+    expect(result.references.failures.join()).toContain('elements.scoreTYPO');
+  });
+
+  test('rejects a row reference whose key is not one of the table rows', () => {
+    const spec = clone(baseSpec());
+    const sc = sheet(spec, 'Scorecard');
+    if (sc.kind !== 'form') throw new Error('fixture drift');
+    const block = sc.blocks[1];
+    if (block.kind !== 'computed') throw new Error('fixture drift');
+    block.formula = '{{row:elements.score@notAnElement}}';
+
+    expect(checkWorkbookSpec(schema, spec).references.failures.join()).toContain('notAnElement');
+  });
+
+  test('rejects a row reference into a table whose rows depend on the deal', () => {
+    // `stakeholders` has no fixed row for a formula to point at.
+    const spec = clone(baseSpec());
+    const sc = sheet(spec, 'Scorecard');
+    if (sc.kind !== 'form') throw new Error('fixture drift');
+    const block = sc.blocks[1];
+    if (block.kind !== 'computed') throw new Error('fixture drift');
+    block.formula = '{{row:stakeholders.name@0}}';
+
+    expect(checkWorkbookSpec(schema, spec).references.failures.join()).toContain('stakeholders');
+  });
+
+  test('rejects {{this:…}} outside a table column', () => {
+    const spec = clone(baseSpec());
+    const sc = sheet(spec, 'Scorecard');
+    if (sc.kind !== 'form') throw new Error('fixture drift');
+    const block = sc.blocks[0];
+    if (block.kind !== 'computed') throw new Error('fixture drift');
+    block.formula = '{{this:score}}';
+
+    expect(checkWorkbookSpec(schema, spec).references.failures.join()).toContain('this:score');
+  });
+});
+
+describe('checkWorkbookSpec — identity and layout', () => {
+  test('rejects two cells sharing an id, because a reference would be ambiguous', () => {
+    const spec = clone(baseSpec());
+    const sc = sheet(spec, 'Scorecard');
+    if (sc.kind !== 'form') throw new Error('fixture drift');
+    const block = sc.blocks[0];
+    if (block.kind !== 'computed') throw new Error('fixture drift');
+    block.id = 'acv';
+
+    expect(checkWorkbookSpec(schema, spec).ids.failures.join()).toContain('acv');
+  });
+
+  test('rejects a sheet name Excel will not accept', () => {
+    const spec = clone(baseSpec());
+    spec.sheets[0].name = 'Deal/Review';
+    expect(checkWorkbookSpec(schema, spec).layout.failures.join()).toContain('Deal/Review');
+  });
+
+  test('rejects two tables on one sheet whose columns overlap', () => {
+    // Side-by-side tables are how two collections share a sheet and still grow downward;
+    // an overlap means one would overwrite the other as rows are added.
+    const spec = clone(baseSpec());
+    const sh = sheet(spec, 'Stakeholders');
+    if (sh.kind !== 'table') throw new Error('fixture drift');
+    sh.tables.push({
+      id: 'second',
+      source: { kind: 'list', jsonPath: 'team.f5' },
+      anchorColumn: 2,
+      headerRow: 1,
+      columns: [{ id: 'teamName', header: 'Name', role: 'input', jsonPath: 'name', valueType: 'string' }],
+    });
+
+    expect(checkWorkbookSpec(schema, spec).layout.failures.join()).toMatch(/overlap/i);
+  });
+
+  test('accepts two tables on one sheet that are clear of each other', () => {
+    const spec = clone(baseSpec());
+    const sh = sheet(spec, 'Stakeholders');
+    if (sh.kind !== 'table') throw new Error('fixture drift');
+    sh.tables.push({
+      id: 'second',
+      source: { kind: 'list', jsonPath: 'team.f5' },
+      anchorColumn: 4,
+      headerRow: 1,
+      columns: [{ id: 'teamName', header: 'Name', role: 'input', jsonPath: 'name', valueType: 'string' }],
+    });
+
+    expect(checkWorkbookSpec(schema, spec).layout.failures).toEqual([]);
+  });
+});
+
+describe('the shipped workbook-spec.json', () => {
+  const shipped = JSON.parse(fs.readFileSync(path.join(import.meta.dir, 'workbook-spec.json'), 'utf8')) as WorkbookSpec;
+
+  test('passes every rule against the shipped schema', () => {
+    const result = checkWorkbookSpec(schema, shipped);
+    expect(result).toMatchObject({ ok: true });
+  });
+
+  test('captures all eight element scores', () => {
+    expect(checkWorkbookSpec(schema, shipped).elements.failures).toEqual([]);
+  });
+
+  test('is formula-driven — the Scorecard is entirely computed', () => {
+    // The whole point of the rebuild: the legacy template carried exactly one formula.
+    const scorecard = shipped.sheets.find((s) => s.name === 'Scorecard');
+    if (scorecard?.kind !== 'form') throw new Error('Scorecard must be a form sheet');
+    const valueBlocks = scorecard.blocks.filter((b) => b.kind === 'field' || b.kind === 'computed');
+    expect(valueBlocks.length).toBeGreaterThan(10);
+    expect(valueBlocks.every((b) => b.kind === 'computed')).toBe(true);
+  });
+
+  test('gives every deal collection a table, so nothing is capped', () => {
+    // Visa has 14 team members against the legacy sheet's 8 formatted rows.
+    const tableSources = shipped.sheets
+      .filter((s) => s.kind === 'table')
+      .flatMap((s) => (s.kind === 'table' ? s.tables : []))
+      .map((t) => (t.source.kind === 'list' ? t.source.jsonPath : t.source.kind));
+    for (const collection of [
+      'stakeholders',
+      'closePlan.milestones',
+      'closePlan.criticalActions',
+      'team.f5',
+      'team.partner',
+    ]) {
+      expect(tableSources).toContain(collection);
+    }
+  });
+});

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -1,0 +1,430 @@
+/**
+ * The workbook spec: a declarative description of the MEDDPICC workbook, and the guard that
+ * keeps it honest against the deal schema.
+ *
+ * `workbook-spec.json` IS the template. The generator turns spec + deal into an `.xlsx`; the
+ * reader will walk the same spec to pull edits back out. One document drives both
+ * directions, so a column cannot exist in one and not the other.
+ *
+ * Three properties the format is built for:
+ *
+ * - **Schema-related.** Every cell that holds a human's input names its `jsonPath`, and the
+ *   guard resolves each one against the deal schema. A mistyped path fails the build rather
+ *   than silently writing a value nowhere.
+ * - **Formula-driven.** Formulas name other cells symbolically — `{{ref:acv}}`,
+ *   `{{col:elements.score}}` — and the generator resolves them to addresses. Insert a row
+ *   and every formula still points at the right place, which is the failure mode that makes
+ *   hand-addressed spreadsheets rot.
+ * - **Round-trippable.** Each cell declares a `role`. Only `input` cells go back into the
+ *   JSON; `computed` and `derived` cells are outputs, and the guard refuses a cell that
+ *   claims to be both.
+ *
+ * Collections live in tables on sheets where they can grow downward, so nothing is capped —
+ * the legacy sheet formatted eight team rows and quietly dropped the rest.
+ */
+import { resolveSchemaPath } from './schema-path';
+import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
+import type { StyleName } from './xlsx';
+
+/** What a cell holds. Determines its style, and later its coercion on the way back in. */
+export type ValueType =
+  | 'string'
+  | 'text'
+  | 'integer'
+  | 'number'
+  | 'currency'
+  | 'percent'
+  | 'date'
+  | 'boolean'
+  | 'score'
+  | 'rating';
+
+/**
+ * Value type -> style name. The spec never names a style directly: the type already implies
+ * one, and two ways to say the same thing is two ways to disagree.
+ */
+export const VALUE_TYPE_STYLE: Record<ValueType, StyleName> = {
+  string: 'default',
+  text: 'text',
+  integer: 'number',
+  number: 'number',
+  currency: 'currency',
+  percent: 'percent',
+  date: 'date',
+  boolean: 'default',
+  score: 'score',
+  rating: 'default',
+};
+
+/**
+ * `input` — a human's value, written from the deal and read back out.
+ * `computed` — a formula the workbook evaluates. Never read back.
+ * `derived` — filled by the generator from the schema or the engine (a definition, a
+ *   question, a completion status). Not a formula, and still never read back: the engine
+ *   recomputes it, so a hand-edited cell would be a lie the next time it ran.
+ */
+export type CellRole = 'input' | 'computed' | 'derived';
+
+export interface SpecColumn {
+  id: string;
+  header: string;
+  role: CellRole;
+  valueType: ValueType;
+  /** For `input`. Relative to the item for a list source; may carry one `*` for a keyed source. */
+  jsonPath?: string;
+  /** For `computed`. May use `{{this:…}}` to name another column in the same row. */
+  formula?: string;
+  width?: number;
+}
+
+/**
+ * Where a table's rows come from.
+ *
+ * `list` rows depend on the deal and are unbounded. The keyed sources have a fixed row per
+ * key, which is what lets a formula point at one of them by name.
+ */
+export type SpecTableSource =
+  | { kind: 'list'; jsonPath: string }
+  | { kind: 'elements' }
+  | { kind: 'sections' }
+  | { kind: 'fixed'; keys: string[] }
+  | { kind: 'elementResponses' };
+
+export interface SpecTable {
+  id: string;
+  source: SpecTableSource;
+  /** 1-based column the table starts at. Two tables share a sheet by sitting side by side. */
+  anchorColumn: number;
+  headerRow: number;
+  /** Blank rows to keep below the data so the table has room to grow in Excel. */
+  minRows?: number;
+  columns: SpecColumn[];
+}
+
+export type SpecBlock =
+  | { kind: 'title'; text: string }
+  | { kind: 'section'; text: string }
+  | { kind: 'spacer' }
+  | { kind: 'field'; id: string; label: string; jsonPath: string; valueType: ValueType; height?: number }
+  | { kind: 'computed'; id: string; label: string; formula: string; valueType: ValueType; height?: number };
+
+export type SpecSheet =
+  | { name: string; kind: 'form'; blocks: SpecBlock[]; columns?: { min: number; max: number; width: number }[] }
+  | { name: string; kind: 'table'; tables: SpecTable[] };
+
+export interface WorkbookSpec {
+  version: number;
+  sheets: SpecSheet[];
+}
+
+export interface SpecCheck {
+  ok: boolean;
+  /** Every `input` path resolves against the deal schema. */
+  schemaPaths: { checked: number; failures: string[] };
+  /** All eight scored elements are captured, exactly once each. */
+  elements: { failures: string[] };
+  /** No two input cells claim the same path — that would make the read-back ambiguous. */
+  duplicates: { failures: string[] };
+  /** Cell, table and column ids are unique where a reference has to pick one out. */
+  ids: { checked: number; failures: string[] };
+  /** Each cell's role, jsonPath, formula and valueType agree with one another. */
+  roles: { failures: string[] };
+  /** Every `{{…}}` in a formula names something that exists. */
+  references: { checked: number; failures: string[] };
+  /** Sheet names Excel accepts, and tables that do not sit on top of each other. */
+  layout: { failures: string[] };
+}
+
+const WILDCARD = '*';
+
+/**
+ * Expand a spec path into the concrete schema paths it stands for.
+ *
+ * `qualification.*.score` over the eight elements becomes eight paths. `responses[]` means
+ * "one cell per entry"; for schema resolution the first index answers the same question as
+ * any other, so it collapses to `[0]`.
+ */
+export function expandJsonPath(jsonPath: string, keys: readonly string[]): string[] {
+  const base = jsonPath.replace(/\[\]/g, '[0]');
+  const wildcards = base.split(WILDCARD).length - 1;
+  if (wildcards === 0) return [base];
+  if (wildcards > 1) throw new Error(`"${jsonPath}" has more than one wildcard; a path may expand over one axis only`);
+  return keys.map((k) => base.replace(WILDCARD, k));
+}
+
+export interface SpecReference {
+  kind: 'ref' | 'col' | 'row' | 'this';
+  target: string;
+  raw: string;
+}
+
+const REFERENCE = /\{\{(ref|col|row|this):([^}]+)\}\}/g;
+
+/** Pull the symbolic cell references out of a formula, in the order they appear. */
+export function parseReferences(formula: string): SpecReference[] {
+  return [...formula.matchAll(REFERENCE)].map((m) => ({
+    kind: m[1] as SpecReference['kind'],
+    target: m[2],
+    raw: m[0],
+  }));
+}
+
+/** The keys a `*` expands over for this source, or [] when the source has no key axis. */
+function expansionKeys(source: SpecTableSource): readonly string[] {
+  switch (source.kind) {
+    case 'elements':
+    case 'elementResponses':
+      return QUALIFICATION_ELEMENTS;
+    case 'sections':
+      return SECTION_ORDER;
+    case 'fixed':
+      return source.keys;
+    case 'list':
+      return [];
+  }
+}
+
+/**
+ * The row keys a formula may point at, or null when the rows depend on the deal.
+ *
+ * `elementResponses` expands over the eight elements but has one row per response, so its
+ * row count is deal-dependent and no formula may name a row of it.
+ */
+function fixedRowKeys(source: SpecTableSource): readonly string[] | null {
+  switch (source.kind) {
+    case 'elements':
+      return QUALIFICATION_ELEMENTS;
+    case 'sections':
+      return SECTION_ORDER;
+    case 'fixed':
+      return source.keys;
+    case 'list':
+    case 'elementResponses':
+      return null;
+  }
+}
+
+/** Excel rejects these in a sheet name, and caps the name at 31 characters. */
+const ILLEGAL_SHEET_CHARS = /[[\]:*?/\\]/;
+
+interface Collected {
+  /** Form-sheet cells addressable as `{{ref:id}}`. */
+  namedCells: Map<string, { sheet: string; label: string }>;
+  tables: Map<string, { sheet: string; table: SpecTable }>;
+  /** Every input cell, with the concrete schema paths it writes. */
+  inputs: Array<{ where: string; paths: string[] }>;
+  /** Every formula, with the table it belongs to when it is a column formula. */
+  formulas: Array<{ where: string; formula: string; table: SpecTable | null }>;
+}
+
+function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected {
+  const out: Collected = { namedCells: new Map(), tables: new Map(), inputs: [], formulas: [] };
+
+  const checkValueType = (where: string, valueType: ValueType) => {
+    if (!(valueType in VALUE_TYPE_STYLE)) roles.push(`${where}: unknown valueType "${valueType}"`);
+  };
+
+  for (const sheet of spec.sheets) {
+    if (sheet.kind === 'form') {
+      for (const block of sheet.blocks) {
+        if (block.kind !== 'field' && block.kind !== 'computed') continue;
+        const where = `${sheet.name}.${block.id}`;
+        if (out.namedCells.has(block.id)) {
+          ids.push(`duplicate cell id "${block.id}" (${out.namedCells.get(block.id)?.sheet} and ${sheet.name})`);
+        }
+        out.namedCells.set(block.id, { sheet: sheet.name, label: block.label });
+        checkValueType(where, block.valueType);
+
+        if (block.kind === 'field') {
+          if (!block.jsonPath) {
+            roles.push(`${where}: a field must name a jsonPath`);
+          } else if (block.jsonPath.includes(WILDCARD)) {
+            roles.push(`${where}: a form field cannot use a wildcard — there is no key axis to expand it over`);
+          } else {
+            out.inputs.push({ where, paths: [block.jsonPath] });
+          }
+        } else {
+          out.formulas.push({ where, formula: block.formula, table: null });
+        }
+      }
+      continue;
+    }
+
+    for (const table of sheet.tables) {
+      if (out.tables.has(table.id)) {
+        ids.push(`duplicate table id "${table.id}" (${out.tables.get(table.id)?.sheet} and ${sheet.name})`);
+      }
+      out.tables.set(table.id, { sheet: sheet.name, table });
+
+      const seenColumns = new Set<string>();
+      for (const column of table.columns) {
+        const where = `${table.id}.${column.id}`;
+        if (seenColumns.has(column.id)) ids.push(`${where}: duplicate column id`);
+        seenColumns.add(column.id);
+        checkValueType(where, column.valueType);
+
+        if (column.role === 'input') {
+          if (column.formula) roles.push(`${where}: an input column cannot also carry a formula`);
+          if (!column.jsonPath) {
+            roles.push(`${where}: an input column must name a jsonPath`);
+            continue;
+          }
+          const relative =
+            table.source.kind === 'list' ? `${table.source.jsonPath}.${column.jsonPath}` : column.jsonPath;
+          try {
+            out.inputs.push({ where, paths: expandJsonPath(relative, expansionKeys(table.source)) });
+          } catch (e) {
+            roles.push(`${where}: ${e instanceof Error ? e.message : String(e)}`);
+          }
+        } else if (column.role === 'computed') {
+          if (column.jsonPath) {
+            roles.push(`${where}: a computed column cannot claim a jsonPath — a derived value must not flow back`);
+          }
+          if (!column.formula) {
+            roles.push(`${where}: a computed column must carry a formula`);
+            continue;
+          }
+          out.formulas.push({ where, formula: column.formula, table });
+        } else {
+          if (column.jsonPath) roles.push(`${where}: a derived column must not claim a jsonPath`);
+          if (column.formula) roles.push(`${where}: a derived column must not carry a formula`);
+        }
+      }
+    }
+  }
+
+  return out;
+}
+
+function checkReferences(collected: Collected): { checked: number; failures: string[] } {
+  const failures: string[] = [];
+  let checked = 0;
+
+  for (const { where, formula, table } of collected.formulas) {
+    for (const ref of parseReferences(formula)) {
+      checked++;
+      if (ref.kind === 'ref') {
+        if (!collected.namedCells.has(ref.target)) failures.push(`${where}: ${ref.raw} names no cell`);
+        continue;
+      }
+      if (ref.kind === 'this') {
+        if (!table) {
+          failures.push(`${where}: ${ref.raw} is only meaningful inside a table column`);
+        } else if (!table.columns.some((c) => c.id === ref.target)) {
+          failures.push(`${where}: ${ref.raw} names no column of table "${table.id}"`);
+        }
+        continue;
+      }
+
+      const [locator, rowKey] = ref.target.split('@');
+      const dot = locator.indexOf('.');
+      if (dot < 0) {
+        failures.push(`${where}: ${ref.raw} must be <table>.<column>`);
+        continue;
+      }
+      const tableId = locator.slice(0, dot);
+      const columnId = locator.slice(dot + 1);
+      const found = collected.tables.get(tableId);
+      if (!found) {
+        failures.push(`${where}: ${ref.raw} names no table "${tableId}"`);
+        continue;
+      }
+      if (!found.table.columns.some((c) => c.id === columnId)) {
+        failures.push(`${where}: ${ref.raw} names no column "${locator}"`);
+        continue;
+      }
+      if (ref.kind === 'row') {
+        const keys = fixedRowKeys(found.table.source);
+        if (!keys) {
+          failures.push(`${where}: ${ref.raw} points at one row of "${tableId}", whose rows depend on the deal`);
+        } else if (!rowKey || !keys.includes(rowKey)) {
+          failures.push(`${where}: ${ref.raw} names no row "${rowKey ?? ''}" of "${tableId}"`);
+        }
+      }
+    }
+  }
+
+  return { checked, failures };
+}
+
+function checkLayout(spec: WorkbookSpec): string[] {
+  const failures: string[] = [];
+  const seen = new Set<string>();
+
+  for (const sheet of spec.sheets) {
+    if (seen.has(sheet.name)) failures.push(`duplicate sheet name "${sheet.name}"`);
+    seen.add(sheet.name);
+    if (sheet.name.length === 0 || sheet.name.length > 31) {
+      failures.push(`sheet name "${sheet.name}" must be 1-31 characters`);
+    }
+    if (ILLEGAL_SHEET_CHARS.test(sheet.name)) {
+      failures.push(`sheet name "${sheet.name}" contains a character Excel forbids`);
+    }
+    if (sheet.kind !== 'table') continue;
+
+    // Two tables share a sheet by sitting side by side; both grow downward for ever, so
+    // overlapping column ranges means one eventually writes over the other.
+    const spans = sheet.tables.map((t) => ({
+      id: t.id,
+      from: t.anchorColumn,
+      to: t.anchorColumn + t.columns.length - 1,
+    }));
+    for (let i = 0; i < spans.length; i++) {
+      for (let j = i + 1; j < spans.length; j++) {
+        if (spans[i].from <= spans[j].to && spans[j].from <= spans[i].to) {
+          failures.push(`tables "${spans[i].id}" and "${spans[j].id}" overlap on sheet "${sheet.name}"`);
+        }
+      }
+    }
+  }
+
+  return failures;
+}
+
+/**
+ * Validate the workbook spec against the deal schema.
+ *
+ * The check that matters most is `elements`: MEDDPICC is a 0-4 score across eight elements,
+ * and a spec that captures seven of them looks entirely plausible while quietly scoring the
+ * deal out of 28. The same class of near-miss shipped once already in `cell-mapping.json`,
+ * where every target resolved against the schema and every one of them named a label cell.
+ */
+export function checkWorkbookSpec(schema: unknown, spec: WorkbookSpec): SpecCheck {
+  const roleFailures: string[] = [];
+  const idFailures: string[] = [];
+  const collected = collect(spec, roleFailures, idFailures);
+
+  const allPaths = collected.inputs.flatMap((i) => i.paths);
+  const schemaFailures = [...new Set(allPaths)].filter((p) => !resolveSchemaPath(schema, p));
+
+  const counts = new Map<string, number>();
+  for (const p of allPaths) counts.set(p, (counts.get(p) ?? 0) + 1);
+  const duplicateFailures = [...counts.entries()]
+    .filter(([, n]) => n > 1)
+    .map(([p, n]) => `${p} is written by ${n} cells; the read-back would be ambiguous`);
+
+  const elementFailures = QUALIFICATION_ELEMENTS.filter((el) => !counts.has(`qualification.${el}.score`)).map(
+    (el) => `no input cell captures qualification.${el}.score`,
+  );
+
+  const references = checkReferences(collected);
+  const layoutFailures = checkLayout(spec);
+
+  return {
+    ok:
+      schemaFailures.length === 0 &&
+      elementFailures.length === 0 &&
+      duplicateFailures.length === 0 &&
+      idFailures.length === 0 &&
+      roleFailures.length === 0 &&
+      references.failures.length === 0 &&
+      layoutFailures.length === 0,
+    schemaPaths: { checked: allPaths.length, failures: schemaFailures },
+    elements: { failures: elementFailures },
+    duplicates: { failures: duplicateFailures },
+    ids: { checked: collected.namedCells.size + collected.tables.size, failures: idFailures },
+    roles: { failures: roleFailures },
+    references,
+    layout: { failures: layoutFailures },
+  };
+}

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -158,7 +158,9 @@ export interface SpecReference {
   raw: string;
 }
 
-const REFERENCE = /\{\{(ref|col|row|this):([^}]+)\}\}/g;
+const REFERENCE = /\{\{(ref|col|row|this):([^{}]+)\}\}/g;
+/** Any `{{…}}`, well formed or not — what the parser above ignores, this one still sees. */
+const PLACEHOLDER = /\{\{([^{}]*)\}\}/g;
 
 /** Pull the symbolic cell references out of a formula, in the order they appear. */
 export function parseReferences(formula: string): SpecReference[] {
@@ -167,6 +169,25 @@ export function parseReferences(formula: string): SpecReference[] {
     target: m[2],
     raw: m[0],
   }));
+}
+
+/**
+ * Placeholders that look like references but are not.
+ *
+ * {@link parseReferences} only matches the four kinds it knows, so a typo — `{{reff:…}}`,
+ * a missing kind, an unclosed brace — is invisible to it and to every check built on it.
+ * Silence would mean the placeholder survived into the generated formula, where Excel would
+ * see literal braces. So the malformed ones are found separately and always reported.
+ */
+export function findMalformedReferences(formula: string): string[] {
+  const bad = [...formula.matchAll(PLACEHOLDER)].filter((m) => !/^(ref|col|row|this):.+$/.test(m[1])).map((m) => m[0]);
+
+  // An unclosed `{{` matches neither pattern, so it can only be caught by counting.
+  const opens = formula.match(/\{\{/g)?.length ?? 0;
+  const closes = formula.match(/\}\}/g)?.length ?? 0;
+  if (opens !== closes) bad.push(`unbalanced braces in "${formula}"`);
+
+  return bad;
 }
 
 /** The keys a `*` expands over for this source, or [] when the source has no key axis. */
@@ -215,10 +236,12 @@ interface Collected {
   inputs: Array<{ where: string; paths: string[] }>;
   /** Every formula, with the table it belongs to when it is a column formula. */
   formulas: Array<{ where: string; formula: string; table: SpecTable | null }>;
+  /** Inputs whose path could not even be formed — before any schema lookup. */
+  pathIssues: string[];
 }
 
 function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected {
-  const out: Collected = { namedCells: new Map(), tables: new Map(), inputs: [], formulas: [] };
+  const out: Collected = { namedCells: new Map(), tables: new Map(), inputs: [], formulas: [], pathIssues: [] };
 
   const checkValueType = (where: string, valueType: ValueType) => {
     if (!(valueType in VALUE_TYPE_STYLE)) roles.push(`${where}: unknown valueType "${valueType}"`);
@@ -272,7 +295,17 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
           const relative =
             table.source.kind === 'list' ? `${table.source.jsonPath}.${column.jsonPath}` : column.jsonPath;
           try {
-            out.inputs.push({ where, paths: expandJsonPath(relative, expansionKeys(table.source)) });
+            // A source with no key axis has nothing for a wildcard to expand over, so the
+            // expansion would silently produce zero paths and the column would vanish from
+            // the schema check — present in the workbook, writing nowhere.
+            const paths = expandJsonPath(relative, expansionKeys(table.source));
+            if (paths.length === 0) {
+              out.pathIssues.push(
+                `${where}: "${relative}" expands to no path — table "${table.id}" has no keys to expand a wildcard over`,
+              );
+              continue;
+            }
+            out.inputs.push({ where, paths });
           } catch (e) {
             roles.push(`${where}: ${e instanceof Error ? e.message : String(e)}`);
           }
@@ -301,6 +334,10 @@ function checkReferences(collected: Collected): { checked: number; failures: str
   let checked = 0;
 
   for (const { where, formula, table } of collected.formulas) {
+    for (const bad of findMalformedReferences(formula)) {
+      checked++;
+      failures.push(`${where}: ${bad} is not a reference this spec understands`);
+    }
     for (const ref of parseReferences(formula)) {
       checked++;
       if (ref.kind === 'ref') {
@@ -395,7 +432,10 @@ export function checkWorkbookSpec(schema: unknown, spec: WorkbookSpec): SpecChec
   const collected = collect(spec, roleFailures, idFailures);
 
   const allPaths = collected.inputs.flatMap((i) => i.paths);
-  const schemaFailures = [...new Set(allPaths)].filter((p) => !resolveSchemaPath(schema, p));
+  const schemaFailures = [
+    ...collected.pathIssues,
+    ...[...new Set(allPaths)].filter((p) => !resolveSchemaPath(schema, p)),
+  ];
 
   const counts = new Map<string, number>();
   for (const p of allPaths) counts.set(p, (counts.get(p) ?? 0) + 1);

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'bun:test';
+import { A1, buildWorkbook, columnLetter, STYLE_IDS } from './xlsx';
+import { readZip } from './zip';
+
+const dec = (b: Uint8Array) => new TextDecoder().decode(b);
+
+/** The parts every .xlsx must carry for Excel to open it without offering to repair. */
+const REQUIRED_PARTS = [
+  '[Content_Types].xml',
+  '_rels/.rels',
+  'xl/workbook.xml',
+  'xl/_rels/workbook.xml.rels',
+  'xl/styles.xml',
+  'xl/worksheets/sheet1.xml',
+];
+
+const minimal = () =>
+  buildWorkbook([
+    {
+      name: 'Deal',
+      rows: [
+        { row: 1, cells: [{ ref: 'A1', value: 'MEDDPICC', style: 'title' }] },
+        {
+          row: 2,
+          cells: [
+            { ref: 'A2', value: 'Account', style: 'label' },
+            { ref: 'B2', value: 'Visa, Inc.', style: 'text' },
+          ],
+        },
+      ],
+    },
+  ]);
+
+describe('columnLetter / A1', () => {
+  test('maps 1-based indexes to spreadsheet columns', () => {
+    expect([1, 26, 27, 52, 53].map(columnLetter)).toEqual(['A', 'Z', 'AA', 'AZ', 'BA']);
+  });
+  test('A1 composes a reference', () => {
+    expect(A1(2, 3)).toBe('B3');
+  });
+});
+
+describe('buildWorkbook — container', () => {
+  test('emits every part Excel requires', () => {
+    const parts = readZip(minimal());
+    for (const p of REQUIRED_PARTS) expect(parts.has(p)).toBe(true);
+  });
+
+  test('[Content_Types] declares an override for every sheet it ships', () => {
+    // A sheet present in the zip but missing from [Content_Types] is the single most
+    // common way a hand-written xlsx makes Excel offer to repair it.
+    const parts = readZip(
+      buildWorkbook([
+        { name: 'Deal', rows: [] },
+        { name: 'Scorecard', rows: [] },
+      ]),
+    );
+    const ct = dec(parts.get('[Content_Types].xml')?.data as Uint8Array);
+    expect(ct).toContain('/xl/worksheets/sheet1.xml');
+    expect(ct).toContain('/xl/worksheets/sheet2.xml');
+    expect(parts.has('xl/worksheets/sheet2.xml')).toBe(true);
+  });
+
+  test('every sheet in workbook.xml has a matching relationship id', () => {
+    const parts = readZip(
+      buildWorkbook([
+        { name: 'Deal', rows: [] },
+        { name: 'Scorecard', rows: [] },
+      ]),
+    );
+    const wb = dec(parts.get('xl/workbook.xml')?.data as Uint8Array);
+    const rels = dec(parts.get('xl/_rels/workbook.xml.rels')?.data as Uint8Array);
+    for (const id of [...wb.matchAll(/r:id="(rId\d+)"/g)].map((m) => m[1])) {
+      expect(rels).toContain(`Id="${id}"`);
+    }
+  });
+
+  test('sheet names are XML-escaped, not injected raw', () => {
+    const parts = readZip(buildWorkbook([{ name: 'A & B <deal>', rows: [] }]));
+    const wb = dec(parts.get('xl/workbook.xml')?.data as Uint8Array);
+    expect(wb).toContain('A &amp; B &lt;deal&gt;');
+    expect(wb).not.toContain('<deal>');
+  });
+});
+
+describe('buildWorkbook — cells', () => {
+  test('writes a string as an inline string, so sharedStrings is never needed', () => {
+    const sheet = dec(readZip(minimal()).get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+    expect(sheet).toContain('t="inlineStr"');
+    expect(sheet).toContain('<t xml:space="preserve">Visa, Inc.</t>');
+  });
+
+  test('writes a number bare, so the sheet can compute on it', () => {
+    const sheet = dec(
+      readZip(
+        buildWorkbook([{ name: 'S', rows: [{ row: 1, cells: [{ ref: 'A1', value: 473687, style: 'currency' }] }] }]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+    expect(sheet).toContain('<v>473687</v>');
+    expect(sheet).not.toContain('inlineStr');
+  });
+
+  test('writes a formula as <f> with no cached value', () => {
+    // No <v>: Excel computes on open. A stale cached value would be worse than none.
+    const sheet = dec(
+      readZip(buildWorkbook([{ name: 'S', rows: [{ row: 1, cells: [{ ref: 'A1', formula: 'SUM(B1:B8)' }] }] }])).get(
+        'xl/worksheets/sheet1.xml',
+      )?.data as Uint8Array,
+    );
+    expect(sheet).toContain('<f>SUM(B1:B8)</f>');
+    expect(sheet).not.toMatch(/<f>SUM\(B1:B8\)<\/f><v>/);
+  });
+
+  test('escapes text and formulas that contain XML metacharacters', () => {
+    const sheet = dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'S',
+            rows: [
+              {
+                row: 1,
+                cells: [
+                  { ref: 'A1', value: 'A & B <x>' },
+                  { ref: 'B1', formula: 'IF(A1<5,"lo","hi")' },
+                ],
+              },
+            ],
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+    expect(sheet).toContain('A &amp; B &lt;x&gt;');
+    expect(sheet).toContain('IF(A1&lt;5,&quot;lo&quot;,&quot;hi&quot;)');
+  });
+
+  test('a named style resolves to its index in styles.xml', () => {
+    const sheet = dec(
+      minimal().length ? (readZip(minimal()).get('xl/worksheets/sheet1.xml')?.data as Uint8Array) : new Uint8Array(),
+    );
+    expect(sheet).toContain(`s="${STYLE_IDS.title}"`);
+    expect(sheet).toContain(`s="${STYLE_IDS.label}"`);
+  });
+
+  test('rejects an unknown style name rather than emitting a wrong index', () => {
+    // A bad index silently mis-styles a cell, or makes Excel reject the file — the one
+    // failure mode of a hand-written styles.xml, so it fails loudly at build time.
+    expect(() =>
+      buildWorkbook([{ name: 'S', rows: [{ row: 1, cells: [{ ref: 'A1', value: 'x', style: 'nope' as never }] }] }]),
+    ).toThrow(/nope/);
+  });
+});
+
+describe('styles.xml', () => {
+  test('declares exactly as many cellXfs as the palette names', () => {
+    // The mapping from name to index is positional; a mismatch here means every style
+    // after the gap is silently wrong.
+    const styles = dec(readZip(minimal()).get('xl/styles.xml')?.data as Uint8Array);
+    const count = Number(styles.match(/<cellXfs count="(\d+)"/)?.[1]);
+    expect(count).toBe(Object.keys(STYLE_IDS).length);
+    expect([...styles.matchAll(/<xf /g)].length).toBeGreaterThanOrEqual(count);
+  });
+
+  test('every custom numFmtId referenced by a cellXf is defined', () => {
+    const styles = dec(readZip(minimal()).get('xl/styles.xml')?.data as Uint8Array);
+    const defined = new Set([...styles.matchAll(/<numFmt numFmtId="(\d+)"/g)].map((m) => m[1]));
+    const cellXfs = styles.slice(styles.indexOf('<cellXfs'));
+    for (const m of cellXfs.matchAll(/numFmtId="(\d+)"/g)) {
+      const id = Number(m[1]);
+      if (id >= 164) expect(defined.has(String(id))).toBe(true); // 164+ is the custom range
+    }
+  });
+});

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -1,0 +1,310 @@
+/**
+ * A small OOXML writer: enough of the `.xlsx` format to emit a real, formula-driven
+ * workbook from scratch.
+ *
+ * `fill.ts` injects values into a template someone else authored. This builds the workbook
+ * itself, which is what a formula-driven sheet needs — formulas, named styles and (later)
+ * tables and conditional formatting have to be authored, not injected.
+ *
+ * The hard part of hand-writing xlsx is `styles.xml`: cells reference styles by INDEX into
+ * `cellXfs`, so an off-by-one silently mis-styles every cell after the gap, and a dangling
+ * `numFmtId` makes Excel offer to repair the file. Both are addressed the same way — a
+ * fixed, named palette (see {@link STYLE_IDS}) whose indexes are derived from one ordered
+ * list, with tests asserting the count matches and every custom format is defined. Callers
+ * name a style; they never write an index.
+ *
+ * Strings are written inline (`t="inlineStr"`) rather than through `sharedStrings.xml`.
+ * That trades a little file size for one fewer part to keep consistent, and it is the same
+ * choice `fill.ts` already makes.
+ */
+import { writeZip } from './zip';
+
+const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const NS_MAIN = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main';
+const NS_REL_DOC = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const NS_REL_PKG = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+/** Custom number formats start at 164; below that the ids are reserved by the format. */
+const NUMFMT_CURRENCY = 164;
+const NUMFMT_PERCENT = 165;
+const NUMFMT_DATE = 166;
+
+const XML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+};
+
+export function escapeXml(text: string): string {
+  return text.replace(/[&<>"']/g, (c) => XML_ESCAPES[c]);
+}
+
+/** 1 -> "A", 26 -> "Z", 27 -> "AA". */
+export function columnLetter(oneBased: number): string {
+  let n = Math.max(1, oneBased);
+  let out = '';
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    out = String.fromCharCode(65 + rem) + out;
+    n = Math.floor((n - 1) / 26);
+  }
+  return out;
+}
+
+/** Compose an A1 reference from 1-based column and row. */
+export function A1(col: number, row: number): string {
+  return `${columnLetter(col)}${row}`;
+}
+
+/**
+ * The style palette, in `cellXfs` order — the index of each name IS its `s=` attribute.
+ *
+ * Deliberately small and fixed. Arbitrary per-cell formatting would mean generating fonts,
+ * fills and borders on demand and keeping four parallel indexes correct; a curated palette
+ * covers what a deal review needs and can be read and reviewed in one screen.
+ */
+const STYLE_ORDER = [
+  'default',
+  'title',
+  'sectionHeader',
+  'columnHeader',
+  'label',
+  'text',
+  'number',
+  'currency',
+  'percent',
+  'date',
+  'score',
+  'ragRed',
+  'ragAmber',
+  'ragGreen',
+  'muted',
+] as const;
+
+export type StyleName = (typeof STYLE_ORDER)[number];
+
+/** Name -> `cellXfs` index. Derived from one list so the two cannot drift. */
+export const STYLE_IDS: Record<StyleName, number> = Object.fromEntries(
+  STYLE_ORDER.map((name, i) => [name, i]),
+) as Record<StyleName, number>;
+
+/** Font index per style, into the `<fonts>` list below. */
+const FONT_DEFAULT = 0;
+const FONT_BOLD = 1;
+const FONT_TITLE = 2;
+const FONT_WHITE_BOLD = 3;
+const FONT_ITALIC_GREY = 4;
+
+/** Fill index per style, into the `<fills>` list below. */
+const FILL_NONE = 0;
+// index 1 is the format-reserved gray125 placeholder; Excel expects it present and unused
+const FILL_DARK = 2;
+const FILL_HEADER = 3;
+const FILL_RED = 4;
+const FILL_AMBER = 5;
+const FILL_GREEN = 6;
+
+interface StyleDef {
+  font: number;
+  fill: number;
+  numFmt: number;
+  wrap?: boolean;
+  center?: boolean;
+}
+
+const STYLE_DEFS: Record<StyleName, StyleDef> = {
+  default: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: 0 },
+  title: { font: FONT_TITLE, fill: FILL_NONE, numFmt: 0 },
+  sectionHeader: { font: FONT_WHITE_BOLD, fill: FILL_DARK, numFmt: 0 },
+  columnHeader: { font: FONT_BOLD, fill: FILL_HEADER, numFmt: 0 },
+  label: { font: FONT_BOLD, fill: FILL_NONE, numFmt: 0 },
+  text: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: 0, wrap: true },
+  number: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: 0 },
+  currency: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: NUMFMT_CURRENCY },
+  percent: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: NUMFMT_PERCENT },
+  date: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: NUMFMT_DATE },
+  score: { font: FONT_BOLD, fill: FILL_NONE, numFmt: 0, center: true },
+  ragRed: { font: FONT_BOLD, fill: FILL_RED, numFmt: 0, center: true },
+  ragAmber: { font: FONT_BOLD, fill: FILL_AMBER, numFmt: 0, center: true },
+  ragGreen: { font: FONT_BOLD, fill: FILL_GREEN, numFmt: 0, center: true },
+  muted: { font: FONT_ITALIC_GREY, fill: FILL_NONE, numFmt: 0 },
+};
+
+function stylesXml(): string {
+  const fonts = [
+    '<font><sz val="11"/><name val="Calibri"/></font>',
+    '<font><b/><sz val="11"/><name val="Calibri"/></font>',
+    '<font><b/><sz val="16"/><name val="Calibri"/></font>',
+    '<font><b/><sz val="11"/><color rgb="FFFFFFFF"/><name val="Calibri"/></font>',
+    '<font><i/><sz val="10"/><color rgb="FF6B6B6B"/><name val="Calibri"/></font>',
+  ];
+  const fills = [
+    '<fill><patternFill patternType="none"/></fill>',
+    '<fill><patternFill patternType="gray125"/></fill>',
+    '<fill><patternFill patternType="solid"><fgColor rgb="FF1F3864"/><bgColor indexed="64"/></patternFill></fill>',
+    '<fill><patternFill patternType="solid"><fgColor rgb="FFD9E2F3"/><bgColor indexed="64"/></patternFill></fill>',
+    '<fill><patternFill patternType="solid"><fgColor rgb="FFF8CBAD"/><bgColor indexed="64"/></patternFill></fill>',
+    '<fill><patternFill patternType="solid"><fgColor rgb="FFFFE699"/><bgColor indexed="64"/></patternFill></fill>',
+    '<fill><patternFill patternType="solid"><fgColor rgb="FFC6E0B4"/><bgColor indexed="64"/></patternFill></fill>',
+  ];
+  const border =
+    '<border><left style="thin"><color rgb="FFD0D0D0"/></left><right style="thin"><color rgb="FFD0D0D0"/></right>' +
+    '<top style="thin"><color rgb="FFD0D0D0"/></top><bottom style="thin"><color rgb="FFD0D0D0"/></bottom><diagonal/></border>';
+
+  const xfs = STYLE_ORDER.map((name) => {
+    const d = STYLE_DEFS[name];
+    const align =
+      d.wrap || d.center
+        ? `<alignment${d.wrap ? ' wrapText="1" vertical="top"' : ''}${d.center ? ' horizontal="center"' : ''}/>`
+        : '';
+    const applies = `${d.numFmt ? ' applyNumberFormat="1"' : ''}${d.font ? ' applyFont="1"' : ''}${d.fill ? ' applyFill="1"' : ''}${align ? ' applyAlignment="1"' : ''}`;
+    return `<xf numFmtId="${d.numFmt}" fontId="${d.font}" fillId="${d.fill}" borderId="1" xfId="0"${applies}>${align}</xf>`;
+  });
+
+  return (
+    `${XML_HEADER}<styleSheet xmlns="${NS_MAIN}">` +
+    `<numFmts count="3">` +
+    `<numFmt numFmtId="${NUMFMT_CURRENCY}" formatCode="&quot;$&quot;#,##0"/>` +
+    `<numFmt numFmtId="${NUMFMT_PERCENT}" formatCode="0.0%"/>` +
+    `<numFmt numFmtId="${NUMFMT_DATE}" formatCode="yyyy-mm-dd"/>` +
+    `</numFmts>` +
+    `<fonts count="${fonts.length}">${fonts.join('')}</fonts>` +
+    `<fills count="${fills.length}">${fills.join('')}</fills>` +
+    // borderId 0 must exist and be empty; ours is index 1.
+    `<borders count="2"><border><left/><right/><top/><bottom/><diagonal/></border>${border}</borders>` +
+    `<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>` +
+    `<cellXfs count="${xfs.length}">${xfs.join('')}</cellXfs>` +
+    `<cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>` +
+    `</styleSheet>`
+  );
+}
+
+/** One cell: a literal value, or a formula, or both omitted for a styled blank. */
+export interface CellSpec {
+  ref: string;
+  value?: string | number | boolean;
+  formula?: string;
+  style?: StyleName;
+}
+
+export interface RowSpec {
+  row: number;
+  cells: CellSpec[];
+  height?: number;
+}
+
+export interface SheetSpec {
+  name: string;
+  rows: RowSpec[];
+  /** Column widths, 1-based index -> width in characters. */
+  columns?: { min: number; max: number; width: number }[];
+  /** Freeze everything above this row (a header freeze). */
+  freezeAtRow?: number;
+}
+
+function cellXml(cell: CellSpec): string {
+  const style = cell.style;
+  if (style !== undefined && !(style in STYLE_IDS)) {
+    throw new Error(`Unknown style "${style}" for cell ${cell.ref} — add it to STYLE_ORDER or use an existing name`);
+  }
+  const s = style === undefined ? '' : ` s="${STYLE_IDS[style]}"`;
+
+  if (cell.formula !== undefined) {
+    // No cached <v>: Excel computes on open. Writing a value we guessed would be worse —
+    // it would show a stale number until something forced a recalculation.
+    return `<c r="${cell.ref}"${s}><f>${escapeXml(cell.formula)}</f></c>`;
+  }
+  if (cell.value === undefined) return `<c r="${cell.ref}"${s}/>`;
+  if (typeof cell.value === 'number') {
+    if (!Number.isFinite(cell.value)) throw new Error(`Cell ${cell.ref} has a non-finite number`);
+    return `<c r="${cell.ref}"${s}><v>${cell.value}</v></c>`;
+  }
+  if (typeof cell.value === 'boolean') return `<c r="${cell.ref}"${s} t="b"><v>${cell.value ? 1 : 0}</v></c>`;
+  return `<c r="${cell.ref}"${s} t="inlineStr"><is><t xml:space="preserve">${escapeXml(cell.value)}</t></is></c>`;
+}
+
+function sheetXml(sheet: SheetSpec): string {
+  const cols = sheet.columns?.length
+    ? `<cols>${sheet.columns.map((c) => `<col min="${c.min}" max="${c.max}" width="${c.width}" customWidth="1"/>`).join('')}</cols>`
+    : '';
+  const pane = sheet.freezeAtRow
+    ? `<pane ySplit="${sheet.freezeAtRow}" topLeftCell="A${sheet.freezeAtRow + 1}" activePane="bottomLeft" state="frozen"/>`
+    : '';
+  const rows = sheet.rows
+    .map(
+      (r) =>
+        `<row r="${r.row}"${r.height ? ` ht="${r.height}" customHeight="1"` : ''}>${r.cells.map(cellXml).join('')}</row>`,
+    )
+    .join('');
+  return (
+    `${XML_HEADER}<worksheet xmlns="${NS_MAIN}" xmlns:r="${NS_REL_DOC}">` +
+    `<sheetViews><sheetView workbookViewId="0">${pane}</sheetView></sheetViews>` +
+    `<sheetFormatPr defaultRowHeight="15"/>${cols}` +
+    `<sheetData>${rows}</sheetData>` +
+    `</worksheet>`
+  );
+}
+
+/**
+ * Build a complete `.xlsx` from sheet specs.
+ *
+ * Every part Excel requires is emitted together — the container, the relationships, the
+ * workbook, the styles and one worksheet per sheet — because a sheet present in the zip but
+ * absent from `[Content_Types].xml` (or missing its relationship) is the usual cause of
+ * Excel's "we found a problem with some content" prompt.
+ */
+export function buildWorkbook(sheets: readonly SheetSpec[]): Uint8Array {
+  if (sheets.length === 0) throw new Error('A workbook needs at least one sheet');
+
+  const enc = (s: string) => new TextEncoder().encode(s);
+  const sheetPath = (i: number) => `xl/worksheets/sheet${i + 1}.xml`;
+
+  const contentTypes =
+    `${XML_HEADER}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+    `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+    `<Default Extension="xml" ContentType="application/xml"/>` +
+    `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
+    `<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>` +
+    sheets
+      .map(
+        (_, i) =>
+          `<Override PartName="/${sheetPath(i)}" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`,
+      )
+      .join('') +
+    `</Types>`;
+
+  const rootRels =
+    `${XML_HEADER}<Relationships xmlns="${NS_REL_PKG}">` +
+    `<Relationship Id="rId1" Type="${NS_REL_DOC}/officeDocument" Target="xl/workbook.xml"/>` +
+    `</Relationships>`;
+
+  // Sheets take rId1..rIdN; styles takes the next id after them.
+  const stylesRelId = `rId${sheets.length + 1}`;
+  const workbookRels =
+    `${XML_HEADER}<Relationships xmlns="${NS_REL_PKG}">` +
+    sheets
+      .map(
+        (_, i) =>
+          `<Relationship Id="rId${i + 1}" Type="${NS_REL_DOC}/worksheet" Target="worksheets/sheet${i + 1}.xml"/>`,
+      )
+      .join('') +
+    `<Relationship Id="${stylesRelId}" Type="${NS_REL_DOC}/styles" Target="styles.xml"/>` +
+    `</Relationships>`;
+
+  const workbook =
+    `${XML_HEADER}<workbook xmlns="${NS_MAIN}" xmlns:r="${NS_REL_DOC}">` +
+    `<sheets>` +
+    sheets.map((s, i) => `<sheet name="${escapeXml(s.name)}" sheetId="${i + 1}" r:id="rId${i + 1}"/>`).join('') +
+    `</sheets></workbook>`;
+
+  return writeZip([
+    { name: '[Content_Types].xml', data: enc(contentTypes) },
+    { name: '_rels/.rels', data: enc(rootRels) },
+    { name: 'xl/workbook.xml', data: enc(workbook) },
+    { name: 'xl/_rels/workbook.xml.rels', data: enc(workbookRels) },
+    { name: 'xl/styles.xml', data: enc(stylesXml()) },
+    ...sheets.map((s, i) => ({ name: sheetPath(i), data: enc(sheetXml(s)) })),
+  ]);
+}

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/tests/test_engine.sh
+++ b/plugins/meddpicc/scripts/tests/test_engine.sh
@@ -159,6 +159,46 @@ test_engine_fill_is_deterministic() {
   }
 }
 
+test_engine_check_spec_ok() {
+  _engine_precheck || return 0
+  bun "$PLUGIN_ROOT/engine/cli.ts" check-spec >/dev/null || {
+    echo "check-spec failed on the shipped workbook spec"
+    return 1
+  }
+}
+
+test_engine_check_spec_detects_a_dropped_element() {
+  _engine_precheck || return 0
+  local tmp
+  tmp=$(mktemp -d)
+  # Pin the wildcard to seven of the eight elements. The workbook still looks complete and
+  # every path still resolves; the deal is just quietly scored out of 28.
+  jq '(.sheets[] | select(.name == "Qualification") | .tables[0].source) =
+        {"kind": "fixed", "keys": ["metrics","economicBuyer","decisionCriteria","decisionProcess","paperProcess","implicateThePain","competition"]}' \
+    "$PLUGIN_ROOT/engine/workbook-spec.json" >"$tmp/spec.json"
+  if bun "$PLUGIN_ROOT/engine/cli.ts" check-spec --spec "$tmp/spec.json" >/dev/null 2>&1; then
+    echo "expected non-zero exit for a spec missing an element score"
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+test_engine_check_spec_detects_a_broken_formula_reference() {
+  _engine_precheck || return 0
+  local tmp
+  tmp=$(mktemp -d)
+  # Rename a column the Scorecard's formulas point at. Nothing else changes.
+  jq '(.sheets[] | select(.name == "Qualification") | .tables[0].columns[] | select(.id == "score") | .id) = "renamed"' \
+    "$PLUGIN_ROOT/engine/workbook-spec.json" >"$tmp/spec.json"
+  if bun "$PLUGIN_ROOT/engine/cli.ts" check-spec --spec "$tmp/spec.json" >/dev/null 2>&1; then
+    echo "expected non-zero exit for a formula naming a column that no longer exists"
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
 test_engine_check_mappings_detects_a_target_aimed_at_a_label() {
   _engine_precheck || return 0
   local tmp

--- a/plugins/meddpicc/scripts/tests/test_engine.sh
+++ b/plugins/meddpicc/scripts/tests/test_engine.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 # End-to-end acceptance for the MEDDPICC engine CLI.
 
+# Skipping when bun is absent keeps the suite usable on a bare machine, but in CI a skip
+# would be a green gate that ran nothing. REQUIRE_BUN makes the absence a failure instead.
 _engine_precheck() {
-  command -v bun >/dev/null 2>&1 || {
-    echo "SKIP: bun unavailable"
-    return 1
-  }
+  command -v bun >/dev/null 2>&1 && return 0
+  # Aborts the whole run rather than returning: a missing runtime is a configuration error,
+  # and every one of these tests would otherwise report a green skip having run nothing.
+  if [ "${REQUIRE_BUN:-0}" = "1" ]; then
+    echo "FATAL: bun is required (REQUIRE_BUN=1) but is not installed" >&2
+    exit 1
+  fi
+  echo "SKIP: bun unavailable"
+  return 1
 }
 
 test_engine_score_matches_example() {

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# run-plugin-tests.sh — run every plugin's test suite.
+#
+# Each plugin ships `scripts/tests/run-tests.sh` (shell acceptance) and, where it has a
+# TypeScript engine, `*.test.ts` files run by bun. Until now nothing ran either in CI, so a
+# plugin could merge with its own guards failing — including the workbook-spec guard, whose
+# entire job is to fail the build.
+#
+# KNOWN_RED is deliberately not an allowlist of green plugins. An allowlist rots silently: a
+# newly added plugin would inherit no gate at all, which is the same failure this script
+# exists to close. Instead every plugin must pass, and the few that are already red are
+# named here against a tracking issue.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 2
+
+# Plugins with pre-existing failures, tracked in issue #873. Remove a name when its suite
+# goes green; the run warns when one of these passes, so the list has a visible expiry.
+#
+# The warning is not a failure on purpose. Some of these suites shell out to a cloud CLI and
+# so fail differently on a developer's machine than on a CI runner, and a gate that flaps
+# between the two gets switched off rather than fixed.
+KNOWN_RED=(aws azure gcloud salesforce salesforce-legacy)
+
+# A missing runtime must not read as a pass: the per-plugin suites skip themselves when bun
+# is absent, which in CI would be a silent no-op gate.
+export REQUIRE_BUN=1
+
+command -v bun >/dev/null 2>&1 || {
+  echo "FATAL: bun is required to run the plugin test suites" >&2
+  exit 2
+}
+
+is_known_red() {
+  local name="$1" p
+  for p in "${KNOWN_RED[@]}"; do [ "$p" = "$name" ] && return 0; done
+  return 1
+}
+
+failed=()
+unexpectedly_green=()
+
+for suite in plugins/*/scripts/tests/run-tests.sh; do
+  [ -f "$suite" ] || continue
+  plugin="$(basename "$(dirname "$(dirname "$(dirname "$suite")")")")"
+  printf '\n==> %s\n' "$plugin"
+
+  ok=0
+  bash "$suite" || ok=1
+
+  # Only run bun tests where the plugin actually has some.
+  if find "plugins/$plugin" -name '*.test.ts' -not -path '*/node_modules/*' -print -quit | grep -q .; then
+    # Install first where there is a lockfile. Without it every import of a devDependency
+    # fails with "Cannot find module", which reads exactly like broken code and is not.
+    # Frozen so a stale lockfile fails here rather than resolving to something else.
+    if [ -f "plugins/$plugin/bun.lock" ]; then
+      (cd "plugins/$plugin" && bun install --frozen-lockfile) || ok=1
+    fi
+    (cd "plugins/$plugin" && bun test .) || ok=1
+  fi
+
+  if is_known_red "$plugin"; then
+    if [ "$ok" -eq 0 ]; then
+      unexpectedly_green+=("$plugin")
+    else
+      printf '    (known red — not failing the build)\n'
+    fi
+  elif [ "$ok" -ne 0 ]; then
+    failed+=("$plugin")
+  fi
+done
+
+status=0
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  printf '\nFAILED: %s\n' "${failed[*]}" >&2
+  status=1
+fi
+
+if [ "${#unexpectedly_green[@]}" -gt 0 ]; then
+  printf '\nWARNING: listed in KNOWN_RED but now passing: %s\n' "${unexpectedly_green[*]}" >&2
+  printf 'Remove them from KNOWN_RED in %s so the gate starts holding them green.\n' "$0" >&2
+fi
+
+[ "$status" -eq 0 ] && printf '\nAll gated plugin suites passed.\n'
+exit "$status"


### PR DESCRIPTION
## What this is

Stage 1b of the modern-workbook rebuild: the **template as data**, and the guard that keeps
it honest. Nothing generates a file yet — `fill` is still what produces the report, and it
stays until the stage that replaces it.

Why the rebuild exists, measured rather than assumed: in both the shipped F5 Deal Review
Sheet and a completed copy there is **1 formula**, **0 conditional formatting rules**,
**0 named ranges** and **0 cells mentioning "score"**. MEDDPICC is a 0-4 framework across
eight elements; the engine computes a total, a percentage and a RAG rating, and there is
nowhere in that workbook to put any of it.

## Three pieces

**`engine/xlsx.ts`** — an OOXML writer that builds a complete `.xlsx` from scratch. The
fiddly part is `styles.xml`: a cell names a style by index into `cellXfs`, so an off-by-one
silently mis-styles everything after the gap and a dangling `numFmtId` makes Excel offer to
repair the file. Both are handled the same way — one ordered palette, indexes derived from
it, callers name a style and never write an index. Formulas are written as bare `<f>` with
no cached value, because a value we guessed would show as a stale number until something
forced a recalculation.

**`engine/workbook-spec.json`** — the template. Every input cell names its `jsonPath`, so
the workbook is tied to the schema rather than to a coordinate someone typed. Formulas name
other cells symbolically (`{{ref:acv}}`, `{{col:elements.score}}`,
`{{row:elements.score@champion}}`, `{{this:previousScore}}`) so inserting a row cannot break
them. Every collection sits in a table on a sheet where it can grow — the legacy sheet
formats eight team rows and quietly drops the rest of a 14-person team.

**`engine/workbook-spec.ts` + `check-spec`** — the guard. Every input path resolves against
the schema; all eight scored elements are captured exactly once; no two cells claim one
value; a `computed` or `derived` cell cannot claim a `jsonPath`; every `{{…}}` names
something real; side-by-side tables cannot overlap.

The check that matters is the element count. A spec capturing seven of the eight looks
entirely plausible while scoring the deal out of 28 — and the same class of near-miss
already shipped once in `cell-mapping.json`, where every target resolved against the schema
and every one of them named a label cell.

## Verification

The risk the plan flagged is closed, in real Excel rather than by reasoning: a generated
workbook **opened with no repair prompt**, and the formulas **computed from bare `<f>` with
no cached value** (`B3*B4` → 284212.2, `IF(B4>=6,"Green",…)` → "Green").

- `bun test engine/` — 114 pass, 0 fail
- `scripts/tests/run-tests.sh` — 27 passed, 0 failed
- `scripts/run-plugin-tests.sh` — exit 0 (214 unit tests, 18 shell suites)
- Biome — exit 0; shellcheck and shfmt — exit 0
- Guard mutation-checked: a typo in a path, a dropped element, a renamed referenced column,
  two colliding tables, and a computed column claiming a path are each caught. The
  shipped-spec test is not vacuous.

## Second-opinion review

Codex reported **three findings, all three CONFIRMED by reproducing them** — none refuted.
Fixed in the second commit, each with a test that was red first.

1. **Malformed placeholders bypassed validation.** `{{reff:scoreTotal}}` matched no
   reference pattern, so it was invisible to the parser and to every check built on it —
   `ok: true`, and the braces would have reached Excel. `findMalformedReferences` now
   catches unknown kinds, missing kinds and unbalanced braces.
2. **A wildcard on a list column expanded to nothing.** List sources have no key axis, so
   the column contributed zero paths and vanished from the schema check — present in the
   workbook, writing nowhere. Zero-expansion is now a failure.
3. **None of it ran in CI.** No workflow invoked bun, the plugin suites or `check-spec`.
   Fixed by `scripts/run-plugin-tests.sh` and a new job in `Validate Plugins`, with
   `REQUIRE_BUN=1` turning a missing runtime into a hard abort rather than a green skip.

## Scope I am flagging rather than absorbing

Adding that CI job surfaced two things beyond this PR, both in **#873**:

- **Five plugins fail today** — `aws`, `azure`, `gcloud` (deterministic name drift: the
  suites expect `aws-status`/`azure-status`/`gcloud-status`), `salesforce` (a real
  sync/async hook mismatch plus a 5 s timeout shelling out to the real `sf` CLI), and
  `salesforce-legacy`. They are named in `KNOWN_RED` so the runner is honest rather than
  green-by-omission. That list is deliberately of what is *broken*, not of what is
  *checked*, so a newly added plugin is gated by default.
- **The new job cannot block a merge.** Required checks on `main` are only
  `check / Check linked issues`, `lint / Lint Code Base` and `audit / Translation
  freshness`. Adding this one is branch protection, governed by docs-control.

Closes #870
