### PR TITLE
Sanitise PATH per binary — /usr/bin holds gh on the runner

### DIFF
--- a/scripts/check-tests-are-hermetic.sh
+++ b/scripts/check-tests-are-hermetic.sh
@@ -36,11 +36,9 @@ command -v bun >/dev/null 2>&1 || {
 STUB_BIN="$(mktemp -d)"
 trap 'rm -rf "$STUB_BIN"' EXIT
 
-# Keep only what the suites genuinely need; everything else resolves from /usr/bin and /bin.
-for tool in bun jq git node npm; do
-  path="$(command -v "$tool" 2>/dev/null)" && ln -sf "$path" "$STUB_BIN/$tool"
-done
-
+# The stubs are PREPENDED to the real PATH, so every genuine utility stays reachable and
+# only the cloud CLIs are shadowed. Rebuilding a minimal PATH instead would make a missing
+# coreutil look like a hermeticity failure.
 for cli in "${CLIS[@]}"; do
   printf '#!/bin/sh\nsleep %s\n' "$SLEEP_SECONDS" >"$STUB_BIN/$cli"
   chmod +x "$STUB_BIN/$cli"
@@ -53,7 +51,7 @@ for dir in plugins/*/; do
   find "$dir" -name '*.test.ts' -not -path '*/node_modules/*' -print -quit | grep -q . || continue
 
   printf '\n==> %s\n' "$plugin"
-  if ! (cd "$dir" && PATH="$STUB_BIN:/usr/bin:/bin" bun test .); then
+  if ! (cd "$dir" && PATH="$STUB_BIN:$PATH" bun test .); then
     failed+=("$plugin")
   fi
 done

--- a/scripts/check-tests-are-hermetic.sh
+++ b/scripts/check-tests-are-hermetic.sh
@@ -38,7 +38,7 @@ trap 'rm -rf "$STUB_BIN"' EXIT
 
 # The stubs are PREPENDED to the real PATH, so every genuine utility stays reachable and
 # only the cloud CLIs are shadowed. Rebuilding a minimal PATH instead would make a missing
-# coreutil look like a hermeticity failure.
+# ordinary utility look like a hermeticity failure.
 for cli in "${CLIS[@]}"; do
   printf '#!/bin/sh\nsleep %s\n' "$SLEEP_SECONDS" >"$STUB_BIN/$cli"
   chmod +x "$STUB_BIN/$cli"

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -33,23 +33,44 @@ command -v bun >/dev/null 2>&1 || {
 #
 # Removing the binaries from PATH makes each of them skip, visibly. They still run for real
 # on a developer machine, which is where a CLI and credentials actually exist.
-CLI_FREE_PATH=""
+#
+# Exclusion is per BINARY, not per directory. Dropping whole directories looked simpler and
+# broke the runner immediately: `gh` lives in /usr/bin there, so the whole of /usr/bin went,
+# taking dirname, basename and everything else with it. On a Mac the CLIs sit in
+# /opt/homebrew/bin next to bun, so the flaw was invisible locally.
+CLI_NAMES=(aws az gcloud gh glab sf)
+SANITIZED_BIN="$(mktemp -d)"
+# Resolve rm before PATH changes: the trap fires with the sanitized PATH in effect.
+RM_BIN="$(command -v rm)"
+trap '"$RM_BIN" -rf "$SANITIZED_BIN"' EXIT
+
 IFS=':' read -r -a _path_entries <<<"$PATH"
 for _entry in "${_path_entries[@]}"; do
-  _has_cli=0
-  for _cli in aws az gcloud gh glab sf; do
-    [ -x "$_entry/$_cli" ] && _has_cli=1
+  [ -d "$_entry" ] || continue
+  for _exe in "$_entry"/*; do
+    [ -f "$_exe" ] && [ -x "$_exe" ] || continue
+    _name="${_exe##*/}"
+    for _cli in "${CLI_NAMES[@]}"; do
+      [ "$_name" = "$_cli" ] && continue 2
+    done
+    # First one wins, which preserves the precedence the original PATH had.
+    [ -e "$SANITIZED_BIN/$_name" ] || ln -s "$_exe" "$SANITIZED_BIN/$_name"
   done
-  # Keep a directory that holds a cloud CLI only if dropping it would cost us bun.
-  if [ "$_has_cli" -eq 1 ] && [ ! -x "$_entry/bun" ]; then continue; fi
-  CLI_FREE_PATH="${CLI_FREE_PATH:+$CLI_FREE_PATH:}$_entry"
 done
-export PATH="$CLI_FREE_PATH"
+export PATH="$SANITIZED_BIN"
 
-for _cli in aws az gcloud gh glab sf; do
+# Fail loudly rather than run a gate that is quietly not what it claims to be.
+for _cli in "${CLI_NAMES[@]}"; do
   if command -v "$_cli" >/dev/null 2>&1; then
-    printf 'note: %s is still reachable at %s (it shares a directory with bun)\n' "$_cli" "$(command -v "$_cli")"
+    printf 'FATAL: %s is still on PATH at %s after sanitising\n' "$_cli" "$(command -v "$_cli")" >&2
+    exit 2
   fi
+done
+for _needed in bun jq git bash dirname basename; do
+  command -v "$_needed" >/dev/null 2>&1 || {
+    printf 'FATAL: sanitising PATH lost %s\n' "$_needed" >&2
+    exit 2
+  }
 done
 
 failed=()


### PR DESCRIPTION
## What broke

`main` is red. #879 made the gate strip cloud CLIs from `PATH` — correct goal, wrong
granularity. It dropped whole **directories** that contained a cloud CLI, and on the runner
`gh` lives in `/usr/bin`:

```
./scripts/run-plugin-tests.sh: line 59: dirname: command not found
```

Eight seconds, no tests run.

It passed locally because on macOS the cloud CLIs sit in `/opt/homebrew/bin` next to `bun`,
which the "keep the directory if it also has bun" escape hatch retained, so `/usr/bin` was
never a candidate. The platform difference that change exists to address is the one that hid
the bug in it — which is the same failure mode as the tests it was fixing, one level up.

## The fix

Exclude per **binary**: mirror every executable on `PATH` into a temp directory as symlinks,
skip the six CLI names, use that as `PATH`. First one wins, so precedence survives.

And fail loudly instead of degrading quietly — abort if a cloud CLI is still reachable after
sanitising, or if sanitising cost `bun`, `jq`, `git`, `bash`, `dirname` or `basename`.
Either would leave a gate that is not the thing it claims to be, which is how this got
through in the first place. `rm` is resolved before `PATH` changes, because the `EXIT` trap
runs under the sanitised one.

`check-tests-are-hermetic.sh` now prepends its stubs to the real `PATH` rather than
rebuilding a minimal one, so a missing coreutil cannot masquerade as a hermeticity failure.

## Verification

**The property, measured directly** rather than inferred from a green suite:

```
before: 1840 names
after:  1834 names
removed: aws az gcloud gh glab sf
added:   (none)
```

**The runner's shape, simulated:** a single `PATH` directory of 962 entries containing `gh`,
`az`, `aws` and `bun` together — the layout that broke #879. Gate exits 0.

Two failures that simulation showed at first (`sha256sum: command not found` in github-ops,
`npm is detected when available` in salesforce) were gaps in my fake mirror — macOS has no
`sha256sum`, and I had omitted `npm` — not defects in the script. Worth stating because
"the simulation failed" and "the code is wrong" looked identical for a minute.

| check | result |
| --- | --- |
| `run-plugin-tests.sh` | exit 0 |
| `check-tests-are-hermetic.sh` | exit 0 |
| runner-shaped single-dir PATH | exit 0 |
| shellcheck, shfmt | exit 0 |

Closes #880
