### PR TITLE
Run Validate Plugins on every PR — a required check cannot have a paths filter

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1,26 +1,23 @@
 ---
 name: Validate Plugins
 
+# No `paths:` filter, deliberately.
+#
+# `Run plugin test suites` is a REQUIRED check (docs-control #846). GitHub treats a required
+# context that never reports as permanently pending, so a path filter would deadlock every
+# PR that touches no plugin or script file — which is most of them: five of the last twelve
+# merged here were governance sync PRs editing only root and .github files.
+#
+# Running unconditionally costs about two minutes per PR and removes a whole class of
+# unmergeable-through-no-fault-of-yours. If that ever becomes the wrong trade, the fix is a
+# companion job that reports the same context trivially when nothing relevant changed —
+# not restoring the filter under a required check.
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
-    paths:
-      - "plugins/**"
-      - ".xcsh-plugin/**"
-      - "scripts/validate-plugins.sh"
-      - "scripts/check-version-bumps.sh"
-      - "scripts/run-plugin-tests.sh"
-      - "scripts/check-tests-are-hermetic.sh"
   push:
     branches: [main]
-    paths:
-      - "plugins/**"
-      - ".xcsh-plugin/**"
-      - "scripts/validate-plugins.sh"
-      - "scripts/check-version-bumps.sh"
-      - "scripts/run-plugin-tests.sh"
-      - "scripts/check-tests-are-hermetic.sh"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why now

`Run plugin test suites` is a required check as of docs-control #846. Its workflow has a
`paths:` filter, and a required context that never reports stays **pending forever** — so
any PR that touches no plugin or script file becomes unmergeable.

I raised this as a caveat on #846 and called it a judgement call. Then I counted. Five of
the last twelve merged PRs would deadlock:

```
#876 #872 #869 #865 #861 — all "chore: sync managed files from governance template"
```

Those are opened automatically and edit only root and `.github/` files. The next one
deadlocks, probably within a day. That is not a judgement call any more.

## Change

Remove the `paths:` filter so the workflow always reports. `validate` is ~9s, `test` ~2min.

The alternative — a companion job that reports the same context trivially when nothing
relevant changed — is more machinery for the same outcome, and two workflows racing to
report one context name is its own failure mode. The comment in the file says so, and says
what to do if two minutes per PR ever becomes the wrong trade.

## Verification

- `actionlint` — exit 0.
- YAML parses; triggers are `pull_request` (branches + types) and `push` (branches), jobs
  unchanged (`validate`, `test`).
- This PR is itself the test: it touches only `.github/`, so under the old filter the
  required check would not have reported at all. If `Run plugin test suites` shows up green
  below, the fix works.

Closes #882
