### PR TITLE
MEDDPICC: generate the workbook from the spec (stage 1c)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and this project adheres to
   (Excel says 14, the engine says 21). It runs on request via `MEDDPICC_EXCEL_UAT=1`, since
   opening Excel takes over the foreground.
 
+  Three defects the review found, all reproduced before being fixed. **A partly-qualified deal
+  displayed as 100%**: `COUNT` ignores blank cells, so an unscored element shrank the
+  denominator instead of counting as zero — one element at 4 and seven unscored showed 4/4
+  beside a Red rating, where the engine said 12.5%. Score cells now write 0 when the deal has
+  no score, matching `computeScore`, and the maximum counts the always-populated element
+  column. `generate` now **validates the spec and the deal before writing**, so a mistyped
+  `jsonPath` fails loudly instead of becoming an empty cell that reads as "not filled in yet".
+  And `dateToSerial` **rejects impossible dates** rather than rolling them forward: it was
+  turning `2026-02-31` into `2026-03-03`, a close date three days late that nothing downstream
+  would question.
+
 
 - **Plugin tests no longer depend on a real cloud CLI** (`aws` v1.2.2, `azure` v1.2.2,
   `gcloud` v1.2.2, `github` v1.2.2, `gitlab` v1.2.3, `salesforce` v1.3.3) — 32 tests across

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v2.5.0 — the workbook generator. `engine/generate.ts` turns the spec plus a
+  deal into a real `.xlsx`: `generate <deal.json> --out <file>`, or `--plan` to print where
+  every input cell landed without writing anything.
+
+  It resolves in two passes, because a formula's text depends on where other cells ended up.
+  The first decides addresses, the second substitutes `{{ref:…}}`, `{{col:…}}`, `{{row:…}}`
+  and `{{this:…}}` for them — so nothing in the spec names a coordinate and inserting a field
+  cannot break a formula on another sheet. Dates are written as Excel serials rather than
+  text, without which `closeDate - TODAY()` is a `#VALUE!` error.
+
+  `planWorkbook` also returns `inputCells`: every cell holding a human's value, with the
+  `jsonPath` it came from. That is the contract the round-trip reader will consume, so both
+  directions are defined by one map.
+
+  **Verified against real Excel, not just against our own writer.** `scripts/uat-generate-excel.sh`
+  generates a workbook, opens it, reads the Scorecard back and compares it with what
+  `engine score` computes by a completely different route: 21/32, 65.6%, Yellow from both, no
+  error values on any sheet, no repair prompt. Mutation-checked — pointing one formula at the
+  neighbouring column keeps `check-spec` green and the file valid, and the UAT catches it
+  (Excel says 14, the engine says 21). It runs on request via `MEDDPICC_EXCEL_UAT=1`, since
+  opening Excel takes over the foreground.
+
+
 - **Plugin tests no longer depend on a real cloud CLI** (`aws` v1.2.2, `azure` v1.2.2,
   `gcloud` v1.2.2, `github` v1.2.2, `gitlab` v1.2.3, `salesforce` v1.3.3) — 32 tests across
   six plugins spawned `aws`, `az`, `gcloud`, `gh` or `sf`, because every tool factory built

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/.xcsh-plugin/resources.json
+++ b/plugins/meddpicc/.xcsh-plugin/resources.json
@@ -8,6 +8,6 @@
   "engine": {
     "runtime": "bun",
     "entry": "engine/cli.ts",
-    "commands": ["validate", "next", "score", "hint", "fill", "check-mappings", "check-spec"]
+    "commands": ["validate", "next", "score", "hint", "fill", "check-mappings", "check-spec", "generate"]
   }
 }

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -3,6 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { computeCompletion } from './completion';
 import { applyFill, planFill } from './fill';
+import { generateWorkbook, planWorkbook } from './generate';
 import { computeElementHint, computeHintOverview } from './hint';
 import { checkMappings } from './mappings';
 import { computeScore } from './score';
@@ -132,6 +133,41 @@ async function main(): Promise<number> {
     return result.ok ? 0 : 1;
   }
 
+  if (command === 'generate') {
+    const dealPath = rest[0];
+    if (!dealPath) {
+      process.stderr.write(
+        'Usage: cli.ts generate <deal.json> [--out <file.xlsx>] [--plan] [--spec <workbook-spec.json>]\n',
+      );
+      return 1;
+    }
+    const schema = await readJson(SCHEMA_PATH);
+    const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
+    const deal = await readJson(dealPath);
+
+    // `--plan` reports where every input landed without writing a file — that map is what
+    // the round-trip reader consumes, so being able to inspect it is worth a flag.
+    if (rest.includes('--plan')) {
+      const plan = planWorkbook(schema, spec, deal);
+      print({
+        sheets: plan.sheets.map((s) => ({ name: s.name, rows: s.rows.length })),
+        namedCells: plan.namedCells,
+        inputCells: plan.inputCells,
+      });
+      return 0;
+    }
+
+    const outPath = flag(rest, '--out');
+    if (!outPath) {
+      process.stderr.write('generate needs --out <file.xlsx> (or --plan to inspect the layout)\n');
+      return 1;
+    }
+    await Bun.write(outPath, generateWorkbook(schema, spec, deal));
+    const plan = planWorkbook(schema, spec, deal);
+    print({ out: outPath, sheets: plan.sheets.length, inputCells: plan.inputCells.length });
+    return 0;
+  }
+
   if (command === 'check-spec') {
     const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
     const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
@@ -141,7 +177,7 @@ async function main(): Promise<number> {
   }
 
   process.stderr.write(
-    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, fill, check-mappings, check-spec\n`,
+    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, fill, generate, check-mappings, check-spec\n`,
   );
   return 1;
 }

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -145,6 +145,23 @@ async function main(): Promise<number> {
     const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
     const deal = await readJson(dealPath);
 
+    // Refuse before writing rather than producing a plausible-looking workbook from bad
+    // input. A mistyped jsonPath becomes an empty cell and a wrong type becomes a blank
+    // one, and either reads as "that field is not filled in yet" instead of "the spec is
+    // broken". Both checks are cheap and deterministic, so there is no reason to skip them.
+    const specCheck = checkWorkbookSpec(schema, spec);
+    if (!specCheck.ok) {
+      process.stderr.write('Refusing to generate: the workbook spec does not check out.\n');
+      print(specCheck);
+      return 1;
+    }
+    const dealCheck = validateDeal(deal, schema);
+    if (!dealCheck.valid) {
+      process.stderr.write(`Refusing to generate: ${dealPath} does not validate against the schema.\n`);
+      print(dealCheck);
+      return 1;
+    }
+
     // `--plan` reports where every input landed without writing a file — that map is what
     // the round-trip reader consumes, so being able to inspect it is worth a flag.
     if (rest.includes('--plan')) {

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { dateToSerial, generateWorkbook, planWorkbook } from './generate';
+import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
+import type { WorkbookSpec } from './workbook-spec';
+import { readZip } from './zip';
+
+const here = import.meta.dir;
+const schema = JSON.parse(fs.readFileSync(path.join(here, '..', 'schema', 'meddpicc-schema.json'), 'utf8'));
+const spec = JSON.parse(fs.readFileSync(path.join(here, 'workbook-spec.json'), 'utf8')) as WorkbookSpec;
+const deal = JSON.parse(fs.readFileSync(path.join(here, '..', 'schema', 'example-deal.json'), 'utf8'));
+
+const plan = planWorkbook(schema, spec, deal);
+const sheet = (name: string) => {
+  const found = plan.sheets.find((s) => s.name === name);
+  if (!found) throw new Error(`no sheet ${name}`);
+  return found;
+};
+const cellAt = (sheetName: string, ref: string) => {
+  for (const row of sheet(sheetName).rows) {
+    const c = row.cells.find((x) => x.ref === ref);
+    if (c) return c;
+  }
+  return undefined;
+};
+/** Every cell of every sheet, flattened, for whole-workbook assertions. */
+const allCells = () => plan.sheets.flatMap((s) => s.rows.flatMap((r) => r.cells.map((c) => ({ sheet: s.name, ...c }))));
+
+describe('dateToSerial', () => {
+  // 1899-12-30 is serial 0 in the 1900 date system Excel actually implements.
+  test('maps known dates to the serials Excel uses', () => {
+    expect(dateToSerial('1900-01-01')).toBe(2);
+    expect(dateToSerial('2026-06-30')).toBe(46203);
+  });
+
+  test('returns null for a value that is not a date', () => {
+    expect(dateToSerial('')).toBeNull();
+    expect(dateToSerial('not-a-date')).toBeNull();
+  });
+});
+
+describe('planWorkbook — every sheet in the spec is emitted', () => {
+  test('one sheet per spec sheet, in order', () => {
+    expect(plan.sheets.map((s) => s.name)).toEqual(spec.sheets.map((s) => s.name));
+  });
+});
+
+describe('planWorkbook — form layout', () => {
+  test('a field puts its label in column A and its value in column B on one row', () => {
+    const input = plan.inputCells.find((c) => c.jsonPath === 'metadata.accountName');
+    expect(input).toBeDefined();
+    expect(input?.sheet).toBe('Deal');
+    const [, col, row] = /^([A-Z]+)(\d+)$/.exec(input?.address ?? '') ?? [];
+    expect(col).toBe('B');
+    expect(cellAt('Deal', `A${row}`)?.value).toBe('Account name');
+    expect(cellAt('Deal', `B${row}`)?.value).toBe('Acme Corporation');
+  });
+
+  test('the title is the first row and section headers appear as their own rows', () => {
+    expect(cellAt('Deal', 'A1')?.value).toBe('MEDDPICC Deal Review');
+    const labels = sheet('Deal')
+      .rows.flatMap((r) => r.cells)
+      .filter((c) => c.ref.startsWith('A'))
+      .map((c) => c.value);
+    expect(labels).toContain('Revenue');
+    expect(labels).toContain('Three Whys — F5');
+  });
+
+  test('rows are unique and ascending — nothing lands on top of anything else', () => {
+    for (const s of plan.sheets) {
+      const rows = s.rows.map((r) => r.row);
+      expect(rows, `${s.name} rows ascending`).toEqual([...rows].sort((a, b) => a - b));
+      expect(new Set(rows).size, `${s.name} rows unique`).toBe(rows.length);
+      for (const r of s.rows) {
+        const refs = r.cells.map((c) => c.ref);
+        expect(new Set(refs).size, `${s.name} row ${r.row} refs unique`).toBe(refs.length);
+      }
+    }
+  });
+});
+
+describe('planWorkbook — values by type', () => {
+  test('a date becomes a serial, so the sheet can subtract it from TODAY()', () => {
+    const closeDate = plan.inputCells.find((c) => c.jsonPath === 'metadata.closeDate');
+    const cell = cellAt('Deal', closeDate?.address ?? '');
+    expect(cell?.value).toBe(dateToSerial('2026-06-30'));
+    expect(typeof cell?.value).toBe('number');
+  });
+
+  test('a percent stays the underlying fraction', () => {
+    const win = plan.inputCells.find((c) => c.jsonPath === 'metadata.winProbability');
+    expect(cellAt('Deal', win?.address ?? '')?.value).toBe(0.5);
+  });
+
+  test('currency is a bare number', () => {
+    const acv = plan.inputCells.find((c) => c.jsonPath === 'metadata.revenue.acv');
+    expect(cellAt('Deal', acv?.address ?? '')?.value).toBe(85000);
+  });
+
+  test('a boolean stays a boolean', () => {
+    const mustSayYes = plan.inputCells.filter((c) => c.jsonPath.endsWith('mustSayYes'));
+    expect(mustSayYes.length).toBeGreaterThan(0);
+    const values = mustSayYes.map((c) => cellAt('Stakeholders', c.address)?.value).filter((v) => v !== undefined);
+    expect(values.some((v) => typeof v === 'boolean')).toBe(true);
+  });
+
+  test('an absent value leaves the cell empty rather than writing "undefined"', () => {
+    for (const c of allCells()) {
+      expect(typeof c.value === 'string' ? c.value : '').not.toBe('undefined');
+    }
+  });
+});
+
+describe('planWorkbook — derived cells come from the schema, not from prose', () => {
+  test('each element row carries the definition the schema declares', () => {
+    const definition = cellAt('Qualification', 'B2')?.value;
+    expect(typeof definition).toBe('string');
+    expect(definition).toContain('Quantified business outcomes');
+  });
+
+  test('the rubric cell shows the wording for that element at its own score', () => {
+    // metrics scores 3 in the example deal; the schema's level-3 text must be what shows.
+    const metricsScore = (deal.qualification.metrics as { score: number }).score;
+    const rubric = schema.properties.qualification.properties.metrics.properties.scoreDefinition.default[
+      String(metricsScore)
+    ] as string;
+    const row = QUALIFICATION_ELEMENTS.indexOf('metrics') + 2;
+    expect(cellAt('Qualification', `F${row}`)?.value).toBe(rubric);
+  });
+
+  test('every element gets a row, in the canonical order', () => {
+    const names = QUALIFICATION_ELEMENTS.map((_, i) => cellAt('Qualification', `A${i + 2}`)?.value);
+    expect(names).toEqual([...QUALIFICATION_ELEMENTS]);
+  });
+
+  test('the completion sheet lists every tracked section with its computed status', () => {
+    const names = SECTION_ORDER.map((_, i) => cellAt('Completion', `A${i + 2}`)?.value);
+    expect(names).toEqual([...SECTION_ORDER]);
+    const metricsStatus = cellAt('Completion', 'B2')?.value;
+    expect(['not_started', 'partial', 'complete']).toContain(metricsStatus);
+  });
+
+  test('questions come from the schema and pair with the responses in the deal', () => {
+    const q = cellAt('Questions', 'C2')?.value;
+    const a = cellAt('Questions', 'D2')?.value;
+    expect(q).toBe(schema.properties.qualification.properties.metrics.properties.questions.default[0]);
+    expect(a).toBe((deal.qualification.metrics as { responses: string[] }).responses[0]);
+  });
+});
+
+describe('planWorkbook — collections are not capped', () => {
+  test('every stakeholder in the deal gets a row', () => {
+    const names = (deal.stakeholders as Array<{ name: string }>).map((s) => s.name);
+    const written = names.map((_, i) => cellAt('Stakeholders', `A${i + 2}`)?.value);
+    expect(written).toEqual(names);
+  });
+
+  test('a team larger than the legacy sheet formatted still fits', () => {
+    // The F5 template formats 8 team rows and silently drops the rest.
+    const big = JSON.parse(JSON.stringify(deal));
+    big.team.f5 = Array.from({ length: 14 }, (_, i) => ({ name: `Person ${i + 1}`, role: 'SE' }));
+    const p = planWorkbook(schema, spec, big);
+    const team = p.sheets.find((s) => s.name === 'Team');
+    const written = Array.from(
+      { length: 14 },
+      (_, i) => team?.rows.find((r) => r.row === i + 2)?.cells.find((c) => c.ref === `A${i + 2}`)?.value,
+    );
+    expect(written).toEqual(big.team.f5.map((m: { name: string }) => m.name));
+  });
+
+  test('an empty collection still leaves the header and the blank rows the spec asks for', () => {
+    const empty = JSON.parse(JSON.stringify(deal));
+    empty.stakeholders = [];
+    const p = planWorkbook(schema, spec, empty);
+    const sh = p.sheets.find((s) => s.name === 'Stakeholders');
+    expect(sh?.rows.find((r) => r.row === 1)?.cells[0]?.value).toBe('Name');
+  });
+});
+
+describe('planWorkbook — formula references resolve to addresses', () => {
+  test('no placeholder survives into any formula', () => {
+    for (const c of allCells()) {
+      expect(c.formula ?? '').not.toContain('{{');
+      expect(c.formula ?? '').not.toContain('}}');
+    }
+  });
+
+  test('a column reference becomes the data range of that column', () => {
+    const total = plan.namedCells.scoreTotal;
+    const cell = cellAt('Scorecard', total.split('!')[1] ?? total);
+    // Eight elements starting at row 2.
+    expect(cell?.formula).toBe('SUM(Qualification!C2:C9)');
+  });
+
+  test('a keyed row reference points at that key own row', () => {
+    const cell = cellAt('Scorecard', plan.namedCells.championScore.split('!')[1] ?? '');
+    const championRow = QUALIFICATION_ELEMENTS.indexOf('champion') + 2;
+    expect(cell?.formula).toBe(`Qualification!C${championRow}`);
+  });
+
+  test('a same-sheet reference is not sheet-qualified, a cross-sheet one is', () => {
+    const percent = cellAt('Scorecard', plan.namedCells.scorePercent.split('!')[1] ?? '');
+    // scoreTotal and scoreMaximum are on the Scorecard too, so no prefix.
+    expect(percent?.formula).not.toContain('Scorecard!');
+    expect(percent?.formula).toMatch(/^IF\(B\d+=0,0,B\d+\/B\d+\)$/);
+  });
+
+  test('a sheet name containing a space is quoted', () => {
+    const overdue = cellAt('Scorecard', plan.namedCells.actionsOverdue.split('!')[1] ?? '');
+    expect(overdue?.formula).toContain("'Close Plan'!");
+  });
+
+  test('{{this:…}} resolves to the same row of the same table', () => {
+    // Qualification's `change` column is score - previousScore, per row.
+    expect(cellAt('Qualification', 'E2')?.formula).toBe('C2-D2');
+    expect(cellAt('Qualification', 'E9')?.formula).toBe('C9-D9');
+  });
+});
+
+describe('planWorkbook — the input map stage 3 will read back', () => {
+  test('reports one entry per input cell, with its address and type', () => {
+    expect(plan.inputCells.length).toBeGreaterThan(50);
+    for (const c of plan.inputCells) {
+      expect(c.address).toMatch(/^[A-Z]+\d+$/);
+      expect(plan.sheets.some((s) => s.name === c.sheet)).toBe(true);
+    }
+  });
+
+  test('never reports a computed or derived cell as an input', () => {
+    // A derived value must not flow back into the deal as if a human typed it.
+    const scorecard = plan.inputCells.filter((c) => c.sheet === 'Scorecard');
+    expect(scorecard).toEqual([]);
+    const addresses = new Set(plan.inputCells.map((c) => `${c.sheet}!${c.address}`));
+    for (const c of allCells()) {
+      if (c.formula !== undefined) expect(addresses.has(`${c.sheet}!${c.ref}`)).toBe(false);
+    }
+  });
+
+  test('no two input cells claim the same address', () => {
+    const keys = plan.inputCells.map((c) => `${c.sheet}!${c.address}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe('generateWorkbook', () => {
+  test('produces a zip carrying every part and one worksheet per sheet', () => {
+    const parts = readZip(generateWorkbook(schema, spec, deal));
+    expect(parts.has('[Content_Types].xml')).toBe(true);
+    expect(parts.has('xl/workbook.xml')).toBe(true);
+    for (let i = 0; i < spec.sheets.length; i++) {
+      expect(parts.has(`xl/worksheets/sheet${i + 1}.xml`)).toBe(true);
+    }
+  });
+
+  test('is deterministic — the same deal twice gives the same bytes', () => {
+    const a = generateWorkbook(schema, spec, deal);
+    const b = generateWorkbook(schema, spec, deal);
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+});

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -259,3 +259,57 @@ describe('generateWorkbook', () => {
     expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
   });
 });
+
+describe('a partly-qualified deal is not flattered by the workbook', () => {
+  // Excel's COUNT ignores blanks, so a denominator of COUNT(score)*4 shrank with the data:
+  // one element scored 4 and seven unscored displayed 4/4 = 100% next to a Red rating, while
+  // the engine said 12.5%. MEDDPICC scores out of 32 whether or not anyone has looked yet.
+  const partial = (() => {
+    const d = JSON.parse(JSON.stringify(deal));
+    for (const el of QUALIFICATION_ELEMENTS) {
+      if (el !== 'metrics') delete d.qualification[el].score;
+    }
+    d.qualification.metrics.score = 4;
+    d.scoring = { elementScores: { metrics: 4 } };
+    return d;
+  })();
+
+  test('an unscored element is written as 0, matching how the engine counts it', () => {
+    const p = planWorkbook(schema, spec, partial);
+    const q = p.sheets.find((s) => s.name === 'Qualification');
+    const scores = QUALIFICATION_ELEMENTS.map(
+      (_, i) => q?.rows.find((r) => r.row === i + 2)?.cells.find((c) => c.ref === `C${i + 2}`)?.value,
+    );
+    expect(scores).toEqual([4, 0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  test('the maximum does not shrink when scores are missing', () => {
+    // Counting the element-name column keeps the denominator at the number of elements.
+    const maximum = cellAt('Scorecard', plan.namedCells.scoreMaximum.split('!')[1] ?? '');
+    expect(maximum?.formula).toBe('COUNTA(Qualification!A2:A9)*4');
+  });
+});
+
+describe('dateToSerial rejects what is not a date', () => {
+  test('refuses an impossible calendar date instead of rolling it forward', () => {
+    // Date.UTC turns 2026-02-31 into 2026-03-03 — a close date silently three days late.
+    expect(dateToSerial('2026-02-31')).toBeNull();
+    expect(dateToSerial('2026-04-31')).toBeNull();
+    expect(dateToSerial('2026-13-01')).toBeNull();
+    expect(dateToSerial('2026-00-10')).toBeNull();
+  });
+
+  test('accepts a real leap day and rejects a fake one', () => {
+    expect(dateToSerial('2024-02-29')).not.toBeNull();
+    expect(dateToSerial('2026-02-29')).toBeNull();
+  });
+
+  test('refuses trailing garbage', () => {
+    expect(dateToSerial('2026-06-30XYZ')).toBeNull();
+    expect(dateToSerial('2026-06-30-01')).toBeNull();
+  });
+
+  test('still accepts the date-time form the schema uses for lastSyncDate', () => {
+    expect(dateToSerial('2026-05-05T14:30:00Z')).toBe(dateToSerial('2026-05-05'));
+  });
+});

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -1,0 +1,412 @@
+/**
+ * Turn a workbook spec plus a deal into a workbook.
+ *
+ * Two passes, because a formula's text depends on where other cells landed. The first walks
+ * the spec and decides the address of every named cell and every table column; the second
+ * emits the cells, substituting `{{ref:…}}`, `{{col:…}}`, `{{row:…}}` and `{{this:…}}` for
+ * the addresses the first pass chose. Nothing in the spec names a coordinate, so inserting a
+ * field cannot silently break a formula three sheets away.
+ *
+ * `planWorkbook` returns the sheet specs AND `inputCells` — every cell that holds a human's
+ * value, with the `jsonPath` it came from. That map is the contract the round-trip reader
+ * will consume, and stating it here keeps the two directions from drifting.
+ */
+import { computeCompletion } from './completion';
+import { computeElementHint } from './hint';
+import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
+import {
+  parseReferences,
+  type SpecBlock,
+  type SpecColumn,
+  type SpecTable,
+  type SpecTableSource,
+  VALUE_TYPE_STYLE,
+  type ValueType,
+  type WorkbookSpec,
+} from './workbook-spec';
+import { A1, buildWorkbook, type CellSpec, type RowSpec, type SheetSpec } from './xlsx';
+
+/** Excel's 1900 date system counts from 1899-12-30, and that offset is the whole trick. */
+const EXCEL_EPOCH_UTC = Date.UTC(1899, 11, 30);
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * An ISO date as the number Excel stores, or null when the value is not a date.
+ *
+ * A date written as text looks right and breaks arithmetic: `closeDate - TODAY()` on a string
+ * is a #VALUE! error, and the Deal sheet does exactly that.
+ */
+export function dateToSerial(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (!m) return null;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const utc = Date.UTC(y, mo - 1, d);
+  if (Number.isNaN(utc)) return null;
+  return Math.round((utc - EXCEL_EPOCH_UTC) / MS_PER_DAY);
+}
+
+/** Follow a dotted/indexed path into the deal. Returns undefined rather than throwing. */
+function readPath(root: unknown, dottedPath: string): unknown {
+  let node: unknown = root;
+  for (const part of dottedPath.split('.')) {
+    const m = /^([^[\]]*)((?:\[\d+\])*)$/.exec(part);
+    const key = m?.[1] ?? part;
+    if (key) {
+      if (node === null || typeof node !== 'object') return undefined;
+      node = (node as Record<string, unknown>)[key];
+    }
+    for (const idx of m?.[2]?.match(/\d+/g) ?? []) {
+      if (!Array.isArray(node)) return undefined;
+      node = node[Number(idx)];
+    }
+  }
+  return node;
+}
+
+/** Coerce a deal value for a cell of this type. `undefined` means leave the cell blank. */
+function toCellValue(value: unknown, valueType: ValueType): string | number | boolean | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (valueType === 'date') return dateToSerial(value) ?? String(value);
+  if (valueType === 'boolean') return typeof value === 'boolean' ? value : String(value);
+  if (valueType === 'integer' || valueType === 'number' || valueType === 'currency' || valueType === 'percent') {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  return String(value);
+}
+
+const sheetPrefix = (name: string) => (/^[A-Za-z0-9_]+$/.test(name) ? `${name}!` : `'${name.replace(/'/g, "''")}'!`);
+
+/** Row keys for a keyed source, or null when the rows depend on the deal. */
+function keysOf(source: SpecTableSource): readonly string[] | null {
+  switch (source.kind) {
+    case 'elements':
+      return QUALIFICATION_ELEMENTS;
+    case 'sections':
+      return SECTION_ORDER;
+    case 'fixed':
+      return source.keys;
+    case 'list':
+    case 'elementResponses':
+      return null;
+  }
+}
+
+interface TableLayout {
+  sheet: string;
+  table: SpecTable;
+  headerRow: number;
+  firstDataRow: number;
+  rowCount: number;
+  /** Column id -> 1-based column index. */
+  columns: Map<string, number>;
+  /** For a keyed source, the key at each data row. */
+  rowKeys: readonly string[] | null;
+  /** Rows to emit: one entry per data row, carrying whatever that row is about. */
+  items: Array<{ key?: string; listIndex?: number; element?: string; index?: number }>;
+}
+
+export interface InputCell {
+  jsonPath: string;
+  sheet: string;
+  address: string;
+  valueType: ValueType;
+}
+
+export interface WorkbookPlan {
+  sheets: SheetSpec[];
+  /** Named form cells -> `Sheet!Address`. */
+  namedCells: Record<string, string>;
+  inputCells: InputCell[];
+}
+
+/** Rows for a table, resolved against the deal. */
+function resolveRows(table: SpecTable, deal: unknown, schema: unknown): TableLayout['items'] {
+  const source = table.source;
+  const keys = keysOf(source);
+  if (keys) return keys.map((key) => ({ key }));
+
+  if (source.kind === 'elementResponses') {
+    const rows: TableLayout['items'] = [];
+    for (const element of QUALIFICATION_ELEMENTS) {
+      const questions = computeElementHint(schema, element).questions;
+      const responses = readPath(deal, `qualification.${element}.responses`);
+      const answers = Array.isArray(responses) ? responses : [];
+      // One row per question, plus any answer beyond the questions the schema declares —
+      // an extra response is data someone entered, and dropping it silently is the bug the
+      // legacy sheet had.
+      const count = Math.max(questions.length, answers.length);
+      for (let i = 0; i < count; i++) rows.push({ element, index: i });
+    }
+    return rows;
+  }
+
+  const list = readPath(deal, source.jsonPath);
+  const items = Array.isArray(list) ? list : [];
+  const padded = Math.max(items.length, table.minRows ?? 0);
+  // The index is what makes each row's jsonPath distinct — `stakeholders[3].name`, not
+  // `stakeholders.name` — which is what lets the reader put a value back where it came from.
+  return Array.from({ length: padded }, (_, i) => ({ listIndex: i }));
+}
+
+/** Pass 1: decide where everything goes. */
+function layout(
+  schema: unknown,
+  spec: WorkbookSpec,
+  deal: unknown,
+): {
+  named: Map<string, { sheet: string; address: string }>;
+  tables: Map<string, TableLayout>;
+  formRows: Map<string, Array<{ block: SpecBlock; row: number }>>;
+} {
+  const named = new Map<string, { sheet: string; address: string }>();
+  const tables = new Map<string, TableLayout>();
+  const formRows = new Map<string, Array<{ block: SpecBlock; row: number }>>();
+
+  for (const s of spec.sheets) {
+    if (s.kind === 'form') {
+      const rows: Array<{ block: SpecBlock; row: number }> = [];
+      let row = 1;
+      for (const block of s.blocks) {
+        rows.push({ block, row });
+        if (block.kind === 'field' || block.kind === 'computed') {
+          named.set(block.id, { sheet: s.name, address: A1(2, row) });
+        }
+        row++;
+      }
+      formRows.set(s.name, rows);
+      continue;
+    }
+
+    for (const table of s.tables) {
+      const columns = new Map<string, number>();
+      table.columns.forEach((c, i) => {
+        columns.set(c.id, table.anchorColumn + i);
+      });
+      const items = resolveRows(table, deal, schema);
+      tables.set(table.id, {
+        sheet: s.name,
+        table,
+        headerRow: table.headerRow,
+        firstDataRow: table.headerRow + 1,
+        rowCount: items.length,
+        columns,
+        rowKeys: keysOf(table.source),
+        items,
+      });
+    }
+  }
+
+  return { named, tables, formRows };
+}
+
+/** Replace every `{{…}}` with an address, relative to the sheet (and row) doing the asking. */
+function resolveFormula(
+  formula: string,
+  ctx: { sheet: string; table?: TableLayout; row?: number },
+  named: Map<string, { sheet: string; address: string }>,
+  tables: Map<string, TableLayout>,
+): string {
+  let out = formula;
+  for (const ref of parseReferences(formula)) {
+    let replacement: string;
+
+    if (ref.kind === 'ref') {
+      const target = named.get(ref.target);
+      if (!target) throw new Error(`${ctx.sheet}: {{ref:${ref.target}}} names no cell`);
+      replacement = target.sheet === ctx.sheet ? target.address : `${sheetPrefix(target.sheet)}${target.address}`;
+    } else if (ref.kind === 'this') {
+      if (!ctx.table || ctx.row === undefined) {
+        throw new Error(`${ctx.sheet}: {{this:${ref.target}}} outside a table row`);
+      }
+      const col = ctx.table.columns.get(ref.target);
+      if (!col) throw new Error(`${ctx.table.table.id}: {{this:${ref.target}}} names no column`);
+      replacement = A1(col, ctx.row);
+    } else {
+      const [locator, rowKey] = ref.target.split('@');
+      const dot = locator.indexOf('.');
+      const found = tables.get(locator.slice(0, dot));
+      const col = found?.columns.get(locator.slice(dot + 1));
+      if (!found || !col) throw new Error(`${ctx.sheet}: ${ref.raw} does not resolve`);
+      const prefix = found.sheet === ctx.sheet ? '' : sheetPrefix(found.sheet);
+
+      if (ref.kind === 'row') {
+        const index = found.rowKeys?.indexOf(rowKey ?? '') ?? -1;
+        if (index < 0) throw new Error(`${ctx.sheet}: ${ref.raw} names no row`);
+        replacement = `${prefix}${A1(col, found.firstDataRow + index)}`;
+      } else {
+        // An empty table still needs a syntactically valid range, so span at least one row.
+        const last = found.firstDataRow + Math.max(found.rowCount, 1) - 1;
+        replacement = `${prefix}${A1(col, found.firstDataRow)}:${A1(col, last)}`;
+      }
+    }
+
+    out = out.split(ref.raw).join(replacement);
+  }
+  return out;
+}
+
+/** The value a `derived` column shows. Everything here comes from the schema or the engine. */
+function derivedValue(
+  column: SpecColumn,
+  entry: TableLayout['items'][number],
+  table: SpecTable,
+  schema: unknown,
+  deal: unknown,
+  completion: Record<string, string>,
+): string | number | boolean | undefined {
+  const source = table.source.kind;
+
+  if (source === 'elements') {
+    const element = entry.key as string;
+    const hint = computeElementHint(schema, element);
+    if (column.id === 'element') return element;
+    if (column.id === 'definition') return hint.definition;
+    if (column.id === 'rubric') {
+      const score = readPath(deal, `qualification.${element}.score`);
+      return hint.scoreDefinition[String(typeof score === 'number' ? score : 0)] ?? '';
+    }
+    if (column.id === 'status') return completion[element];
+    return undefined;
+  }
+
+  if (source === 'sections') {
+    const section = entry.key as string;
+    if (column.id === 'section') return section;
+    if (column.id === 'status') return completion[section];
+    return undefined;
+  }
+
+  if (source === 'elementResponses') {
+    const element = entry.element as string;
+    const index = entry.index as number;
+    if (column.id === 'element') return element;
+    if (column.id === 'position') return index + 1;
+    if (column.id === 'question') return computeElementHint(schema, element).questions[index];
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown): WorkbookPlan {
+  const { named, tables, formRows } = layout(schema, spec, deal);
+  const completion = computeCompletion(deal).completionStatus as Record<string, string>;
+  const inputCells: InputCell[] = [];
+  const sheets: SheetSpec[] = [];
+
+  for (const s of spec.sheets) {
+    if (s.kind === 'form') {
+      const rows: RowSpec[] = [];
+      for (const { block, row } of formRows.get(s.name) ?? []) {
+        const cells: CellSpec[] = [];
+
+        if (block.kind === 'title') cells.push({ ref: A1(1, row), value: block.text, style: 'title' });
+        if (block.kind === 'section') cells.push({ ref: A1(1, row), value: block.text, style: 'sectionHeader' });
+
+        if (block.kind === 'field' || block.kind === 'computed') {
+          cells.push({ ref: A1(1, row), value: block.label, style: 'label' });
+          const style = VALUE_TYPE_STYLE[block.valueType];
+          const ref = A1(2, row);
+          if (block.kind === 'field') {
+            const value = toCellValue(readPath(deal, block.jsonPath), block.valueType);
+            cells.push({ ref, value, style });
+            inputCells.push({ jsonPath: block.jsonPath, sheet: s.name, address: ref, valueType: block.valueType });
+          } else {
+            cells.push({
+              ref,
+              formula: resolveFormula(block.formula, { sheet: s.name }, named, tables),
+              style,
+            });
+          }
+        }
+
+        if (cells.length > 0) rows.push({ row, cells, height: 'height' in block ? block.height : undefined });
+      }
+      sheets.push({ name: s.name, rows, columns: s.columns, freezeAtRow: 1 });
+      continue;
+    }
+
+    // A table sheet: header row(s) then data rows, one table per column band.
+    const byRow = new Map<number, CellSpec[]>();
+    const push = (row: number, cell: CellSpec) => {
+      const list = byRow.get(row) ?? [];
+      list.push(cell);
+      byRow.set(row, list);
+    };
+    let widest = 0;
+
+    for (const table of s.tables) {
+      const info = tables.get(table.id);
+      if (!info) continue;
+      widest = Math.max(widest, table.anchorColumn + table.columns.length - 1);
+
+      table.columns.forEach((column, i) => {
+        const col = table.anchorColumn + i;
+        push(table.headerRow, { ref: A1(col, table.headerRow), value: column.header, style: 'columnHeader' });
+
+        info.items.forEach((entry, r) => {
+          const row = info.firstDataRow + r;
+          const ref = A1(col, row);
+          const style = VALUE_TYPE_STYLE[column.valueType];
+
+          if (column.role === 'computed' && column.formula) {
+            push(row, {
+              ref,
+              formula: resolveFormula(column.formula, { sheet: s.name, table: info, row }, named, tables),
+              style,
+            });
+            return;
+          }
+
+          if (column.role === 'input' && column.jsonPath) {
+            const jsonPath = inputPathFor(table, column, entry);
+            const value = toCellValue(readPath(deal, jsonPath), column.valueType);
+            push(row, { ref, value, style });
+            inputCells.push({ jsonPath, sheet: s.name, address: ref, valueType: column.valueType });
+            return;
+          }
+
+          push(row, {
+            ref,
+            value: derivedValue(column, entry, table, schema, deal, completion),
+            style,
+          });
+        });
+      });
+    }
+
+    const columns = s.tables.flatMap((t) =>
+      t.columns.map((c, i) => ({ min: t.anchorColumn + i, max: t.anchorColumn + i, width: c.width ?? 18 })),
+    );
+    sheets.push({
+      name: s.name,
+      rows: [...byRow.entries()].sort(([a], [b]) => a - b).map(([row, cells]) => ({ row, cells })),
+      columns,
+      freezeAtRow: 1,
+    });
+  }
+
+  return {
+    sheets,
+    namedCells: Object.fromEntries([...named].map(([id, v]) => [id, `${v.sheet}!${v.address}`])),
+    inputCells,
+  };
+}
+
+/** The concrete deal path an input column writes for one row. */
+function inputPathFor(table: SpecTable, column: SpecColumn, entry: TableLayout['items'][number]): string {
+  const relative = column.jsonPath as string;
+  if (table.source.kind === 'list') {
+    return `${table.source.jsonPath}[${entry.listIndex}].${relative}`;
+  }
+  if (table.source.kind === 'elementResponses') {
+    return relative.replace('*', entry.element as string).replace('[]', `[${entry.index}]`);
+  }
+  return relative.replace('*', entry.key as string);
+}
+
+export function generateWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown): Uint8Array {
+  return buildWorkbook(planWorkbook(schema, spec, deal).sheets);
+}

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -38,11 +38,17 @@ const MS_PER_DAY = 86_400_000;
  */
 export function dateToSerial(value: unknown): number | null {
   if (typeof value !== 'string') return null;
-  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  // Anchored, and a time part only in the `T…` form the schema uses for lastSyncDate.
+  // Left open-ended, the pattern accepted `2026-06-30XYZ` and quietly used the date.
+  const m = /^(\d{4})-(\d{2})-(\d{2})(?:[T ].*)?$/.exec(value);
   if (!m) return null;
   const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
   const utc = Date.UTC(y, mo - 1, d);
   if (Number.isNaN(utc)) return null;
+  // Date.UTC rolls impossible components forward — 2026-02-31 becomes 2026-03-03, a close
+  // date three days late that nothing downstream would question. Reject rather than shift.
+  const back = new Date(utc);
+  if (back.getUTCFullYear() !== y || back.getUTCMonth() !== mo - 1 || back.getUTCDate() !== d) return null;
   return Math.round((utc - EXCEL_EPOCH_UTC) / MS_PER_DAY);
 }
 
@@ -66,7 +72,12 @@ function readPath(root: unknown, dottedPath: string): unknown {
 
 /** Coerce a deal value for a cell of this type. `undefined` means leave the cell blank. */
 function toCellValue(value: unknown, valueType: ValueType): string | number | boolean | undefined {
-  if (value === undefined || value === null || value === '') return undefined;
+  if (value === undefined || value === null || value === '') {
+    // An unscored element is 0, not blank. `computeScore` already counts it as 0, and Excel's
+    // COUNT/COUNTIF skip blanks — so leaving it empty made the sheet disagree with the engine
+    // and, with COUNT in the denominator, display a partly-qualified deal as 100%.
+    return valueType === 'score' ? 0 : undefined;
+  }
   if (valueType === 'date') return dateToSerial(value) ?? String(value);
   if (valueType === 'boolean') return typeof value === 'boolean' ? value : String(value);
   if (valueType === 'integer' || valueType === 'number' || valueType === 'currency' || valueType === 'percent') {

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -613,7 +613,7 @@
           "kind": "computed",
           "id": "scoreMaximum",
           "label": "Maximum possible",
-          "formula": "COUNT({{col:elements.score}})*4",
+          "formula": "COUNTA({{col:elements.element}})*4",
           "valueType": "number"
         },
         {

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/tests/test_engine.sh
+++ b/plugins/meddpicc/scripts/tests/test_engine.sh
@@ -206,6 +206,83 @@ test_engine_check_spec_detects_a_broken_formula_reference() {
   rm -rf "$tmp"
 }
 
+test_engine_generate_plan_maps_every_input() {
+  _engine_precheck || return 0
+  local out
+  out=$(bun "$PLUGIN_ROOT/engine/cli.ts" generate "$PLUGIN_ROOT/schema/example-deal.json" --plan)
+  [ "$(jq -r '.sheets | length' <<<"$out")" = "8" ] || {
+    echo "expected 8 sheets: $(jq -c '.sheets' <<<"$out")"
+    return 1
+  }
+  # Every input cell must name a real address; a malformed one would throw at write time.
+  local bad
+  bad=$(jq -r '[.inputCells[].address | select(test("^[A-Z]+[0-9]+$") | not)] | join(",")' <<<"$out")
+  [ -z "$bad" ] || {
+    echo "malformed addresses: $bad"
+    return 1
+  }
+  # The Scorecard is entirely computed, so nothing on it may be reported as an input.
+  [ "$(jq -r '[.inputCells[] | select(.sheet == "Scorecard")] | length' <<<"$out")" = "0" ] || {
+    echo "Scorecard reported as holding inputs"
+    return 1
+  }
+}
+
+test_engine_generate_writes_a_workbook() {
+  _engine_precheck || return 0
+  command -v unzip >/dev/null 2>&1 || {
+    echo "SKIP: unzip unavailable"
+    return 0
+  }
+  local tmp
+  tmp=$(mktemp -d)
+  bun "$PLUGIN_ROOT/engine/cli.ts" generate "$PLUGIN_ROOT/schema/example-deal.json" --out "$tmp/out.xlsx" >/dev/null || {
+    echo "generate --out failed"
+    rm -rf "$tmp"
+    return 1
+  }
+  # No placeholder may survive into a worksheet: Excel would show the literal braces.
+  if unzip -p "$tmp/out.xlsx" 'xl/worksheets/sheet*.xml' | grep -q '{{'; then
+    echo "an unresolved {{...}} placeholder reached the workbook"
+    rm -rf "$tmp"
+    return 1
+  fi
+  unzip -p "$tmp/out.xlsx" xl/workbook.xml | grep -q "Scorecard" || {
+    echo "Scorecard sheet missing from the workbook"
+    rm -rf "$tmp"
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+test_engine_generate_is_deterministic() {
+  _engine_precheck || return 0
+  local tmp
+  tmp=$(mktemp -d)
+  bun "$PLUGIN_ROOT/engine/cli.ts" generate "$PLUGIN_ROOT/schema/example-deal.json" --out "$tmp/a.xlsx" >/dev/null
+  bun "$PLUGIN_ROOT/engine/cli.ts" generate "$PLUGIN_ROOT/schema/example-deal.json" --out "$tmp/b.xlsx" >/dev/null
+  cmp -s "$tmp/a.xlsx" "$tmp/b.xlsx" || {
+    echo "generate is not byte-deterministic"
+    rm -rf "$tmp"
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+# Real Excel is the only thing that can tell us a formula computes what we meant. Opening it
+# hijacks the operator's foreground app, so it runs on request rather than on every suite run.
+test_engine_generate_excel_uat() {
+  _engine_precheck || return 0
+  if [ "${MEDDPICC_EXCEL_UAT:-0}" != "1" ]; then
+    echo "SKIP: set MEDDPICC_EXCEL_UAT=1 to drive real Excel"
+    return 0
+  fi
+  bash "$PLUGIN_ROOT/scripts/uat-generate-excel.sh" || {
+    echo "Excel UAT failed"
+    return 1
+  }
+}
+
 test_engine_check_mappings_detects_a_target_aimed_at_a_label() {
   _engine_precheck || return 0
   local tmp

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -16,7 +16,8 @@ set -uo pipefail
 HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 PLUGIN_ROOT="$(cd -- "$HERE/.." && pwd -P)"
 DEAL="${1:-$PLUGIN_ROOT/schema/example-deal.json}"
-OUT="$(mktemp -d)/uat-deal.xlsx"
+WORK="$(mktemp -d)"
+OUT="$WORK/uat-deal.xlsx"
 BOOK="$(basename "$OUT")"
 
 skip() {
@@ -57,10 +58,6 @@ for _ in $(seq 1 30); do
 done
 [ "${opened:-0}" = "1" ] || fail "Excel never listed $BOOK — it most likely offered to repair the file"
 echo "    opened with no repair prompt"
-
-read_cell() {
-  osascript -e "tell application \"Microsoft Excel\" to get value of cell \"$2\" of worksheet \"$1\" of workbook \"$BOOK\"" 2>/dev/null
-}
 
 # Find the Scorecard rows by their labels rather than hard-coded addresses: the layout comes
 # from the spec, so pinning row numbers here would make this fail on a harmless reorder.
@@ -120,5 +117,62 @@ OSA
 echo "    no Excel error values on any sheet"
 
 osascript -e "tell application \"Microsoft Excel\" to close workbook \"$BOOK\" saving no" >/dev/null 2>&1
-rm -rf "$(dirname "$OUT")"
 echo "PASS: Excel opened the generated workbook and its Scorecard agrees with the engine"
+
+# The same comparison on a deal where most elements are unscored — the case that was wrong.
+#
+# MEDDPICC scores out of 32 whether or not anyone has assessed an element yet. With the
+# denominator written as COUNT(score)*4, blanks shrank it: one element at 4 and seven unscored
+# displayed 4/4 = 100% beside a Red rating. The engine said 12.5%. A forecast document that
+# flatters an unqualified deal is worse than no document, so this stays checked.
+command -v jq >/dev/null 2>&1 || {
+  echo "SKIP: jq unavailable for the partial-deal case"
+  exit 0
+}
+
+PARTIAL="$WORK/partial.json"
+jq '(.qualification | keys[]) as $k | .' "$DEAL" >/dev/null 2>&1 || fail "cannot read $DEAL as JSON"
+jq '
+  .qualification |= with_entries(if .key == "metrics" then . else (.value |= del(.score)) end)
+  | .qualification.metrics.score = 4
+  | .scoring = { elementScores: { metrics: 4 } }
+' "$DEAL" >"$PARTIAL" || fail "could not build the partial deal"
+
+PARTIAL_OUT="$WORK/uat-partial.xlsx"
+PARTIAL_BOOK="$(basename "$PARTIAL_OUT")"
+bun "$PLUGIN_ROOT/engine/cli.ts" generate "$PARTIAL" --out "$PARTIAL_OUT" >/dev/null || fail "generate failed on the partial deal"
+
+partial_score="$(bun "$PLUGIN_ROOT/engine/cli.ts" score "$PARTIAL")" || fail "score failed on the partial deal"
+want_partial_pct="$(jq -r '.overallScore' <<<"$partial_score")"
+
+echo "==> opening the partial deal in Excel"
+open -a "Microsoft Excel" "$PARTIAL_OUT" || fail "could not open the partial workbook"
+for _ in $(seq 1 30); do
+  if osascript -e 'tell application "Microsoft Excel" to get name of every workbook' 2>/dev/null | grep -qF "$PARTIAL_BOOK"; then
+    partial_opened=1
+    break
+  fi
+  sleep 2
+done
+[ "${partial_opened:-0}" = "1" ] || fail "Excel never listed $PARTIAL_BOOK"
+
+got_partial_raw="$(
+  osascript <<OSA 2>/dev/null
+tell application "Microsoft Excel"
+  repeat with r from 1 to 60
+    set a to (get value of cell ("A" & r) of worksheet "Scorecard" of workbook "$PARTIAL_BOOK")
+    if (a as string) is "Overall score" then
+      return (get value of cell ("B" & r) of worksheet "Scorecard" of workbook "$PARTIAL_BOOK") as string
+    end if
+  end repeat
+  return "NOT-FOUND"
+end tell
+OSA
+)"
+got_partial="$(awk -v v="$got_partial_raw" 'BEGIN { printf "%.1f", v * 100 }')"
+echo "    partly-qualified overall score: Excel=$got_partial% engine=$want_partial_pct%"
+osascript -e "tell application \"Microsoft Excel\" to close workbook \"$PARTIAL_BOOK\" saving no" >/dev/null 2>&1
+[ "$got_partial" = "$want_partial_pct" ] || fail "Excel showed $got_partial% for a partly-qualified deal, engine says $want_partial_pct%"
+
+rm -rf "$WORK"
+echo "PASS: a partly-qualified deal reads the same in Excel as in the engine"

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# uat-generate-excel.sh — open a generated workbook in real Excel and check it computed.
+#
+# The unit tests assert what we WRITE. They cannot assert what Excel makes of it, and that
+# is the part with the interesting failure modes: a malformed part makes Excel offer to
+# repair rather than open, a date written as text turns arithmetic into #VALUE!, and a
+# formula referring to the wrong range is perfectly well-formed and silently wrong.
+#
+# So this drives the real application: generate, open, read the Scorecard back, and compare
+# it against what `engine score` computes from the same deal by a completely different route.
+# Agreement between the two is the evidence; either alone proves much less.
+#
+# macOS with Excel only. Skips, loudly, anywhere else.
+set -uo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PLUGIN_ROOT="$(cd -- "$HERE/.." && pwd -P)"
+DEAL="${1:-$PLUGIN_ROOT/schema/example-deal.json}"
+OUT="$(mktemp -d)/uat-deal.xlsx"
+BOOK="$(basename "$OUT")"
+
+skip() {
+  echo "SKIP: $1"
+  exit 0
+}
+
+command -v bun >/dev/null 2>&1 || skip "bun unavailable"
+command -v osascript >/dev/null 2>&1 || skip "not macOS (no osascript)"
+[ -d "/Applications/Microsoft Excel.app" ] || skip "Microsoft Excel is not installed"
+
+fail() {
+  echo "FAIL: $1" >&2
+  osascript -e "tell application \"Microsoft Excel\" to close workbook \"$BOOK\" saving no" >/dev/null 2>&1
+  exit 1
+}
+
+echo "==> generating $OUT"
+bun "$PLUGIN_ROOT/engine/cli.ts" generate "$DEAL" --out "$OUT" >/dev/null || fail "generate exited non-zero"
+
+# What the engine says, by its own arithmetic.
+score_json="$(bun "$PLUGIN_ROOT/engine/cli.ts" score "$DEAL")" || fail "score exited non-zero"
+want_sum="$(jq -r '.sum' <<<"$score_json")"
+want_rating="$(jq -r '.overallRating' <<<"$score_json")"
+want_pct="$(jq -r '.overallScore' <<<"$score_json")"
+
+echo "==> opening in Excel"
+open -a "Microsoft Excel" "$OUT" || fail "could not open Excel"
+
+# A repair prompt leaves the workbook absent from the application's list, so its presence is
+# the "opened cleanly" assertion — there is no separate dialog to interrogate.
+for _ in $(seq 1 30); do
+  if osascript -e 'tell application "Microsoft Excel" to get name of every workbook' 2>/dev/null | grep -qF "$BOOK"; then
+    opened=1
+    break
+  fi
+  sleep 2
+done
+[ "${opened:-0}" = "1" ] || fail "Excel never listed $BOOK — it most likely offered to repair the file"
+echo "    opened with no repair prompt"
+
+read_cell() {
+  osascript -e "tell application \"Microsoft Excel\" to get value of cell \"$2\" of worksheet \"$1\" of workbook \"$BOOK\"" 2>/dev/null
+}
+
+# Find the Scorecard rows by their labels rather than hard-coded addresses: the layout comes
+# from the spec, so pinning row numbers here would make this fail on a harmless reorder.
+find_value() {
+  osascript <<OSA 2>/dev/null
+tell application "Microsoft Excel"
+  repeat with r from 1 to 60
+    set a to (get value of cell ("A" & r) of worksheet "Scorecard" of workbook "$BOOK")
+    if (a as string) is "$1" then
+      return (get value of cell ("B" & r) of worksheet "Scorecard" of workbook "$BOOK") as string
+    end if
+  end repeat
+  return "NOT-FOUND"
+end tell
+OSA
+}
+
+got_sum="$(find_value 'Total score')"
+got_rating="$(find_value 'Rating')"
+got_pct_raw="$(find_value 'Overall score')"
+
+echo "    Total score: Excel=$got_sum engine=$want_sum"
+[ "${got_sum%.*}" = "$want_sum" ] || fail "Excel computed $got_sum, engine says $want_sum"
+
+echo "    Rating: Excel=$got_rating engine=$want_rating"
+[ "$got_rating" = "$want_rating" ] || fail "Excel rated $got_rating, engine says $want_rating"
+
+# Excel holds the fraction; the engine reports a percentage to one decimal.
+got_pct="$(awk -v v="$got_pct_raw" 'BEGIN { printf "%.1f", v * 100 }')"
+echo "    Overall score: Excel=$got_pct% engine=$want_pct%"
+[ "$got_pct" = "$want_pct" ] || fail "Excel computed $got_pct%, engine says $want_pct%"
+
+# A formula pointing at the wrong range is well-formed and wrong; an error value is at least
+# loud. Check for the loud ones across every sheet.
+errors="$(
+  osascript <<OSA 2>/dev/null
+tell application "Microsoft Excel"
+  set errs to ""
+  repeat with ws in every worksheet of workbook "$BOOK"
+    try
+      set vals to (get value of (get used range of ws))
+      repeat with rw in vals
+        repeat with v in rw
+          set s to (v as string)
+          if s is in {"#REF!", "#VALUE!", "#DIV/0!", "#N/A", "#NAME?", "#NULL!", "#NUM!"} then
+            set errs to errs & (get name of ws) & ":" & s & " "
+          end if
+        end repeat
+      end repeat
+    end try
+  end repeat
+  return errs
+end tell
+OSA
+)"
+[ -z "${errors// /}" ] || fail "Excel error values present: $errors"
+echo "    no Excel error values on any sheet"
+
+osascript -e "tell application \"Microsoft Excel\" to close workbook \"$BOOK\" saving no" >/dev/null 2>&1
+rm -rf "$(dirname "$OUT")"
+echo "PASS: Excel opened the generated workbook and its Scorecard agrees with the engine"


### PR DESCRIPTION
## What

Stage 1c of the modern-workbook plan: **the generator**. `engine/generate.ts` turns the spec
plus a deal into a real `.xlsx`.

```
bun engine/cli.ts generate deal.json --out deal.xlsx
bun engine/cli.ts generate deal.json --plan     # where every input cell landed
```

Two passes, because a formula's text depends on where other cells ended up: pass one assigns
addresses, pass two substitutes `{{ref:…}}`, `{{col:…}}`, `{{row:…}}` and `{{this:…}}`.
Nothing in the spec names a coordinate, so adding a field cannot quietly break a formula on
another sheet.

`planWorkbook` also returns **`inputCells`** — every cell holding a human's value with the
`jsonPath` it came from. That is what stage 3 reads to pull edits back out, so defining it now
is what stops the two directions drifting.

## Verified against real Excel, not against our own writer

`scripts/uat-generate-excel.sh` generates, opens the file, reads the Scorecard back, and
compares it with what `engine score` computes by a completely different route.

```
opened with no repair prompt
Total score:   Excel=21   engine=21
Rating:        Excel=Yellow  engine=Yellow
Overall score: Excel=65.6%   engine=65.6%
no Excel error values on any sheet
```

Agreement between two independent computations is the evidence; either alone proves much less.

**Mutation-checked, because a check that cannot fail is decoration.** Pointing `scoreTotal` at
the neighbouring column leaves `check-spec` green and the workbook perfectly valid — and the
UAT catches it (Excel 14, engine 21).

## Three review findings, all confirmed

Codex returned three. Every one was real, and the first was serious.

**1 — a partly-qualified deal displayed as 100%.** `COUNT` ignores blanks, so writing an
unscored element as an empty cell shrank the denominator with the data. Reproduced in Excel:
one element at 4 and seven unscored showed **Total 4 / Maximum 4 / Overall 100% / Rating
Red** — wrong, and self-contradictory. The engine said 12.5%.

Fixed at both ends: a score cell writes 0 when absent (which is what `computeScore` already
assumes), and the maximum counts the derived, always-populated element column. Re-verified in
Excel: **4 / 32 / 12.5% / Red**. The UAT now checks a partly-qualified deal every run.

**2 — `generate` validated nothing.** A mistyped `jsonPath` became an empty cell, which reads
as "nobody filled that in yet" rather than "the spec is broken". It now runs
`checkWorkbookSpec` and `validateDeal` first and refuses, writing nothing. Verified that a bad
spec, a bad `jsonPath` and a wrongly-typed deal each exit 1, while the shipped deal *and* a
mid-qualification partial deal still pass — a check that blocked normal use would be worse
than none.

**3 — impossible dates rolled forward.** `2026-02-31` and `2026-03-03` both returned serial
46084, so a typo became a close date three days late. `2026-13-01` was accepted, and the
unanchored pattern took `2026-06-30XYZ`. Now anchored and round-tripped.

## Verification

| check | result |
| --- | --- |
| `bun test engine/` | 150 pass, 0 fail |
| `scripts/tests/run-tests.sh` | 30 passed, 1 skipped (Excel UAT, on request), 0 failed |
| `scripts/uat-generate-excel.sh` | PASS on the example deal **and** a partly-qualified one |
| `run-plugin-tests.sh` / `check-tests-are-hermetic.sh` | exit 0 |
| Biome, shellcheck, shfmt | exit 0 |
| byte-determinism | same deal twice, identical bytes |

## Scope

Out of scope, still ahead: Excel Tables, conditional formatting and data validation (stage 2);
reading a workbook back (stage 3). `fill` and the legacy cell mapping stay untouched until the
stage that replaces them, so there is never a moment with two competing formats or none.

One note on the Excel UAT: it runs behind `MEDDPICC_EXCEL_UAT=1` rather than on every suite
run, because opening Excel takes over the foreground of whoever is running the tests.

Closes #884
