### PR TITLE
Fix every plugin test suite the new CI job exposed, and drop KNOWN_RED

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "docs-tools",
       "description": "MDX content validation and review tools for f5-sales-demo docs repos",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -28,7 +28,7 @@
     {
       "name": "sales-engineer",
       "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -58,7 +58,7 @@
     {
       "name": "docs-pipeline",
       "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -73,7 +73,7 @@
     {
       "name": "brand",
       "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -113,7 +113,7 @@
     {
       "name": "devcontainer",
       "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5-sales-demo devcontainer",
-      "version": "1.1.6",
+      "version": "1.1.7",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -128,7 +128,7 @@
     {
       "name": "platform",
       "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -157,7 +157,7 @@
     {
       "name": "osint-framework",
       "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -172,7 +172,7 @@
     {
       "name": "firecrawl",
       "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -187,7 +187,7 @@
     {
       "name": "salesforce-legacy",
       "description": "[ARCHIVED] Original Claude Code-only Salesforce CLI automation. Replaced by unified salesforce plugin with native xcsh tool support.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -202,7 +202,7 @@
     {
       "name": "salesforce",
       "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -240,7 +240,7 @@
     {
       "name": "cloudstatus",
       "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -264,7 +264,7 @@
     {
       "name": "azure",
       "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -289,7 +289,7 @@
     {
       "name": "aws",
       "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -314,7 +314,7 @@
     {
       "name": "gcloud",
       "description": "Google Cloud CLI integration — container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -339,7 +339,7 @@
     {
       "name": "gitlab",
       "description": "GitLab CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via glab CLI",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -364,7 +364,7 @@
     {
       "name": "github",
       "description": "GitHub CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via gh CLI",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ and this project adheres to
 
 ## [Unreleased]
 
+Every plugin test suite now runs in CI, and the failures that surfaced are fixed.
+
+- **Portable setup-wizard tests** (`aws` v1.2.1, `azure` v1.2.1, `gcloud` v1.2.1,
+  `github` v1.2.1, `gitlab` v1.2.2, `salesforce` v1.3.2) — `runSetupWizard` resolved the
+  install command from `process.platform` and shelled out to `which`, so the tests asserted
+  `brew` and passed only on macOS. Each wizard now accepts an injected `detectPlatform`, and
+  each suite covers macOS, Linux and a host with no package manager — the last of which was
+  a live branch nobody asserted.
+
+- **Tests no longer drive real cloud CLIs** (`salesforce` v1.3.2, `azure` v1.2.1) — a
+  `sf_setup` validation test ran four genuine `sf config set target-org … --global`
+  commands, writing to the developer's own `~/.sf/config.json`, and `az_exec` spawned `az`
+  to check argument validation. Both tools take an injected executor now. The
+  Salesforce extension-load suite genuinely needs the CLI and is skipped, visibly, when it
+  is absent.
+
+- **Stale plugin names** (`aws` v1.2.1, `azure` v1.2.1, `gcloud` v1.2.1,
+  `salesforce-legacy` v1.0.1) — the suites asserted the pre-rename names
+  (`aws-status`, `salesforce`) that nothing else in the repo still used, and azure's
+  tool-factory list predated the rename that gave each file its verb.
+
+- **Credential scanners no longer search `node_modules`** (12 plugins) — with dependencies
+  installed, the scan reported five lines of `bun-types`' own npmrc documentation as
+  hardcoded credentials. Six plugins already excluded it; the rest do now.
+
+- **`salesforce-legacy` hook test** v1.0.1 — it symlinked `/usr/bin/bash`, which does not
+  exist on macOS, so the scrubbed `PATH` held no usable shell and the hook never ran.
+
+- **`meddpicc`** v2.4.1 — credential-scanner exclusion only.
+
+- No plugin is exempt from the gate any more: `run-plugin-tests.sh` drops its `KNOWN_RED`
+  list, since every named plugin is green.
+
 - **`meddpicc`** bumped to v2.4.0 — foundations for a formula-driven workbook generated
   from the schema. Adds `engine/xlsx.ts`, an OOXML writer that emits a complete `.xlsx`
   from scratch with a fixed, named style palette, and `engine/workbook-spec.json`, a

--- a/plugins/aws/.xcsh-plugin/plugin.json
+++ b/plugins/aws/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws",
   "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/aws",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/aws/package.json
+++ b/plugins/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-aws",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AWS CLI status for xcsh welcome screen",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "AWS",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/aws/scripts/tests/test_structure.sh
+++ b/plugins/aws/scripts/tests/test_structure.sh
@@ -22,8 +22,8 @@ test_plugin_json_valid() {
 
   local name
   name=$(jq -r '.name' "$pj")
-  [ "$name" = "aws-status" ] || {
-    echo "name=$name, expected aws-status"
+  [ "$name" = "aws" ] || {
+    echo "name=$name, expected aws"
     return 1
   }
 
@@ -35,20 +35,20 @@ test_plugin_json_valid() {
   }
 }
 
-# T1.2 — marketplace.json has a matching aws-status entry
+# T1.2 — marketplace.json has a matching aws entry
 test_marketplace_entry() {
   local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
   local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
 
   local mp_name
-  mp_name=$(jq -r '.plugins[] | select(.name == "aws-status") | .name' "$mj")
-  [ "$mp_name" = "aws-status" ] || {
-    echo "aws-status entry missing from marketplace.json"
+  mp_name=$(jq -r '.plugins[] | select(.name == "aws") | .name' "$mj")
+  [ "$mp_name" = "aws" ] || {
+    echo "aws entry missing from marketplace.json"
     return 1
   }
 
   local mp_ver
-  mp_ver=$(jq -r '.plugins[] | select(.name == "aws-status") | .version' "$mj")
+  mp_ver=$(jq -r '.plugins[] | select(.name == "aws") | .version' "$mj")
   local pj_ver
   pj_ver=$(jq -r '.version' "$pj")
   [ "$mp_ver" = "$pj_ver" ] || {
@@ -57,9 +57,9 @@ test_marketplace_entry() {
   }
 
   local src
-  src=$(jq -r '.plugins[] | select(.name == "aws-status") | .source' "$mj")
-  [ "$src" = "./plugins/aws-status" ] || {
-    echo "source=$src, expected ./plugins/aws-status"
+  src=$(jq -r '.plugins[] | select(.name == "aws") | .source' "$mj")
+  [ "$src" = "./plugins/aws" ] || {
+    echo "source=$src, expected ./plugins/aws"
     return 1
   }
 }
@@ -225,9 +225,9 @@ test_T1_12_src_index_exports_default_factory() {
   fi
 }
 
-# T1.13 — extension tool count (skipped: aws-status registers 0 tools)
+# T1.13 — extension tool count (skipped: aws registers 0 tools)
 test_T1_13_extension_registers_tools() {
-  echo "SKIP: aws-status does not register tools"
+  echo "SKIP: aws does not register tools"
   return 0
 }
 
@@ -240,15 +240,15 @@ test_T1_14_tool_factories_exist() {
   fi
 }
 
-# T1.15 — hooks.json references /aws-status:setup, not brew
+# T1.15 — hooks.json references /aws:setup, not brew
 test_T1_15_hook_references_setup_command() {
   local hook="$PLUGIN_ROOT/hooks/hooks.json"
   if [[ ! -f "$hook" ]]; then
     echo "FAIL: hooks.json missing"
     return 1
   fi
-  if ! grep -q "aws-status:setup" "$hook"; then
-    echo "FAIL: hooks.json should reference /aws-status:setup"
+  if ! grep -q "aws:setup" "$hook"; then
+    echo "FAIL: hooks.json should reference /aws:setup"
     return 1
   fi
   if grep -q "brew install" "$hook"; then

--- a/plugins/aws/src/wizard.ts
+++ b/plugins/aws/src/wizard.ts
@@ -84,12 +84,20 @@ export async function runSetupWizard(
     cwd: string;
     reload?: () => Promise<void>;
   },
-  options?: { checkCliInstalled?: () => boolean },
+  options?: {
+    checkCliInstalled?: () => boolean;
+  /**
+   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+   * which made every install assertion below depend on the machine running it — they
+   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+   */
+    detectPlatform?: () => Promise<PlatformInfo>;
+  },
 ): Promise<void> {
   const checkCli = options?.checkCliInstalled ?? awsIsInstalled;
 
   // --- Platform detection (deterministic, no prompts) ---
-  const platform = await detectPlatform();
+  const platform = await (options?.detectPlatform ?? detectPlatform)();
   const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
   ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
 

--- a/plugins/aws/src/wizard.ts
+++ b/plugins/aws/src/wizard.ts
@@ -86,11 +86,11 @@ export async function runSetupWizard(
   },
   options?: {
     checkCliInstalled?: () => boolean;
-  /**
-   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
-   * which made every install assertion below depend on the machine running it — they
-   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
-   */
+    /**
+     * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+     * which made every install assertion below depend on the machine running it — they
+     * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+     */
     detectPlatform?: () => Promise<PlatformInfo>;
   },
 ): Promise<void> {

--- a/plugins/aws/test/wizard.test.ts
+++ b/plugins/aws/test/wizard.test.ts
@@ -1,10 +1,40 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { PlatformInfo } from '../src/platform';
 import { buildAuthStep, buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
 
 // ---------------------------------------------------------------------------
 // Helper builders — exact command assertions
 // ---------------------------------------------------------------------------
+
+/**
+ * The wizard branches on credential environment variables, so a developer machine or CI
+ * runner with cloud credentials exported takes a different auth path and these tests fail
+ * for a reason that has nothing to do with the code. Clear them around every case; the ones
+ * that exercise a credential path set what they need themselves.
+ */
+const CREDENTIAL_VARS = [
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_PROFILE',
+  'AWS_REGION',
+  'AWS_DEFAULT_REGION',
+];
+let savedCredentials: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedCredentials = Object.fromEntries(CREDENTIAL_VARS.map((key) => [key, process.env[key]]));
+  for (const key of CREDENTIAL_VARS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of CREDENTIAL_VARS) {
+    const value = savedCredentials[key];
+    // Assigning undefined would store the string "undefined", so absent means delete.
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 describe('buildInstallStep', () => {
   it('macOS brew command is exactly brew install awscli', () => {
@@ -226,7 +256,17 @@ describe('runSetupWizard — aws not installed', () => {
 
     await runSetupWizard(pi, ctx, { ...awsNotInstalledThenInstalled, ...on(LINUX) });
 
-    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(["apt","install","-y","awscli"]);
+    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(['apt', 'install', '-y', 'awscli']);
+  });
+
+  it('no package manager shows the manual install link', async () => {
+    const { pi, calls } = buildMockPi();
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false, ...on(BARE) });
+
+    expect(notifications.find((n) => n.message.includes('docs.aws.amazon.com'))?.type).toBe('error');
+    expect(calls).toHaveLength(0);
   });
 
   it('install failure shows error', async () => {

--- a/plugins/aws/test/wizard.test.ts
+++ b/plugins/aws/test/wizard.test.ts
@@ -177,6 +177,15 @@ describe('runSetupWizard — aws installed, SSO auth', () => {
 // runSetupWizard — aws NOT installed (auto-install flow)
 // ---------------------------------------------------------------------------
 
+// The wizard resolves the install command from the host it runs on. These tests inject the
+// platform instead, so each one asserts the same thing on a developer's Mac and on a Linux
+// CI runner — previously they asserted `brew` and so passed only on macOS.
+const MACOS: PlatformInfo = { os: 'darwin', arch: 'arm64', packageManagers: ['brew'], isCorporateManaged: false };
+const LINUX: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: ['apt'], isCorporateManaged: false };
+const BARE: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+
+const on = (platform: PlatformInfo) => ({ detectPlatform: async () => platform });
+
 describe('runSetupWizard — aws not installed', () => {
   let installCount = 0;
   const awsNotInstalledThenInstalled = {
@@ -186,7 +195,7 @@ describe('runSetupWizard — aws not installed', () => {
     },
   };
 
-  it('auto-installs via preferred package manager and notifies restart', async () => {
+  it('auto-installs via brew on macOS and notifies restart', async () => {
     installCount = 0;
     const { pi, calls } = buildMockPi({
       'brew install awscli': { stdout: 'installed', stderr: '', code: 0 },
@@ -199,7 +208,7 @@ describe('runSetupWizard — aws not installed', () => {
     });
     const { ctx, notifications } = buildMockCtx();
 
-    await runSetupWizard(pi, ctx, awsNotInstalledThenInstalled);
+    await runSetupWizard(pi, ctx, { ...awsNotInstalledThenInstalled, ...on(MACOS) });
 
     const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('awscli'));
     expect(installCall).toBeDefined();
@@ -208,13 +217,25 @@ describe('runSetupWizard — aws not installed', () => {
     expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
   });
 
+  it('auto-installs via apt on Linux', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'apt install': { stdout: 'installed', stderr: '', code: 0 },
+    });
+    const { ctx } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { ...awsNotInstalledThenInstalled, ...on(LINUX) });
+
+    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(["apt","install","-y","awscli"]);
+  });
+
   it('install failure shows error', async () => {
     const { pi } = buildMockPi({
       'brew install awscli': { stdout: '', stderr: 'permission denied', code: 1 },
     });
     const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
 
-    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false });
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false, ...on(MACOS) });
 
     expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
   });

--- a/plugins/azure/.xcsh-plugin/plugin.json
+++ b/plugins/azure/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "azure",
   "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/azure",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/azure/package.json
+++ b/plugins/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-azure",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Azure CLI tools for xcsh — native az command execution, subscription/resource/VM management, and welcome screen status",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Azure",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/azure/scripts/tests/test_structure.sh
+++ b/plugins/azure/scripts/tests/test_structure.sh
@@ -22,8 +22,8 @@ test_plugin_json_valid() {
 
   local name
   name=$(jq -r '.name' "$pj")
-  [ "$name" = "azure-status" ] || {
-    echo "name=$name, expected azure-status"
+  [ "$name" = "azure" ] || {
+    echo "name=$name, expected azure"
     return 1
   }
 
@@ -35,20 +35,20 @@ test_plugin_json_valid() {
   }
 }
 
-# T1.2 — marketplace.json has a matching azure-status entry
+# T1.2 — marketplace.json has a matching azure entry
 test_marketplace_entry() {
   local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
   local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
 
   local mp_name
-  mp_name=$(jq -r '.plugins[] | select(.name == "azure-status") | .name' "$mj")
-  [ "$mp_name" = "azure-status" ] || {
-    echo "azure-status entry missing from marketplace.json"
+  mp_name=$(jq -r '.plugins[] | select(.name == "azure") | .name' "$mj")
+  [ "$mp_name" = "azure" ] || {
+    echo "azure entry missing from marketplace.json"
     return 1
   }
 
   local mp_ver
-  mp_ver=$(jq -r '.plugins[] | select(.name == "azure-status") | .version' "$mj")
+  mp_ver=$(jq -r '.plugins[] | select(.name == "azure") | .version' "$mj")
   local pj_ver
   pj_ver=$(jq -r '.version' "$pj")
   [ "$mp_ver" = "$pj_ver" ] || {
@@ -57,9 +57,9 @@ test_marketplace_entry() {
   }
 
   local src
-  src=$(jq -r '.plugins[] | select(.name == "azure-status") | .source' "$mj")
-  [ "$src" = "./plugins/azure-status" ] || {
-    echo "source=$src, expected ./plugins/azure-status"
+  src=$(jq -r '.plugins[] | select(.name == "azure") | .source' "$mj")
+  [ "$src" = "./plugins/azure" ] || {
+    echo "source=$src, expected ./plugins/azure"
     return 1
   }
 }
@@ -248,7 +248,7 @@ test_T1_14_tool_factories_exist() {
     return 0
   fi
   local missing=()
-  for f in az-account.ts az-group.ts az-resource.ts az-vm.ts az-exec.ts az-help.ts; do
+  for f in az-account-show.ts az-group-list.ts az-resource-list.ts az-vm-list.ts az-exec.ts az-help.ts; do
     [[ -f "$tools_dir/$f" ]] || missing+=("$f")
   done
   if [[ ${#missing[@]} -gt 0 ]]; then
@@ -257,15 +257,15 @@ test_T1_14_tool_factories_exist() {
   fi
 }
 
-# T1.15 — hooks.json references /azure-status:setup, not brew
+# T1.15 — hooks.json references /azure:setup, not brew
 test_T1_15_hook_references_setup_command() {
   local hook="$PLUGIN_ROOT/hooks/hooks.json"
   if [[ ! -f "$hook" ]]; then
     echo "FAIL: hooks.json missing"
     return 1
   fi
-  if ! grep -q "azure-status:setup" "$hook"; then
-    echo "FAIL: hooks.json should reference /azure-status:setup"
+  if ! grep -q "azure:setup" "$hook"; then
+    echo "FAIL: hooks.json should reference /azure:setup"
     return 1
   fi
   if grep -q "brew install" "$hook"; then

--- a/plugins/azure/src/tools/az-exec.ts
+++ b/plugins/azure/src/tools/az-exec.ts
@@ -1,3 +1,4 @@
+import type { AzExecApi } from '../az/exec';
 import type { PluginInterface } from '../az/types';
 import azExecDescription from '../prompts/az-exec.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, textResult } from './shared';
@@ -116,7 +117,12 @@ export function buildAzArgs(args: string[]): string[] {
   return hasOutput ? [...args] : [...args, '--output', 'json'];
 }
 
-export function createAzExecTool(pi: PluginInterface) {
+/**
+ * `makeApi` exists so a validation test can assert what the tool lets through without
+ * spawning the real `az`. Two of them did, which made the suite depend on whether the CLI
+ * was installed and how long it took to answer.
+ */
+export function createAzExecTool(pi: PluginInterface, makeApi: (cwd: string) => AzExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -159,7 +165,7 @@ export function createAzExecTool(pi: PluginInterface) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = buildAzArgs(params.args);
 
       try {

--- a/plugins/azure/src/wizard.ts
+++ b/plugins/azure/src/wizard.ts
@@ -87,11 +87,11 @@ export async function runSetupWizard(
   },
   options?: {
     checkCliInstalled?: () => boolean;
-  /**
-   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
-   * which made every install assertion below depend on the machine running it — they
-   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
-   */
+    /**
+     * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+     * which made every install assertion below depend on the machine running it — they
+     * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+     */
     detectPlatform?: () => Promise<PlatformInfo>;
   },
 ): Promise<void> {

--- a/plugins/azure/src/wizard.ts
+++ b/plugins/azure/src/wizard.ts
@@ -85,12 +85,20 @@ export async function runSetupWizard(
     cwd: string;
     reload?: () => Promise<void>;
   },
-  options?: { checkCliInstalled?: () => boolean },
+  options?: {
+    checkCliInstalled?: () => boolean;
+  /**
+   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+   * which made every install assertion below depend on the machine running it — they
+   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+   */
+    detectPlatform?: () => Promise<PlatformInfo>;
+  },
 ): Promise<void> {
   const checkCli = options?.checkCliInstalled ?? azIsInstalled;
 
   // --- Platform detection (deterministic, no prompts) ---
-  const platform = await detectPlatform();
+  const platform = await (options?.detectPlatform ?? detectPlatform)();
   const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
   ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
 

--- a/plugins/azure/test/tools/az-exec.test.ts
+++ b/plugins/azure/test/tools/az-exec.test.ts
@@ -127,7 +127,11 @@ describe('buildAzArgs (output flag handling)', () => {
 });
 
 describe('az_exec execute', () => {
-  const tool = createAzExecTool({ typebox: mockTypebox });
+  // These cases are about what validation lets through, not about what `az` replies. They
+  // used to spawn the real binary to find out, so they passed or timed out depending on
+  // whether the CLI was installed on the machine running them.
+  const stubbedAz = async () => ({ stdout: '[]', stderr: '', exitCode: 0 });
+  const tool = createAzExecTool({ typebox: mockTypebox }, () => ({ exec: stubbedAz }));
 
   it('rejects empty args array', async () => {
     const result = await tool.execute('id', { args: [] }, null, null, { cwd: '/tmp' });

--- a/plugins/azure/test/wizard.test.ts
+++ b/plugins/azure/test/wizard.test.ts
@@ -1,10 +1,33 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { PlatformInfo } from '../src/platform';
 import { buildAuthStep, buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
 
 // ---------------------------------------------------------------------------
 // Helper builders — exact command assertions
 // ---------------------------------------------------------------------------
+
+/**
+ * The wizard branches on credential environment variables, so a developer machine or CI
+ * runner with cloud credentials exported takes a different auth path and these tests fail
+ * for a reason that has nothing to do with the code. Clear them around every case; the ones
+ * that exercise a credential path set what they need themselves.
+ */
+const CREDENTIAL_VARS = ['AZURE_CLIENT_ID', 'AZURE_CLIENT_SECRET', 'AZURE_TENANT_ID'];
+let savedCredentials: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedCredentials = Object.fromEntries(CREDENTIAL_VARS.map((key) => [key, process.env[key]]));
+  for (const key of CREDENTIAL_VARS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of CREDENTIAL_VARS) {
+    const value = savedCredentials[key];
+    // Assigning undefined would store the string "undefined", so absent means delete.
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 describe('buildInstallStep', () => {
   it('macOS brew command is exactly brew install azure-cli', () => {
@@ -226,7 +249,17 @@ describe('runSetupWizard — az not installed', () => {
 
     await runSetupWizard(pi, ctx, { ...azNotInstalledThenInstalled, ...on(LINUX) });
 
-    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(["apt","install","-y","azure-cli"]);
+    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(['apt', 'install', '-y', 'azure-cli']);
+  });
+
+  it('no package manager shows the manual install link', async () => {
+    const { pi, calls } = buildMockPi();
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false, ...on(BARE) });
+
+    expect(notifications.find((n) => n.message.includes('learn.microsoft.com'))?.type).toBe('error');
+    expect(calls).toHaveLength(0);
   });
 
   it('install failure shows error', async () => {
@@ -247,13 +280,12 @@ describe('runSetupWizard — az not installed', () => {
 
 describe('runSetupWizard — service principal auth', () => {
   const azInstalled = { checkCliInstalled: () => true };
-  const originalEnv = { ...process.env };
 
   it('auto-detects service principal from environment', async () => {
     process.env.AZURE_CLIENT_ID = 'test-client-id';
     process.env.AZURE_CLIENT_SECRET = 'test-secret';
     process.env.AZURE_TENANT_ID = 'test-tenant-id';
-    try {
+    {
       const { pi, calls } = buildMockPi({
         '--version': { stdout: 'azure-cli 2.60.0\n', stderr: '', code: 0 },
         '--service-principal': { stdout: '', stderr: '', code: 0 },
@@ -270,10 +302,6 @@ describe('runSetupWizard — service principal auth', () => {
       const spCall = calls.find((c) => c.args.includes('--service-principal'));
       expect(spCall).toBeDefined();
       expect(notifications.find((n) => n.message.includes('service principal'))).toBeDefined();
-    } finally {
-      process.env.AZURE_CLIENT_ID = originalEnv.AZURE_CLIENT_ID;
-      process.env.AZURE_CLIENT_SECRET = originalEnv.AZURE_CLIENT_SECRET;
-      process.env.AZURE_TENANT_ID = originalEnv.AZURE_TENANT_ID;
     }
   });
 
@@ -281,7 +309,7 @@ describe('runSetupWizard — service principal auth', () => {
     process.env.AZURE_CLIENT_ID = 'test-client-id';
     process.env.AZURE_CLIENT_SECRET = 'test-secret';
     process.env.AZURE_TENANT_ID = 'test-tenant-id';
-    try {
+    {
       const { pi } = buildMockPi({
         '--version': { stdout: 'azure-cli 2.60.0\n', stderr: '', code: 0 },
         '--service-principal': { stdout: '', stderr: 'AADSTS7000215', code: 1 },
@@ -291,10 +319,6 @@ describe('runSetupWizard — service principal auth', () => {
       await runSetupWizard(pi, ctx, azInstalled);
 
       expect(notifications.find((n) => n.message.includes('Authentication failed'))?.type).toBe('error');
-    } finally {
-      process.env.AZURE_CLIENT_ID = originalEnv.AZURE_CLIENT_ID;
-      process.env.AZURE_CLIENT_SECRET = originalEnv.AZURE_CLIENT_SECRET;
-      process.env.AZURE_TENANT_ID = originalEnv.AZURE_TENANT_ID;
     }
   });
 });

--- a/plugins/azure/test/wizard.test.ts
+++ b/plugins/azure/test/wizard.test.ts
@@ -177,6 +177,15 @@ describe('runSetupWizard — az installed, web auth', () => {
 // runSetupWizard — az NOT installed (auto-install flow)
 // ---------------------------------------------------------------------------
 
+// The wizard resolves the install command from the host it runs on. These tests inject the
+// platform instead, so each one asserts the same thing on a developer's Mac and on a Linux
+// CI runner — previously they asserted `brew` and so passed only on macOS.
+const MACOS: PlatformInfo = { os: 'darwin', arch: 'arm64', packageManagers: ['brew'], isCorporateManaged: false };
+const LINUX: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: ['apt'], isCorporateManaged: false };
+const BARE: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+
+const on = (platform: PlatformInfo) => ({ detectPlatform: async () => platform });
+
 describe('runSetupWizard — az not installed', () => {
   let installCount = 0;
   const azNotInstalledThenInstalled = {
@@ -186,7 +195,7 @@ describe('runSetupWizard — az not installed', () => {
     },
   };
 
-  it('auto-installs via preferred package manager and notifies restart', async () => {
+  it('auto-installs via brew on macOS and notifies restart', async () => {
     installCount = 0;
     const { pi, calls } = buildMockPi({
       'brew install azure-cli': { stdout: 'installed', stderr: '', code: 0 },
@@ -199,7 +208,7 @@ describe('runSetupWizard — az not installed', () => {
     });
     const { ctx, notifications } = buildMockCtx();
 
-    await runSetupWizard(pi, ctx, azNotInstalledThenInstalled);
+    await runSetupWizard(pi, ctx, { ...azNotInstalledThenInstalled, ...on(MACOS) });
 
     const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('azure-cli'));
     expect(installCall).toBeDefined();
@@ -208,13 +217,25 @@ describe('runSetupWizard — az not installed', () => {
     expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
   });
 
+  it('auto-installs via apt on Linux', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'apt install': { stdout: 'installed', stderr: '', code: 0 },
+    });
+    const { ctx } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { ...azNotInstalledThenInstalled, ...on(LINUX) });
+
+    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(["apt","install","-y","azure-cli"]);
+  });
+
   it('install failure shows error', async () => {
     const { pi } = buildMockPi({
       'brew install azure-cli': { stdout: '', stderr: 'permission denied', code: 1 },
     });
     const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
 
-    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false });
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false, ...on(MACOS) });
 
     expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
   });

--- a/plugins/brand/.xcsh-plugin/plugin.json
+++ b/plugins/brand/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brand",
-  "description": "F5 corporate branding enforcement \u2014 colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
-  "version": "1.0.2",
+  "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
+  "version": "1.0.3",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/brand",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/brand/package.json
+++ b/plugins/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brand",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards",
   "license": "Apache-2.0"
 }

--- a/plugins/brand/scripts/tests/test_security.sh
+++ b/plugins/brand/scripts/tests/test_security.sh
@@ -10,6 +10,7 @@ test_no_hardcoded_credentials() {
 
   local matches
   matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' --include='*.mdx' |
     grep -v 'README.md' ||
     true)

--- a/plugins/cloudstatus/.xcsh-plugin/plugin.json
+++ b/plugins/cloudstatus/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudstatus",
-  "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API \u2014 status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
-  "version": "1.3.0",
+  "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
+  "version": "1.3.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/cloudstatus",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/cloudstatus/package.json
+++ b/plugins/cloudstatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudstatus",
-  "version": "1.0.0",
+  "version": "1.3.1",
   "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API",
   "license": "Apache-2.0"
 }

--- a/plugins/cloudstatus/scripts/tests/test_security.sh
+++ b/plugins/cloudstatus/scripts/tests/test_security.sh
@@ -8,6 +8,7 @@ test_no_hardcoded_api_keys() {
   local patterns='api_key[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|apikey[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|Bearer [A-Za-z0-9]{20,}'
   local matches
   matches=$(grep -rIin -E "$patterns" \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
     --include='*.md' --include='*.json' ||
     true)
@@ -23,6 +24,7 @@ test_no_hardcoded_api_keys() {
 test_no_credential_echo() {
   local matches
   matches=$(grep -rIin -E 'echo.*\$(.*password|.*secret|.*token|.*api.key)' \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" \
     --include='*.md' ||
     true)
@@ -38,6 +40,7 @@ test_no_credential_echo() {
 test_no_eval_user_input() {
   local matches
   matches=$(grep -rIin -E 'eval\s+.*\$\{?[a-zA-Z]' \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
     --include='*.md' --include='*.sh' |
     grep -v '#.*eval' |

--- a/plugins/devcontainer/.xcsh-plugin/plugin.json
+++ b/plugins/devcontainer/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer",
-  "description": "Container awareness \u2014 tool catalog, self-identity, self-diagnosis, and maintenance for the f5-sales-demo devcontainer",
-  "version": "1.1.6",
+  "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5-sales-demo devcontainer",
+  "version": "1.1.7",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/devcontainer",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/devcontainer/package.json
+++ b/plugins/devcontainer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devcontainer",
-  "version": "1.0.0",
+  "version": "1.1.7",
   "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance",
   "license": "Apache-2.0"
 }

--- a/plugins/devcontainer/scripts/tests/test_security.sh
+++ b/plugins/devcontainer/scripts/tests/test_security.sh
@@ -8,6 +8,7 @@ test_no_hardcoded_credentials() {
   local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}|api_key=[A-Za-z0-9]'
   local matches
   matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' |
     grep -v 'README.md' ||
     true)

--- a/plugins/docs-pipeline/.xcsh-plugin/plugin.json
+++ b/plugins/docs-pipeline/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-pipeline",
-  "description": "Documentation pipeline architecture \u2014 config ownership, release dispatch chain, content authoring, managed files, local preview",
-  "version": "1.0.2",
+  "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
+  "version": "1.0.3",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/docs-pipeline",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/docs-pipeline/package.json
+++ b/plugins/docs-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-pipeline",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring",
   "license": "Apache-2.0"
 }

--- a/plugins/docs-pipeline/scripts/tests/test_security.sh
+++ b/plugins/docs-pipeline/scripts/tests/test_security.sh
@@ -10,6 +10,7 @@ test_no_hardcoded_credentials() {
 
   local matches
   matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' --include='*.mdx' |
     grep -v 'README.md' ||
     true)

--- a/plugins/docs-tools/.xcsh-plugin/plugin.json
+++ b/plugins/docs-tools/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-tools",
   "description": "MDX content validation and review tools for f5-sales-demo docs repos",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/docs-tools",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/docs-tools/package.json
+++ b/plugins/docs-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-tools",
-  "version": "1.0.0",
+  "version": "1.1.3",
   "description": "MDX content validation and review tools",
   "license": "Apache-2.0"
 }

--- a/plugins/docs-tools/scripts/tests/test_security.sh
+++ b/plugins/docs-tools/scripts/tests/test_security.sh
@@ -10,6 +10,7 @@ test_no_hardcoded_credentials() {
 
   local matches
   matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' --include='*.mdx' |
     grep -v 'README.md' ||
     true)

--- a/plugins/firecrawl/.xcsh-plugin/plugin.json
+++ b/plugins/firecrawl/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "firecrawl",
-  "description": "Local self-hosted firecrawl web scraping \u2014 scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
-  "version": "1.1.0",
+  "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
+  "version": "1.1.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/firecrawl",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/firecrawl/package.json
+++ b/plugins/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "Local self-hosted firecrawl web scraping via local firecrawl API",
   "license": "Apache-2.0"
 }

--- a/plugins/firecrawl/scripts/tests/test_security.sh
+++ b/plugins/firecrawl/scripts/tests/test_security.sh
@@ -8,6 +8,7 @@ test_no_hardcoded_api_keys() {
   local patterns='api_key[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|apikey[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|Bearer [A-Za-z0-9]{20,}'
   local matches
   matches=$(grep -rIin -E "$patterns" \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
     --include='*.md' --include='*.json' ||
     true)
@@ -23,6 +24,7 @@ test_no_hardcoded_api_keys() {
 test_no_credential_echo() {
   local matches
   matches=$(grep -rIin -E 'echo.*\$(.*password|.*secret|.*token|.*api.key)' \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" \
     --include='*.md' ||
     true)
@@ -38,6 +40,7 @@ test_no_credential_echo() {
 test_no_eval_user_input() {
   local matches
   matches=$(grep -rIin -E 'eval\s+.*\$\{?[a-zA-Z]' \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
     --include='*.md' --include='*.sh' |
     grep -v '#.*eval' ||

--- a/plugins/gcloud/.xcsh-plugin/plugin.json
+++ b/plugins/gcloud/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gcloud",
   "description": "Google Cloud CLI integration — container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/gcloud",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/gcloud/package.json
+++ b/plugins/gcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-gcloud",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Google Cloud CLI status for xcsh welcome screen",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GCloud",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/gcloud/scripts/tests/test_structure.sh
+++ b/plugins/gcloud/scripts/tests/test_structure.sh
@@ -22,8 +22,8 @@ test_plugin_json_valid() {
 
   local name
   name=$(jq -r '.name' "$pj")
-  [ "$name" = "gcloud-status" ] || {
-    echo "name=$name, expected gcloud-status"
+  [ "$name" = "gcloud" ] || {
+    echo "name=$name, expected gcloud"
     return 1
   }
 
@@ -35,20 +35,20 @@ test_plugin_json_valid() {
   }
 }
 
-# T1.2 — marketplace.json has a matching gcloud-status entry
+# T1.2 — marketplace.json has a matching gcloud entry
 test_marketplace_entry() {
   local mj="$MARKETPLACE_ROOT/.xcsh-plugin/marketplace.json"
   local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
 
   local mp_name
-  mp_name=$(jq -r '.plugins[] | select(.name == "gcloud-status") | .name' "$mj")
-  [ "$mp_name" = "gcloud-status" ] || {
-    echo "gcloud-status entry missing from marketplace.json"
+  mp_name=$(jq -r '.plugins[] | select(.name == "gcloud") | .name' "$mj")
+  [ "$mp_name" = "gcloud" ] || {
+    echo "gcloud entry missing from marketplace.json"
     return 1
   }
 
   local mp_ver
-  mp_ver=$(jq -r '.plugins[] | select(.name == "gcloud-status") | .version' "$mj")
+  mp_ver=$(jq -r '.plugins[] | select(.name == "gcloud") | .version' "$mj")
   local pj_ver
   pj_ver=$(jq -r '.version' "$pj")
   [ "$mp_ver" = "$pj_ver" ] || {
@@ -57,9 +57,9 @@ test_marketplace_entry() {
   }
 
   local src
-  src=$(jq -r '.plugins[] | select(.name == "gcloud-status") | .source' "$mj")
-  [ "$src" = "./plugins/gcloud-status" ] || {
-    echo "source=$src, expected ./plugins/gcloud-status"
+  src=$(jq -r '.plugins[] | select(.name == "gcloud") | .source' "$mj")
+  [ "$src" = "./plugins/gcloud" ] || {
+    echo "source=$src, expected ./plugins/gcloud"
     return 1
   }
 }
@@ -225,9 +225,9 @@ test_T1_12_src_index_exports_default_factory() {
   fi
 }
 
-# T1.13 — extension tool count (skipped: gcloud-status registers 0 tools)
+# T1.13 — extension tool count (skipped: gcloud registers 0 tools)
 test_T1_13_extension_registers_tools() {
-  echo "SKIP: gcloud-status does not register tools"
+  echo "SKIP: gcloud does not register tools"
   return 0
 }
 
@@ -240,15 +240,15 @@ test_T1_14_tool_factories_exist() {
   fi
 }
 
-# T1.15 — hooks.json references /gcloud-status:setup, not brew
+# T1.15 — hooks.json references /gcloud:setup, not brew
 test_T1_15_hook_references_setup_command() {
   local hook="$PLUGIN_ROOT/hooks/hooks.json"
   if [[ ! -f "$hook" ]]; then
     echo "FAIL: hooks.json missing"
     return 1
   fi
-  if ! grep -q "gcloud-status:setup" "$hook"; then
-    echo "FAIL: hooks.json should reference /gcloud-status:setup"
+  if ! grep -q "gcloud:setup" "$hook"; then
+    echo "FAIL: hooks.json should reference /gcloud:setup"
     return 1
   fi
   if grep -q "brew install" "$hook"; then

--- a/plugins/gcloud/src/wizard.ts
+++ b/plugins/gcloud/src/wizard.ts
@@ -78,12 +78,20 @@ export async function runSetupWizard(
     cwd: string;
     reload?: () => Promise<void>;
   },
-  options?: { checkCliInstalled?: () => boolean },
+  options?: {
+    checkCliInstalled?: () => boolean;
+  /**
+   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+   * which made every install assertion below depend on the machine running it — they
+   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+   */
+    detectPlatform?: () => Promise<PlatformInfo>;
+  },
 ): Promise<void> {
   const checkCli = options?.checkCliInstalled ?? gcloudIsInstalled;
 
   // --- Platform detection (deterministic, no prompts) ---
-  const platform = await detectPlatform();
+  const platform = await (options?.detectPlatform ?? detectPlatform)();
   const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
   ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
 

--- a/plugins/gcloud/src/wizard.ts
+++ b/plugins/gcloud/src/wizard.ts
@@ -80,11 +80,11 @@ export async function runSetupWizard(
   },
   options?: {
     checkCliInstalled?: () => boolean;
-  /**
-   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
-   * which made every install assertion below depend on the machine running it — they
-   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
-   */
+    /**
+     * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+     * which made every install assertion below depend on the machine running it — they
+     * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+     */
     detectPlatform?: () => Promise<PlatformInfo>;
   },
 ): Promise<void> {

--- a/plugins/gcloud/test/wizard.test.ts
+++ b/plugins/gcloud/test/wizard.test.ts
@@ -173,6 +173,15 @@ describe('runSetupWizard — gcloud installed, web auth', () => {
 // runSetupWizard — gcloud NOT installed (auto-install flow)
 // ---------------------------------------------------------------------------
 
+// The wizard resolves the install command from the host it runs on. These tests inject the
+// platform instead, so each one asserts the same thing on a developer's Mac and on a Linux
+// CI runner — previously they asserted `brew` and so passed only on macOS.
+const MACOS: PlatformInfo = { os: 'darwin', arch: 'arm64', packageManagers: ['brew'], isCorporateManaged: false };
+const LINUX: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: ['apt'], isCorporateManaged: false };
+const BARE: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+
+const on = (platform: PlatformInfo) => ({ detectPlatform: async () => platform });
+
 describe('runSetupWizard — gcloud not installed', () => {
   let installCount = 0;
   const gcloudNotInstalledThenInstalled = {
@@ -182,7 +191,7 @@ describe('runSetupWizard — gcloud not installed', () => {
     },
   };
 
-  it('auto-installs via preferred package manager and notifies restart', async () => {
+  it('auto-installs via brew on macOS and notifies restart', async () => {
     installCount = 0;
     const { pi, calls } = buildMockPi({
       'brew install --cask google-cloud-sdk': { stdout: 'installed', stderr: '', code: 0 },
@@ -191,7 +200,7 @@ describe('runSetupWizard — gcloud not installed', () => {
     });
     const { ctx, notifications } = buildMockCtx();
 
-    await runSetupWizard(pi, ctx, gcloudNotInstalledThenInstalled);
+    await runSetupWizard(pi, ctx, { ...gcloudNotInstalledThenInstalled, ...on(MACOS) });
 
     const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('google-cloud-sdk'));
     expect(installCall).toBeDefined();
@@ -200,13 +209,25 @@ describe('runSetupWizard — gcloud not installed', () => {
     expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
   });
 
+  it('auto-installs via apt on Linux', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'apt install': { stdout: 'installed', stderr: '', code: 0 },
+    });
+    const { ctx } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { ...gcloudNotInstalledThenInstalled, ...on(LINUX) });
+
+    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(["apt","install","-y","google-cloud-sdk"]);
+  });
+
   it('install failure shows error', async () => {
     const { pi } = buildMockPi({
       'brew install --cask google-cloud-sdk': { stdout: '', stderr: 'permission denied', code: 1 },
     });
     const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
 
-    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false });
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false, ...on(MACOS) });
 
     expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
   });

--- a/plugins/gcloud/test/wizard.test.ts
+++ b/plugins/gcloud/test/wizard.test.ts
@@ -1,10 +1,33 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { PlatformInfo } from '../src/platform';
 import { buildAuthStep, buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
 
 // ---------------------------------------------------------------------------
 // Helper builders — exact command assertions
 // ---------------------------------------------------------------------------
+
+/**
+ * The wizard branches on credential environment variables, so a developer machine or CI
+ * runner with cloud credentials exported takes a different auth path and these tests fail
+ * for a reason that has nothing to do with the code. Clear them around every case; the ones
+ * that exercise a credential path set what they need themselves.
+ */
+const CREDENTIAL_VARS = ['GOOGLE_APPLICATION_CREDENTIALS'];
+let savedCredentials: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedCredentials = Object.fromEntries(CREDENTIAL_VARS.map((key) => [key, process.env[key]]));
+  for (const key of CREDENTIAL_VARS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of CREDENTIAL_VARS) {
+    const value = savedCredentials[key];
+    // Assigning undefined would store the string "undefined", so absent means delete.
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 describe('buildInstallStep', () => {
   it('macOS brew command is exactly brew install --cask google-cloud-sdk', () => {
@@ -218,7 +241,17 @@ describe('runSetupWizard — gcloud not installed', () => {
 
     await runSetupWizard(pi, ctx, { ...gcloudNotInstalledThenInstalled, ...on(LINUX) });
 
-    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(["apt","install","-y","google-cloud-sdk"]);
+    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(['apt', 'install', '-y', 'google-cloud-sdk']);
+  });
+
+  it('no package manager shows the manual install link', async () => {
+    const { pi, calls } = buildMockPi();
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkCliInstalled: () => false, ...on(BARE) });
+
+    expect(notifications.find((n) => n.message.includes('cloud.google.com'))?.type).toBe('error');
+    expect(calls).toHaveLength(0);
   });
 
   it('install failure shows error', async () => {

--- a/plugins/github/.xcsh-plugin/plugin.json
+++ b/plugins/github/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "description": "GitHub CLI integration — native xcsh tools (gh_repo_view, gh_issue_view, gh_pr_view, gh_pr_diff, gh_pr_checkout, gh_pr_push, gh_run_watch, gh_search_issues, gh_search_prs), profile collection, and service status",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-github",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "GitHub CLI integration for xcsh — native tools for repos, issues, PRs, diffs, Actions, and search",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GitHub",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "GitHub CLI integration",
     "extensions": [
       "src/index.ts"

--- a/plugins/github/src/wizard.ts
+++ b/plugins/github/src/wizard.ts
@@ -31,12 +31,20 @@ export async function runSetupWizard(
     cwd: string;
     reload?: () => Promise<void>;
   },
-  options?: { checkGhInstalled?: () => boolean },
+  options?: {
+    checkGhInstalled?: () => boolean;
+  /**
+   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+   * which made every install assertion below depend on the machine running it — they
+   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+   */
+    detectPlatform?: () => Promise<PlatformInfo>;
+  },
 ): Promise<void> {
   const checkGh = options?.checkGhInstalled ?? ghIsInstalled;
 
   // --- Platform detection (deterministic, no prompts) ---
-  const platform = await detectPlatform();
+  const platform = await (options?.detectPlatform ?? detectPlatform)();
   const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
   ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
 

--- a/plugins/github/src/wizard.ts
+++ b/plugins/github/src/wizard.ts
@@ -33,11 +33,11 @@ export async function runSetupWizard(
   },
   options?: {
     checkGhInstalled?: () => boolean;
-  /**
-   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
-   * which made every install assertion below depend on the machine running it — they
-   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
-   */
+    /**
+     * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+     * which made every install assertion below depend on the machine running it — they
+     * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+     */
     detectPlatform?: () => Promise<PlatformInfo>;
   },
 ): Promise<void> {

--- a/plugins/github/test/wizard.test.ts
+++ b/plugins/github/test/wizard.test.ts
@@ -1,10 +1,33 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { PlatformInfo } from '../src/platform';
 import { buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
 
 // ---------------------------------------------------------------------------
 // Helper builders — exact command assertions
 // ---------------------------------------------------------------------------
+
+/**
+ * The wizard branches on credential environment variables, so a developer machine or CI
+ * runner with cloud credentials exported takes a different auth path and these tests fail
+ * for a reason that has nothing to do with the code. Clear them around every case; the ones
+ * that exercise a credential path set what they need themselves.
+ */
+const CREDENTIAL_VARS = ['GITHUB_ALLOW_MUTATIONS', 'GH_TOKEN', 'GITHUB_TOKEN'];
+let savedCredentials: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedCredentials = Object.fromEntries(CREDENTIAL_VARS.map((key) => [key, process.env[key]]));
+  for (const key of CREDENTIAL_VARS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of CREDENTIAL_VARS) {
+    const value = savedCredentials[key];
+    // Assigning undefined would store the string "undefined", so absent means delete.
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 describe('buildInstallStep', () => {
   it('macOS brew command is exactly brew install gh', () => {

--- a/plugins/github/test/wizard.test.ts
+++ b/plugins/github/test/wizard.test.ts
@@ -176,6 +176,15 @@ describe('runSetupWizard — gh installed, auth', () => {
 // runSetupWizard — gh NOT installed (auto-install flow)
 // ---------------------------------------------------------------------------
 
+// The wizard resolves the install command from the host it runs on. These tests inject the
+// platform instead, so each one asserts the same thing on a developer's Mac and on a Linux
+// CI runner — previously they asserted `brew` and passed only on macOS.
+const MACOS: PlatformInfo = { os: 'darwin', arch: 'arm64', packageManagers: ['brew'], isCorporateManaged: false };
+const LINUX: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: ['apt'], isCorporateManaged: false };
+const BARE: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+
+const on = (platform: PlatformInfo) => ({ detectPlatform: async () => platform });
+
 describe('runSetupWizard — gh not installed', () => {
   let installCount = 0;
   const ghNotInstalledThenInstalled = {
@@ -185,7 +194,7 @@ describe('runSetupWizard — gh not installed', () => {
     },
   };
 
-  it('auto-installs via preferred package manager and notifies restart', async () => {
+  it('auto-installs via brew on macOS and notifies restart', async () => {
     installCount = 0;
     const { pi, calls } = buildMockPi({
       'brew install gh': { stdout: 'installed', stderr: '', code: 0 },
@@ -198,7 +207,7 @@ describe('runSetupWizard — gh not installed', () => {
     });
     const { ctx, notifications } = buildMockCtx();
 
-    await runSetupWizard(pi, ctx, ghNotInstalledThenInstalled);
+    await runSetupWizard(pi, ctx, { ...ghNotInstalledThenInstalled, ...on(MACOS) });
 
     const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('gh'));
     expect(installCall).toBeDefined();
@@ -207,29 +216,43 @@ describe('runSetupWizard — gh not installed', () => {
     expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
   });
 
+  it('auto-installs via apt on Linux', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'apt install': { stdout: 'installed', stderr: '', code: 0 },
+      '--version': { stdout: 'gh version 2.50.0', stderr: '', code: 0 },
+      'auth status': { stdout: 'Logged in to github.com as octocat', stderr: '', code: 0 },
+    });
+    const { ctx } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { ...ghNotInstalledThenInstalled, ...on(LINUX) });
+
+    const installCall = calls.find((c) => c.cmd === 'sudo');
+    expect(installCall?.args).toEqual(['apt', 'install', '-y', 'gh']);
+  });
+
   it('install failure shows error', async () => {
     const { pi } = buildMockPi({
       'brew install gh': { stdout: '', stderr: 'permission denied', code: 1 },
     });
     const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
 
-    await runSetupWizard(pi, ctx, { checkGhInstalled: () => false });
+    await runSetupWizard(pi, ctx, { checkGhInstalled: () => false, ...on(MACOS) });
 
     expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
   });
 
   it('no package manager shows manual install link', async () => {
-    const { pi } = buildMockPi();
+    // Previously this asserted only "some error was notified", which the install-failure
+    // path satisfies too — so it passed without ever reaching the branch it names. With the
+    // platform injected it can state the actual expectation.
+    const { pi, calls } = buildMockPi();
     const { ctx, notifications } = buildMockCtx();
 
-    // Override detectPlatform — wizard calls it internally, but we test the downstream effect
-    // by using a checkGhInstalled that always returns false and empty install options
-    await runSetupWizard(pi, ctx, { checkGhInstalled: () => false });
+    await runSetupWizard(pi, ctx, { checkGhInstalled: () => false, ...on(BARE) });
 
-    // On macOS with brew available this won't trigger — but the flow exits on install failure
-    // This test validates the error path exists
-    const hasError = notifications.some((n) => n.type === 'error');
-    expect(hasError).toBe(true);
+    expect(notifications.find((n) => n.message.includes('cli.github.com'))?.type).toBe('error');
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/plugins/gitlab/.xcsh-plugin/plugin.json
+++ b/plugins/gitlab/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitlab",
   "description": "GitLab CLI integration — native xcsh tools (glab_setup, glab_issue_list, glab_issue_view, glab_search), welcome screen status, and issue management via glab CLI",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-gitlab",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "GitLab CLI integration for xcsh — native tools, welcome screen status, issue management",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GitLab",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "GitLab CLI integration",
     "extensions": [
       "src/index.ts"

--- a/plugins/gitlab/src/wizard.ts
+++ b/plugins/gitlab/src/wizard.ts
@@ -31,12 +31,20 @@ export async function runSetupWizard(
     cwd: string;
     reload?: () => Promise<void>;
   },
-  options?: { checkGlabInstalled?: () => boolean },
+  options?: {
+    checkGlabInstalled?: () => boolean;
+  /**
+   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+   * which made every install assertion below depend on the machine running it — they
+   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+   */
+    detectPlatform?: () => Promise<PlatformInfo>;
+  },
 ): Promise<void> {
   const checkGlab = options?.checkGlabInstalled ?? glabIsInstalled;
 
   // --- Platform detection (deterministic, no prompts) ---
-  const platform = await detectPlatform();
+  const platform = await (options?.detectPlatform ?? detectPlatform)();
   const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
   ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
 

--- a/plugins/gitlab/src/wizard.ts
+++ b/plugins/gitlab/src/wizard.ts
@@ -33,11 +33,11 @@ export async function runSetupWizard(
   },
   options?: {
     checkGlabInstalled?: () => boolean;
-  /**
-   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
-   * which made every install assertion below depend on the machine running it — they
-   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
-   */
+    /**
+     * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+     * which made every install assertion below depend on the machine running it — they
+     * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+     */
     detectPlatform?: () => Promise<PlatformInfo>;
   },
 ): Promise<void> {

--- a/plugins/gitlab/test/wizard.test.ts
+++ b/plugins/gitlab/test/wizard.test.ts
@@ -175,6 +175,15 @@ describe('runSetupWizard — glab installed, auth', () => {
 // runSetupWizard — glab NOT installed (auto-install flow)
 // ---------------------------------------------------------------------------
 
+// The wizard resolves the install command from the host it runs on. These tests inject the
+// platform instead, so each one asserts the same thing on a developer's Mac and on a Linux
+// CI runner — previously they asserted `brew` and so passed only on macOS.
+const MACOS: PlatformInfo = { os: 'darwin', arch: 'arm64', packageManagers: ['brew'], isCorporateManaged: false };
+const LINUX: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: ['apt'], isCorporateManaged: false };
+const BARE: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+
+const on = (platform: PlatformInfo) => ({ detectPlatform: async () => platform });
+
 describe('runSetupWizard — glab not installed', () => {
   let installCount = 0;
   const glabNotInstalledThenInstalled = {
@@ -184,7 +193,7 @@ describe('runSetupWizard — glab not installed', () => {
     },
   };
 
-  it('auto-installs via preferred package manager and notifies restart', async () => {
+  it('auto-installs via brew on macOS and notifies restart', async () => {
     installCount = 0;
     const { pi, calls } = buildMockPi({
       'brew install glab': { stdout: 'installed', stderr: '', code: 0 },
@@ -197,7 +206,7 @@ describe('runSetupWizard — glab not installed', () => {
     });
     const { ctx, notifications } = buildMockCtx();
 
-    await runSetupWizard(pi, ctx, glabNotInstalledThenInstalled);
+    await runSetupWizard(pi, ctx, { ...glabNotInstalledThenInstalled, ...on(MACOS) });
 
     const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('glab'));
     expect(installCall).toBeDefined();
@@ -206,25 +215,40 @@ describe('runSetupWizard — glab not installed', () => {
     expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
   });
 
+  it('offers no installer on Linux, so it points at the manual instructions', async () => {
+    // gitlab only builds install options for macOS and Windows. Asserting that here
+    // makes the gap visible rather than leaving Linux untested — see the PR discussion.
+    installCount = 0;
+    const { pi, calls } = buildMockPi();
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkGlabInstalled: () => false, ...on(LINUX) });
+
+    expect(notifications.find((n) => n.message.includes('gitlab.com/gitlab-org/cli'))?.type).toBe('error');
+    expect(calls).toHaveLength(0);
+  });
+
   it('install failure shows error', async () => {
     const { pi } = buildMockPi({
       'brew install glab': { stdout: '', stderr: 'permission denied', code: 1 },
     });
     const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
 
-    await runSetupWizard(pi, ctx, { checkGlabInstalled: () => false });
+    await runSetupWizard(pi, ctx, { checkGlabInstalled: () => false, ...on(MACOS) });
 
     expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
   });
 
   it('no package manager shows manual install link', async () => {
-    const { pi } = buildMockPi();
+    // Previously this asserted only "some error was notified", which the install-failure
+    // path satisfies too — so it passed without ever reaching the branch it names.
+    const { pi, calls } = buildMockPi();
     const { ctx, notifications } = buildMockCtx();
 
-    await runSetupWizard(pi, ctx, { checkGlabInstalled: () => false });
+    await runSetupWizard(pi, ctx, { checkGlabInstalled: () => false, ...on(BARE) });
 
-    const hasError = notifications.some((n) => n.type === 'error');
-    expect(hasError).toBe(true);
+    expect(notifications.find((n) => n.message.includes('gitlab.com/gitlab-org/cli'))?.type).toBe('error');
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/plugins/gitlab/test/wizard.test.ts
+++ b/plugins/gitlab/test/wizard.test.ts
@@ -1,10 +1,33 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { PlatformInfo } from '../src/platform';
 import { buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
 
 // ---------------------------------------------------------------------------
 // Helper builders — exact command assertions
 // ---------------------------------------------------------------------------
+
+/**
+ * The wizard branches on credential environment variables, so a developer machine or CI
+ * runner with cloud credentials exported takes a different auth path and these tests fail
+ * for a reason that has nothing to do with the code. Clear them around every case; the ones
+ * that exercise a credential path set what they need themselves.
+ */
+const CREDENTIAL_VARS = ['GITLAB_TOKEN', 'GLAB_TOKEN'];
+let savedCredentials: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedCredentials = Object.fromEntries(CREDENTIAL_VARS.map((key) => [key, process.env[key]]));
+  for (const key of CREDENTIAL_VARS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of CREDENTIAL_VARS) {
+    const value = savedCredentials[key];
+    // Assigning undefined would store the string "undefined", so absent means delete.
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 describe('buildInstallStep', () => {
   it('macOS brew command is exactly brew install glab', () => {

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/tests/test_security.sh
+++ b/plugins/meddpicc/scripts/tests/test_security.sh
@@ -8,6 +8,7 @@ test_no_hardcoded_credentials() {
   local patterns='password[[:space:]]*=|secret[[:space:]]*=|token=[A-Za-z0-9]|Bearer [A-Za-z0-9]{20,}|api_key=[A-Za-z0-9]'
   local matches
   matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' |
     grep -v 'README.md' |
     grep -v 'schema/' ||

--- a/plugins/osint-framework/.xcsh-plugin/plugin.json
+++ b/plugins/osint-framework/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "osint-framework",
   "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/osint-framework/package.json
+++ b/plugins/osint-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osint-framework",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "OSINT Framework tool catalog and investigation skills — 1,064 intelligence-gathering tools across 34 categories",
   "license": "Apache-2.0"
 }

--- a/plugins/osint-framework/scripts/tests/test_security.sh
+++ b/plugins/osint-framework/scripts/tests/test_security.sh
@@ -8,6 +8,7 @@ test_no_hardcoded_api_keys() {
   local patterns='api_key[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|apikey[[:space:]]*=[[:space:]]*["\x27][A-Za-z0-9]{10,}|Bearer [A-Za-z0-9]{20,}'
   local matches
   matches=$(grep -rIin -E "$patterns" \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
     --include='*.md' --include='*.json' |
     grep -v 'OPENCORPORATES_API_KEY' |
@@ -28,6 +29,7 @@ test_no_hardcoded_api_keys() {
 test_no_credential_echo() {
   local matches
   matches=$(grep -rIin -E 'echo.*\$(.*password|.*secret|.*token|.*api.key)' \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" \
     --include='*.md' ||
     true)
@@ -43,6 +45,7 @@ test_no_credential_echo() {
 test_no_eval_user_input() {
   local matches
   matches=$(grep -rIin -E 'eval\s+.*\$\{?[a-zA-Z]' \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills" \
     --include='*.md' --include='*.sh' |
     grep -v '#.*eval' ||
@@ -60,6 +63,7 @@ test_no_hardcoded_secrets_in_skills() {
   local patterns='password[[:space:]]*=[[:space:]]*["\x27][^$][A-Za-z0-9]{5,}|secret[[:space:]]*=[[:space:]]*["\x27][^$][A-Za-z0-9]{5,}'
   local matches
   matches=$(grep -rIin -E "$patterns" \
+    --exclude-dir=node_modules \
     "$PLUGIN_ROOT/skills" \
     --include='*.md' --include='*.json' ||
     true)

--- a/plugins/platform/.xcsh-plugin/plugin.json
+++ b/plugins/platform/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platform",
-  "description": "F5 Distributed Cloud platform automation \u2014 web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
-  "version": "3.1.1",
+  "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
+  "version": "3.1.2",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/platform",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/platform/package.json
+++ b/plugins/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform",
-  "version": "1.0.0",
+  "version": "3.1.2",
   "description": "F5 Distributed Cloud platform automation — web console and spec-aware REST API operations",
   "license": "Apache-2.0"
 }

--- a/plugins/platform/scripts/tests/test_security.sh
+++ b/plugins/platform/scripts/tests/test_security.sh
@@ -8,6 +8,7 @@ test_no_hardcoded_api_tokens() {
   local patterns='F5XC_API_TOKEN=[A-Za-z0-9]|APIToken [A-Za-z0-9]{20,}|Bearer [A-Za-z0-9]{20,}'
   local matches
   matches=$(grep -rIin -E "$patterns" "$PLUGIN_ROOT" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' |
     grep -v 'README.md' |
     grep -v '\$F5XC_API_TOKEN' |
@@ -27,6 +28,7 @@ test_no_credential_echo_in_agents() {
   local agents_dir="$PLUGIN_ROOT/agents"
   local matches
   matches=$(grep -rIin -E 'echo.*\$F5XC_API_TOKEN|echo.*\$F5XC_API_URL.*TOKEN|print.*TOKEN' "$agents_dir" \
+    --exclude-dir=node_modules \
     --include='*.md' ||
     true)
 
@@ -42,6 +44,7 @@ test_no_eval_user_input() {
   local agents_dir="$PLUGIN_ROOT/agents"
   local matches
   matches=$(grep -rIin -E 'eval.*\$|eval.*user|eval.*input' "$agents_dir" \
+    --exclude-dir=node_modules \
     --include='*.md' ||
     true)
 

--- a/plugins/sales-engineer/.xcsh-plugin/plugin.json
+++ b/plugins/sales-engineer/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sales-engineer",
-  "description": "Sales Engineer persona framework for F5 XC demo repositories \u2014 demo execution, environment operations, presentation, Q&A, post-session debrief",
-  "version": "1.0.6",
+  "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
+  "version": "1.0.7",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/sales-engineer",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/sales-engineer/package.json
+++ b/plugins/sales-engineer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sales-engineer",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "description": "Sales Engineer persona framework for demo execution and presentation",
   "license": "Apache-2.0"
 }

--- a/plugins/sales-engineer/scripts/tests/test_security.sh
+++ b/plugins/sales-engineer/scripts/tests/test_security.sh
@@ -10,6 +10,7 @@ test_no_hardcoded_credentials() {
 
   local matches
   matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' --include='*.mdx' |
     grep -v 'README.md' ||
     true)

--- a/plugins/salesforce-legacy/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce-legacy/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce-legacy",
   "description": "[ARCHIVED] Original Claude Code-only Salesforce CLI automation. Replaced by unified salesforce plugin with native xcsh tool support.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/salesforce",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/salesforce-legacy/scripts/tests/test_hook.sh
+++ b/plugins/salesforce-legacy/scripts/tests/test_hook.sh
@@ -30,7 +30,10 @@ test_hook_warns_when_sf_missing() {
   cmd=$(_get_hook_command)
   local tmp
   tmp=$(mktemp -d)
-  ln -s /usr/bin/bash "$tmp/bash"
+  # Resolve bash rather than assuming /usr/bin/bash: that path exists on Linux but not on
+  # macOS, where bash lives in /bin. The dangling symlink made the scrubbed PATH contain no
+  # usable shell at all, so the hook never ran and the test failed for the wrong reason.
+  ln -s "$(command -v bash)" "$tmp/bash"
   ln -s "$(command -v command)" "$tmp/command" 2>/dev/null || true
   local out
   out=$(PATH="$tmp" bash -c "$cmd" 2>&1) || true

--- a/plugins/salesforce-legacy/scripts/tests/test_security.sh
+++ b/plugins/salesforce-legacy/scripts/tests/test_security.sh
@@ -12,6 +12,7 @@ test_no_hardcoded_credentials() {
 
   local matches
   matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' --include='*.mdx' |
     grep -v 'README.md' |
     grep -v '\$SF_ACCESS_TOKEN' |

--- a/plugins/salesforce-legacy/scripts/tests/test_structure.sh
+++ b/plugins/salesforce-legacy/scripts/tests/test_structure.sh
@@ -22,7 +22,7 @@ test_plugin_json_valid() {
 
   local name
   name=$(jq -r '.name' "$pj")
-  [ "$name" = "salesforce" ] || {
+  [ "$name" = "salesforce-legacy" ] || {
     echo "name=$name, expected salesforce"
     return 1
   }
@@ -41,14 +41,14 @@ test_marketplace_entry() {
   local pj="$PLUGIN_ROOT/.xcsh-plugin/plugin.json"
 
   local mp_name
-  mp_name=$(jq -r '.plugins[] | select(.name == "salesforce") | .name' "$mj")
-  [ "$mp_name" = "salesforce" ] || {
+  mp_name=$(jq -r '.plugins[] | select(.name == "salesforce-legacy") | .name' "$mj")
+  [ "$mp_name" = "salesforce-legacy" ] || {
     echo "salesforce entry missing from marketplace.json"
     return 1
   }
 
   local mp_ver
-  mp_ver=$(jq -r '.plugins[] | select(.name == "salesforce") | .version' "$mj")
+  mp_ver=$(jq -r '.plugins[] | select(.name == "salesforce-legacy") | .version' "$mj")
   local pj_ver
   pj_ver=$(jq -r '.version' "$pj")
   [ "$mp_ver" = "$pj_ver" ] || {
@@ -57,8 +57,8 @@ test_marketplace_entry() {
   }
 
   local src
-  src=$(jq -r '.plugins[] | select(.name == "salesforce") | .source' "$mj")
-  [ "$src" = "./plugins/salesforce" ] || {
+  src=$(jq -r '.plugins[] | select(.name == "salesforce-legacy") | .source' "$mj")
+  [ "$src" = "./plugins/salesforce-legacy" ] || {
     echo "source=$src, expected ./plugins/salesforce"
     return 1
   }

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/salesforce/package.json
+++ b/plugins/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-salesforce",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Salesforce pipeline intelligence for xcsh — native tools, context discovery, pipeline reports",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Salesforce",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "Salesforce pipeline intelligence",
     "extensions": [
       "src/index.ts"

--- a/plugins/salesforce/scripts/tests/test_security.sh
+++ b/plugins/salesforce/scripts/tests/test_security.sh
@@ -12,6 +12,7 @@ test_no_hardcoded_credentials() {
 
   local matches
   matches=$(grep -rIin -E "$patterns" "${scan_dirs[@]}" \
+    --exclude-dir=node_modules \
     --include='*.md' --include='*.json' --include='*.mdx' |
     grep -v 'README.md' |
     grep -v '\$SF_ACCESS_TOKEN' |

--- a/plugins/salesforce/src/tools/sf-setup.ts
+++ b/plugins/salesforce/src/tools/sf-setup.ts
@@ -1,12 +1,17 @@
 import { getLoadProfile } from '../context/salesforce-context';
 import sfSetupDescription from '../prompts/sf-setup.md' with { type: 'text' };
-import { execSfJson, execSfRaw } from '../sf/exec';
+import { execSfJson, execSfRaw, type SfExecApi } from '../sf/exec';
 import { formatOrgTable } from '../sf/formatters';
 import { ORG_ALIAS_PATTERN } from '../sf/types';
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { collectAllOrgs, detectErrorType, errorResult, makeExecApi, textResult } from './shared';
 
-export function createSfSetupTool(pi: PluginHost) {
+/**
+ * `makeApi` exists so tests can supply an executor instead of spawning the real `sf`.
+ * Without it a validation test ran four genuine `sf config set target-org … --global`
+ * commands against whatever machine it happened to run on.
+ */
+export function createSfSetupTool(pi: PluginHost, makeApi: (cwd: string) => SfExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -35,7 +40,7 @@ export function createSfSetupTool(pi: PluginHost) {
       _onUpdate: ToolUpdateCallback | undefined,
       ctx: { cwd: string },
     ) {
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const base = { tool: 'sf_setup' as const, action: params.action };
 
       try {

--- a/plugins/salesforce/src/wizard.ts
+++ b/plugins/salesforce/src/wizard.ts
@@ -155,7 +155,15 @@ export async function runSetupWizard(
     cwd: string;
     reload?: () => Promise<void>;
   },
-  options?: { checkSfInstalled?: () => boolean },
+  options?: {
+    checkSfInstalled?: () => boolean;
+  /**
+   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+   * which made every install assertion below depend on the machine running it — they
+   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+   */
+    detectPlatform?: () => Promise<PlatformInfo>;
+  },
 ): Promise<void> {
   const checkSf = options?.checkSfInstalled ?? sfIsInstalled;
 
@@ -167,7 +175,7 @@ export async function runSetupWizard(
   }
 
   // --- Platform detection (deterministic, no prompts) ---
-  const platform = await detectPlatform();
+  const platform = await (options?.detectPlatform ?? detectPlatform)();
   const osLabel = platform.os === 'darwin' ? 'macOS' : platform.os === 'win32' ? 'Windows' : 'Linux';
   ctx.ui.notify(`Detected: ${osLabel} (${platform.arch})`, 'info');
 

--- a/plugins/salesforce/src/wizard.ts
+++ b/plugins/salesforce/src/wizard.ts
@@ -157,11 +157,11 @@ export async function runSetupWizard(
   },
   options?: {
     checkSfInstalled?: () => boolean;
-  /**
-   * Injected by tests. The real one reads `process.platform` and shells out to `which`,
-   * which made every install assertion below depend on the machine running it — they
-   * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
-   */
+    /**
+     * Injected by tests. The real one reads `process.platform` and shells out to `which`,
+     * which made every install assertion below depend on the machine running it — they
+     * asserted `brew` and so passed on macOS and failed on a Linux CI runner.
+     */
     detectPlatform?: () => Promise<PlatformInfo>;
   },
 ): Promise<void> {

--- a/plugins/salesforce/test/integration/extension-load.test.ts
+++ b/plugins/salesforce/test/integration/extension-load.test.ts
@@ -50,7 +50,18 @@ async function buildMockPi(overrides?: Partial<MockPi>): Promise<{
   return { pi, tools, events };
 }
 
-describe('ExtensionFactory integration', () => {
+/**
+ * The factory registers its tools only when the `sf` binary is on PATH (src/index.ts), and
+ * several of these cases then drive that binary for real. So the whole suite is an
+ * integration suite: it is meaningful on a machine with the Salesforce CLI and impossible
+ * without one. It used to fail on such a machine, which reads as "the plugin is broken"
+ * rather than "this environment cannot run these"; a visible skip says the true thing.
+ *
+ * Running them in CI needs the CLI installed and an authenticated org — see the PR.
+ */
+const SF_INSTALLED = Bun.spawnSync([process.platform === 'win32' ? 'where' : 'which', 'sf']).exitCode === 0;
+
+describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration', () => {
   let factory: FactoryFn;
 
   beforeAll(async () => {
@@ -203,14 +214,18 @@ describe('ExtensionFactory integration', () => {
     }
   });
 
-  it('session_start hook runs without throwing', async () => {
+  it('session_start hook returns immediately and does not throw', async () => {
+    // The handler is deliberately synchronous: it kicks the org lookup off in the
+    // background so session start never waits on a CLI call (src/index.ts). The previous
+    // assertion used `.resolves`, which requires a thenable, so it asserted an async
+    // contract the handler was never written to have.
     const { pi, events } = await buildMockPi();
     await factory(pi);
 
     const handler = events.session_start?.[0];
     expect(handler).toBeDefined();
 
-    await expect(handler({}, { cwd: '/tmp' })).resolves.toBeUndefined();
+    expect(handler({}, { cwd: '/tmp' })).toBeUndefined();
   });
 
   it('registers salesforce:setup command', async () => {

--- a/plugins/salesforce/test/integration/extension-load.test.ts
+++ b/plugins/salesforce/test/integration/extension-load.test.ts
@@ -51,26 +51,66 @@ async function buildMockPi(overrides?: Partial<MockPi>): Promise<{
 }
 
 /**
- * The factory registers its tools only when the `sf` binary is on PATH (src/index.ts), and
- * several of these cases then drive that binary for real. So the whole suite is an
- * integration suite: it is meaningful on a machine with the Salesforce CLI and impossible
- * without one. It used to fail on such a machine, which reads as "the plugin is broken"
- * rather than "this environment cannot run these"; a visible skip says the true thing.
+ * The factory registers its TOOLS only when the `sf` binary is on PATH (src/index.ts), and
+ * several cases below then drive that binary for real — those cannot run without the CLI.
  *
- * Running them in CI needs the CLI installed and an authenticated org — see the PR.
+ * What the factory does unconditionally — exporting, registering its command, wiring
+ * hooks — does not need the CLI, and is kept out of the gated block. Skipping it too would
+ * mean a registration regression could ship past a green CI that had simply run nothing.
  */
 const SF_INSTALLED = Bun.spawnSync([process.platform === 'win32' ? 'where' : 'which', 'sf']).exitCode === 0;
 
-describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration', () => {
+async function loadFactory(): Promise<FactoryFn> {
+  const mod = await import('../../src/index');
+  return mod.default as FactoryFn;
+}
+
+describe('ExtensionFactory — no CLI required', () => {
   let factory: FactoryFn;
 
   beforeAll(async () => {
-    const mod = await import('../../src/index');
-    factory = mod.default as FactoryFn;
+    factory = await loadFactory();
   });
 
   it('exports a default function (ExtensionFactory)', () => {
     expect(typeof factory).toBe('function');
+  });
+
+  it('session_start hook returns immediately and does not throw', async () => {
+    // The handler is deliberately synchronous: it kicks the org lookup off in the
+    // background so session start never waits on a CLI call (src/index.ts). The previous
+    // assertion used `.resolves`, which requires a thenable, so it asserted an async
+    // contract the handler was never written to have.
+    const { pi, events } = await buildMockPi();
+    await factory(pi);
+
+    const handler = events.session_start?.[0];
+    expect(handler).toBeDefined();
+
+    expect(handler({}, { cwd: '/tmp' })).toBeUndefined();
+  });
+
+  it('registers salesforce:setup command', async () => {
+    const commands: { name: string; description?: string }[] = [];
+    const { pi } = await buildMockPi();
+
+    (pi as Record<string, unknown>).registerCommand = (name: string, opts: { description?: string }) => {
+      commands.push({ name, description: opts.description });
+    };
+
+    await factory(pi);
+
+    const setup = commands.find((c) => c.name === 'salesforce:setup');
+    expect(setup).toBeDefined();
+    expect(setup?.description).toContain('Install');
+  });
+});
+
+describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration — requires the sf CLI', () => {
+  let factory: FactoryFn;
+
+  beforeAll(async () => {
+    factory = await loadFactory();
   });
 
   it('factory executes without throwing when sf is available', async () => {
@@ -100,6 +140,10 @@ describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration', () => {
   it('each registered tool has required ToolDefinition fields', async () => {
     const { pi, tools } = await buildMockPi();
     await factory(pi);
+
+    // Without this the loop below has nothing to iterate when no tools were registered,
+    // and the test passes having asserted nothing.
+    expect(tools).toHaveLength(6);
 
     for (const tool of tools) {
       expect(typeof tool.name).toBe('string');
@@ -212,35 +256,5 @@ describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration', () => {
       expect(result.message?.customType).toBe('salesforce_hint');
       expect(result.message?.display).toBe(false);
     }
-  });
-
-  it('session_start hook returns immediately and does not throw', async () => {
-    // The handler is deliberately synchronous: it kicks the org lookup off in the
-    // background so session start never waits on a CLI call (src/index.ts). The previous
-    // assertion used `.resolves`, which requires a thenable, so it asserted an async
-    // contract the handler was never written to have.
-    const { pi, events } = await buildMockPi();
-    await factory(pi);
-
-    const handler = events.session_start?.[0];
-    expect(handler).toBeDefined();
-
-    expect(handler({}, { cwd: '/tmp' })).toBeUndefined();
-  });
-
-  it('registers salesforce:setup command', async () => {
-    const commands: { name: string; description?: string }[] = [];
-    const { pi } = await buildMockPi();
-
-    // Add registerCommand to the mock
-    (pi as Record<string, unknown>).registerCommand = (name: string, opts: { description?: string }) => {
-      commands.push({ name, description: opts.description });
-    };
-
-    await factory(pi);
-
-    const setup = commands.find((c) => c.name === 'salesforce:setup');
-    expect(setup).toBeDefined();
-    expect(setup?.description).toContain('Install');
   });
 });

--- a/plugins/salesforce/test/tools/sf-setup.test.ts
+++ b/plugins/salesforce/test/tools/sf-setup.test.ts
@@ -66,17 +66,50 @@ describe('sf_setup execute — validation', () => {
     expect(result.isError).toBe(true);
   });
 
-  it('set_default accepts valid aliases', async () => {
-    const tool = createSfSetupTool(mockPi);
+  it('set_default accepts valid aliases and asks sf to set each one', async () => {
+    // This used to run the real `sf` binary. On a machine with the CLI installed that meant
+    // four genuine `sf config set target-org <alias> --global` writes to ~/.sf/config.json
+    // — a unit test mutating the developer's own Salesforce config — and it blew the 5 s
+    // timeout. Injecting the executor keeps the assertion (validation lets these through)
+    // and removes the side effect.
+    const calls: string[][] = [];
+    const tool = createSfSetupTool(mockPi, () => ({
+      async exec(_command: string, args: string[]) {
+        calls.push(args);
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+    }));
+
     for (const alias of ['my-org', 'prod.org', 'user@domain', 'org_123']) {
       const result = await tool.execute('t1', { action: 'set_default', org: alias }, undefined, undefined, {
         cwd: '/tmp',
       });
-      // Will fail on exec (sf not mocked) but should NOT fail on validation
-      if (result.isError) {
-        expect(result.content[0].text).not.toContain('invalid org alias');
-      }
+      expect(result.isError).toBeFalsy();
     }
+
+    expect(calls).toEqual([
+      ['config', 'set', 'target-org', 'my-org', '--global'],
+      ['config', 'set', 'target-org', 'prod.org', '--global'],
+      ['config', 'set', 'target-org', 'user@domain', '--global'],
+      ['config', 'set', 'target-org', 'org_123', '--global'],
+    ]);
+  });
+
+  it('rejects an invalid alias before running anything', async () => {
+    const calls: string[][] = [];
+    const tool = createSfSetupTool(mockPi, () => ({
+      async exec(_command: string, args: string[]) {
+        calls.push(args);
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+    }));
+
+    const result = await tool.execute('t1', { action: 'set_default', org: 'x;rm -rf /' }, undefined, undefined, {
+      cwd: '/tmp',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(calls).toHaveLength(0);
   });
 
   it('returns unknown action for unrecognized action', async () => {

--- a/plugins/salesforce/test/wizard.test.ts
+++ b/plugins/salesforce/test/wizard.test.ts
@@ -1,10 +1,41 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { PlatformInfo } from '../src/platform';
 import { buildAuthStep, buildInstallStep, buildVerifyCommand, runSetupWizard } from '../src/wizard';
 
 // ---------------------------------------------------------------------------
 // Helper builders — exact command assertions
 // ---------------------------------------------------------------------------
+
+/**
+ * The wizard branches on credential environment variables, so a developer machine or CI
+ * runner with cloud credentials exported takes a different auth path and these tests fail
+ * for a reason that has nothing to do with the code. Clear them around every case; the ones
+ * that exercise a credential path set what they need themselves.
+ */
+const CREDENTIAL_VARS = [
+  'SFDX_AUTH_URL',
+  'SFDX_DISABLE_ENCRYPTION',
+  'SF_ACCESS_TOKEN',
+  'SF_CLIENT_ID',
+  'SF_JWT_KEY_FILE',
+  'SF_ORG_INSTANCE_URL',
+  'SF_USERNAME',
+];
+let savedCredentials: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  savedCredentials = Object.fromEntries(CREDENTIAL_VARS.map((key) => [key, process.env[key]]));
+  for (const key of CREDENTIAL_VARS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of CREDENTIAL_VARS) {
+    const value = savedCredentials[key];
+    // Assigning undefined would store the string "undefined", so absent means delete.
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 describe('buildInstallStep', () => {
   it('macOS brew command is exactly brew install sf', () => {
@@ -277,7 +308,17 @@ describe('runSetupWizard — sf not installed', () => {
 
     await runSetupWizard(pi, ctx, { ...sfNotInstalledThenInstalled, ...on(LINUX) });
 
-    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(["apt","install","-y","sf"]);
+    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(['apt', 'install', '-y', 'sf']);
+  });
+
+  it('no package manager shows the manual install link', async () => {
+    const { pi, calls } = buildMockPi();
+    const { ctx, notifications } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { checkSfInstalled: () => false, ...on(BARE) });
+
+    expect(notifications.find((n) => n.message.includes('developer.salesforce.com'))?.type).toBe('error');
+    expect(calls).toHaveLength(0);
   });
 
   it('install failure shows error', async () => {

--- a/plugins/salesforce/test/wizard.test.ts
+++ b/plugins/salesforce/test/wizard.test.ts
@@ -226,6 +226,15 @@ describe('runSetupWizard — sf installed, web auth', () => {
 // runSetupWizard — sf NOT installed (auto-install flow)
 // ---------------------------------------------------------------------------
 
+// The wizard resolves the install command from the host it runs on. These tests inject the
+// platform instead, so each one asserts the same thing on a developer's Mac and on a Linux
+// CI runner — previously they asserted `brew` and so passed only on macOS.
+const MACOS: PlatformInfo = { os: 'darwin', arch: 'arm64', packageManagers: ['brew'], isCorporateManaged: false };
+const LINUX: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: ['apt'], isCorporateManaged: false };
+const BARE: PlatformInfo = { os: 'linux', arch: 'x64', packageManagers: [], isCorporateManaged: false };
+
+const on = (platform: PlatformInfo) => ({ detectPlatform: async () => platform });
+
 describe('runSetupWizard — sf not installed', () => {
   let installCount = 0;
   const sfNotInstalledThenInstalled = {
@@ -235,7 +244,7 @@ describe('runSetupWizard — sf not installed', () => {
     },
   };
 
-  it('auto-installs via preferred package manager and notifies restart', async () => {
+  it('auto-installs via brew on macOS and notifies restart', async () => {
     installCount = 0;
     const { pi, calls } = buildMockPi({
       'brew install sf': { stdout: 'installed', stderr: '', code: 0 },
@@ -250,7 +259,7 @@ describe('runSetupWizard — sf not installed', () => {
       selectResponses: ['https://login.salesforce.com (standard)'],
     });
 
-    await runSetupWizard(pi, ctx, sfNotInstalledThenInstalled);
+    await runSetupWizard(pi, ctx, { ...sfNotInstalledThenInstalled, ...on(MACOS) });
 
     const installCall = calls.find((c) => c.cmd === 'brew' && c.args.includes('sf'));
     expect(installCall).toBeDefined();
@@ -259,13 +268,25 @@ describe('runSetupWizard — sf not installed', () => {
     expect(notifications.find((n) => n.message.includes('Restart xcsh'))).toBeDefined();
   });
 
+  it('auto-installs via apt on Linux', async () => {
+    installCount = 0;
+    const { pi, calls } = buildMockPi({
+      'apt install': { stdout: 'installed', stderr: '', code: 0 },
+    });
+    const { ctx } = buildMockCtx();
+
+    await runSetupWizard(pi, ctx, { ...sfNotInstalledThenInstalled, ...on(LINUX) });
+
+    expect(calls.find((call) => call.cmd === 'sudo')?.args).toEqual(["apt","install","-y","sf"]);
+  });
+
   it('install failure shows error', async () => {
     const { pi } = buildMockPi({
       'brew install sf': { stdout: '', stderr: 'permission denied', code: 1 },
     });
     const { ctx, notifications } = buildMockCtx({ selectResponses: ['Skip'] });
 
-    await runSetupWizard(pi, ctx, { checkSfInstalled: () => false });
+    await runSetupWizard(pi, ctx, { checkSfInstalled: () => false, ...on(MACOS) });
 
     expect(notifications.find((n) => n.message.includes('Installation failed'))?.type).toBe('error');
   });

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -2,26 +2,17 @@
 # run-plugin-tests.sh — run every plugin's test suite.
 #
 # Each plugin ships `scripts/tests/run-tests.sh` (shell acceptance) and, where it has a
-# TypeScript engine, `*.test.ts` files run by bun. Until now nothing ran either in CI, so a
+# TypeScript engine, `*.test.ts` files run by bun. Nothing ran either in CI until #874, so a
 # plugin could merge with its own guards failing — including the workbook-spec guard, whose
 # entire job is to fail the build.
 #
-# KNOWN_RED is deliberately not an allowlist of green plugins. An allowlist rots silently: a
-# newly added plugin would inherit no gate at all, which is the same failure this script
-# exists to close. Instead every plugin must pass, and the few that are already red are
-# named here against a tracking issue.
+# Every plugin must pass. There is no exemption list: the five plugins that were red when
+# this script landed are fixed (#873), and an allowlist would silently exempt the next
+# plugin someone adds, which is the same failure this exists to close.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 2
-
-# Plugins with pre-existing failures, tracked in issue #873. Remove a name when its suite
-# goes green; the run warns when one of these passes, so the list has a visible expiry.
-#
-# The warning is not a failure on purpose. Some of these suites shell out to a cloud CLI and
-# so fail differently on a developer's machine than on a CI runner, and a gate that flaps
-# between the two gets switched off rather than fixed.
-KNOWN_RED=(aws azure gcloud salesforce salesforce-legacy)
 
 # A missing runtime must not read as a pass: the per-plugin suites skip themselves when bun
 # is absent, which in CI would be a silent no-op gate.
@@ -32,14 +23,7 @@ command -v bun >/dev/null 2>&1 || {
   exit 2
 }
 
-is_known_red() {
-  local name="$1" p
-  for p in "${KNOWN_RED[@]}"; do [ "$p" = "$name" ] && return 0; done
-  return 1
-}
-
 failed=()
-unexpectedly_green=()
 
 for suite in plugins/*/scripts/tests/run-tests.sh; do
   [ -f "$suite" ] || continue
@@ -60,28 +44,12 @@ for suite in plugins/*/scripts/tests/run-tests.sh; do
     (cd "plugins/$plugin" && bun test .) || ok=1
   fi
 
-  if is_known_red "$plugin"; then
-    if [ "$ok" -eq 0 ]; then
-      unexpectedly_green+=("$plugin")
-    else
-      printf '    (known red — not failing the build)\n'
-    fi
-  elif [ "$ok" -ne 0 ]; then
-    failed+=("$plugin")
-  fi
+  [ "$ok" -ne 0 ] && failed+=("$plugin")
 done
-
-status=0
 
 if [ "${#failed[@]}" -gt 0 ]; then
   printf '\nFAILED: %s\n' "${failed[*]}" >&2
-  status=1
+  exit 1
 fi
 
-if [ "${#unexpectedly_green[@]}" -gt 0 ]; then
-  printf '\nWARNING: listed in KNOWN_RED but now passing: %s\n' "${unexpectedly_green[*]}" >&2
-  printf 'Remove them from KNOWN_RED in %s so the gate starts holding them green.\n' "$0" >&2
-fi
-
-[ "$status" -eq 0 ] && printf '\nAll gated plugin suites passed.\n'
-exit "$status"
+printf '\nAll plugin suites passed.\n'


### PR DESCRIPTION
## What happened

The CI job added in #874 ran the plugin test suites for the first time — and failed.
Everything it found was real. This fixes all of it, and `KNOWN_RED` is gone: no plugin is
exempt from the gate any more.

## The failures

**Six suites only passed on a Mac.** `runSetupWizard` resolves the install command from
`process.platform` plus a `which` probe, and the tests asserted the answer that gives on
macOS — `brew`. On the Linux runner the answer is apt, so `github` and `gitlab` failed
outright while `aws`, `azure` and `gcloud` were merely quiet behind `KNOWN_RED`. Each
wizard now takes an injected `detectPlatform`, so a test states the platform it is testing.
Each suite gained a Linux case and a no-package-manager case — the second is the branch
that tells a user to install by hand, and four of the six plugins never asserted it.

**Two tests were driving real cloud CLIs.** `sf_setup`'s "accepts valid aliases" ran four
genuine `sf config set target-org <alias> --global` commands — a unit test writing to the
developer's own `~/.sf/config.json`, and the reason it blew a 5 s timeout on a machine with
the CLI installed. `az_exec` spawned `az` to find out whether argument validation had
rejected something. Both tools now take an injected executor.

**Stale names.** `aws`, `azure` and `gcloud` asserted `aws-status` / `azure-status` /
`gcloud-status`; the directory, `plugin.json`, `marketplace.json` and `hooks.json` all
disagree, so the tests were what drifted. `salesforce-legacy` asserted it was `salesforce`.
Azure's tool-factory list predated the rename that gave each file its verb. Its hook test
symlinked `/usr/bin/bash`, which does not exist on macOS, so the scrubbed `PATH` held no
shell and the hook never ran — a failure that said nothing about the hook.

**A credential scanner searching `node_modules`.** Installing dependencies to run the tests
made `salesforce` report five lines of `bun-types`' own npmrc documentation as hardcoded
credentials. Six plugins already excluded it; the other twelve do now.

## From the second-opinion review

Codex ran twice and produced **two findings, both CONFIRMED by reproducing them** — none
refuted.

1. **Credentialed machines were still nondeterministic.** Injecting the platform fixed one
   axis of host-dependence; the wizards also branch on `AWS_ACCESS_KEY_ID`,
   `AZURE_CLIENT_ID`, `GOOGLE_APPLICATION_CREDENTIALS`, `SFDX_AUTH_URL`. Reproduced:
   exporting AWS credentials fails aws's "handles auth failure", likewise gcloud and
   salesforce. Azure was immune only because its own tests snapshot those three by hand —
   and that restore assigns `originalEnv.X` back, storing the string `"undefined"` when the
   variable was absent. Every wizard suite now clears and correctly restores its credential
   variables.

2. **The Salesforce integration skip was too wide.** Gating the whole extension-load suite
   on `sf` threw away three cases that never needed it. Measured by removing the gate and
   hiding `sf`: four of ten pass, three genuinely CLI-independent and one — "each
   registered tool has required ToolDefinition fields" — passing only because the tools
   array was empty and its loop had nothing to iterate. Split into an ungated block and a
   gated one, with `expect(tools).toHaveLength(6)` so the loop cannot pass vacuously.

## Verification

Every suite, three hostile environments, all green:

| condition | result |
| --- | --- |
| native (all cloud CLIs present) | `run-plugin-tests.sh` exit 0 |
| no cloud CLI on `PATH` at all | exit 0 |
| credentials exported + no CLIs + `process.platform` forced to `linux` | exit 0 |

The harness is sensitive to what it claims to catch:

- Forcing `platform=linux` against the **pre-fix** code reproduces the exact CI failure
  (same two test names).
- Renaming `registerCommand('salesforce:setup')` fails the now-ungated test with `sf`
  absent.
- The sweep dropped from ~13.6 s to ~1.1 s once the tests stopped shelling out.

Biome exit 0 (no diagnostics), shellcheck exit 0, shfmt clean, `validate-plugins.sh` exit 0.

## Still not a merge gate

`Validate Plugins / Run plugin test suites` runs and reports, but required checks on `main`
are only `check / Check linked issues`, `lint / Lint Code Base` and
`audit / Translation freshness` — which is exactly why #874 merged with this job red.
Adding it is branch protection, governed by docs-control, and is the remaining item on
**#873**.

Closes #873
