### PR TITLE
MEDDPICC: Excel Tables, conditional formatting and schema-derived dropdowns (stage 2)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ and this project adheres to
   a path the generator can read constraints from. Two walkers would eventually disagree about
   `$ref` or `allOf`, silently.
 
+  Two defects the review found, both reproduced in Excel before being fixed. **A keyed
+  reference broke under sorting**: `asTable` hands the user a sort button, and
+  `{{row:elements.score@champion}}` had resolved to `Qualification!C8` — champion's row only
+  until someone sorted by score. Measured: after moving that row, the Scorecard went on
+  reporting 3.0 (economicBuyer's score) under the Champion label. Keyed references are now
+  `INDEX(range,MATCH("champion",keyRange,0))`, a table must declare its `keyColumn`, and
+  `check-spec` refuses a `{{row:…}}` into a table that has not. **The Completion column was
+  two-thirds uncoloured**: `computeCompletion` emits `not_started`/`partial`/`complete` while
+  the `statusText` preset matches the closePlan enum `pending`/`in_progress`/`complete` — one
+  shared word, two vocabularies. Added a `completionText` preset for the one it actually uses.
+
   No Reference sheet: inline validation lists made it redundant, and the 0-4 rubric text
   already sits on the Qualification row it describes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v2.6.0 — the workbook is now a working spreadsheet, not just a rendered one.
+
+  **Excel Tables** over all eight collections, so they filter, sort, stripe, and extend when
+  someone types below the last row. This is what stops a collection being capped: the legacy
+  sheet formatted eight team rows and dropped the rest.
+
+  **Conditional formatting** from a curated set of named presets — `score` (0-1 red, 2 amber,
+  3-4 green), `ragText`, `statusText` and `overdueDate`. `ragText` colours the rating *word*
+  rather than re-deriving the engine's brackets from a percentage, so the colours cannot drift
+  from `computeScore` by a rounding step.
+
+  **Dropdowns read from the schema, never authored.** A column says `"validate": true` and the
+  values come from that path's `enum` — or, for a bounded integer like a 0-4 score, from its
+  `minimum`/`maximum`. Add a `roleInDeal` member to the schema and the dropdown gains it; there
+  is no second list to remember. `check-spec` rejects `validate: true` on a path the schema
+  does not constrain, since a dropdown offering nothing looks deliberate and is worse than
+  none.
+
+  Verified by asking Excel what it made of the file, not just whether it opened: 1 Table on
+  Stakeholders, 3 conditional-format rules on the score column, and the role dropdown compared
+  against the schema enum rather than a literal. Mutation-checked both ways — dropping
+  `asTable` makes Excel report 0 tables, and hardcoding a dropdown list makes it disagree with
+  the schema.
+
+  `schemaConstraint` shares one walker with `resolveSchemaPath`, so a path the guard accepts is
+  a path the generator can read constraints from. Two walkers would eventually disagree about
+  `$ref` or `allOf`, silently.
+
+  No Reference sheet: inline validation lists made it redundant, and the 0-4 rubric text
+  already sits on the Qualification row it describes.
+
+
 - **`meddpicc`** v2.5.0 — the workbook generator. `engine/generate.ts` turns the spec plus a
   deal into a real `.xlsx`: `generate <deal.json> --out <file>`, or `--plan` to print where
   every input cell landed without writing anything.

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { computeCompletion } from './completion';
 import { dateToSerial, generateWorkbook, planWorkbook } from './generate';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
 import type { WorkbookSpec } from './workbook-spec';
+import { COMPLETION_STATUSES } from './xlsx';
 import { readZip } from './zip';
 
 const here = import.meta.dir;
@@ -193,10 +195,10 @@ describe('planWorkbook — formula references resolve to addresses', () => {
     expect(cell?.formula).toBe('SUM(Qualification!C2:C9)');
   });
 
-  test('a keyed row reference points at that key own row', () => {
+  test('a keyed row reference looks the key up in the table', () => {
+    // Not the key's row ADDRESS: see "a keyed reference survives the user sorting the table".
     const cell = cellAt('Scorecard', plan.namedCells.championScore.split('!')[1] ?? '');
-    const championRow = QUALIFICATION_ELEMENTS.indexOf('champion') + 2;
-    expect(cell?.formula).toBe(`Qualification!C${championRow}`);
+    expect(cell?.formula).toBe('INDEX(Qualification!C2:C9,MATCH("champion",Qualification!A2:A9,0))');
   });
 
   test('a same-sheet reference is not sheet-qualified, a cross-sheet one is', () => {
@@ -311,5 +313,42 @@ describe('dateToSerial rejects what is not a date', () => {
 
   test('still accepts the date-time form the schema uses for lastSyncDate', () => {
     expect(dateToSerial('2026-05-05T14:30:00Z')).toBe(dateToSerial('2026-05-05'));
+  });
+});
+
+describe('a keyed reference survives the user sorting the table', () => {
+  // Putting a Table on Qualification hands the user a sort button. A formula written as
+  // `Qualification!C8` means "champion" only while the rows are in their original order —
+  // after a sort by score it silently reports a different element under the Champion label.
+  // So a keyed reference has to look the key up, not remember where it was.
+  test('resolves through MATCH on the key column rather than a fixed row', () => {
+    const champion = cellAt('Scorecard', plan.namedCells.championScore.split('!')[1] ?? '')?.formula ?? '';
+    expect(champion).toContain('MATCH("champion"');
+    expect(champion).toMatch(/^INDEX\(Qualification!C\$?2:C\$?9,MATCH\("champion",Qualification!A\$?2:A\$?9,0\)\)$/);
+  });
+
+  test('the economic buyer reference is looked up the same way', () => {
+    const eb = cellAt('Scorecard', plan.namedCells.economicBuyerScore.split('!')[1] ?? '')?.formula ?? '';
+    expect(eb).toContain('MATCH("economicBuyer"');
+    expect(eb).not.toMatch(/Qualification!C\d+$/);
+  });
+});
+
+describe('the Completion sheet is coloured with its own vocabulary', () => {
+  // computeCompletion emits not_started / partial / complete. The closePlan status enum is
+  // pending / in_progress / complete. One preset cannot serve both, and pointing the
+  // Completion column at the closePlan preset left two of its three states uncoloured.
+  test('uses a preset that matches the statuses it actually writes', () => {
+    const completion = spec.sheets.find((s) => s.name === 'Completion');
+    if (completion?.kind !== 'table') throw new Error('Completion must be a table sheet');
+    const status = completion.tables[0].columns.find((c) => c.id === 'status');
+    expect(status?.conditionalFormat).toBe('completionText');
+  });
+
+  test('every status the engine can emit is one the preset colours', () => {
+    const emitted = new Set(Object.values(computeCompletion(deal).completionStatus));
+    for (const status of emitted) {
+      expect(COMPLETION_STATUSES).toContain(status);
+    }
   });
 });

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -271,7 +271,18 @@ function resolveFormula(
       if (ref.kind === 'row') {
         const index = found.rowKeys?.indexOf(rowKey ?? '') ?? -1;
         if (index < 0) throw new Error(`${ctx.sheet}: ${ref.raw} names no row`);
-        replacement = `${prefix}${A1(col, found.firstDataRow + index)}`;
+        // INDEX/MATCH rather than the row's address. `asTable` gives the user a sort button,
+        // and after a sort `Qualification!C8` is a different element than it was — the
+        // Scorecard would go on reporting it under the Champion label.
+        const keyColumnId = found.table.keyColumn;
+        const keyCol = keyColumnId ? found.columns.get(keyColumnId) : undefined;
+        if (!keyCol) {
+          throw new Error(`${ctx.sheet}: ${ref.raw} needs table "${found.table.id}" to declare a valid keyColumn`);
+        }
+        const last = found.firstDataRow + Math.max(found.rowCount, 1) - 1;
+        const valueRange = `${prefix}${A1(col, found.firstDataRow)}:${A1(col, last)}`;
+        const keyRange = `${prefix}${A1(keyCol, found.firstDataRow)}:${A1(keyCol, last)}`;
+        replacement = `INDEX(${valueRange},MATCH("${rowKey}",${keyRange},0))`;
       } else {
         // An empty table still needs a syntactically valid range, so span at least one row.
         const last = found.firstDataRow + Math.max(found.rowCount, 1) - 1;

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -13,6 +13,7 @@
  */
 import { computeCompletion } from './completion';
 import { computeElementHint } from './hint';
+import { schemaConstraint } from './schema-path';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
 import {
   parseReferences,
@@ -24,7 +25,16 @@ import {
   type ValueType,
   type WorkbookSpec,
 } from './workbook-spec';
-import { A1, buildWorkbook, type CellSpec, type RowSpec, type SheetSpec } from './xlsx';
+import {
+  A1,
+  buildWorkbook,
+  type CellSpec,
+  type ConditionalFormat,
+  type RowSpec,
+  type SheetSpec,
+  type TablePart,
+  type Validation,
+} from './xlsx';
 
 /** Excel's 1900 date system counts from 1899-12-30, and that offset is the whole trick. */
 const EXCEL_EPOCH_UTC = Date.UTC(1899, 11, 30);
@@ -130,6 +140,22 @@ export interface WorkbookPlan {
   /** Named form cells -> `Sheet!Address`. */
   namedCells: Record<string, string>;
   inputCells: InputCell[];
+}
+
+/**
+ * The values a dropdown offers, read from the schema.
+ *
+ * An enum lists them directly. A bounded integer — which is what a 0-4 score is — enumerates
+ * its range instead, so the score column gets 0,1,2,3,4 without anyone typing that anywhere.
+ */
+function validationValues(schema: unknown, jsonPath: string): string[] | undefined {
+  const constraint = schemaConstraint(schema, jsonPath);
+  if (!constraint) return undefined;
+  if (constraint.enum) return constraint.enum;
+  const { minimum, maximum } = constraint;
+  if (minimum === undefined || maximum === undefined) return undefined;
+  if (!Number.isInteger(minimum) || !Number.isInteger(maximum) || maximum - minimum > 20) return undefined;
+  return Array.from({ length: maximum - minimum + 1 }, (_, i) => String(minimum + i));
 }
 
 /** Rows for a table, resolved against the deal. */
@@ -335,7 +361,26 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
 
         if (cells.length > 0) rows.push({ row, cells, height: 'height' in block ? block.height : undefined });
       }
-      sheets.push({ name: s.name, rows, columns: s.columns, freezeAtRow: 1 });
+      const formFormats: ConditionalFormat[] = [];
+      const formValidations: Validation[] = [];
+      for (const { block, row } of formRows.get(s.name) ?? []) {
+        if (block.kind !== 'field' && block.kind !== 'computed') continue;
+        const ref = A1(2, row);
+        if (block.conditionalFormat) formFormats.push({ sqref: ref, preset: block.conditionalFormat });
+        if (block.kind === 'field' && block.validate) {
+          const values = validationValues(schema, block.jsonPath);
+          if (values) formValidations.push({ sqref: ref, values });
+        }
+      }
+
+      sheets.push({
+        name: s.name,
+        rows,
+        columns: s.columns,
+        freezeAtRow: 1,
+        conditionalFormats: formFormats.length ? formFormats : undefined,
+        validations: formValidations.length ? formValidations : undefined,
+      });
       continue;
     }
 
@@ -391,11 +436,47 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
     const columns = s.tables.flatMap((t) =>
       t.columns.map((c, i) => ({ min: t.anchorColumn + i, max: t.anchorColumn + i, width: c.width ?? 18 })),
     );
+
+    const tableParts: TablePart[] = [];
+    const tableFormats: ConditionalFormat[] = [];
+    const tableValidations: Validation[] = [];
+
+    for (const table of s.tables) {
+      const info = tables.get(table.id);
+      if (!info) continue;
+      // An Excel Table needs at least one data row in its range, so a collection that is
+      // empty and has no minRows still gets one — a header-only table is rejected outright.
+      const lastRow = info.firstDataRow + Math.max(info.rowCount, 1) - 1;
+
+      if (table.asTable) {
+        tableParts.push({
+          name: table.id,
+          displayName: table.id,
+          ref: `${A1(table.anchorColumn, table.headerRow)}:${A1(table.anchorColumn + table.columns.length - 1, lastRow)}`,
+          columns: table.columns.map((c) => c.header),
+        });
+      }
+
+      table.columns.forEach((column, i) => {
+        const col = table.anchorColumn + i;
+        const sqref = `${A1(col, info.firstDataRow)}:${A1(col, lastRow)}`;
+        if (column.conditionalFormat) tableFormats.push({ sqref, preset: column.conditionalFormat });
+        if (column.role === 'input' && column.validate && column.jsonPath) {
+          // Any row's path resolves to the same schema node, so the first one answers for all.
+          const values = validationValues(schema, inputPathFor(table, column, info.items[0] ?? {}));
+          if (values) tableValidations.push({ sqref, values });
+        }
+      });
+    }
+
     sheets.push({
       name: s.name,
       rows: [...byRow.entries()].sort(([a], [b]) => a - b).map(([row, cells]) => ({ row, cells })),
       columns,
       freezeAtRow: 1,
+      tables: tableParts.length ? tableParts : undefined,
+      conditionalFormats: tableFormats.length ? tableFormats : undefined,
+      validations: tableValidations.length ? tableValidations : undefined,
     });
   }
 

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/schema-path.test.ts
+++ b/plugins/meddpicc/engine/schema-path.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import * as path from 'node:path';
-import { resolveSchemaPath } from './schema-path';
+import { resolveSchemaPath, schemaConstraint } from './schema-path';
 
 const schema = JSON.parse(await Bun.file(path.join(import.meta.dir, '..', 'schema', 'meddpicc-schema.json')).text());
 
@@ -23,5 +23,58 @@ describe('resolveSchemaPath', () => {
   });
   test('returns false for an empty path', () => {
     expect(resolveSchemaPath(schema, '')).toBe(false);
+  });
+});
+
+describe('schemaConstraint', () => {
+  const schema = JSON.parse(
+    require('node:fs').readFileSync(`${import.meta.dir}/../schema/meddpicc-schema.json`, 'utf8'),
+  );
+
+  test('reads an enum off a scalar property', () => {
+    expect(schemaConstraint(schema, 'metadata.dealStatus')?.enum).toEqual([
+      'Discovery',
+      'Validated',
+      'Qualified',
+      'Proposal',
+    ]);
+  });
+
+  test('reads an enum through an array item', () => {
+    expect(schemaConstraint(schema, 'stakeholders.roleInDeal')?.enum).toEqual([
+      'Economic buyer',
+      'Decision maker',
+      'Influencer',
+    ]);
+    expect(schemaConstraint(schema, 'closePlan.criticalActions.status')?.enum).toEqual([
+      'pending',
+      'in_progress',
+      'complete',
+    ]);
+  });
+
+  test('reads numeric bounds, which is what a 0-4 score needs', () => {
+    const score = schemaConstraint(schema, 'qualification.metrics.score');
+    expect(score?.minimum).toBe(0);
+    expect(score?.maximum).toBe(4);
+    expect(score?.type).toBe('integer');
+  });
+
+  test('reads an enum reached through a $ref', () => {
+    // completionStatus.* is a $ref to #/$defs/sectionStatus.
+    expect(schemaConstraint(schema, 'metadata.completionStatus.metrics')?.enum).toEqual([
+      'not_started',
+      'partial',
+      'complete',
+    ]);
+  });
+
+  test('returns undefined for a path that does not resolve', () => {
+    expect(schemaConstraint(schema, 'metadata.nope')).toBeUndefined();
+  });
+
+  test('returns a node with no enum rather than inventing one', () => {
+    expect(schemaConstraint(schema, 'metadata.accountName')?.enum).toBeUndefined();
+    expect(schemaConstraint(schema, 'metadata.accountName')?.type).toBe('string');
   });
 });

--- a/plugins/meddpicc/engine/schema-path.ts
+++ b/plugins/meddpicc/engine/schema-path.ts
@@ -64,14 +64,21 @@ function normalize(node: unknown, root: Schema): Schema | undefined {
   return flatten(d, root);
 }
 
-export function resolveSchemaPath(rootSchema: unknown, dottedPath: string): boolean {
-  if (dottedPath === '') return false;
-  if (!rootSchema || typeof rootSchema !== 'object') return false;
+/**
+ * Walk to the schema node a dotted path names, or undefined when it does not resolve.
+ *
+ * `resolveSchemaPath` is this with the node thrown away. Keeping one walker means a path that
+ * the guard accepts is a path the generator can read constraints from — two walkers would
+ * eventually disagree about `$ref` or `allOf` and the disagreement would be silent.
+ */
+export function findSchemaNode(rootSchema: unknown, dottedPath: string): Schema | undefined {
+  if (dottedPath === '') return undefined;
+  if (!rootSchema || typeof rootSchema !== 'object') return undefined;
   const root = rootSchema as Schema;
   let node: Schema | undefined = normalize(root, root);
 
   for (const tok of tokenize(dottedPath)) {
-    if (!node) return false;
+    if (!node) return undefined;
 
     if (tok.startsWith('[')) {
       node = node.items ? normalize(node.items, root) : undefined;
@@ -81,13 +88,43 @@ export function resolveSchemaPath(rootSchema: unknown, dottedPath: string): bool
     // Auto-descend an array when the next token is a property name (column-style path).
     if (node.type === 'array' || node.items) {
       node = node.items ? normalize(node.items, root) : undefined;
-      if (!node) return false;
+      if (!node) return undefined;
     }
 
     const props = (node.properties as Record<string, unknown>) ?? {};
-    if (!(tok in props)) return false;
+    if (!(tok in props)) return undefined;
     node = normalize(props[tok], root);
   }
 
-  return node !== undefined;
+  return node;
+}
+
+export function resolveSchemaPath(rootSchema: unknown, dottedPath: string): boolean {
+  return findSchemaNode(rootSchema, dottedPath) !== undefined;
+}
+
+export interface SchemaConstraint {
+  type?: string;
+  enum?: string[];
+  minimum?: number;
+  maximum?: number;
+}
+
+/**
+ * The constraints the schema puts on a path: its type, its allowed values, its bounds.
+ *
+ * This is what makes a dropdown impossible to drift. The workbook's validation lists are not
+ * authored anywhere — they are read from the same `enum` the validator enforces, so adding a
+ * deal status in the schema adds it to the dropdown and nothing has to remember to.
+ */
+export function schemaConstraint(rootSchema: unknown, dottedPath: string): SchemaConstraint | undefined {
+  const node = findSchemaNode(rootSchema, dottedPath);
+  if (!node) return undefined;
+  const values = Array.isArray(node.enum) ? node.enum.filter((v): v is string => typeof v === 'string') : undefined;
+  return {
+    type: typeof node.type === 'string' ? node.type : undefined,
+    enum: values && values.length > 0 ? values : undefined,
+    minimum: typeof node.minimum === 'number' ? node.minimum : undefined,
+    maximum: typeof node.maximum === 'number' ? node.maximum : undefined,
+  };
 }

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -4,12 +4,37 @@
     {
       "name": "Deal",
       "kind": "form",
-      "columns": [{ "min": 1, "max": 1, "width": 34 }, { "min": 2, "max": 2, "width": 78 }],
+      "columns": [
+        {
+          "min": 1,
+          "max": 1,
+          "width": 34
+        },
+        {
+          "min": 2,
+          "max": 2,
+          "width": 78
+        }
+      ],
       "blocks": [
-        { "kind": "title", "text": "MEDDPICC Deal Review" },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Deal" },
-        { "kind": "field", "id": "dealId", "label": "Deal ID", "jsonPath": "metadata.dealId", "valueType": "string" },
+        {
+          "kind": "title",
+          "text": "MEDDPICC Deal Review"
+        },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Deal"
+        },
+        {
+          "kind": "field",
+          "id": "dealId",
+          "label": "Deal ID",
+          "jsonPath": "metadata.dealId",
+          "valueType": "string"
+        },
         {
           "kind": "field",
           "id": "accountName",
@@ -36,14 +61,16 @@
           "id": "dealStatus",
           "label": "Deal status",
           "jsonPath": "metadata.dealStatus",
-          "valueType": "string"
+          "valueType": "string",
+          "validate": true
         },
         {
           "kind": "field",
           "id": "forecastStage",
           "label": "Forecast stage",
           "jsonPath": "metadata.forecastStage",
-          "valueType": "string"
+          "valueType": "string",
+          "validate": true
         },
         {
           "kind": "field",
@@ -80,8 +107,13 @@
           "jsonPath": "metadata.reviewDate",
           "valueType": "date"
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Revenue" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Revenue"
+        },
         {
           "kind": "field",
           "id": "revenuePandI",
@@ -131,33 +163,38 @@
           "formula": "IF({{ref:closeDate}}=\"\",\"\",{{ref:closeDate}}-TODAY())",
           "valueType": "number"
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Client interaction" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Client interaction"
+        },
         {
           "kind": "field",
           "id": "lastInteractionDate",
-          "label": "Last interaction — date",
+          "label": "Last interaction \u2014 date",
           "jsonPath": "metadata.lastClientInteraction.date",
           "valueType": "date"
         },
         {
           "kind": "field",
           "id": "lastInteractionOutcome",
-          "label": "Last interaction — outcome",
+          "label": "Last interaction \u2014 outcome",
           "jsonPath": "metadata.lastClientInteraction.outcome",
           "valueType": "text"
         },
         {
           "kind": "field",
           "id": "nextInteractionDate",
-          "label": "Next interaction — date",
+          "label": "Next interaction \u2014 date",
           "jsonPath": "metadata.nextClientInteraction.date",
           "valueType": "date"
         },
         {
           "kind": "field",
           "id": "nextInteractionObjective",
-          "label": "Next interaction — objective",
+          "label": "Next interaction \u2014 objective",
           "jsonPath": "metadata.nextClientInteraction.objective",
           "valueType": "text"
         },
@@ -168,8 +205,13 @@
           "formula": "IF({{ref:lastInteractionDate}}=\"\",\"\",TODAY()-{{ref:lastInteractionDate}})",
           "valueType": "number"
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Three Whys — F5" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Three Whys \u2014 F5"
+        },
         {
           "kind": "field",
           "id": "whyAnything",
@@ -194,8 +236,13 @@
           "valueType": "text",
           "height": 44
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Three Whys — Partner" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Three Whys \u2014 Partner"
+        },
         {
           "kind": "field",
           "id": "partnerName",
@@ -227,8 +274,13 @@
           "valueType": "text",
           "height": 44
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Sales strategy" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Sales strategy"
+        },
         {
           "kind": "field",
           "id": "differentiatedValueProposition",
@@ -245,8 +297,13 @@
           "valueType": "text",
           "height": 60
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Salesforce" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Salesforce"
+        },
         {
           "kind": "field",
           "id": "salesforceOpportunityId",
@@ -290,19 +347,35 @@
       "tables": [
         {
           "id": "elements",
-          "source": { "kind": "elements" },
+          "source": {
+            "kind": "elements"
+          },
           "anchorColumn": 1,
           "headerRow": 1,
           "columns": [
-            { "id": "element", "header": "Element", "role": "derived", "valueType": "string", "width": 20 },
-            { "id": "definition", "header": "Definition", "role": "derived", "valueType": "text", "width": 56 },
+            {
+              "id": "element",
+              "header": "Element",
+              "role": "derived",
+              "valueType": "string",
+              "width": 20
+            },
+            {
+              "id": "definition",
+              "header": "Definition",
+              "role": "derived",
+              "valueType": "text",
+              "width": 56
+            },
             {
               "id": "score",
               "header": "Score (0-4)",
               "role": "input",
               "jsonPath": "qualification.*.score",
               "valueType": "score",
-              "width": 12
+              "width": 12,
+              "conditionalFormat": "score",
+              "validate": true
             },
             {
               "id": "previousScore",
@@ -310,7 +383,9 @@
               "role": "input",
               "jsonPath": "scoring.previousElementScores.*",
               "valueType": "score",
-              "width": 11
+              "width": 11,
+              "conditionalFormat": "score",
+              "validate": true
             },
             {
               "id": "change",
@@ -320,7 +395,13 @@
               "valueType": "number",
               "width": 10
             },
-            { "id": "rubric", "header": "What this score means", "role": "derived", "valueType": "text", "width": 56 },
+            {
+              "id": "rubric",
+              "header": "What this score means",
+              "role": "derived",
+              "valueType": "text",
+              "width": 56
+            },
             {
               "id": "evidence",
               "header": "Evidence",
@@ -337,7 +418,8 @@
               "valueType": "text",
               "width": 52
             }
-          ]
+          ],
+          "asTable": true
         }
       ]
     },
@@ -347,13 +429,33 @@
       "tables": [
         {
           "id": "responses",
-          "source": { "kind": "elementResponses" },
+          "source": {
+            "kind": "elementResponses"
+          },
           "anchorColumn": 1,
           "headerRow": 1,
           "columns": [
-            { "id": "element", "header": "Element", "role": "derived", "valueType": "string", "width": 20 },
-            { "id": "position", "header": "#", "role": "derived", "valueType": "integer", "width": 6 },
-            { "id": "question", "header": "Question", "role": "derived", "valueType": "text", "width": 62 },
+            {
+              "id": "element",
+              "header": "Element",
+              "role": "derived",
+              "valueType": "string",
+              "width": 20
+            },
+            {
+              "id": "position",
+              "header": "#",
+              "role": "derived",
+              "valueType": "integer",
+              "width": 6
+            },
+            {
+              "id": "question",
+              "header": "Question",
+              "role": "derived",
+              "valueType": "text",
+              "width": 62
+            },
             {
               "id": "response",
               "header": "Response",
@@ -362,7 +464,8 @@
               "valueType": "text",
               "width": 84
             }
-          ]
+          ],
+          "asTable": true
         }
       ]
     },
@@ -372,12 +475,22 @@
       "tables": [
         {
           "id": "stakeholders",
-          "source": { "kind": "list", "jsonPath": "stakeholders" },
+          "source": {
+            "kind": "list",
+            "jsonPath": "stakeholders"
+          },
           "anchorColumn": 1,
           "headerRow": 1,
           "minRows": 12,
           "columns": [
-            { "id": "name", "header": "Name", "role": "input", "jsonPath": "name", "valueType": "string", "width": 24 },
+            {
+              "id": "name",
+              "header": "Name",
+              "role": "input",
+              "jsonPath": "name",
+              "valueType": "string",
+              "width": 24
+            },
             {
               "id": "title",
               "header": "Title",
@@ -392,7 +505,8 @@
               "role": "input",
               "jsonPath": "roleInDeal",
               "valueType": "string",
-              "width": 18
+              "width": 18,
+              "validate": true
             },
             {
               "id": "mustSayYes",
@@ -424,7 +538,8 @@
               "role": "input",
               "jsonPath": "viewOfF5",
               "valueType": "string",
-              "width": 14
+              "width": 14,
+              "validate": true
             },
             {
               "id": "f5Owner",
@@ -434,7 +549,8 @@
               "valueType": "string",
               "width": 22
             }
-          ]
+          ],
+          "asTable": true
         }
       ]
     },
@@ -444,7 +560,10 @@
       "tables": [
         {
           "id": "milestones",
-          "source": { "kind": "list", "jsonPath": "closePlan.milestones" },
+          "source": {
+            "kind": "list",
+            "jsonPath": "closePlan.milestones"
+          },
           "anchorColumn": 1,
           "headerRow": 1,
           "minRows": 10,
@@ -463,7 +582,8 @@
               "role": "input",
               "jsonPath": "targetDate",
               "valueType": "date",
-              "width": 14
+              "width": 14,
+              "conditionalFormat": "overdueDate"
             },
             {
               "id": "status",
@@ -471,13 +591,19 @@
               "role": "input",
               "jsonPath": "status",
               "valueType": "string",
-              "width": 14
+              "width": 14,
+              "conditionalFormat": "statusText",
+              "validate": true
             }
-          ]
+          ],
+          "asTable": true
         },
         {
           "id": "actions",
-          "source": { "kind": "list", "jsonPath": "closePlan.criticalActions" },
+          "source": {
+            "kind": "list",
+            "jsonPath": "closePlan.criticalActions"
+          },
           "anchorColumn": 5,
           "headerRow": 1,
           "minRows": 12,
@@ -504,7 +630,8 @@
               "role": "input",
               "jsonPath": "dueDate",
               "valueType": "date",
-              "width": 14
+              "width": 14,
+              "conditionalFormat": "overdueDate"
             },
             {
               "id": "status",
@@ -512,9 +639,12 @@
               "role": "input",
               "jsonPath": "status",
               "valueType": "string",
-              "width": 14
+              "width": 14,
+              "conditionalFormat": "statusText",
+              "validate": true
             }
-          ]
+          ],
+          "asTable": true
         }
       ]
     },
@@ -524,13 +654,30 @@
       "tables": [
         {
           "id": "teamF5",
-          "source": { "kind": "list", "jsonPath": "team.f5" },
+          "source": {
+            "kind": "list",
+            "jsonPath": "team.f5"
+          },
           "anchorColumn": 1,
           "headerRow": 1,
           "minRows": 16,
           "columns": [
-            { "id": "name", "header": "Name", "role": "input", "jsonPath": "name", "valueType": "string", "width": 26 },
-            { "id": "role", "header": "Role", "role": "input", "jsonPath": "role", "valueType": "string", "width": 34 },
+            {
+              "id": "name",
+              "header": "Name",
+              "role": "input",
+              "jsonPath": "name",
+              "valueType": "string",
+              "width": 26
+            },
+            {
+              "id": "role",
+              "header": "Role",
+              "role": "input",
+              "jsonPath": "role",
+              "valueType": "string",
+              "width": 34
+            },
             {
               "id": "dateRequiredFrom",
               "header": "Required from",
@@ -547,17 +694,35 @@
               "valueType": "boolean",
               "width": 11
             }
-          ]
+          ],
+          "asTable": true
         },
         {
           "id": "teamPartner",
-          "source": { "kind": "list", "jsonPath": "team.partner" },
+          "source": {
+            "kind": "list",
+            "jsonPath": "team.partner"
+          },
           "anchorColumn": 6,
           "headerRow": 1,
           "minRows": 10,
           "columns": [
-            { "id": "name", "header": "Name", "role": "input", "jsonPath": "name", "valueType": "string", "width": 26 },
-            { "id": "role", "header": "Role", "role": "input", "jsonPath": "role", "valueType": "string", "width": 34 },
+            {
+              "id": "name",
+              "header": "Name",
+              "role": "input",
+              "jsonPath": "name",
+              "valueType": "string",
+              "width": 26
+            },
+            {
+              "id": "role",
+              "header": "Role",
+              "role": "input",
+              "jsonPath": "role",
+              "valueType": "string",
+              "width": 34
+            },
             {
               "id": "dateRequiredFrom",
               "header": "Required from",
@@ -574,7 +739,8 @@
               "valueType": "boolean",
               "width": 11
             }
-          ]
+          ],
+          "asTable": true
         }
       ]
     },
@@ -584,24 +750,59 @@
       "tables": [
         {
           "id": "sections",
-          "source": { "kind": "sections" },
+          "source": {
+            "kind": "sections"
+          },
           "anchorColumn": 1,
           "headerRow": 1,
           "columns": [
-            { "id": "section", "header": "Section", "role": "derived", "valueType": "string", "width": 26 },
-            { "id": "status", "header": "Status", "role": "derived", "valueType": "string", "width": 16 }
-          ]
+            {
+              "id": "section",
+              "header": "Section",
+              "role": "derived",
+              "valueType": "string",
+              "width": 26
+            },
+            {
+              "id": "status",
+              "header": "Status",
+              "role": "derived",
+              "valueType": "string",
+              "width": 16,
+              "conditionalFormat": "statusText"
+            }
+          ],
+          "asTable": true
         }
       ]
     },
     {
       "name": "Scorecard",
       "kind": "form",
-      "columns": [{ "min": 1, "max": 1, "width": 34 }, { "min": 2, "max": 2, "width": 22 }],
+      "columns": [
+        {
+          "min": 1,
+          "max": 1,
+          "width": 34
+        },
+        {
+          "min": 2,
+          "max": 2,
+          "width": 22
+        }
+      ],
       "blocks": [
-        { "kind": "title", "text": "Scorecard" },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Qualification" },
+        {
+          "kind": "title",
+          "text": "Scorecard"
+        },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Qualification"
+        },
         {
           "kind": "computed",
           "id": "scoreTotal",
@@ -628,7 +829,8 @@
           "id": "scoreRating",
           "label": "Rating",
           "formula": "IF({{ref:scoreTotal}}>=26,\"Green\",IF({{ref:scoreTotal}}>=14,\"Yellow\",\"Red\"))",
-          "valueType": "rating"
+          "valueType": "rating",
+          "conditionalFormat": "ragText"
         },
         {
           "kind": "computed",
@@ -644,8 +846,13 @@
           "formula": "{{ref:scoreTotal}}-{{ref:scorePreviousTotal}}",
           "valueType": "number"
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Weakest links" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Weakest links"
+        },
         {
           "kind": "computed",
           "id": "lowestElement",
@@ -681,8 +888,13 @@
           "formula": "{{row:elements.score@champion}}",
           "valueType": "score"
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Completion" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Completion"
+        },
         {
           "kind": "computed",
           "id": "sectionsComplete",
@@ -718,8 +930,13 @@
           "formula": "COUNTA({{col:responses.response}})",
           "valueType": "number"
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Stakeholders" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Stakeholders"
+        },
         {
           "kind": "computed",
           "id": "stakeholdersMapped",
@@ -755,8 +972,13 @@
           "formula": "COUNTIF({{col:stakeholders.viewOfF5}},\"Negative\")",
           "valueType": "number"
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Close plan" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Close plan"
+        },
         {
           "kind": "computed",
           "id": "milestonesTotal",
@@ -785,8 +1007,13 @@
           "formula": "SUMPRODUCT(({{col:actions.dueDate}}<>\"\")*({{col:actions.dueDate}}<TODAY())*({{col:actions.status}}<>\"complete\"))",
           "valueType": "number"
         },
-        { "kind": "spacer" },
-        { "kind": "section", "text": "Team" },
+        {
+          "kind": "spacer"
+        },
+        {
+          "kind": "section",
+          "text": "Team"
+        },
         {
           "kind": "computed",
           "id": "teamF5Count",

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -419,7 +419,8 @@
               "width": 52
             }
           ],
-          "asTable": true
+          "asTable": true,
+          "keyColumn": "element"
         }
       ]
     },
@@ -769,10 +770,11 @@
               "role": "derived",
               "valueType": "string",
               "width": 16,
-              "conditionalFormat": "statusText"
+              "conditionalFormat": "completionText"
             }
           ],
-          "asTable": true
+          "asTable": true,
+          "keyColumn": "section"
         }
       ]
     },

--- a/plugins/meddpicc/engine/workbook-spec.test.ts
+++ b/plugins/meddpicc/engine/workbook-spec.test.ts
@@ -54,6 +54,8 @@ function baseSpec(): WorkbookSpec {
             source: { kind: 'elements' },
             anchorColumn: 1,
             headerRow: 1,
+            // A `{{row:…}}` reference below needs a column to match the key against.
+            keyColumn: 'element',
             columns: [
               { id: 'element', header: 'Element', role: 'derived', valueType: 'string' },
               { id: 'score', header: 'Score', role: 'input', jsonPath: 'qualification.*.score', valueType: 'score' },

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -108,6 +108,12 @@ export interface SpecTable {
   minRows?: number;
   /** Emit a real Excel Table over the range, so it filters, sorts and extends on typing. */
   asTable?: boolean;
+  /**
+   * The column whose cells hold the row key. Required when a formula points at one row of
+   * this table: a Table can be sorted, so a keyed reference has to look the key up rather
+   * than remember which row it was on.
+   */
+  keyColumn?: string;
   columns: SpecColumn[];
 }
 
@@ -419,6 +425,14 @@ function checkReferences(collected: Collected): { checked: number; failures: str
           failures.push(`${where}: ${ref.raw} points at one row of "${tableId}", whose rows depend on the deal`);
         } else if (!rowKey || !keys.includes(rowKey)) {
           failures.push(`${where}: ${ref.raw} names no row "${rowKey ?? ''}" of "${tableId}"`);
+        }
+        // Resolving this needs a column to MATCH the key against. Without one the only
+        // option is a fixed row address, which the table's own sort button invalidates.
+        const keyColumn = found.table.keyColumn;
+        if (!keyColumn) {
+          failures.push(`${where}: ${ref.raw} needs "${tableId}" to declare a keyColumn`);
+        } else if (!found.table.columns.some((c) => c.id === keyColumn)) {
+          failures.push(`${where}: "${tableId}" declares keyColumn "${keyColumn}", which is not one of its columns`);
         }
       }
     }

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -22,9 +22,9 @@
  * Collections live in tables on sheets where they can grow downward, so nothing is capped —
  * the legacy sheet formatted eight team rows and quietly dropped the rest.
  */
-import { resolveSchemaPath } from './schema-path';
+import { resolveSchemaPath, schemaConstraint } from './schema-path';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
-import type { StyleName } from './xlsx';
+import type { CfPreset, StyleName } from './xlsx';
 
 /** What a cell holds. Determines its style, and later its coercion on the way back in. */
 export type ValueType =
@@ -75,6 +75,14 @@ export interface SpecColumn {
   /** For `computed`. May use `{{this:…}}` to name another column in the same row. */
   formula?: string;
   width?: number;
+  /** A named conditional-format preset (see xlsx.ts). Formatting is spec data, not code. */
+  conditionalFormat?: CfPreset;
+  /**
+   * Offer a dropdown of the values the schema allows. The list is READ from the schema, never
+   * written here — that is the whole point, since a hand-copied list drifts the moment someone
+   * adds an enum member and the workbook goes on offering the old set.
+   */
+  validate?: boolean;
 }
 
 /**
@@ -98,6 +106,8 @@ export interface SpecTable {
   headerRow: number;
   /** Blank rows to keep below the data so the table has room to grow in Excel. */
   minRows?: number;
+  /** Emit a real Excel Table over the range, so it filters, sorts and extends on typing. */
+  asTable?: boolean;
   columns: SpecColumn[];
 }
 
@@ -105,8 +115,25 @@ export type SpecBlock =
   | { kind: 'title'; text: string }
   | { kind: 'section'; text: string }
   | { kind: 'spacer' }
-  | { kind: 'field'; id: string; label: string; jsonPath: string; valueType: ValueType; height?: number }
-  | { kind: 'computed'; id: string; label: string; formula: string; valueType: ValueType; height?: number };
+  | {
+      kind: 'field';
+      id: string;
+      label: string;
+      jsonPath: string;
+      valueType: ValueType;
+      height?: number;
+      conditionalFormat?: CfPreset;
+      validate?: boolean;
+    }
+  | {
+      kind: 'computed';
+      id: string;
+      label: string;
+      formula: string;
+      valueType: ValueType;
+      height?: number;
+      conditionalFormat?: CfPreset;
+    };
 
 export type SpecSheet =
   | { name: string; kind: 'form'; blocks: SpecBlock[]; columns?: { min: number; max: number; width: number }[] }
@@ -133,6 +160,8 @@ export interface SpecCheck {
   references: { checked: number; failures: string[] };
   /** Sheet names Excel accepts, and tables that do not sit on top of each other. */
   layout: { failures: string[] };
+  /** Every `validate: true` names a path the schema actually constrains. */
+  validation: { checked: number; failures: string[] };
 }
 
 const WILDCARD = '*';
@@ -238,10 +267,19 @@ interface Collected {
   formulas: Array<{ where: string; formula: string; table: SpecTable | null }>;
   /** Inputs whose path could not even be formed — before any schema lookup. */
   pathIssues: string[];
+  /** Cells asking for a schema-derived dropdown, with the path the values come from. */
+  validated: Array<{ where: string; path: string }>;
 }
 
 function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected {
-  const out: Collected = { namedCells: new Map(), tables: new Map(), inputs: [], formulas: [], pathIssues: [] };
+  const out: Collected = {
+    namedCells: new Map(),
+    tables: new Map(),
+    inputs: [],
+    formulas: [],
+    pathIssues: [],
+    validated: [],
+  };
 
   const checkValueType = (where: string, valueType: ValueType) => {
     if (!(valueType in VALUE_TYPE_STYLE)) roles.push(`${where}: unknown valueType "${valueType}"`);
@@ -265,6 +303,7 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
             roles.push(`${where}: a form field cannot use a wildcard — there is no key axis to expand it over`);
           } else {
             out.inputs.push({ where, paths: [block.jsonPath] });
+            if (block.validate) out.validated.push({ where, path: block.jsonPath });
           }
         } else {
           out.formulas.push({ where, formula: block.formula, table: null });
@@ -306,8 +345,12 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
               continue;
             }
             out.inputs.push({ where, paths });
+            if (column.validate) out.validated.push({ where, path: paths[0] });
           } catch (e) {
             roles.push(`${where}: ${e instanceof Error ? e.message : String(e)}`);
+          }
+          if (column.validate === true && column.role !== 'input') {
+            roles.push(`${where}: only an input column can carry a dropdown`);
           }
         } else if (column.role === 'computed') {
           if (column.jsonPath) {
@@ -450,6 +493,24 @@ export function checkWorkbookSpec(schema: unknown, spec: WorkbookSpec): SpecChec
   const references = checkReferences(collected);
   const layoutFailures = checkLayout(spec);
 
+  // A dropdown is only honest if the schema says what belongs in it. `validate: true` on a
+  // free-text field would otherwise emit an empty list, which Excel renders as a dropdown
+  // offering nothing — worse than no dropdown, because it looks deliberate.
+  const validationFailures: string[] = [];
+  for (const { where, path } of collected.validated) {
+    const constraint = schemaConstraint(schema, path);
+    if (!constraint) {
+      validationFailures.push(`${where}: "${path}" does not resolve, so there is nothing to build a dropdown from`);
+      continue;
+    }
+    const bounded = constraint.minimum !== undefined && constraint.maximum !== undefined;
+    if (!constraint.enum && !bounded) {
+      validationFailures.push(
+        `${where}: "${path}" has neither an enum nor numeric bounds in the schema — remove validate, or add the constraint there`,
+      );
+    }
+  }
+
   return {
     ok:
       schemaFailures.length === 0 &&
@@ -458,7 +519,8 @@ export function checkWorkbookSpec(schema: unknown, spec: WorkbookSpec): SpecChec
       idFailures.length === 0 &&
       roleFailures.length === 0 &&
       references.failures.length === 0 &&
-      layoutFailures.length === 0,
+      layoutFailures.length === 0 &&
+      validationFailures.length === 0,
     schemaPaths: { checked: allPaths.length, failures: schemaFailures },
     elements: { failures: elementFailures },
     duplicates: { failures: duplicateFailures },
@@ -466,5 +528,6 @@ export function checkWorkbookSpec(schema: unknown, spec: WorkbookSpec): SpecChec
     roles: { failures: roleFailures },
     references,
     layout: { failures: layoutFailures },
+    validation: { checked: collected.validated.length, failures: validationFailures },
   };
 }

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -243,10 +243,10 @@ describe('buildWorkbook — tables, conditional formatting and validation', () =
             { row: 1, cells: [{ ref: 'A1', value: 'Name' }] },
             { row: 2, cells: [{ ref: 'A2', value: 'x' }] },
           ],
-          tables: [{ name: 't', displayName: 't', ref: 'A1:A2', columns: ['Nome'] }],
+          tables: [{ name: 't', displayName: 't', ref: 'A1:A2', columns: ['NotTheHeader'] }],
         },
       ]),
-    ).toThrow(/Nome/);
+    ).toThrow(/NotTheHeader/);
   });
 
   test('rejects a table range with no data row', () => {

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -171,3 +171,118 @@ describe('styles.xml', () => {
     }
   });
 });
+
+describe('buildWorkbook — tables, conditional formatting and validation', () => {
+  const withExtras = () =>
+    buildWorkbook([
+      {
+        name: 'Data',
+        rows: [
+          {
+            row: 1,
+            cells: [
+              { ref: 'A1', value: 'Name', style: 'columnHeader' },
+              { ref: 'B1', value: 'Score', style: 'columnHeader' },
+            ],
+          },
+          {
+            row: 2,
+            cells: [
+              { ref: 'A2', value: 'x' },
+              { ref: 'B2', value: 1, style: 'score' },
+            ],
+          },
+          { row: 3, cells: [{ ref: 'A3' }, { ref: 'B3', style: 'score' }] },
+        ],
+        tables: [{ name: 'people', displayName: 'people', ref: 'A1:B3', columns: ['Name', 'Score'] }],
+        conditionalFormats: [{ sqref: 'B2:B3', preset: 'score' }],
+        validations: [{ sqref: 'B2:B3', values: ['0', '1', '2', '3', '4'] }],
+      },
+    ]);
+
+  // CT_Worksheet is a SEQUENCE: sheetData, then conditionalFormatting, then dataValidations,
+  // and tableParts last. Out of order is not a warning — Excel offers to repair the file.
+  test('emits the worksheet children in the order the schema demands', () => {
+    const sheet = dec(readZip(withExtras()).get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+    const order = ['<sheetData>', '<conditionalFormatting', '<dataValidations', '<tableParts'];
+    const positions = order.map((tag) => sheet.indexOf(tag));
+    for (const p of positions) expect(p).toBeGreaterThan(-1);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  test('ships the table part, its relationship and its content type', () => {
+    const parts = readZip(withExtras());
+    expect(parts.has('xl/tables/table1.xml')).toBe(true);
+    expect(parts.has('xl/worksheets/_rels/sheet1.xml.rels')).toBe(true);
+    const ct = dec(parts.get('[Content_Types].xml')?.data as Uint8Array);
+    expect(ct).toContain('/xl/tables/table1.xml');
+    const rels = dec(parts.get('xl/worksheets/_rels/sheet1.xml.rels')?.data as Uint8Array);
+    const sheet = dec(parts.get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+    const id = /<tablePart r:id="(rId\d+)"\/>/.exec(sheet)?.[1];
+    expect(id).toBeDefined();
+    expect(rels).toContain(`Id="${id}"`);
+  });
+
+  test("a table column's name matches the header cell, which is what Excel checks", () => {
+    const parts = readZip(withExtras());
+    const table = dec(parts.get('xl/tables/table1.xml')?.data as Uint8Array);
+    expect(table).toContain('name="Name"');
+    expect(table).toContain('name="Score"');
+    expect(table).toContain('ref="A1:B3"');
+    expect(table).toContain('headerRowCount="1"');
+  });
+
+  test('rejects a table whose declared columns do not match its cells', () => {
+    // A mismatch here is precisely what makes Excel repair the file, and the message it gives
+    // says nothing useful — so fail at build time with something that does.
+    expect(() =>
+      buildWorkbook([
+        {
+          name: 'Data',
+          rows: [
+            { row: 1, cells: [{ ref: 'A1', value: 'Name' }] },
+            { row: 2, cells: [{ ref: 'A2', value: 'x' }] },
+          ],
+          tables: [{ name: 't', displayName: 't', ref: 'A1:A2', columns: ['Nome'] }],
+        },
+      ]),
+    ).toThrow(/Nome/);
+  });
+
+  test('rejects a table range with no data row', () => {
+    expect(() =>
+      buildWorkbook([
+        {
+          name: 'Data',
+          rows: [{ row: 1, cells: [{ ref: 'A1', value: 'Name' }] }],
+          tables: [{ name: 't', displayName: 't', ref: 'A1:A1', columns: ['Name'] }],
+        },
+      ]),
+    ).toThrow(/data row/);
+  });
+
+  test('every dxfId a rule cites is defined in styles.xml', () => {
+    const parts = readZip(withExtras());
+    const sheet = dec(parts.get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+    const styles = dec(parts.get('xl/styles.xml')?.data as Uint8Array);
+    const declared = Number(/<dxfs count="(\d+)"/.exec(styles)?.[1] ?? 0);
+    expect(declared).toBeGreaterThan(0);
+    const used = [...sheet.matchAll(/dxfId="(\d+)"/g)].map((m) => Number(m[1]));
+    expect(used.length).toBeGreaterThan(0);
+    for (const id of used) expect(id).toBeLessThan(declared);
+  });
+
+  test('a validation list is quoted the way Excel expects', () => {
+    const sheet = dec(readZip(withExtras()).get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+    expect(sheet).toContain('type="list"');
+    expect(sheet).toContain('<formula1>&quot;0,1,2,3,4&quot;</formula1>');
+  });
+
+  test('a sheet with no extras emits none of those elements', () => {
+    const sheet = dec(readZip(minimal()).get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+    expect(sheet).not.toContain('conditionalFormatting');
+    expect(sheet).not.toContain('dataValidations');
+    expect(sheet).not.toContain('tableParts');
+    expect(readZip(minimal()).has('xl/tables/table1.xml')).toBe(false);
+  });
+});

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -154,7 +154,17 @@ export const DXF_IDS: Record<DxfName, number> = Object.fromEntries(DXF_ORDER.map
  * `%FIRST%` is replaced with the first cell of the range, which is how an expression rule
  * refers to "this cell" — Excel evaluates it relatively across the range.
  */
-export type CfPreset = 'score' | 'ragText' | 'statusText' | 'overdueDate';
+export type CfPreset = 'score' | 'ragText' | 'statusText' | 'completionText' | 'overdueDate';
+
+/**
+ * The section statuses `computeCompletion` emits.
+ *
+ * Deliberately NOT the closePlan `status` enum (pending / in_progress / complete): they are
+ * two different vocabularies that happen to share one word. Colouring the completion column
+ * with the closePlan preset left `not_started` and `partial` — two of its three states, and
+ * the two that matter — with no colour at all.
+ */
+export const COMPLETION_STATUSES = ['not_started', 'partial', 'complete'] as const;
 
 interface CfRule {
   type: string;
@@ -176,6 +186,11 @@ const CF_PRESETS: Record<CfPreset, CfRule[]> = {
     { type: 'cellIs', operator: 'equal', formulas: ['"Red"'], dxf: 'red' },
     { type: 'cellIs', operator: 'equal', formulas: ['"Yellow"'], dxf: 'amber' },
     { type: 'cellIs', operator: 'equal', formulas: ['"Green"'], dxf: 'green' },
+  ],
+  completionText: [
+    { type: 'cellIs', operator: 'equal', formulas: ['"complete"'], dxf: 'green' },
+    { type: 'cellIs', operator: 'equal', formulas: ['"partial"'], dxf: 'amber' },
+    { type: 'cellIs', operator: 'equal', formulas: ['"not_started"'], dxf: 'red' },
   ],
   statusText: [
     { type: 'cellIs', operator: 'equal', formulas: ['"complete"'], dxf: 'green' },

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -132,6 +132,81 @@ const STYLE_DEFS: Record<StyleName, StyleDef> = {
   muted: { font: FONT_ITALIC_GREY, fill: FILL_NONE, numFmt: 0 },
 };
 
+/**
+ * Conditional-format fills, in `dxfs` order — the index of each name IS its `dxfId`.
+ * Same discipline as the cell-style palette: one ordered list, indexes derived from it.
+ */
+const DXF_ORDER = ['red', 'amber', 'green'] as const;
+type DxfName = (typeof DXF_ORDER)[number];
+const DXF_FILLS: Record<DxfName, string> = { red: 'FFF8CBAD', amber: 'FFFFE699', green: 'FFC6E0B4' };
+export const DXF_IDS: Record<DxfName, number> = Object.fromEntries(DXF_ORDER.map((name, i) => [name, i])) as Record<
+  DxfName,
+  number
+>;
+
+/**
+ * The conditional-format presets a sheet may ask for, by name.
+ *
+ * A curated set rather than arbitrary rules, for the same reason the style palette is
+ * curated: each one is a few lines of XML that either matches Excel's schema or makes it
+ * offer to repair the file, and three reviewable presets beat a general rule compiler.
+ *
+ * `%FIRST%` is replaced with the first cell of the range, which is how an expression rule
+ * refers to "this cell" — Excel evaluates it relatively across the range.
+ */
+export type CfPreset = 'score' | 'ragText' | 'statusText' | 'overdueDate';
+
+interface CfRule {
+  type: string;
+  operator?: string;
+  formulas: string[];
+  dxf: DxfName;
+}
+
+const CF_PRESETS: Record<CfPreset, CfRule[]> = {
+  // A 0-4 element score. Matches how the engine reads them: 0-1 bad, 2 partial, 3-4 good.
+  score: [
+    { type: 'cellIs', operator: 'lessThan', formulas: ['2'], dxf: 'red' },
+    { type: 'cellIs', operator: 'equal', formulas: ['2'], dxf: 'amber' },
+    { type: 'cellIs', operator: 'greaterThanOrEqual', formulas: ['3'], dxf: 'green' },
+  ],
+  // The rating word itself, so the colours agree with `computeScore` exactly rather than
+  // re-deriving its brackets from a percentage and drifting by a rounding step.
+  ragText: [
+    { type: 'cellIs', operator: 'equal', formulas: ['"Red"'], dxf: 'red' },
+    { type: 'cellIs', operator: 'equal', formulas: ['"Yellow"'], dxf: 'amber' },
+    { type: 'cellIs', operator: 'equal', formulas: ['"Green"'], dxf: 'green' },
+  ],
+  statusText: [
+    { type: 'cellIs', operator: 'equal', formulas: ['"complete"'], dxf: 'green' },
+    { type: 'cellIs', operator: 'equal', formulas: ['"in_progress"'], dxf: 'amber' },
+    { type: 'cellIs', operator: 'equal', formulas: ['"pending"'], dxf: 'red' },
+  ],
+  // Past its date and not blank. A blank cell is "no date set", not "overdue since 1900".
+  overdueDate: [{ type: 'expression', formulas: ['AND(%FIRST%<>"",%FIRST%<TODAY())'], dxf: 'red' }],
+};
+
+export interface TablePart {
+  /** Workbook-unique, no spaces — Excel uses it for structured references. */
+  name: string;
+  displayName: string;
+  /** Includes the header row and at least one data row. */
+  ref: string;
+  /** Must equal the header cells, in order. */
+  columns: string[];
+}
+
+export interface ConditionalFormat {
+  sqref: string;
+  preset: CfPreset;
+}
+
+export interface Validation {
+  sqref: string;
+  /** An explicit list. Excel caps the inline form at 255 characters. */
+  values: string[];
+}
+
 function stylesXml(): string {
   const fonts = [
     '<font><sz val="11"/><name val="Calibri"/></font>',
@@ -177,6 +252,11 @@ function stylesXml(): string {
     `<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>` +
     `<cellXfs count="${xfs.length}">${xfs.join('')}</cellXfs>` +
     `<cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>` +
+    // Differential formats: what a conditional rule applies ON TOP of a cell's own style.
+    // They are a separate list from cellXfs with its own index space, and a rule citing an
+    // index past the end makes Excel repair the file — so, like the palette, the order here
+    // IS the contract (see DXF_IDS).
+    `<dxfs count="${DXF_ORDER.length}">${DXF_ORDER.map((name) => `<dxf><fill><patternFill><bgColor rgb="${DXF_FILLS[name]}"/></patternFill></fill></dxf>`).join('')}</dxfs>` +
     `</styleSheet>`
   );
 }
@@ -202,6 +282,9 @@ export interface SheetSpec {
   columns?: { min: number; max: number; width: number }[];
   /** Freeze everything above this row (a header freeze). */
   freezeAtRow?: number;
+  tables?: TablePart[];
+  conditionalFormats?: ConditionalFormat[];
+  validations?: Validation[];
 }
 
 function cellXml(cell: CellSpec): string {
@@ -225,7 +308,76 @@ function cellXml(cell: CellSpec): string {
   return `<c r="${cell.ref}"${s} t="inlineStr"><is><t xml:space="preserve">${escapeXml(cell.value)}</t></is></c>`;
 }
 
-function sheetXml(sheet: SheetSpec): string {
+/** The header text actually present in a table's first row, in column order. */
+function headerTextsFor(sheet: SheetSpec, ref: string): string[] {
+  const m = /^([A-Z]+)(\d+):([A-Z]+)(\d+)$/.exec(ref);
+  if (!m) throw new Error(`Table ref "${ref}" on sheet "${sheet.name}" is not a range like A1:H12`);
+  const [firstCol, headerRow, lastCol, lastRow] = [m[1], Number(m[2]), m[3], Number(m[4])];
+  if (lastRow <= headerRow) {
+    throw new Error(`Table ref "${ref}" on sheet "${sheet.name}" has no data row — Excel rejects a header-only table`);
+  }
+  const colIndex = (letters: string) => [...letters].reduce((n, c) => n * 26 + (c.charCodeAt(0) - 64), 0);
+  const row = sheet.rows.find((r) => r.row === headerRow);
+  const out: string[] = [];
+  for (let c = colIndex(firstCol); c <= colIndex(lastCol); c++) {
+    const cell = row?.cells.find((x) => x.ref === A1(c, headerRow));
+    out.push(typeof cell?.value === 'string' ? cell.value : '');
+  }
+  return out;
+}
+
+function tableXml(table: TablePart, id: number): string {
+  const columns = table.columns.map((name, i) => `<tableColumn id="${i + 1}" name="${escapeXml(name)}"/>`).join('');
+  return (
+    `${XML_HEADER}<table xmlns="${NS_MAIN}" id="${id}" name="${escapeXml(table.name)}" ` +
+    `displayName="${escapeXml(table.displayName)}" ref="${table.ref}" headerRowCount="1">` +
+    `<autoFilter ref="${table.ref}"/>` +
+    `<tableColumns count="${table.columns.length}">${columns}</tableColumns>` +
+    `<tableStyleInfo name="TableStyleMedium2" showFirstColumn="0" showLastColumn="0" showRowStripes="1" showColumnStripes="0"/>` +
+    `</table>`
+  );
+}
+
+function conditionalFormattingXml(formats: ConditionalFormat[] | undefined): string {
+  if (!formats?.length) return '';
+  let priority = 1;
+  return formats
+    .map((format) => {
+      const first = format.sqref.split(':')[0];
+      const rules = CF_PRESETS[format.preset]
+        .map((rule) => {
+          const formulas = rule.formulas
+            .map((f) => `<formula>${escapeXml(f.split('%FIRST%').join(first))}</formula>`)
+            .join('');
+          const operator = rule.operator ? ` operator="${rule.operator}"` : '';
+          return `<cfRule type="${rule.type}"${operator} dxfId="${DXF_IDS[rule.dxf]}" priority="${priority++}">${formulas}</cfRule>`;
+        })
+        .join('');
+      return `<conditionalFormatting sqref="${format.sqref}">${rules}</conditionalFormatting>`;
+    })
+    .join('');
+}
+
+function dataValidationsXml(validations: Validation[] | undefined): string {
+  if (!validations?.length) return '';
+  const entries = validations
+    .map((v) => {
+      // The inline list form is a quoted, comma-joined string — and Excel caps it at 255
+      // characters, so say so loudly rather than emitting something it will silently drop.
+      const list = v.values.join(',');
+      if (list.length > 255) {
+        throw new Error(`Validation list for ${v.sqref} is ${list.length} characters; Excel allows 255`);
+      }
+      return (
+        `<dataValidation type="list" allowBlank="1" showInputMessage="1" showErrorMessage="1" sqref="${v.sqref}">` +
+        `<formula1>${escapeXml(`"${list}"`)}</formula1></dataValidation>`
+      );
+    })
+    .join('');
+  return `<dataValidations count="${validations.length}">${entries}</dataValidations>`;
+}
+
+function sheetXml(sheet: SheetSpec, tableIds: number[]): string {
   const cols = sheet.columns?.length
     ? `<cols>${sheet.columns.map((c) => `<col min="${c.min}" max="${c.max}" width="${c.width}" customWidth="1"/>`).join('')}</cols>`
     : '';
@@ -238,11 +390,38 @@ function sheetXml(sheet: SheetSpec): string {
         `<row r="${r.row}"${r.height ? ` ht="${r.height}" customHeight="1"` : ''}>${r.cells.map(cellXml).join('')}</row>`,
     )
     .join('');
+  for (const table of sheet.tables ?? []) {
+    const headers = headerTextsFor(sheet, table.ref);
+    if (headers.length !== table.columns.length) {
+      throw new Error(
+        `Table "${table.name}" declares ${table.columns.length} columns but its ref spans ${headers.length}`,
+      );
+    }
+    table.columns.forEach((name, i) => {
+      if (headers[i] !== name) {
+        throw new Error(
+          `Table "${table.name}" column ${i + 1} is declared "${name}" but the header cell says "${headers[i]}" — ` +
+            'Excel repairs a table whose column names do not match its header row',
+        );
+      }
+    });
+  }
+
+  const tableParts = tableIds.length
+    ? `<tableParts count="${tableIds.length}">${tableIds.map((_, i) => `<tablePart r:id="rId${i + 1}"/>`).join('')}</tableParts>`
+    : '';
+
+  // CT_Worksheet is a sequence, not a bag: sheetData, then conditionalFormatting, then
+  // dataValidations, with tableParts last. Emitting these out of order does not warn — it
+  // makes Excel offer to repair the file, with a message that names nothing useful.
   return (
     `${XML_HEADER}<worksheet xmlns="${NS_MAIN}" xmlns:r="${NS_REL_DOC}">` +
     `<sheetViews><sheetView workbookViewId="0">${pane}</sheetView></sheetViews>` +
     `<sheetFormatPr defaultRowHeight="15"/>${cols}` +
     `<sheetData>${rows}</sheetData>` +
+    conditionalFormattingXml(sheet.conditionalFormats) +
+    dataValidationsXml(sheet.validations) +
+    tableParts +
     `</worksheet>`
   );
 }
@@ -261,6 +440,27 @@ export function buildWorkbook(sheets: readonly SheetSpec[]): Uint8Array {
   const enc = (s: string) => new TextEncoder().encode(s);
   const sheetPath = (i: number) => `xl/worksheets/sheet${i + 1}.xml`;
 
+  // Tables are numbered across the whole workbook, and each sheet keeps its own relationship
+  // ids starting at rId1 — a table's r:id is scoped to the worksheet that references it.
+  let nextTableId = 1;
+  const tableIdsBySheet = sheets.map((s) => (s.tables ?? []).map(() => nextTableId++));
+  const allTables = sheets.flatMap((s, i) =>
+    (s.tables ?? []).map((table, j) => ({ table, id: tableIdsBySheet[i][j] })),
+  );
+
+  const displayNames = new Set<string>();
+  for (const { table } of allTables) {
+    // Excel treats displayName as a workbook-wide identifier for structured references, and
+    // silently repairs a duplicate rather than reporting one.
+    if (displayNames.has(table.displayName)) {
+      throw new Error(`Two tables share the displayName "${table.displayName}"; it must be unique in the workbook`);
+    }
+    if (/\s/.test(table.displayName) || /^\d/.test(table.displayName)) {
+      throw new Error(`Table displayName "${table.displayName}" must not contain a space or start with a digit`);
+    }
+    displayNames.add(table.displayName);
+  }
+
   const contentTypes =
     `${XML_HEADER}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
     `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
@@ -271,6 +471,12 @@ export function buildWorkbook(sheets: readonly SheetSpec[]): Uint8Array {
       .map(
         (_, i) =>
           `<Override PartName="/${sheetPath(i)}" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`,
+      )
+      .join('') +
+    allTables
+      .map(
+        ({ id }) =>
+          `<Override PartName="/xl/tables/table${id}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"/>`,
       )
       .join('') +
     `</Types>`;
@@ -299,12 +505,28 @@ export function buildWorkbook(sheets: readonly SheetSpec[]): Uint8Array {
     sheets.map((s, i) => `<sheet name="${escapeXml(s.name)}" sheetId="${i + 1}" r:id="rId${i + 1}"/>`).join('') +
     `</sheets></workbook>`;
 
+  // A worksheet that references a table needs its own rels part pointing at it.
+  const sheetRels = tableIdsBySheet.flatMap((ids, i) => {
+    if (ids.length === 0) return [];
+    const entries = ids
+      .map((id, j) => `<Relationship Id="rId${j + 1}" Type="${NS_REL_DOC}/table" Target="../tables/table${id}.xml"/>`)
+      .join('');
+    return [
+      {
+        name: `xl/worksheets/_rels/sheet${i + 1}.xml.rels`,
+        data: enc(`${XML_HEADER}<Relationships xmlns="${NS_REL_PKG}">${entries}</Relationships>`),
+      },
+    ];
+  });
+
   return writeZip([
     { name: '[Content_Types].xml', data: enc(contentTypes) },
     { name: '_rels/.rels', data: enc(rootRels) },
     { name: 'xl/workbook.xml', data: enc(workbook) },
     { name: 'xl/_rels/workbook.xml.rels', data: enc(workbookRels) },
     { name: 'xl/styles.xml', data: enc(stylesXml()) },
-    ...sheets.map((s, i) => ({ name: sheetPath(i), data: enc(sheetXml(s)) })),
+    ...sheets.map((s, i) => ({ name: sheetPath(i), data: enc(sheetXml(s, tableIdsBySheet[i])) })),
+    ...sheetRels,
+    ...allTables.map(({ table, id }) => ({ name: `xl/tables/table${id}.xml`, data: enc(tableXml(table, id)) })),
   ]);
 }

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -116,8 +116,43 @@ OSA
 [ -z "${errors// /}" ] || fail "Excel error values present: $errors"
 echo "    no Excel error values on any sheet"
 
-osascript -e "tell application \"Microsoft Excel\" to close workbook \"$BOOK\" saving no" >/dev/null 2>&1
 echo "PASS: Excel opened the generated workbook and its Scorecard agrees with the engine"
+
+# Stage 2 added Excel Tables, conditional formatting and dropdowns. The file opening proves
+# the XML is well-formed; it does not prove Excel made anything of it. Ask Excel directly.
+#
+# A heredoc, not `osascript -e`: the AppleScript needs its own double quotes around sheet and
+# workbook names, and nesting those inside a shell string is how the first version of this
+# silently produced empty answers that looked like missing features.
+ask() {
+  osascript <<OSA 2>/dev/null
+tell application "Microsoft Excel"
+  return ($1) as string
+end tell
+OSA
+}
+
+tables_seen="$(ask "count of list objects of worksheet \"Stakeholders\" of workbook \"$BOOK\"")"
+echo "    Excel sees ${tables_seen:-<none>} table(s) on Stakeholders"
+[ "$tables_seen" = "1" ] || fail "expected 1 Excel Table on Stakeholders, Excel reports '$tables_seen'"
+
+rules_seen="$(ask "count of format conditions of range \"C2:C9\" of worksheet \"Qualification\" of workbook \"$BOOK\"")"
+echo "    Excel sees ${rules_seen:-<none>} conditional-format rule(s) on the score column"
+[ "$rules_seen" = "3" ] || fail "expected 3 conditional-format rules on the score column, Excel reports '$rules_seen'"
+
+# The point of deriving dropdowns from the schema is that they cannot drift from it, so compare
+# what Excel offers against what the schema says rather than against a literal repeated here.
+want_roles="$(jq -r '.properties.stakeholders.items.properties.roleInDeal.enum | join(",")' "$PLUGIN_ROOT/schema/meddpicc-schema.json")"
+got_roles="$(ask "formula1 of (validation of range \"C2\" of worksheet \"Stakeholders\" of workbook \"$BOOK\")")"
+echo "    role dropdown: Excel=[$got_roles] schema=[$want_roles]"
+[ "$got_roles" = "$want_roles" ] || fail "the role dropdown does not match the schema enum"
+
+got_scores="$(ask "formula1 of (validation of range \"C2\" of worksheet \"Qualification\" of workbook \"$BOOK\")")"
+echo "    score dropdown: Excel=[$got_scores]"
+[ "$got_scores" = "0,1,2,3,4" ] || fail "the score dropdown is '$got_scores', expected 0,1,2,3,4"
+echo "PASS: Excel recognises the tables, the conditional formats and the schema-derived dropdowns"
+
+osascript -e "tell application \"Microsoft Excel\" to close workbook \"$BOOK\" saving no" >/dev/null 2>&1
 
 # The same comparison on a deal where most elements are unscored — the case that was wrong.
 #

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -152,6 +152,43 @@ echo "    score dropdown: Excel=[$got_scores]"
 [ "$got_scores" = "0,1,2,3,4" ] || fail "the score dropdown is '$got_scores', expected 0,1,2,3,4"
 echo "PASS: Excel recognises the tables, the conditional formats and the schema-derived dropdowns"
 
+# Putting a Table on Qualification hands the user a sort button, and a formula written as
+# `Qualification!C8` means "champion" only until they press it. Moving the key to another row
+# is what a sort does; the Scorecard must follow the key, not the address.
+#
+# Measured with the fixed-address form this replaced: Champion read 4.0, then 3.0 after the
+# swap — economicBuyer's score, reported under the Champion label, with nothing to notice.
+swap_result="$(
+  osascript <<OSA 2>/dev/null
+tell application "Microsoft Excel"
+  set wb to workbook "$BOOK"
+  set sc to worksheet "Scorecard" of wb
+  set q to worksheet "Qualification" of wb
+  set champRow to 0
+  repeat with r from 1 to 60
+    if ((get value of cell ("A" & r) of sc) as string) is "Champion" then set champRow to r
+  end repeat
+  if champRow is 0 then return "NO-CHAMPION-ROW"
+  set nameA to (get value of cell "A3" of q) as string
+  set nameB to (get value of cell "A8" of q) as string
+  set scoreA to (get value of cell "C3" of q)
+  set scoreB to (get value of cell "C8" of q)
+  set wasVal to (get value of cell ("B" & champRow) of sc) as string
+  set value of range "A3" of q to nameB
+  set value of range "C3" of q to scoreB
+  set value of range "A8" of q to nameA
+  set value of range "C8" of q to scoreA
+  set nowVal to (get value of cell ("B" & champRow) of sc) as string
+  return wasVal & "|" & nowVal
+end tell
+OSA
+)"
+was_champ="${swap_result%%|*}"
+now_champ="${swap_result##*|}"
+echo "    Champion score before moving its row = $was_champ, after = $now_champ"
+[ -n "$was_champ" ] && [ "$was_champ" = "$now_champ" ] || fail "a keyed reference did not follow its key ($swap_result)"
+echo "PASS: keyed references follow the key, so sorting the table cannot mislabel a score"
+
 osascript -e "tell application \"Microsoft Excel\" to close workbook \"$BOOK\" saving no" >/dev/null 2>&1
 
 # The same comparison on a deal where most elements are unscored — the case that was wrong.


### PR DESCRIPTION
## What

Stage 2: the workbook becomes a working spreadsheet rather than a rendered one.

**Excel Tables** over all eight collections — they filter, sort, stripe, and extend when
someone types below the last row. That last property is the point: it is what stops a
collection being capped, which is the legacy sheet's actual bug (eight team rows formatted,
the rest silently dropped).

**Conditional formatting** from four named presets, the same discipline as the style palette:
`score`, `ragText`, `statusText`, `completionText`, `overdueDate`. `ragText` colours the rating
*word* rather than re-deriving the engine's brackets from a percentage, so the colours cannot
drift from `computeScore` by a rounding step.

**Dropdowns read from the schema, never authored.** A column says `"validate": true` and the
values come from that path's `enum` — or, for a bounded integer like a 0-4 score, from its
`minimum`/`maximum`. Add a `roleInDeal` member to the schema and the dropdown gains it; there
is no second list to remember. `check-spec` rejects `validate: true` where the schema
constrains nothing, because a dropdown offering no values looks deliberate and is worse than
none.

## Verified by asking Excel what it made of the file

Opening proves the XML is well-formed. It does not prove Excel read any of it, so the UAT asks:

```
Excel sees 1 table(s) on Stakeholders
Excel sees 3 conditional-format rule(s) on the score column
role dropdown: Excel=[Economic buyer,Decision maker,Influencer] schema=[Economic buyer,Decision maker,Influencer]
score dropdown: Excel=[0,1,2,3,4]
```

The role dropdown is compared against the **schema**, not a literal in the test — which is the
property being claimed. Mutation-checked: dropping `asTable` makes Excel report 0 tables, and
hardcoding a dropdown list makes it disagree with the schema.

## Two review findings, both confirmed — one caused by this PR

**Sorting the table mislabelled a score.** `asTable` hands the user a sort button, and
`{{row:elements.score@champion}}` had resolved to the literal `Qualification!C8`. Reproduced:
move that row and the Scorecard reports **3.0 — economicBuyer's score — under the Champion
label**, with nothing about the sheet suggesting a problem.

Keyed references are now `INDEX(range,MATCH("champion",keyRange,0))`; a table must declare its
`keyColumn`; `check-spec` refuses a `{{row:…}}` into one that has not. Re-measured: 4.0 before
the swap, 4.0 after. The mutation is what makes that evidence rather than decoration, so the
swap is a permanent UAT assertion.

**Completion was two-thirds uncoloured.** `computeCompletion` emits
`not_started`/`partial`/`complete`; `statusText` matches the closePlan enum
`pending`/`in_progress`/`complete`. One shared word, two vocabularies — so the two states worth
seeing had no colour. Added `completionText`, plus a test asserting every status the engine can
emit is one the preset covers, so they cannot drift apart quietly again.

## The OOXML is unforgiving

`CT_Worksheet` is a sequence — `sheetData`, `conditionalFormatting`, `dataValidations`,
`tableParts` last — and out of order is not a warning but a repair prompt naming nothing.
`buildWorkbook` now refuses at build time, with a message saying which: a table whose column
names disagree with its header row, a header-only range, a duplicate `displayName`, a `dxfId`
past the end of `<dxfs>`, and a validation list over Excel's 255-character cap.

## Verification

| check | result |
| --- | --- |
| `bun test engine/` | 168 pass, 0 fail |
| `scripts/tests/run-tests.sh` | 30 passed, 1 skipped, 0 failed |
| `scripts/uat-generate-excel.sh` | 4 PASS blocks — opens/computes, features recognised, keyed refs survive a sort, partial deal agrees |
| `run-plugin-tests.sh` | exit 0 |
| Biome, shellcheck, shfmt | exit 0 |

Two mistakes on the way, both of which looked like missing features rather than broken tests:
the first version of those Excel assertions nested double quotes inside `osascript -e` and
returned empty strings, and I had appended them after the workbook was already closed. Also
worth knowing: `before` and `after` are AppleScript reserved words, and `cell` works for reads
where writes need `range`.

No Reference sheet in the end — inline validation lists made it redundant, and the 0-4 rubric
text already sits on the Qualification row it describes.

Closes #886
