### PR TITLE
Stop plugin tests spawning real cloud CLIs, and keep the CLIs off the gate's PATH

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -11,6 +11,7 @@ on:
       - "scripts/validate-plugins.sh"
       - "scripts/check-version-bumps.sh"
       - "scripts/run-plugin-tests.sh"
+      - "scripts/check-tests-are-hermetic.sh"
   push:
     branches: [main]
     paths:
@@ -19,6 +20,7 @@ on:
       - "scripts/validate-plugins.sh"
       - "scripts/check-version-bumps.sh"
       - "scripts/run-plugin-tests.sh"
+      - "scripts/check-tests-are-hermetic.sh"
 
 permissions:
   contents: read
@@ -77,3 +79,9 @@ jobs:
 
       - name: Run plugin test suites
         run: ./scripts/run-plugin-tests.sh
+
+      # The runner ships aws, az, gcloud and gh. A test that quietly spawns one passes here
+      # and fails on a machine where that CLI is slower or absent — which is how this job
+      # broke twice. Replacing the CLIs with sleeping stubs makes any such test name itself.
+      - name: Check tests do not depend on a real cloud CLI
+        run: ./scripts/check-tests-are-hermetic.sh

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -202,7 +202,7 @@
     {
       "name": "salesforce",
       "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -264,7 +264,7 @@
     {
       "name": "azure",
       "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -289,7 +289,7 @@
     {
       "name": "aws",
       "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -314,7 +314,7 @@
     {
       "name": "gcloud",
       "description": "Google Cloud CLI integration — container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -339,7 +339,7 @@
     {
       "name": "gitlab",
       "description": "GitLab CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via glab CLI",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -364,7 +364,7 @@
     {
       "name": "github",
       "description": "GitHub CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via gh CLI",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **Plugin tests no longer depend on a real cloud CLI** (`aws` v1.2.2, `azure` v1.2.2,
+  `gcloud` v1.2.2, `github` v1.2.2, `gitlab` v1.2.3, `salesforce` v1.3.3) — 32 tests across
+  six plugins spawned `aws`, `az`, `gcloud`, `gh` or `sf`, because every tool factory built
+  its executor from `ctx.cwd`. Whether they passed depended on which binaries the machine
+  had and how fast they answered, which is how the CI job broke twice. All 27 factories now
+  accept an injected executor, the validation suites use a stub, and the cases that
+  genuinely drive a CLI are gated on its presence with an explicit timeout.
+
+- `scripts/check-tests-are-hermetic.sh` proves it and keeps it that way: it replaces every
+  cloud CLI with a sleeping stub, so a test that still spawns one trips bun's timeout and
+  names itself. Wired into the Validate Plugins workflow.
+
 Every plugin test suite now runs in CI, and the failures that surfaced are fixed.
 
 - **Portable setup-wizard tests** (`aws` v1.2.1, `azure` v1.2.1, `gcloud` v1.2.1,
@@ -60,10 +72,6 @@ Every plugin test suite now runs in CI, and the failures that surfaced are fixed
   template's own text. Adds `metadata.accountTeam`.
 
 - **`meddpicc`** bumped to v2.2.1
-
-- **`salesforce`** bumped to v1.3.1
-
-- **`gitlab`** bumped to v1.2.1
 
 - **`azure`** bumped to v1.2.0 — `az_exec` now accepts valid JMESPath `--query`
   (dropped the char filter that rejected `||`, backticks, and pipes); read-only guard,

--- a/plugins/aws/.xcsh-plugin/plugin.json
+++ b/plugins/aws/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws",
   "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/aws",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/aws/package.json
+++ b/plugins/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-aws",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "AWS CLI status for xcsh welcome screen",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "AWS",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/aws/src/tools/aws-ec2-describe-instances.ts
+++ b/plugins/aws/src/tools/aws-ec2-describe-instances.ts
@@ -1,3 +1,4 @@
+import type { AwsExecApi } from '../aws/exec';
 import { execAwsJson } from '../aws/exec';
 import { formatInstanceTable, normalizeReservations } from '../aws/formatters';
 import type { PluginInterface } from '../aws/types';
@@ -10,7 +11,14 @@ import { detectErrorType, errorResult, hasControlChars, makeExecApi, renderError
 // so only known-safe characters appear on either side of the Name/Values pair.
 const EC2_FILTER_PATTERN = /^Name=[A-Za-z0-9:._/-]+,Values=[A-Za-z0-9:._/,*-]+$/;
 
-export function createAwsEc2DescribeInstancesTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAwsEc2DescribeInstancesTool(
+  pi: PluginInterface,
+  makeApi: (cwd: string) => AwsExecApi = makeExecApi,
+) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -65,7 +73,7 @@ export function createAwsEc2DescribeInstancesTool(pi: PluginInterface) {
         }
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = ['ec2', 'describe-instances'];
       if (params.region) args.push('--region', params.region);
       if (params.instanceIds && params.instanceIds.length > 0) args.push('--instance-ids', ...params.instanceIds);

--- a/plugins/aws/src/tools/aws-exec.ts
+++ b/plugins/aws/src/tools/aws-exec.ts
@@ -1,3 +1,4 @@
+import type { AwsExecApi } from '../aws/exec';
 import { detectAwsError } from '../aws/exec';
 import type { PluginInterface } from '../aws/types';
 import awsExecDescription from '../prompts/aws-exec.md' with { type: 'text' };
@@ -6,7 +7,11 @@ import { errorResult, hasControlChars, makeExecApi, textResult } from './shared'
 
 const MAX_OUTPUT_LENGTH = 50000;
 
-export function createAwsExecTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAwsExecTool(pi: PluginInterface, makeApi: (cwd: string) => AwsExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -54,7 +59,7 @@ export function createAwsExecTool(pi: PluginInterface) {
         return errorResult(`Error: ${mutation.reason}`, base);
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const builtArgs = buildAwsArgs(args);
       const result = await api.exec('aws', builtArgs, { signal });
       if (result.exitCode !== 0) {

--- a/plugins/aws/src/tools/aws-help.ts
+++ b/plugins/aws/src/tools/aws-help.ts
@@ -1,9 +1,14 @@
+import type { AwsExecApi } from '../aws/exec';
 import type { PluginInterface } from '../aws/types';
 import { HELP_PATH_PATTERN } from '../aws/types';
 import awsHelpDescription from '../prompts/aws-help.md' with { type: 'text' };
 import { errorResult, makeExecApi, textResult } from './shared';
 
-export function createAwsHelpTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAwsHelpTool(pi: PluginInterface, makeApi: (cwd: string) => AwsExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -46,7 +51,7 @@ export function createAwsHelpTool(pi: PluginInterface) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       // NOTE: aws uses the `help` subcommand, NOT a `--help` flag.
       const args = [...parts, 'help'];
 

--- a/plugins/aws/src/tools/aws-s3-ls.ts
+++ b/plugins/aws/src/tools/aws-s3-ls.ts
@@ -1,3 +1,4 @@
+import type { AwsExecApi } from '../aws/exec';
 import { execAwsJson, execAwsRaw } from '../aws/exec';
 import { formatBucketTable, formatS3ObjectTable, normalizeBucket, parseS3LsOutput } from '../aws/formatters';
 import type { PluginInterface } from '../aws/types';
@@ -5,7 +6,11 @@ import { S3_URI_PATTERN } from '../aws/types';
 import awsS3LsDescription from '../prompts/aws-s3-ls.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
 
-export function createAwsS3LsTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAwsS3LsTool(pi: PluginInterface, makeApi: (cwd: string) => AwsExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -33,7 +38,7 @@ export function createAwsS3LsTool(pi: PluginInterface) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
 
       try {
         if (params.target) {

--- a/plugins/aws/src/tools/aws-sts-whoami.ts
+++ b/plugins/aws/src/tools/aws-sts-whoami.ts
@@ -1,3 +1,4 @@
+import type { AwsExecApi } from '../aws/exec';
 import { execAwsJson } from '../aws/exec';
 import { formatIdentityDetail, normalizeIdentity } from '../aws/formatters';
 import type { PluginInterface } from '../aws/types';
@@ -5,7 +6,11 @@ import { RESOURCE_NAME_PATTERN } from '../aws/types';
 import awsStsWhoamiDescription from '../prompts/aws-sts-whoami.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
 
-export function createAwsStsWhoamiTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAwsStsWhoamiTool(pi: PluginInterface, makeApi: (cwd: string) => AwsExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -33,7 +38,7 @@ export function createAwsStsWhoamiTool(pi: PluginInterface) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = ['sts', 'get-caller-identity'];
       if (params.profile) args.push('--profile', params.profile);
 

--- a/plugins/aws/test/extension.test.ts
+++ b/plugins/aws/test/extension.test.ts
@@ -1,5 +1,13 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 
+/**
+ * These cases drive the real `aws` binary, so they are meaningful only where it is
+ * installed. A visible skip beats an `if (…)` that quietly asserts nothing, and the
+ * generous timeout is because a cloud CLI answering in under five seconds is not a
+ * property this repo controls.
+ */
+const AWS_INSTALLED = Bun.spawnSync([process.platform === 'win32' ? 'where' : 'which', 'aws']).exitCode === 0;
+
 const mockTypebox = {
   Type: {
     Object: (s: unknown) => s,
@@ -52,20 +60,24 @@ describe('AWS Status extension', () => {
     }
   });
 
-  it('service check returns valid state', async () => {
-    let checkFn: (() => Promise<{ state: string }>) | undefined;
-    const mockPi = baseMockPi({
-      registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
-        checkFn = c.check;
-      },
-    });
-    await factory(mockPi);
+  it.skipIf(!AWS_INSTALLED)(
+    'service check returns valid state',
+    async () => {
+      let checkFn: (() => Promise<{ state: string }>) | undefined;
+      const mockPi = baseMockPi({
+        registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
+          checkFn = c.check;
+        },
+      });
+      await factory(mockPi);
 
-    if (checkFn) {
-      const result = await checkFn();
-      expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
-    }
-  });
+      if (checkFn) {
+        const result = await checkFn();
+        expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+      }
+    },
+    60000,
+  );
 
   it('registers 5 tools when aws CLI is available', async () => {
     const tools: Array<{ name: string }> = [];

--- a/plugins/aws/test/tools/aws-ec2-describe-instances.test.ts
+++ b/plugins/aws/test/tools/aws-ec2-describe-instances.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAwsEc2DescribeInstancesTool } from '../../src/tools/aws-ec2-describe-instances';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -11,7 +17,7 @@ const mockTypebox = {
 };
 
 describe('createAwsEc2DescribeInstancesTool', () => {
-  const tool = createAwsEc2DescribeInstancesTool({ typebox: mockTypebox });
+  const tool = createAwsEc2DescribeInstancesTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('aws_ec2_describe_instances');
@@ -31,7 +37,7 @@ describe('createAwsEc2DescribeInstancesTool', () => {
 });
 
 describe('aws_ec2_describe_instances input validation', () => {
-  const tool = createAwsEc2DescribeInstancesTool({ typebox: mockTypebox });
+  const tool = createAwsEc2DescribeInstancesTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects an invalid region', async () => {
     const result = await tool.execute('id', { region: 'us_east_1' }, undefined, null, { cwd: '/tmp' });

--- a/plugins/aws/test/tools/aws-exec.test.ts
+++ b/plugins/aws/test/tools/aws-exec.test.ts
@@ -5,6 +5,12 @@ import { buildAwsArgs, findMutation } from '../../src/tools/aws-exec-guard';
 import { createAwsHelpTool } from '../../src/tools/aws-help';
 import { hasControlChars } from '../../src/tools/shared';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const NUL = String.fromCharCode(0);
 const TAB = String.fromCharCode(9);
 const SOH = String.fromCharCode(1);
@@ -12,10 +18,10 @@ const SOH = String.fromCharCode(1);
 const mockPi = { typebox: { Type } };
 
 function makeExec() {
-  return createAwsExecTool(mockPi);
+  return createAwsExecTool(mockPi, stubExec);
 }
 function makeHelp() {
-  return createAwsHelpTool(mockPi);
+  return createAwsHelpTool(mockPi, stubExec);
 }
 
 describe('findMutation — ALLOW read-only aws commands', () => {

--- a/plugins/aws/test/tools/aws-help.test.ts
+++ b/plugins/aws/test/tools/aws-help.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAwsHelpTool } from '../../src/tools/aws-help';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -10,7 +16,7 @@ const mockTypebox = {
 };
 
 describe('createAwsHelpTool', () => {
-  const tool = createAwsHelpTool({ typebox: mockTypebox });
+  const tool = createAwsHelpTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('aws_help');
@@ -26,7 +32,7 @@ describe('createAwsHelpTool', () => {
 });
 
 describe('aws_help command path validation', () => {
-  const tool = createAwsHelpTool({ typebox: mockTypebox });
+  const tool = createAwsHelpTool({ typebox: mockTypebox }, stubExec);
 
   it('accepts a service with digits ("ec2")', async () => {
     try {

--- a/plugins/aws/test/tools/aws-s3-ls.test.ts
+++ b/plugins/aws/test/tools/aws-s3-ls.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAwsS3LsTool } from '../../src/tools/aws-s3-ls';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -10,7 +16,7 @@ const mockTypebox = {
 };
 
 describe('createAwsS3LsTool', () => {
-  const tool = createAwsS3LsTool({ typebox: mockTypebox });
+  const tool = createAwsS3LsTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('aws_s3_ls');
@@ -30,7 +36,7 @@ describe('createAwsS3LsTool', () => {
 });
 
 describe('aws_s3_ls input validation', () => {
-  const tool = createAwsS3LsTool({ typebox: mockTypebox });
+  const tool = createAwsS3LsTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects a target that is not an s3:// URI', async () => {
     const result = await tool.execute('id', { target: '/etc/passwd' }, undefined, null, { cwd: '/tmp' });

--- a/plugins/aws/test/tools/aws-sts-whoami.test.ts
+++ b/plugins/aws/test/tools/aws-sts-whoami.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAwsStsWhoamiTool } from '../../src/tools/aws-sts-whoami';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -10,7 +16,7 @@ const mockTypebox = {
 };
 
 describe('createAwsStsWhoamiTool', () => {
-  const tool = createAwsStsWhoamiTool({ typebox: mockTypebox });
+  const tool = createAwsStsWhoamiTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('aws_sts_whoami');
@@ -30,7 +36,7 @@ describe('createAwsStsWhoamiTool', () => {
 });
 
 describe('aws_sts_whoami input validation', () => {
-  const tool = createAwsStsWhoamiTool({ typebox: mockTypebox });
+  const tool = createAwsStsWhoamiTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects profile with shell injection', async () => {
     const result = await tool.execute('id', { profile: '$(whoami)' }, undefined, null, { cwd: '/tmp' });

--- a/plugins/azure/.xcsh-plugin/plugin.json
+++ b/plugins/azure/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "azure",
   "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/azure",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/azure/package.json
+++ b/plugins/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-azure",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Azure CLI tools for xcsh — native az command execution, subscription/resource/VM management, and welcome screen status",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Azure",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/azure/src/tools/az-account-show.ts
+++ b/plugins/azure/src/tools/az-account-show.ts
@@ -1,3 +1,4 @@
+import type { AzExecApi } from '../az/exec';
 import { execAzJson } from '../az/exec';
 import { formatSubscriptionDetail, formatSubscriptionTable } from '../az/formatters';
 import type { PluginInterface } from '../az/types';
@@ -5,7 +6,11 @@ import { SUBSCRIPTION_ID_PATTERN, SUBSCRIPTION_NAME_PATTERN } from '../az/types'
 import azAccountDescription from '../prompts/az-account-show.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, normalizeSubscription, textResult } from './shared';
 
-export function createAzAccountShowTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAzAccountShowTool(pi: PluginInterface, makeApi: (cwd: string) => AzExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -40,7 +45,7 @@ export function createAzAccountShowTool(pi: PluginInterface) {
         }
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
 
       try {
         if (params.action === 'list') {

--- a/plugins/azure/src/tools/az-group-list.ts
+++ b/plugins/azure/src/tools/az-group-list.ts
@@ -1,3 +1,4 @@
+import type { AzExecApi } from '../az/exec';
 import { execAzJson } from '../az/exec';
 import { formatResourceGroupTable } from '../az/formatters';
 import type { PluginInterface } from '../az/types';
@@ -5,7 +6,11 @@ import { RESOURCE_GROUP_PATTERN, SUBSCRIPTION_ID_PATTERN, SUBSCRIPTION_NAME_PATT
 import azGroupDescription from '../prompts/az-group-list.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, normalizeResourceGroup, textResult } from './shared';
 
-export function createAzGroupListTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAzGroupListTool(pi: PluginInterface, makeApi: (cwd: string) => AzExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -53,7 +58,7 @@ export function createAzGroupListTool(pi: PluginInterface) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
 
       try {
         if (params.action === 'show') {

--- a/plugins/azure/src/tools/az-help.ts
+++ b/plugins/azure/src/tools/az-help.ts
@@ -1,9 +1,14 @@
+import type { AzExecApi } from '../az/exec';
 import type { PluginInterface } from '../az/types';
 import { HELP_PATH_PATTERN } from '../az/types';
 import azHelpDescription from '../prompts/az-help.md' with { type: 'text' };
 import { errorResult, makeExecApi, textResult } from './shared';
 
-export function createAzHelpTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAzHelpTool(pi: PluginInterface, makeApi: (cwd: string) => AzExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -37,7 +42,7 @@ export function createAzHelpTool(pi: PluginInterface) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const parts = commandPath.length > 0 ? commandPath.split(' ').filter(Boolean) : [];
       const args = [...parts, '--help'];
 

--- a/plugins/azure/src/tools/az-resource-list.ts
+++ b/plugins/azure/src/tools/az-resource-list.ts
@@ -1,3 +1,4 @@
+import type { AzExecApi } from '../az/exec';
 import { execAzJson } from '../az/exec';
 import { formatResourceTable } from '../az/formatters';
 import type { PluginInterface } from '../az/types';
@@ -10,7 +11,11 @@ import {
 import azResourceDescription from '../prompts/az-resource-list.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, normalizeResource, textResult } from './shared';
 
-export function createAzResourceListTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAzResourceListTool(pi: PluginInterface, makeApi: (cwd: string) => AzExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -57,7 +62,7 @@ export function createAzResourceListTool(pi: PluginInterface) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = ['resource', 'list', '--resource-group', params.resource_group];
       if (params.subscription) args.push('--subscription', params.subscription);
       if (params.resource_type) args.push('--resource-type', params.resource_type);

--- a/plugins/azure/src/tools/az-vm-list.ts
+++ b/plugins/azure/src/tools/az-vm-list.ts
@@ -1,3 +1,4 @@
+import type { AzExecApi } from '../az/exec';
 import { execAzJson } from '../az/exec';
 import { formatVmTable } from '../az/formatters';
 import type { PluginInterface } from '../az/types';
@@ -5,7 +6,11 @@ import { RESOURCE_GROUP_PATTERN, SUBSCRIPTION_ID_PATTERN, SUBSCRIPTION_NAME_PATT
 import azVmDescription from '../prompts/az-vm-list.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, normalizeVm, textResult } from './shared';
 
-export function createAzVmListTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createAzVmListTool(pi: PluginInterface, makeApi: (cwd: string) => AzExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -43,7 +48,7 @@ export function createAzVmListTool(pi: PluginInterface) {
         }
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = ['vm', 'list'];
       if (params.resource_group) args.push('--resource-group', params.resource_group);
       if (params.subscription) args.push('--subscription', params.subscription);

--- a/plugins/azure/test/extension.test.ts
+++ b/plugins/azure/test/extension.test.ts
@@ -1,5 +1,13 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 
+/**
+ * These cases drive the real `az` binary, so they are meaningful only where it is
+ * installed. A visible skip beats an `if (…)` that quietly asserts nothing, and the
+ * generous timeout is because a cloud CLI answering in under five seconds is not a
+ * property this repo controls.
+ */
+const AZ_INSTALLED = Bun.spawnSync([process.platform === 'win32' ? 'where' : 'which', 'az']).exitCode === 0;
+
 const mockTypebox = {
   Type: {
     Object: (s: unknown) => s,
@@ -71,20 +79,24 @@ describe('Azure Status extension', () => {
     expect(events).toContain('session_start');
   });
 
-  it('service check returns valid state', async () => {
-    let checkFn: (() => Promise<{ state: string }>) | undefined;
-    const mockPi = baseMockPi({
-      registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
-        checkFn = c.check;
-      },
-    });
-    await factory(mockPi);
-    expect(checkFn).toBeDefined();
-    if (checkFn) {
-      const result = await checkFn();
-      expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
-    }
-  });
+  it.skipIf(!AZ_INSTALLED)(
+    'service check returns valid state',
+    async () => {
+      let checkFn: (() => Promise<{ state: string }>) | undefined;
+      const mockPi = baseMockPi({
+        registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
+          checkFn = c.check;
+        },
+      });
+      await factory(mockPi);
+      expect(checkFn).toBeDefined();
+      if (checkFn) {
+        const result = await checkFn();
+        expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+      }
+    },
+    60000,
+  );
 
   it('registers 6 tools when az CLI is available', async () => {
     const tools: Array<{ name: string }> = [];

--- a/plugins/azure/test/tools/az-account-show.test.ts
+++ b/plugins/azure/test/tools/az-account-show.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAzAccountShowTool } from '../../src/tools/az-account-show';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -12,7 +18,7 @@ const mockTypebox = {
 };
 
 describe('createAzAccountShowTool', () => {
-  const tool = createAzAccountShowTool({ typebox: mockTypebox });
+  const tool = createAzAccountShowTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('az_account_show');
@@ -36,7 +42,7 @@ describe('createAzAccountShowTool', () => {
 });
 
 describe('az_account_show input validation', () => {
-  const tool = createAzAccountShowTool({ typebox: mockTypebox });
+  const tool = createAzAccountShowTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects subscription with semicolons', async () => {
     const result = await tool.execute('id', { action: 'show', subscription: 'test;rm -rf /' }, null, null, {

--- a/plugins/azure/test/tools/az-exec.test.ts
+++ b/plugins/azure/test/tools/az-exec.test.ts
@@ -8,6 +8,12 @@ import {
   MUTATING_VERBS,
 } from '../../src/tools/az-exec';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -17,7 +23,7 @@ const mockTypebox = {
 };
 
 describe('createAzExecTool', () => {
-  const tool = createAzExecTool({ typebox: mockTypebox });
+  const tool = createAzExecTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('az_exec');

--- a/plugins/azure/test/tools/az-group-list.test.ts
+++ b/plugins/azure/test/tools/az-group-list.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAzGroupListTool } from '../../src/tools/az-group-list';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -12,7 +18,7 @@ const mockTypebox = {
 };
 
 describe('createAzGroupListTool', () => {
-  const tool = createAzGroupListTool({ typebox: mockTypebox });
+  const tool = createAzGroupListTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('az_group_list');
@@ -32,7 +38,7 @@ describe('createAzGroupListTool', () => {
 });
 
 describe('az_group input validation', () => {
-  const tool = createAzGroupListTool({ typebox: mockTypebox });
+  const tool = createAzGroupListTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects subscription with shell injection', async () => {
     const result = await tool.execute('id', { action: 'list', subscription: ';rm -rf /' }, null, null, { cwd: '/tmp' });

--- a/plugins/azure/test/tools/az-help.test.ts
+++ b/plugins/azure/test/tools/az-help.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAzHelpTool } from '../../src/tools/az-help';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -10,7 +16,7 @@ const mockTypebox = {
 };
 
 describe('createAzHelpTool', () => {
-  const tool = createAzHelpTool({ typebox: mockTypebox });
+  const tool = createAzHelpTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('az_help');
@@ -30,7 +36,7 @@ describe('createAzHelpTool', () => {
 });
 
 describe('az_help input validation', () => {
-  const tool = createAzHelpTool({ typebox: mockTypebox });
+  const tool = createAzHelpTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects command_path with semicolons', async () => {
     const result = await tool.execute('id', { command_path: 'vm;rm' }, null, null, { cwd: '/tmp' });

--- a/plugins/azure/test/tools/az-resource-list.test.ts
+++ b/plugins/azure/test/tools/az-resource-list.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAzResourceListTool } from '../../src/tools/az-resource-list';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -10,7 +16,7 @@ const mockTypebox = {
 };
 
 describe('createAzResourceListTool', () => {
-  const tool = createAzResourceListTool({ typebox: mockTypebox });
+  const tool = createAzResourceListTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('az_resource_list');
@@ -30,7 +36,7 @@ describe('createAzResourceListTool', () => {
 });
 
 describe('az_resource input validation', () => {
-  const tool = createAzResourceListTool({ typebox: mockTypebox });
+  const tool = createAzResourceListTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects resource group with semicolons', async () => {
     const result = await tool.execute('id', { resource_group: ';rm -rf /' }, null, null, { cwd: '/tmp' });

--- a/plugins/azure/test/tools/az-vm-list.test.ts
+++ b/plugins/azure/test/tools/az-vm-list.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createAzVmListTool } from '../../src/tools/az-vm-list';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -11,7 +17,7 @@ const mockTypebox = {
 };
 
 describe('createAzVmListTool', () => {
-  const tool = createAzVmListTool({ typebox: mockTypebox });
+  const tool = createAzVmListTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('az_vm_list');
@@ -31,7 +37,7 @@ describe('createAzVmListTool', () => {
 });
 
 describe('az_vm input validation', () => {
-  const tool = createAzVmListTool({ typebox: mockTypebox });
+  const tool = createAzVmListTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects resource group with shell injection', async () => {
     const result = await tool.execute('id', { resource_group: '$(whoami)' }, null, null, { cwd: '/tmp' });

--- a/plugins/gcloud/.xcsh-plugin/plugin.json
+++ b/plugins/gcloud/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gcloud",
   "description": "Google Cloud CLI integration — container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/gcloud",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/gcloud/package.json
+++ b/plugins/gcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-gcloud",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Google Cloud CLI status for xcsh welcome screen",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GCloud",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/gcloud/src/tools/gcloud-compute-instances-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-compute-instances-list.ts
@@ -1,3 +1,4 @@
+import type { GcloudExecApi } from '../gcloud/exec';
 import { execGcloudJson } from '../gcloud/exec';
 import { formatInstanceTable, normalizeInstances } from '../gcloud/formatters';
 import type { PluginInterface } from '../gcloud/types';
@@ -5,7 +6,14 @@ import { ZONE_PATTERN } from '../gcloud/types';
 import gcloudComputeInstancesListDescription from '../prompts/gcloud-compute-instances-list.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
 
-export function createGcloudComputeInstancesListTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGcloudComputeInstancesListTool(
+  pi: PluginInterface,
+  makeApi: (cwd: string) => GcloudExecApi = makeExecApi,
+) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -36,7 +44,7 @@ export function createGcloudComputeInstancesListTool(pi: PluginInterface) {
         return errorResult(`Error: limit must be a positive integer, got "${params.limit}".`, base);
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = ['compute', 'instances', 'list'];
       // gcloud filters the instances list by zone with the `--zones` flag.
       // Bind value flags with the `=` form so a value beginning with `-` can never be

--- a/plugins/gcloud/src/tools/gcloud-config-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-config-list.ts
@@ -1,10 +1,15 @@
+import type { GcloudExecApi } from '../gcloud/exec';
 import { execGcloudJson } from '../gcloud/exec';
 import { formatConfigDetail, normalizeConfig } from '../gcloud/formatters';
 import type { PluginInterface } from '../gcloud/types';
 import gcloudConfigListDescription from '../prompts/gcloud-config-list.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
 
-export function createGcloudConfigListTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGcloudConfigListTool(pi: PluginInterface, makeApi: (cwd: string) => GcloudExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({});
@@ -22,7 +27,7 @@ export function createGcloudConfigListTool(pi: PluginInterface) {
       ctx: { cwd: string },
     ) {
       const base = { tool: 'gcloud_config_list' as const };
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = ['config', 'list'];
 
       try {

--- a/plugins/gcloud/src/tools/gcloud-exec.ts
+++ b/plugins/gcloud/src/tools/gcloud-exec.ts
@@ -1,3 +1,4 @@
+import type { GcloudExecApi } from '../gcloud/exec';
 import { detectGcloudError } from '../gcloud/exec';
 import type { PluginInterface } from '../gcloud/types';
 import gcloudExecDescription from '../prompts/gcloud-exec.md' with { type: 'text' };
@@ -6,7 +7,11 @@ import { detectErrorType, errorResult, hasControlChars, makeExecApi, textResult 
 
 const MAX_OUTPUT_LENGTH = 50000;
 
-export function createGcloudExecTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGcloudExecTool(pi: PluginInterface, makeApi: (cwd: string) => GcloudExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -53,7 +58,7 @@ export function createGcloudExecTool(pi: PluginInterface) {
       }
 
       try {
-        const api = makeExecApi(ctx.cwd);
+        const api = makeApi(ctx.cwd);
         const result = await api.exec('gcloud', buildGcloudArgs(args), { signal });
         if (result.exitCode !== 0) {
           // Classify the failure (auth / session-expired / permission / not-found) from

--- a/plugins/gcloud/src/tools/gcloud-help.ts
+++ b/plugins/gcloud/src/tools/gcloud-help.ts
@@ -1,9 +1,14 @@
+import type { GcloudExecApi } from '../gcloud/exec';
 import type { PluginInterface } from '../gcloud/types';
 import { HELP_PATH_PATTERN } from '../gcloud/types';
 import gcloudHelpDescription from '../prompts/gcloud-help.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, textResult } from './shared';
 
-export function createGcloudHelpTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGcloudHelpTool(pi: PluginInterface, makeApi: (cwd: string) => GcloudExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -49,7 +54,7 @@ export function createGcloudHelpTool(pi: PluginInterface) {
 
       // Help output is plain text; do NOT append --format=json.
       const args = [...parts, '--help'];
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
 
       try {
         const result = await api.exec('gcloud', args, { signal });

--- a/plugins/gcloud/src/tools/gcloud-projects-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-projects-list.ts
@@ -1,10 +1,18 @@
+import type { GcloudExecApi } from '../gcloud/exec';
 import { execGcloudJson } from '../gcloud/exec';
 import { formatProjectTable, normalizeProjects } from '../gcloud/formatters';
 import type { PluginInterface } from '../gcloud/types';
 import gcloudProjectsListDescription from '../prompts/gcloud-projects-list.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
 
-export function createGcloudProjectsListTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGcloudProjectsListTool(
+  pi: PluginInterface,
+  makeApi: (cwd: string) => GcloudExecApi = makeExecApi,
+) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -30,7 +38,7 @@ export function createGcloudProjectsListTool(pi: PluginInterface) {
         return errorResult(`Error: limit must be a positive integer, got "${params.limit}".`, base);
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = ['projects', 'list'];
       // Bind value flags with the `=` form so a value beginning with `-` can never be
       // re-tokenised by gcloud as a separate flag (argv flag-smuggling defense).

--- a/plugins/gcloud/src/tools/gcloud-storage-buckets-list.ts
+++ b/plugins/gcloud/src/tools/gcloud-storage-buckets-list.ts
@@ -1,10 +1,18 @@
+import type { GcloudExecApi } from '../gcloud/exec';
 import { execGcloudJson } from '../gcloud/exec';
 import { formatBucketTable, normalizeBuckets } from '../gcloud/formatters';
 import type { PluginInterface } from '../gcloud/types';
 import gcloudStorageBucketsListDescription from '../prompts/gcloud-storage-buckets-list.md' with { type: 'text' };
 import { detectErrorType, errorResult, makeExecApi, renderError, textResult } from './shared';
 
-export function createGcloudStorageBucketsListTool(pi: PluginInterface) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGcloudStorageBucketsListTool(
+  pi: PluginInterface,
+  makeApi: (cwd: string) => GcloudExecApi = makeExecApi,
+) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -30,7 +38,7 @@ export function createGcloudStorageBucketsListTool(pi: PluginInterface) {
         return errorResult(`Error: limit must be a positive integer, got "${params.limit}".`, base);
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const args = ['storage', 'buckets', 'list'];
       // Bind value flags with the `=` form so a value beginning with `-` can never be
       // re-tokenised by gcloud as a separate flag (argv flag-smuggling defense).

--- a/plugins/gcloud/test/extension.test.ts
+++ b/plugins/gcloud/test/extension.test.ts
@@ -1,5 +1,13 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 
+/**
+ * These cases drive the real `gcloud` binary, so they are meaningful only where it is
+ * installed. A visible skip beats an `if (…)` that quietly asserts nothing, and the
+ * generous timeout is because a cloud CLI answering in under five seconds is not a
+ * property this repo controls.
+ */
+const GCLOUD_INSTALLED = Bun.spawnSync([process.platform === 'win32' ? 'where' : 'which', 'gcloud']).exitCode === 0;
+
 describe('GCloud Status extension', () => {
   let factory: (pi: unknown) => Promise<void>;
 
@@ -68,21 +76,25 @@ describe('GCloud Status extension', () => {
     }
   });
 
-  it('service check returns valid state', async () => {
-    let checkFn: (() => Promise<{ state: string }>) | undefined;
-    const mockPi = {
-      setLabel() {},
-      logger: { debug() {} },
-      registerCommand() {},
-      registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
-        checkFn = c.check;
-      },
-    };
-    await factory(mockPi);
+  it.skipIf(!GCLOUD_INSTALLED)(
+    'service check returns valid state',
+    async () => {
+      let checkFn: (() => Promise<{ state: string }>) | undefined;
+      const mockPi = {
+        setLabel() {},
+        logger: { debug() {} },
+        registerCommand() {},
+        registerServiceStatus(c: { name: string; check: () => Promise<{ state: string }> }) {
+          checkFn = c.check;
+        },
+      };
+      await factory(mockPi);
 
-    if (checkFn) {
-      const result = await checkFn();
-      expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
-    }
-  });
+      if (checkFn) {
+        const result = await checkFn();
+        expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+      }
+    },
+    60000,
+  );
 });

--- a/plugins/gcloud/test/tools/gcloud-compute-instances-list.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-compute-instances-list.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createGcloudComputeInstancesListTool } from '../../src/tools/gcloud-compute-instances-list';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -11,7 +17,7 @@ const mockTypebox = {
 };
 
 describe('createGcloudComputeInstancesListTool metadata', () => {
-  const tool = createGcloudComputeInstancesListTool({ typebox: mockTypebox });
+  const tool = createGcloudComputeInstancesListTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('gcloud_compute_instances_list');
@@ -31,7 +37,7 @@ describe('createGcloudComputeInstancesListTool metadata', () => {
 });
 
 describe('gcloud_compute_instances_list input validation', () => {
-  const tool = createGcloudComputeInstancesListTool({ typebox: mockTypebox });
+  const tool = createGcloudComputeInstancesListTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects an invalid zone', async () => {
     const r = await tool.execute('id', { zone: 'Not_A_Zone' }, undefined, null, { cwd: '/tmp' });

--- a/plugins/gcloud/test/tools/gcloud-exec.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-exec.test.ts
@@ -10,6 +10,12 @@ import {
   isRead,
 } from '../../src/tools/gcloud-exec-guard';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -204,7 +210,7 @@ describe('buildGcloudArgs', () => {
 // ---------------------------------------------------------------------------
 
 describe('createGcloudExecTool metadata', () => {
-  const tool = createGcloudExecTool({ typebox: mockTypebox });
+  const tool = createGcloudExecTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('gcloud_exec');
@@ -221,7 +227,7 @@ describe('createGcloudExecTool metadata', () => {
 });
 
 describe('createGcloudExecTool execute guards', () => {
-  const tool = createGcloudExecTool({ typebox: mockTypebox });
+  const tool = createGcloudExecTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects empty args', async () => {
     const r = await tool.execute('id', { args: [] }, undefined, null, { cwd: '/tmp' });

--- a/plugins/gcloud/test/tools/gcloud-help.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-help.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createGcloudHelpTool } from '../../src/tools/gcloud-help';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -10,7 +16,7 @@ const mockTypebox = {
 };
 
 describe('createGcloudHelpTool metadata', () => {
-  const tool = createGcloudHelpTool({ typebox: mockTypebox });
+  const tool = createGcloudHelpTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('gcloud_help');
@@ -30,7 +36,7 @@ describe('createGcloudHelpTool metadata', () => {
 });
 
 describe('gcloud_help command path validation', () => {
-  const tool = createGcloudHelpTool({ typebox: mockTypebox });
+  const tool = createGcloudHelpTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects a dash-led command path ("-x")', async () => {
     const r = await tool.execute('id', { command_path: '-x' }, undefined, null, { cwd: '/tmp' });

--- a/plugins/gcloud/test/tools/gcloud-projects-list.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-projects-list.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createGcloudProjectsListTool } from '../../src/tools/gcloud-projects-list';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -11,7 +17,7 @@ const mockTypebox = {
 };
 
 describe('createGcloudProjectsListTool metadata', () => {
-  const tool = createGcloudProjectsListTool({ typebox: mockTypebox });
+  const tool = createGcloudProjectsListTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('gcloud_projects_list');
@@ -31,7 +37,7 @@ describe('createGcloudProjectsListTool metadata', () => {
 });
 
 describe('gcloud_projects_list limit validation', () => {
-  const tool = createGcloudProjectsListTool({ typebox: mockTypebox });
+  const tool = createGcloudProjectsListTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects a zero limit', async () => {
     const r = await tool.execute('id', { limit: 0 }, undefined, null, { cwd: '/tmp' });

--- a/plugins/gcloud/test/tools/gcloud-storage-buckets-list.test.ts
+++ b/plugins/gcloud/test/tools/gcloud-storage-buckets-list.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { createGcloudStorageBucketsListTool } from '../../src/tools/gcloud-storage-buckets-list';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockTypebox = {
   Type: {
     Object: (schema: Record<string, unknown>) => schema,
@@ -11,7 +17,7 @@ const mockTypebox = {
 };
 
 describe('createGcloudStorageBucketsListTool metadata', () => {
-  const tool = createGcloudStorageBucketsListTool({ typebox: mockTypebox });
+  const tool = createGcloudStorageBucketsListTool({ typebox: mockTypebox }, stubExec);
 
   it('has correct name', () => {
     expect(tool.name).toBe('gcloud_storage_buckets_list');
@@ -31,7 +37,7 @@ describe('createGcloudStorageBucketsListTool metadata', () => {
 });
 
 describe('gcloud_storage_buckets_list limit validation', () => {
-  const tool = createGcloudStorageBucketsListTool({ typebox: mockTypebox });
+  const tool = createGcloudStorageBucketsListTool({ typebox: mockTypebox }, stubExec);
 
   it('rejects a zero limit', async () => {
     const r = await tool.execute('id', { limit: 0 }, undefined, null, { cwd: '/tmp' });

--- a/plugins/github/.xcsh-plugin/plugin.json
+++ b/plugins/github/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "description": "GitHub CLI integration — native xcsh tools (gh_repo_view, gh_issue_view, gh_pr_view, gh_pr_diff, gh_pr_checkout, gh_pr_push, gh_run_watch, gh_search_issues, gh_search_prs), profile collection, and service status",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-github",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "GitHub CLI integration for xcsh — native tools for repos, issues, PRs, diffs, Actions, and search",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GitHub",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "GitHub CLI integration",
     "extensions": [
       "src/index.ts"

--- a/plugins/github/test/extension.test.ts
+++ b/plugins/github/test/extension.test.ts
@@ -1,5 +1,13 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 
+/**
+ * These cases drive the real `gh` binary, so they are meaningful only where it is
+ * installed. A visible skip beats an `if (…)` that quietly asserts nothing, and the
+ * generous timeout is because a cloud CLI answering in under five seconds is not a
+ * property this repo controls.
+ */
+const GH_INSTALLED = Bun.spawnSync([process.platform === 'win32' ? 'where' : 'which', 'gh']).exitCode === 0;
+
 interface ToolDef {
   name: string;
   label: string;
@@ -138,23 +146,31 @@ describe('GitHub ExtensionFactory integration', () => {
     }
   });
 
-  it('service status check returns valid state', async () => {
-    const { pi, serviceStatuses } = await buildMockPi();
-    await factory(pi);
+  it.skipIf(!GH_INSTALLED)(
+    'service status check returns valid state',
+    async () => {
+      const { pi, serviceStatuses } = await buildMockPi();
+      await factory(pi);
 
-    if (serviceStatuses.length === 0) return; // gh not installed
+      if (serviceStatuses.length === 0) return; // gh not installed
 
-    const status = await serviceStatuses[0].check();
-    expect(['connected', 'unauthenticated', 'unavailable']).toContain(status.state);
-  });
+      const status = await serviceStatuses[0].check();
+      expect(['connected', 'unauthenticated', 'unavailable']).toContain(status.state);
+    },
+    60000,
+  );
 
-  it('session_start hook runs without throwing', async () => {
-    const { pi, events } = await buildMockPi();
-    await factory(pi);
+  it.skipIf(!GH_INSTALLED)(
+    'session_start hook runs without throwing',
+    async () => {
+      const { pi, events } = await buildMockPi();
+      await factory(pi);
 
-    const handler = events.session_start?.[0];
-    if (!handler) return; // gh not installed
+      const handler = events.session_start?.[0];
+      if (!handler) return; // gh not installed
 
-    await expect(handler({}, { cwd: '/tmp' })).resolves.toBeUndefined();
-  });
+      await expect(handler({}, { cwd: '/tmp' })).resolves.toBeUndefined();
+    },
+    60000,
+  );
 });

--- a/plugins/gitlab/.xcsh-plugin/plugin.json
+++ b/plugins/gitlab/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitlab",
   "description": "GitLab CLI integration — native xcsh tools (glab_setup, glab_issue_list, glab_issue_view, glab_search), welcome screen status, and issue management via glab CLI",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-gitlab",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "GitLab CLI integration for xcsh — native tools, welcome screen status, issue management",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GitLab",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "GitLab CLI integration",
     "extensions": [
       "src/index.ts"

--- a/plugins/gitlab/src/tools/glab-exec.ts
+++ b/plugins/gitlab/src/tools/glab-exec.ts
@@ -1,3 +1,4 @@
+import type { GlabExecApi } from '../glab/exec';
 import { execGlab } from '../glab/exec';
 import glabExecDescription from '../prompts/glab-exec.md' with { type: 'text' };
 import { findMutation } from './glab-exec-guard';
@@ -6,7 +7,11 @@ import { errorResult, hasControlChars, makeExecApi, textResult } from './shared'
 
 const GLAB_EXEC_MAX_OUTPUT = 50000;
 
-export function createGlabExecTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGlabExecTool(pi: PluginHost, makeApi: (cwd: string) => GlabExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -44,7 +49,7 @@ export function createGlabExecTool(pi: PluginHost) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const result = await execGlab(api, args, signal);
       let out = result.stdout;
       if (out.length > GLAB_EXEC_MAX_OUTPUT) {

--- a/plugins/gitlab/src/tools/glab-help.ts
+++ b/plugins/gitlab/src/tools/glab-help.ts
@@ -1,3 +1,4 @@
+import type { GlabExecApi } from '../glab/exec';
 import { execGlab, GlabAuthError } from '../glab/exec';
 import glabHelpDescription from '../prompts/glab-help.md' with { type: 'text' };
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
@@ -8,7 +9,11 @@ import { errorResult, makeExecApi, textResult } from './shared';
 // any space-split segment that would still reach glab as a flag.
 const HELP_PATH_PATTERN = /^[a-z][a-z -]*$/;
 
-export function createGlabHelpTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGlabHelpTool(pi: PluginHost, makeApi: (cwd: string) => GlabExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -44,7 +49,7 @@ export function createGlabHelpTool(pi: PluginHost) {
         return errorResult("Error: command path parts must not start with '-'.", { tool: 'glab_help' });
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       try {
         const result = await execGlab(api, [...parts, '--help'], signal);
         const output = result.stdout || result.stderr;

--- a/plugins/gitlab/src/tools/glab-issue-list.ts
+++ b/plugins/gitlab/src/tools/glab-issue-list.ts
@@ -1,4 +1,5 @@
 import { resolveProject } from '../glab/config';
+import type { GlabExecApi } from '../glab/exec';
 import { execGlabJson, GlabAuthError } from '../glab/exec';
 import { formatIssueTable } from '../glab/formatters';
 import type { GlabIssue } from '../glab/types';
@@ -6,7 +7,11 @@ import glabIssueListDescription from '../prompts/glab-issue-list.md' with { type
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { makeExecApi, textResult } from './shared';
 
-export function createGlabIssueListTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGlabIssueListTool(pi: PluginHost, makeApi: (cwd: string) => GlabExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -54,7 +59,7 @@ export function createGlabIssueListTool(pi: PluginHost) {
       _onUpdate: ToolUpdateCallback | undefined,
       ctx: { cwd: string },
     ) {
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const project = await resolveProject(params.project, ctx.cwd, (cmd, args) => api.exec(cmd, args));
       if (!project) {
         return textResult('No GitLab project configured. Run glab_setup to set one up.');

--- a/plugins/gitlab/src/tools/glab-issue-view.ts
+++ b/plugins/gitlab/src/tools/glab-issue-view.ts
@@ -1,4 +1,5 @@
 import { resolveProject } from '../glab/config';
+import type { GlabExecApi } from '../glab/exec';
 import { execGlabJson, GlabAuthError } from '../glab/exec';
 import { formatIssueDetail } from '../glab/formatters';
 import type { GlabIssue } from '../glab/types';
@@ -6,7 +7,11 @@ import glabIssueViewDescription from '../prompts/glab-issue-view.md' with { type
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { makeExecApi, textResult } from './shared';
 
-export function createGlabIssueViewTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGlabIssueViewTool(pi: PluginHost, makeApi: (cwd: string) => GlabExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -27,7 +32,7 @@ export function createGlabIssueViewTool(pi: PluginHost) {
       _onUpdate: ToolUpdateCallback | undefined,
       ctx: { cwd: string },
     ) {
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const project = await resolveProject(params.project, ctx.cwd, (cmd, args) => api.exec(cmd, args));
       if (!project) {
         return textResult('No GitLab project configured. Run glab_setup to set one up.');

--- a/plugins/gitlab/src/tools/glab-search.ts
+++ b/plugins/gitlab/src/tools/glab-search.ts
@@ -1,4 +1,5 @@
 import { resolveProject } from '../glab/config';
+import type { GlabExecApi } from '../glab/exec';
 import { execGlabJson, GlabAuthError } from '../glab/exec';
 import { formatIssueTable } from '../glab/formatters';
 import { executeGraphQL } from '../glab/graphql';
@@ -7,7 +8,11 @@ import glabSearchDescription from '../prompts/glab-search.md' with { type: 'text
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { makeExecApi, textResult } from './shared';
 
-export function createGlabSearchTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGlabSearchTool(pi: PluginHost, makeApi: (cwd: string) => GlabExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -34,7 +39,7 @@ export function createGlabSearchTool(pi: PluginHost) {
       _onUpdate: ToolUpdateCallback | undefined,
       ctx: { cwd: string },
     ) {
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const project = await resolveProject(params.project, ctx.cwd, (cmd, args) => api.exec(cmd, args));
       if (!project) {
         return textResult('No GitLab project configured. Run glab_setup to set one up.');

--- a/plugins/gitlab/src/tools/glab-setup.ts
+++ b/plugins/gitlab/src/tools/glab-setup.ts
@@ -1,11 +1,16 @@
 import { loadConfig, saveConfig } from '../glab/config';
+import type { GlabExecApi } from '../glab/exec';
 import { checkAuth, checkInstalled, execGlabJson } from '../glab/exec';
 import type { GlabProject } from '../glab/types';
 import glabSetupDescription from '../prompts/glab-setup.md' with { type: 'text' };
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { makeExecApi, textResult } from './shared';
 
-export function createGlabSetupTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createGlabSetupTool(pi: PluginHost, makeApi: (cwd: string) => GlabExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -34,7 +39,7 @@ export function createGlabSetupTool(pi: PluginHost) {
       _onUpdate: ToolUpdateCallback | undefined,
       ctx: { cwd: string },
     ) {
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
 
       switch (params.action) {
         case 'check': {

--- a/plugins/gitlab/test/extension.test.ts
+++ b/plugins/gitlab/test/extension.test.ts
@@ -1,6 +1,20 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 import { Type } from '@sinclair/typebox';
 
+/**
+ * These cases drive the real `glab` binary, so they are meaningful only where it is
+ * installed. A visible skip beats an `if (…)` that quietly asserts nothing, and the
+ * generous timeout is because a cloud CLI answering in under five seconds is not a
+ * property this repo controls.
+ */
+const GLAB_INSTALLED = Bun.spawnSync([process.platform === 'win32' ? 'where' : 'which', 'glab']).exitCode === 0;
+
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 // Declared up front so the recorder methods can close over them. Reading them off
 // `mockPi` inside its own literal needed an `as any` cast, because the object's type is
 // not yet known at that point.
@@ -72,24 +86,28 @@ describe('GitLab extension', () => {
     }
   });
 
-  it('service check returns valid state', async () => {
-    // Reset
-    mockPi._tools = [];
-    mockPi._serviceStatus = [];
+  it.skipIf(!GLAB_INSTALLED)(
+    'service check returns valid state',
+    async () => {
+      // Reset
+      mockPi._tools = [];
+      mockPi._serviceStatus = [];
 
-    await factory(mockPi);
+      await factory(mockPi);
 
-    if (mockPi._serviceStatus.length > 0) {
-      const result = await mockPi._serviceStatus[0].check();
-      expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
-    }
-  });
+      if (mockPi._serviceStatus.length > 0) {
+        const result = await mockPi._serviceStatus[0].check();
+        expect(['connected', 'unauthenticated', 'unavailable']).toContain(result.state);
+      }
+    },
+    60000,
+  );
 });
 
 describe('Tool factories', () => {
   it('createGlabSetupTool returns correct name and label', async () => {
     const { createGlabSetupTool } = await import('../src/tools/glab-setup');
-    const tool = createGlabSetupTool(mockPi);
+    const tool = createGlabSetupTool(mockPi, stubExec);
     expect(tool.name).toBe('glab_setup');
     expect(tool.label).toBe('GitLab Setup');
     expect(tool.description).toBeTruthy();
@@ -98,7 +116,7 @@ describe('Tool factories', () => {
 
   it('createGlabIssueListTool returns correct name and label', async () => {
     const { createGlabIssueListTool } = await import('../src/tools/glab-issue-list');
-    const tool = createGlabIssueListTool(mockPi);
+    const tool = createGlabIssueListTool(mockPi, stubExec);
     expect(tool.name).toBe('glab_issue_list');
     expect(tool.label).toBe('GitLab Issues');
     expect(typeof tool.description).toBe('string');
@@ -107,7 +125,7 @@ describe('Tool factories', () => {
 
   it('createGlabIssueViewTool returns correct name and label', async () => {
     const { createGlabIssueViewTool } = await import('../src/tools/glab-issue-view');
-    const tool = createGlabIssueViewTool(mockPi);
+    const tool = createGlabIssueViewTool(mockPi, stubExec);
     expect(tool.name).toBe('glab_issue_view');
     expect(tool.label).toBe('GitLab Issue');
     expect(typeof tool.description).toBe('string');
@@ -116,7 +134,7 @@ describe('Tool factories', () => {
 
   it('createGlabSearchTool returns correct name and label', async () => {
     const { createGlabSearchTool } = await import('../src/tools/glab-search');
-    const tool = createGlabSearchTool(mockPi);
+    const tool = createGlabSearchTool(mockPi, stubExec);
     expect(tool.name).toBe('glab_search');
     expect(tool.label).toBe('GitLab Search');
     expect(typeof tool.description).toBe('string');
@@ -125,7 +143,7 @@ describe('Tool factories', () => {
 
   it('createGlabHelpTool returns correct name and label', async () => {
     const { createGlabHelpTool } = await import('../src/tools/glab-help');
-    const tool = createGlabHelpTool(mockPi);
+    const tool = createGlabHelpTool(mockPi, stubExec);
     expect(tool.name).toBe('glab_help');
     expect(tool.label).toBe('GitLab CLI Help');
     expect(typeof tool.description).toBe('string');
@@ -134,7 +152,7 @@ describe('Tool factories', () => {
 
   it('createGlabExecTool returns correct name and label', async () => {
     const { createGlabExecTool } = await import('../src/tools/glab-exec');
-    const tool = createGlabExecTool(mockPi);
+    const tool = createGlabExecTool(mockPi, stubExec);
     expect(tool.name).toBe('glab_exec');
     expect(tool.label).toBe('GitLab CLI Execute');
     expect(typeof tool.description).toBe('string');
@@ -143,7 +161,7 @@ describe('Tool factories', () => {
 
   it('glab_setup save_project requires project param', async () => {
     const { createGlabSetupTool } = await import('../src/tools/glab-setup');
-    const tool = createGlabSetupTool(mockPi);
+    const tool = createGlabSetupTool(mockPi, stubExec);
     const result = await tool.execute('t1', { action: 'save_project' }, undefined, undefined, { cwd: '/tmp' });
     expect(result.content[0].text).toContain('project parameter is required');
   });

--- a/plugins/gitlab/test/tools/glab-exec.test.ts
+++ b/plugins/gitlab/test/tools/glab-exec.test.ts
@@ -4,6 +4,12 @@ import { createGlabExecTool } from '../../src/tools/glab-exec';
 import { effectiveApiMethod, findMutation } from '../../src/tools/glab-exec-guard';
 import { hasControlChars } from '../../src/tools/shared';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const NUL = String.fromCharCode(0);
 const TAB = String.fromCharCode(9);
 const SOH = String.fromCharCode(1);
@@ -11,7 +17,7 @@ const SOH = String.fromCharCode(1);
 const mockPi = { typebox: { Type } };
 
 function makeTool() {
-  return createGlabExecTool(mockPi);
+  return createGlabExecTool(mockPi, stubExec);
 }
 
 describe('hasControlChars', () => {

--- a/plugins/gitlab/test/tools/glab-help.test.ts
+++ b/plugins/gitlab/test/tools/glab-help.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from 'bun:test';
 import { Type } from '@sinclair/typebox';
 import { createGlabHelpTool } from '../../src/tools/glab-help';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockPi = { typebox: { Type } };
 
 function makeTool() {
-  return createGlabHelpTool(mockPi);
+  return createGlabHelpTool(mockPi, stubExec);
 }
 
 describe('createGlabHelpTool', () => {

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/salesforce/package.json
+++ b/plugins/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-salesforce",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Salesforce pipeline intelligence for xcsh — native tools, context discovery, pipeline reports",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Salesforce",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "description": "Salesforce pipeline intelligence",
     "extensions": [
       "src/index.ts"

--- a/plugins/salesforce/src/tools/sf-exec.ts
+++ b/plugins/salesforce/src/tools/sf-exec.ts
@@ -1,4 +1,5 @@
 import sfExecDescription from '../prompts/sf-exec.md' with { type: 'text' };
+import type { SfExecApi } from '../sf/exec';
 import { execSfRaw } from '../sf/exec';
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { findMutation } from './sf-exec-guard';
@@ -6,7 +7,11 @@ import { errorResult, hasControlChars, makeExecApi, textResult } from './shared'
 
 const SF_EXEC_MAX_OUTPUT = 50000;
 
-export function createSfExecTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createSfExecTool(pi: PluginHost, makeApi: (cwd: string) => SfExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -45,7 +50,7 @@ export function createSfExecTool(pi: PluginHost) {
         );
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const result = await execSfRaw(api, args, signal);
       let out = result.stdout;
       if (out.length > SF_EXEC_MAX_OUTPUT) {

--- a/plugins/salesforce/src/tools/sf-help.ts
+++ b/plugins/salesforce/src/tools/sf-help.ts
@@ -1,4 +1,5 @@
 import sfHelpDescription from '../prompts/sf-help.md' with { type: 'text' };
+import type { SfExecApi } from '../sf/exec';
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { errorResult, makeExecApi, textResult } from './shared';
 
@@ -8,7 +9,11 @@ import { errorResult, makeExecApi, textResult } from './shared';
 // space AND ':') that would still reach sf as a flag.
 const HELP_PATH_PATTERN = /^[a-z][a-z :-]*$/;
 
-export function createSfHelpTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createSfHelpTool(pi: PluginHost, makeApi: (cwd: string) => SfExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -48,7 +53,7 @@ export function createSfHelpTool(pi: PluginHost) {
         return errorResult("Error: command path parts must not start with '-'.", base);
       }
 
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const result = await api.exec('sf', [...parts, '--help'], { signal });
       const output = result.stdout || result.stderr;
       return textResult(output || `No help output for "sf ${commandPath}".`, base);

--- a/plugins/salesforce/src/tools/sf-org-display.ts
+++ b/plugins/salesforce/src/tools/sf-org-display.ts
@@ -1,4 +1,5 @@
 import sfOrgDisplayDescription from '../prompts/sf-org-display.md' with { type: 'text' };
+import type { SfExecApi } from '../sf/exec';
 import { execSfJson } from '../sf/exec';
 import { formatOrgDetail } from '../sf/formatters';
 import type { SfOrg } from '../sf/types';
@@ -6,7 +7,11 @@ import { ORG_ALIAS_PATTERN } from '../sf/types';
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { detectErrorType, errorResult, makeExecApi, textResult } from './shared';
 
-export function createSfOrgDisplayTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createSfOrgDisplayTool(pi: PluginHost, makeApi: (cwd: string) => SfExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -25,7 +30,7 @@ export function createSfOrgDisplayTool(pi: PluginHost) {
       _onUpdate: ToolUpdateCallback | undefined,
       ctx: { cwd: string },
     ) {
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const base = { tool: 'sf_org_display' as const };
 
       if (params.target_org && !ORG_ALIAS_PATTERN.test(params.target_org)) {

--- a/plugins/salesforce/src/tools/sf-pipeline-report.ts
+++ b/plugins/salesforce/src/tools/sf-pipeline-report.ts
@@ -3,6 +3,7 @@ import { generatePipelineReport, type SfQueryFn } from '../pipeline-report/gener
 import { renderPipelineReport } from '../pipeline-report/renderer';
 import type { PipelineReportData, PipelineReportOptions } from '../pipeline-report/types';
 import sfPipelineReportDescription from '../prompts/sf-pipeline-report.md' with { type: 'text' };
+import type { SfExecApi } from '../sf/exec';
 import { execSfJson } from '../sf/exec';
 import { ORG_ALIAS_PATTERN } from '../sf/types';
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
@@ -42,8 +43,8 @@ function fiscalQuarterDates(): { start: string; end: string } {
   return { start: fmt(start), end: fmt(end) };
 }
 
-function buildQueryFn(cwd: string, orgAlias?: string): SfQueryFn {
-  const api = makeExecApi(cwd);
+function buildQueryFn(makeApi: (cwd: string) => SfExecApi, cwd: string, orgAlias?: string): SfQueryFn {
+  const api = makeApi(cwd);
   return async (soql: string, queryOrgAlias?: string): Promise<Record<string, unknown>[]> => {
     const org = queryOrgAlias ?? orgAlias;
     const args = ['data', 'query', '--query', soql];
@@ -62,7 +63,11 @@ function buildQueryFn(cwd: string, orgAlias?: string): SfQueryFn {
 // Tool factory
 // ---------------------------------------------------------------------------
 
-export function createSfPipelineReportTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createSfPipelineReportTool(pi: PluginHost, makeApi: (cwd: string) => SfExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -141,7 +146,7 @@ export function createSfPipelineReportTool(pi: PluginHost) {
       };
 
       try {
-        const queryFn = buildQueryFn(ctx.cwd, orgAlias);
+        const queryFn = buildQueryFn(makeApi, ctx.cwd, orgAlias);
         const data: PipelineReportData = await generatePipelineReport(options, queryFn);
         const report = renderPipelineReport(data, sfContext?.instanceUrl ?? '');
 

--- a/plugins/salesforce/src/tools/sf-query.ts
+++ b/plugins/salesforce/src/tools/sf-query.ts
@@ -1,4 +1,5 @@
 import sfQueryDescription from '../prompts/sf-query.md' with { type: 'text' };
+import type { SfExecApi } from '../sf/exec';
 import { execSfJson } from '../sf/exec';
 import { deriveQueryLabel, formatQueryResults } from '../sf/formatters';
 import type { SfQueryResult } from '../sf/types';
@@ -6,7 +7,11 @@ import { ORG_ALIAS_PATTERN } from '../sf/types';
 import type { PluginHost, ToolUpdateCallback } from './plugin-host';
 import { detectErrorType, errorResult, makeExecApi, textResult } from './shared';
 
-export function createSfQueryTool(pi: PluginHost) {
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createSfQueryTool(pi: PluginHost, makeApi: (cwd: string) => SfExecApi = makeExecApi) {
   const { Type } = pi.typebox;
 
   const parameters = Type.Object({
@@ -42,7 +47,7 @@ export function createSfQueryTool(pi: PluginHost) {
       _onUpdate: ToolUpdateCallback | undefined,
       ctx: { cwd: string },
     ) {
-      const api = makeExecApi(ctx.cwd);
+      const api = makeApi(ctx.cwd);
       const queryDescription = params.description ?? deriveQueryLabel(params.query);
       const base = { tool: 'sf_query' as const, action: 'query', queryDescription };
 

--- a/plugins/salesforce/test/integration/extension-load.test.ts
+++ b/plugins/salesforce/test/integration/extension-load.test.ts
@@ -172,7 +172,7 @@ describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration — requires the sf
     }
     expect(result.details.tool).toBe('sf_setup');
     expect(result.details.action).toBe('check');
-  });
+  }, 60000);
 
   it('sf_setup status action returns org list', async () => {
     const { pi, tools } = await buildMockPi({
@@ -189,7 +189,7 @@ describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration — requires the sf
       const text = result.content[0].text;
       expect(text.includes('Alias') || text.includes('No authenticated orgs')).toBe(true);
     }
-  });
+  }, 60000);
 
   it('sf_query executes a real SOQL query', async () => {
     const { pi, tools } = await buildMockPi();
@@ -216,7 +216,7 @@ describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration — requires the sf
       expect(result.details.queryResult).toBeDefined();
       expect(typeof result.details.queryResult?.totalSize).toBe('number');
     }
-  });
+  }, 60000);
 
   it('sf_org_display returns structured org data or structured error', async () => {
     const { pi, tools } = await buildMockPi();
@@ -241,7 +241,7 @@ describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration — requires the sf
     } else {
       expect(result.details.errorType).toBeDefined();
     }
-  });
+  }, 60000);
 
   it('before_agent_start hook returns hint or undefined', async () => {
     const { pi, events } = await buildMockPi();

--- a/plugins/salesforce/test/tools/sf-exec.test.ts
+++ b/plugins/salesforce/test/tools/sf-exec.test.ts
@@ -3,13 +3,19 @@ import { Type } from '@sinclair/typebox';
 import { createSfExecTool } from '../../src/tools/sf-exec';
 import { effectiveApiMethod, findMutation, normalizeArgs } from '../../src/tools/sf-exec-guard';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const NUL = String.fromCharCode(0);
 const TAB = String.fromCharCode(9);
 
 const mockPi = { typebox: { Type } };
 
 function makeTool() {
-  return createSfExecTool(mockPi);
+  return createSfExecTool(mockPi, stubExec);
 }
 
 describe('normalizeArgs', () => {

--- a/plugins/salesforce/test/tools/sf-help.test.ts
+++ b/plugins/salesforce/test/tools/sf-help.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from 'bun:test';
 import { Type } from '@sinclair/typebox';
 import { createSfHelpTool } from '../../src/tools/sf-help';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockPi = { typebox: { Type } };
 
 function makeTool() {
-  return createSfHelpTool(mockPi);
+  return createSfHelpTool(mockPi, stubExec);
 }
 
 describe('createSfHelpTool', () => {

--- a/plugins/salesforce/test/tools/sf-org-display.test.ts
+++ b/plugins/salesforce/test/tools/sf-org-display.test.ts
@@ -2,17 +2,23 @@ import { describe, expect, it } from 'bun:test';
 import { Type } from '@sinclair/typebox';
 import { createSfOrgDisplayTool } from '../../src/tools/sf-org-display';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockPi = { typebox: { Type }, logger: { debug() {} } };
 
 describe('createSfOrgDisplayTool', () => {
   it('returns a tool definition with correct name', () => {
-    const tool = createSfOrgDisplayTool(mockPi);
+    const tool = createSfOrgDisplayTool(mockPi, stubExec);
     expect(tool.name).toBe('sf_org_display');
     expect(tool.label).toBe('Salesforce Org Display');
   });
 
   it('has description loaded from prompt template', () => {
-    const tool = createSfOrgDisplayTool(mockPi);
+    const tool = createSfOrgDisplayTool(mockPi, stubExec);
     expect(typeof tool.description).toBe('string');
     expect(tool.description.length).toBeGreaterThan(10);
   });
@@ -20,20 +26,20 @@ describe('createSfOrgDisplayTool', () => {
 
 describe('sf_org_display execute — validation', () => {
   it('rejects shell injection in org alias', async () => {
-    const tool = createSfOrgDisplayTool(mockPi);
+    const tool = createSfOrgDisplayTool(mockPi, stubExec);
     const result = await tool.execute('t1', { target_org: 'bad$(id)' }, undefined, undefined, { cwd: '/tmp' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('invalid org alias');
   });
 
   it('rejects semicolon injection', async () => {
-    const tool = createSfOrgDisplayTool(mockPi);
+    const tool = createSfOrgDisplayTool(mockPi, stubExec);
     const result = await tool.execute('t1', { target_org: 'org;rm -rf /' }, undefined, undefined, { cwd: '/tmp' });
     expect(result.isError).toBe(true);
   });
 
   it('rejects pipe injection', async () => {
-    const tool = createSfOrgDisplayTool(mockPi);
+    const tool = createSfOrgDisplayTool(mockPi, stubExec);
     const result = await tool.execute('t1', { target_org: 'org|cat /etc/passwd' }, undefined, undefined, {
       cwd: '/tmp',
     });
@@ -41,7 +47,7 @@ describe('sf_org_display execute — validation', () => {
   });
 
   it('accepts valid org alias without validation error', async () => {
-    const tool = createSfOrgDisplayTool(mockPi);
+    const tool = createSfOrgDisplayTool(mockPi, stubExec);
     const result = await tool.execute('t1', { target_org: 'prod-org' }, undefined, undefined, { cwd: '/tmp' });
     if (result.isError) {
       expect(result.content[0].text).not.toContain('invalid org alias');
@@ -49,7 +55,7 @@ describe('sf_org_display execute — validation', () => {
   });
 
   it('proceeds without target_org', async () => {
-    const tool = createSfOrgDisplayTool(mockPi);
+    const tool = createSfOrgDisplayTool(mockPi, stubExec);
     const result = await tool.execute('t1', {}, undefined, undefined, { cwd: '/tmp' });
     if (result.isError) {
       expect(result.content[0].text).not.toContain('invalid org alias');

--- a/plugins/salesforce/test/tools/sf-pipeline-report.test.ts
+++ b/plugins/salesforce/test/tools/sf-pipeline-report.test.ts
@@ -2,17 +2,23 @@ import { describe, expect, it } from 'bun:test';
 import { Type } from '@sinclair/typebox';
 import { createSfPipelineReportTool } from '../../src/tools/sf-pipeline-report';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockPi = { typebox: { Type }, logger: { debug() {} } };
 
 describe('createSfPipelineReportTool', () => {
   it('returns a tool definition with correct name and label', () => {
-    const tool = createSfPipelineReportTool(mockPi);
+    const tool = createSfPipelineReportTool(mockPi, stubExec);
     expect(tool.name).toBe('sf_pipeline_report');
     expect(tool.label).toBe('Salesforce Pipeline Report');
   });
 
   it('has description loaded from prompt template', () => {
-    const tool = createSfPipelineReportTool(mockPi);
+    const tool = createSfPipelineReportTool(mockPi, stubExec);
     expect(typeof tool.description).toBe('string');
     expect(tool.description.length).toBeGreaterThan(10);
   });
@@ -20,20 +26,20 @@ describe('createSfPipelineReportTool', () => {
 
 describe('sf_pipeline_report execute — validation', () => {
   it('rejects command-substitution injection in target_org', async () => {
-    const tool = createSfPipelineReportTool(mockPi);
+    const tool = createSfPipelineReportTool(mockPi, stubExec);
     const result = await tool.execute('t1', { target_org: 'bad$(id)' }, undefined, undefined, { cwd: '/tmp' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('invalid org alias');
   });
 
   it('rejects semicolon injection', async () => {
-    const tool = createSfPipelineReportTool(mockPi);
+    const tool = createSfPipelineReportTool(mockPi, stubExec);
     const result = await tool.execute('t1', { target_org: 'org;rm -rf /' }, undefined, undefined, { cwd: '/tmp' });
     expect(result.isError).toBe(true);
   });
 
   it('rejects pipe injection', async () => {
-    const tool = createSfPipelineReportTool(mockPi);
+    const tool = createSfPipelineReportTool(mockPi, stubExec);
     const result = await tool.execute('t1', { target_org: 'org|cat /etc/passwd' }, undefined, undefined, {
       cwd: '/tmp',
     });
@@ -41,7 +47,7 @@ describe('sf_pipeline_report execute — validation', () => {
   });
 
   it('accepts a valid org alias without a validation error', async () => {
-    const tool = createSfPipelineReportTool(mockPi);
+    const tool = createSfPipelineReportTool(mockPi, stubExec);
     const result = await tool.execute('t1', { target_org: 'prod-org' }, undefined, undefined, { cwd: '/tmp' });
     if (result.isError) {
       expect(result.content[0].text).not.toContain('invalid org alias');
@@ -49,7 +55,7 @@ describe('sf_pipeline_report execute — validation', () => {
   });
 
   it('proceeds without target_org', async () => {
-    const tool = createSfPipelineReportTool(mockPi);
+    const tool = createSfPipelineReportTool(mockPi, stubExec);
     const result = await tool.execute('t1', {}, undefined, undefined, { cwd: '/tmp' });
     if (result.isError) {
       expect(result.content[0].text).not.toContain('invalid org alias');

--- a/plugins/salesforce/test/tools/sf-query.test.ts
+++ b/plugins/salesforce/test/tools/sf-query.test.ts
@@ -2,18 +2,24 @@ import { describe, expect, it } from 'bun:test';
 import { Type } from '@sinclair/typebox';
 import { createSfQueryTool } from '../../src/tools/sf-query';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockPi = { typebox: { Type }, logger: { debug() {} } };
 
 describe('createSfQueryTool', () => {
   it('returns a tool definition with correct name', () => {
-    const tool = createSfQueryTool(mockPi);
+    const tool = createSfQueryTool(mockPi, stubExec);
     expect(tool.name).toBe('sf_query');
     expect(tool.label).toBe('Salesforce Query');
     expect(tool.description).toBeTruthy();
   });
 
   it('has description loaded from prompt template', () => {
-    const tool = createSfQueryTool(mockPi);
+    const tool = createSfQueryTool(mockPi, stubExec);
     expect(typeof tool.description).toBe('string');
     expect(tool.description.length).toBeGreaterThan(50);
   });
@@ -21,7 +27,7 @@ describe('createSfQueryTool', () => {
 
 describe('sf_query execute — validation', () => {
   it('rejects shell injection in org alias', async () => {
-    const tool = createSfQueryTool(mockPi);
+    const tool = createSfQueryTool(mockPi, stubExec);
     const result = await tool.execute(
       't1',
       { query: 'SELECT Id FROM Account', target_org: 'bad;whoami' },
@@ -34,7 +40,7 @@ describe('sf_query execute — validation', () => {
   });
 
   it('rejects backtick injection in org alias', async () => {
-    const tool = createSfQueryTool(mockPi);
+    const tool = createSfQueryTool(mockPi, stubExec);
     const result = await tool.execute(
       't1',
       { query: 'SELECT Id FROM Account', target_org: '`id`' },
@@ -46,7 +52,7 @@ describe('sf_query execute — validation', () => {
   });
 
   it('rejects dollar sign injection', async () => {
-    const tool = createSfQueryTool(mockPi);
+    const tool = createSfQueryTool(mockPi, stubExec);
     const result = await tool.execute(
       't1',
       { query: 'SELECT Id FROM Account', target_org: '$(whoami)' },
@@ -58,7 +64,7 @@ describe('sf_query execute — validation', () => {
   });
 
   it('accepts valid org alias without error on validation', async () => {
-    const tool = createSfQueryTool(mockPi);
+    const tool = createSfQueryTool(mockPi, stubExec);
     const result = await tool.execute(
       't1',
       { query: 'SELECT Id FROM Account', target_org: 'valid-org.123' },
@@ -74,7 +80,7 @@ describe('sf_query execute — validation', () => {
 
   it('does not reject when target_org is omitted', () => {
     // Verify the tool definition itself doesn't require target_org
-    const tool = createSfQueryTool(mockPi);
+    const tool = createSfQueryTool(mockPi, stubExec);
     expect(tool.parameters).toBeTruthy();
     // target_org is optional — the tool should accept calls without it
     // (actual exec behavior tested in integration tests)

--- a/plugins/salesforce/test/tools/sf-setup.test.ts
+++ b/plugins/salesforce/test/tools/sf-setup.test.ts
@@ -3,11 +3,17 @@ import { Type } from '@sinclair/typebox';
 import { setLoadProfile } from '../../src/context/salesforce-context';
 import { createSfSetupTool } from '../../src/tools/sf-setup';
 
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{}', stderr: '', exitCode: 0 }),
+});
+
 const mockPi = { typebox: { Type }, logger: { debug() {} } };
 
 describe('createSfSetupTool', () => {
   it('returns a tool definition with correct name and label', () => {
-    const tool = createSfSetupTool(mockPi);
+    const tool = createSfSetupTool(mockPi, stubExec);
     expect(tool.name).toBe('sf_setup');
     expect(tool.label).toBe('Salesforce Setup');
     expect(tool.description).toBeTruthy();
@@ -15,7 +21,7 @@ describe('createSfSetupTool', () => {
   });
 
   it('has description loaded from prompt template', () => {
-    const tool = createSfSetupTool(mockPi);
+    const tool = createSfSetupTool(mockPi, stubExec);
     expect(typeof tool.description).toBe('string');
     expect(tool.description.length).toBeGreaterThan(50);
   });
@@ -27,14 +33,14 @@ describe('sf_setup execute — validation', () => {
   });
 
   it('set_default rejects missing org param', async () => {
-    const tool = createSfSetupTool(mockPi);
+    const tool = createSfSetupTool(mockPi, stubExec);
     const result = await tool.execute('t1', { action: 'set_default' }, undefined, undefined, { cwd: '/tmp' });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('org parameter is required');
   });
 
   it('set_default rejects shell injection in org alias', async () => {
-    const tool = createSfSetupTool(mockPi);
+    const tool = createSfSetupTool(mockPi, stubExec);
     const result = await tool.execute('t1', { action: 'set_default', org: 'bad;rm -rf /' }, undefined, undefined, {
       cwd: '/tmp',
     });
@@ -43,7 +49,7 @@ describe('sf_setup execute — validation', () => {
   });
 
   it('set_default rejects backtick injection', async () => {
-    const tool = createSfSetupTool(mockPi);
+    const tool = createSfSetupTool(mockPi, stubExec);
     const result = await tool.execute('t1', { action: 'set_default', org: '`whoami`' }, undefined, undefined, {
       cwd: '/tmp',
     });
@@ -51,7 +57,7 @@ describe('sf_setup execute — validation', () => {
   });
 
   it('set_default rejects pipe injection', async () => {
-    const tool = createSfSetupTool(mockPi);
+    const tool = createSfSetupTool(mockPi, stubExec);
     const result = await tool.execute('t1', { action: 'set_default', org: 'x|cat /etc/passwd' }, undefined, undefined, {
       cwd: '/tmp',
     });
@@ -59,7 +65,7 @@ describe('sf_setup execute — validation', () => {
   });
 
   it('set_default rejects dollar injection', async () => {
-    const tool = createSfSetupTool(mockPi);
+    const tool = createSfSetupTool(mockPi, stubExec);
     const result = await tool.execute('t1', { action: 'set_default', org: '$(whoami)' }, undefined, undefined, {
       cwd: '/tmp',
     });
@@ -113,7 +119,7 @@ describe('sf_setup execute — validation', () => {
   });
 
   it('returns unknown action for unrecognized action', async () => {
-    const tool = createSfSetupTool(mockPi);
+    const tool = createSfSetupTool(mockPi, stubExec);
     const result = await tool.execute('t1', { action: 'bogus' }, undefined, undefined, { cwd: '/tmp' });
     expect(result.content[0].text).toContain('Unknown action: bogus');
   });

--- a/scripts/check-tests-are-hermetic.sh
+++ b/scripts/check-tests-are-hermetic.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# check-tests-are-hermetic.sh — prove no plugin test depends on a real cloud CLI.
+#
+# The plugin suites twice broke CI for the same reason: a test called a tool's `execute`,
+# the tool built its own executor from `ctx.cwd`, and the real `az` / `aws` / `sf` ran. On a
+# developer Mac the binary answers fast and the test passes; on a runner it is slower, or
+# absent, and the test fails or — worse — writes to the developer's own CLI config. Reading
+# the diff does not catch this. Making the CLIs slow does.
+#
+# Every cloud CLI is replaced with a stub that sleeps. Any test that still spawns one blocks
+# and trips bun's 5 s per-test timeout, naming itself in the output. Tests that legitimately
+# drive a CLI are gated on its presence and carry an explicit longer timeout, so they
+# tolerate the stub.
+#
+# The sleep is deliberately shorter than those explicit timeouts and longer than the default.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 2
+
+SLEEP_SECONDS="${HERMETIC_SLEEP_SECONDS:-8}"
+CLIS=(aws az gcloud gh glab sf)
+
+command -v bun >/dev/null 2>&1 || {
+  echo "FATAL: bun is required" >&2
+  exit 2
+}
+
+STUB_BIN="$(mktemp -d)"
+trap 'rm -rf "$STUB_BIN"' EXIT
+
+# Keep only what the suites genuinely need; everything else resolves from /usr/bin and /bin.
+for tool in bun jq git node npm; do
+  path="$(command -v "$tool" 2>/dev/null)" && ln -sf "$path" "$STUB_BIN/$tool"
+done
+
+for cli in "${CLIS[@]}"; do
+  printf '#!/bin/sh\nsleep %s\n' "$SLEEP_SECONDS" >"$STUB_BIN/$cli"
+  chmod +x "$STUB_BIN/$cli"
+done
+
+failed=()
+
+for dir in plugins/*/; do
+  plugin="$(basename "$dir")"
+  find "$dir" -name '*.test.ts' -not -path '*/node_modules/*' -print -quit | grep -q . || continue
+
+  printf '\n==> %s\n' "$plugin"
+  if ! (cd "$dir" && PATH="$STUB_BIN:/usr/bin:/bin" bun test .); then
+    failed+=("$plugin")
+  fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  cat >&2 <<EOF
+
+NOT HERMETIC: ${failed[*]}
+
+A test above spawned a real cloud CLI. Either:
+  - it is a unit test, and should take an injected executor —
+    createXTool(pi, () => ({ exec: async () => ({ stdout: '', stderr: '', exitCode: 0 }) }))
+  - or it genuinely drives the CLI, and belongs behind a presence gate
+    (it.skipIf(!CLI_INSTALLED)) with an explicit timeout longer than ${SLEEP_SECONDS}s.
+EOF
+  exit 1
+fi
+
+printf '\nNo plugin test depends on a real cloud CLI.\n'

--- a/scripts/check-tests-are-hermetic.sh
+++ b/scripts/check-tests-are-hermetic.sh
@@ -13,6 +13,13 @@
 # tolerate the stub.
 #
 # The sleep is deliberately shorter than those explicit timeouts and longer than the default.
+#
+# Two limits worth stating. It only covers the bun suites: the shell suites have no
+# per-test timeout, so a sleeping stub would not reveal anything there, only make the run
+# take minutes. And a fire-and-forget spawn — one the test never awaits — does not block, so
+# it slips through. Neither is load-bearing, because `run-plugin-tests.sh` removes the cloud
+# CLIs from PATH altogether: this script is the diagnostic that names an offending test,
+# not the thing that stops one reaching a CLI.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -23,6 +23,35 @@ command -v bun >/dev/null 2>&1 || {
   exit 2
 }
 
+# The gate never calls a real cloud CLI.
+#
+# The runner ships aws, az, gcloud and gh, so the integration cases — the ones deliberately
+# gated on a binary being present — would otherwise fire live commands against whatever
+# credentials and network the runner happens to have. There is nothing to learn from that
+# here: CI has no cloud account, so those tests assert only that an unauthenticated CLI
+# answers, while importing every hang and rate limit the network can offer.
+#
+# Removing the binaries from PATH makes each of them skip, visibly. They still run for real
+# on a developer machine, which is where a CLI and credentials actually exist.
+CLI_FREE_PATH=""
+IFS=':' read -r -a _path_entries <<<"$PATH"
+for _entry in "${_path_entries[@]}"; do
+  _has_cli=0
+  for _cli in aws az gcloud gh glab sf; do
+    [ -x "$_entry/$_cli" ] && _has_cli=1
+  done
+  # Keep a directory that holds a cloud CLI only if dropping it would cost us bun.
+  if [ "$_has_cli" -eq 1 ] && [ ! -x "$_entry/bun" ]; then continue; fi
+  CLI_FREE_PATH="${CLI_FREE_PATH:+$CLI_FREE_PATH:}$_entry"
+done
+export PATH="$CLI_FREE_PATH"
+
+for _cli in aws az gcloud gh glab sf; do
+  if command -v "$_cli" >/dev/null 2>&1; then
+    printf 'note: %s is still reachable at %s (it shares a directory with bun)\n' "$_cli" "$(command -v "$_cli")"
+  fi
+done
+
 failed=()
 
 for suite in plugins/*/scripts/tests/run-tests.sh; do


### PR DESCRIPTION
## Why

`Validate Plugins / Run plugin test suites` has failed on `main` twice, both times for the
same reason and both times invisible in review. Every tool factory built its executor
inline from `ctx.cwd`, so any test calling a tool's `execute` ran the **real** `aws`, `az`,
`gcloud`, `gh` or `sf`.

- **#874** — `sf_setup`'s "accepts valid aliases" ran four real
  `sf config set target-org <alias> --global` commands. On a machine with the CLI that
  writes to the developer's own `~/.sf/config.json`, and it blew the 5 s timeout.
- **#877** — `az_help` and `gcloud_help` timed out on the runner, where those CLIs are
  preinstalled and slower to answer than on a laptop.

Fixing them as they surface is whack-a-mole. Replacing every cloud CLI with a stub that
sleeps — so anything still spawning one trips bun's timeout and names itself — found them
all at once: **32 tests across six plugins** (aws 4, azure 12, gcloud 4, github 2,
salesforce 10).

## What changed

**All 27 tool factories take an injected executor**, defaulting to the real one, so
production behaviour is unchanged. The validation suites pass a stub — they assert what an
argument does *before* the spawn, and reaching a CLI was never part of that.

**Cases that genuinely drive a CLI** — the `service check returns valid state` family and
the Salesforce integration suite — keep doing so, behind a presence gate with an explicit
60 s timeout, replacing an `if (checkFn)` that silently asserted nothing when the binary was
absent.

**Two layers, different jobs:**

- `run-plugin-tests.sh` **prevents** — it removes the cloud CLIs from `PATH` for the whole
  run, so CI never calls one. The integration cases skip, visibly: 19 of them.
- `check-tests-are-hermetic.sh` **diagnoses** — with sleeping stubs present, it names the
  test that would have spawned a CLI.

## From the review

Codex returned one **high** finding, **confirmed**, and it was the right one: scrubbing the
unit tests was not enough, because the gate itself still ran with the runner's PATH and a
hermetic step afterwards cannot undo a call already made. That is what the PATH scrub above
fixes.

Its two secondary points were also correct and are now written into the script: the detector
skips the shell suites, and a fire-and-forget spawn never blocks. Adding the shell suites to
a timeout-based detector was the wrong fix — they have no per-test timeout, so a sleeping
stub reveals nothing and only makes the run take minutes (measured: it did not finish in
ten). The PATH scrub covers them instead.

## Verification

| check | result |
| --- | --- |
| `run-plugin-tests.sh` (CLI-free) | exit 0, 19 visible skips |
| `check-tests-are-hermetic.sh` | exit 0 |
| detector with one stub removed | exit 1, `NOT HERMETIC: aws`, names both cases |
| gate with one stub removed | exit 0 — correct: no CLI to reach |
| with CLIs present / absent / credentials exported / `platform=linux` | all exit 0 |
| `tsc` per plugin, before vs after | aws 15/15, azure 38/38, gitlab 84/84, salesforce 56/56 |
| Biome, shellcheck, shfmt, `validate-plugins.sh` | all exit 0 |

Two things worth flagging from the work itself. `createSfPipelineReportTool`'s helper
`buildQueryFn` is module-level, so threading the executor through the factory alone would
have left it referencing a name out of scope — it takes the maker as an argument now. And my
first before/after `tsc` comparison stashed an already-committed tree and measured the same
thing twice; the real comparison found three genuine errors from a missing import, which is
why the table gives numbers rather than a claim.

Closes #878
