### PR TITLE
feat(herdr): add herdr agent skill as a marketplace plugin

### DIFF
--- a/.github/workflows/herdr-skill-freshness.yml
+++ b/.github/workflows/herdr-skill-freshness.yml
@@ -1,0 +1,81 @@
+---
+name: Herdr Skill Freshness
+
+# `plugins/herdr/skills/herdr/SKILL.md` is vendored verbatim from ogulcancelik/herdr.
+# Nothing in this repo can detect upstream edits, so without this job the vendored copy
+# silently rots — and it documents a CLI whose command surface changes.
+#
+# Deliberately GitHub-hosted: the self-hosted `code-review` runners were decommissioned,
+# so this must not depend on a runner label that no longer exists.
+#
+# NOT a required check, and it carries a `paths:` filter. Required + filtered deadlocks
+# PRs that touch nothing relevant (see the header of validate-plugins.yml for why).
+on:
+  schedule:
+    # Mondays 06:17 UTC — off the :00 mark so this does not pile onto the hour boundary.
+    - cron: '17 6 * * 1'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'plugins/herdr/**'
+      - '.github/workflows/herdr-skill-freshness.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+    github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  freshness:
+    name: Vendored SKILL.md matches upstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Ref is pinned here and recorded in plugins/herdr/UPSTREAM.md. Keep both in step.
+      - name: Fetch upstream SKILL.md
+        env:
+          UPSTREAM_URL: https://raw.githubusercontent.com/ogulcancelik/herdr/master/SKILL.md
+        run: |
+          set -euo pipefail
+          # A failed fetch must FAIL the job. Falling through on a network blip would make
+          # "upstream unreachable" indistinguishable from "no drift".
+          curl -fsSL --retry 3 --retry-delay 5 --max-time 60 \
+            "$UPSTREAM_URL" -o /tmp/upstream-SKILL.md
+          test -s /tmp/upstream-SKILL.md
+
+      - name: Compare against vendored copy
+        run: |
+          set -euo pipefail
+          VENDORED=plugins/herdr/skills/herdr/SKILL.md
+          test -f "$VENDORED"
+
+          if diff -u "$VENDORED" /tmp/upstream-SKILL.md; then
+            echo "Vendored SKILL.md matches upstream."
+            echo "sha256: $(sha256sum "$VENDORED" | cut -d' ' -f1)"
+            exit 0
+          fi
+
+          # Quoted heredoc: contents are literal, so backticks and trailing
+          # backslashes in the remediation snippet need no shell escaping.
+          cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
+          ## Herdr skill drift detected
+
+          The vendored `SKILL.md` no longer matches upstream `ogulcancelik/herdr@master`.
+
+          ```bash
+          curl -fsSL https://raw.githubusercontent.com/ogulcancelik/herdr/master/SKILL.md \
+            -o plugins/herdr/skills/herdr/SKILL.md
+          scripts/bump-version.sh herdr patch
+          # then update the table in plugins/herdr/UPSTREAM.md
+          ```
+          MD
+
+          echo "::error::Vendored plugins/herdr/skills/herdr/SKILL.md differs from upstream. Re-vendor and bump the plugin version."
+          exit 1

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,8 @@
+# Vendored third-party markdown. These files are redistributed VERBATIM from
+# upstream and must stay byte-identical — herdr-skill-freshness.yml fails when
+# they drift. House markdown style therefore cannot be applied to them: fixing a
+# lint finding here would break the very check that proves the copy is authentic.
+#
+# Keep this list minimal and scoped to exact files, never whole directories, so
+# first-party markdown in the same plugin is still linted.
+plugins/herdr/skills/herdr/SKILL.md

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -385,6 +385,21 @@
           "authLoginCmd": "gh auth login"
         }
       ]
+    },
+    {
+      "name": "herdr",
+      "description": "Control Herdr, a terminal multiplexer for coding agents — inspect workspaces, tabs and panes, split panes, run commands without stealing focus, read pane output, and coordinate sibling agents. Requires HERDR_ENV=1.",
+      "version": "1.0.0",
+      "author": {
+        "name": "f5-sales-demo"
+      },
+      "source": "./plugins/herdr",
+      "category": "development",
+      "keywords": ["herdr", "terminal", "multiplexer", "panes", "agents"],
+      "tags": ["terminal", "orchestration", "agents", "xcsh-extension"],
+      "license": "Apache-2.0",
+      "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/herdr",
+      "repository": "https://github.com/f5-sales-demo/marketplace"
     }
   ]
 }

--- a/plugins/herdr/.xcsh-plugin/plugin.json
+++ b/plugins/herdr/.xcsh-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "herdr",
+  "description": "Control Herdr, a terminal multiplexer for coding agents — inspect workspaces, tabs and panes, split panes, run commands without stealing focus, read pane output, and coordinate sibling agents. Requires HERDR_ENV=1.",
+  "version": "1.0.0",
+  "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/herdr",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "f5-sales-demo"
+  }
+}

--- a/plugins/herdr/UPSTREAM.md
+++ b/plugins/herdr/UPSTREAM.md
@@ -1,0 +1,34 @@
+# Upstream provenance — herdr skill
+
+`skills/herdr/SKILL.md` is vendored **verbatim** from the Herdr project. Do not edit it here; change
+it upstream and re-vendor, otherwise `herdr-skill-freshness.yml` will fail.
+
+| Field | Value |
+|---|---|
+| Upstream repository | <https://github.com/ogulcancelik/herdr> |
+| Upstream path | `SKILL.md` (repository root) |
+| Pinned ref | `master` |
+| Vendored commit | `81f355fadac7d0d45b077dfc28f9f679add6bbb6` |
+| Last upstream change to `SKILL.md` | `0f161fac287011b3e216383e2b8482f049fd6a7b` (2026-07-21) |
+| SHA-256 of vendored file | `0786182f02ebf92708e09d82d79e4614d1a9c30bfc337643cc2af1d0fb9db29f` |
+| Size | 10140 bytes |
+| Retrieved | 2026-07-28 |
+| Upstream license | Apache-2.0 |
+
+## Attribution
+
+Herdr is licensed under the Apache License 2.0 (see the upstream `LICENSE`). This plugin
+redistributes `SKILL.md` unmodified under those terms. Copyright remains with the Herdr authors.
+
+## Re-vendoring procedure
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ogulcancelik/herdr/master/SKILL.md \
+  -o plugins/herdr/skills/herdr/SKILL.md
+shasum -a 256 plugins/herdr/skills/herdr/SKILL.md   # update the table above
+scripts/bump-version.sh herdr patch                 # keeps catalog + plugin.json in lockstep
+```
+
+Update **Vendored commit**, **SHA-256**, **Size**, and **Retrieved** in the table when you do this.
+The freshness workflow compares the live upstream file against the vendored copy, so a stale table
+with a correct file still passes — but the table is the human record of what was reviewed.

--- a/plugins/herdr/skills/herdr/SKILL.md
+++ b/plugins/herdr/skills/herdr/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: herdr
+description: "Control Herdr, a terminal multiplexer for coding agents. Use only when the user explicitly mentions Herdr or asks to use Herdr to inspect or control panes, tabs, workspaces, commands, or another agent. Do not use merely because a task could benefit from a background terminal, delegation, or parallel work. Requires HERDR_ENV=1."
+---
+
+# Herdr
+
+Herdr organizes terminals into workspaces, tabs, and panes, recognizes coding agents running inside panes, and exposes the current session through the `herdr` CLI.
+
+Before issuing any control command, verify that this agent is running inside a Herdr-managed pane:
+
+```bash
+test "${HERDR_ENV:-}" = 1
+```
+
+If the check fails, say that you are not running inside Herdr and stop. Do not inspect or control the focused Herdr session from outside Herdr.
+
+When the check passes, the `herdr` binary in `PATH` talks to the current session. Use it to inspect neighboring work, create terminal layout, start agents and commands, read output, and wait for state changes.
+
+## Learn the current CLI
+
+The installed binary is the authority for command syntax. Start with:
+
+```bash
+herdr --help
+```
+
+Then print the relevant command group by running the group without a subcommand:
+
+```bash
+herdr agent
+herdr pane
+herdr workspace
+herdr tab
+herdr worktree
+herdr terminal
+herdr notification
+herdr integration
+herdr session
+```
+
+Do not run bare `herdr` for discovery; it launches or attaches the TUI. Do not probe a mutating nested command by omitting arguments. Commands such as `herdr workspace create` are valid with defaults and will execute.
+
+Most control commands return JSON. Read identifiers and state from those responses instead of predicting them.
+
+## Understand layout, panes, and agents
+
+Choose the primitive that matches the job:
+
+- Workspace, tab, and pane topology organize terminal locations.
+- Pane commands control raw terminals, shells, tests, servers, input, and output.
+- Agent commands control the recognized coding agent currently occupying a pane.
+
+A pane exists whether or not it contains an agent. `agent start` requires an existing available shell pane and never creates, splits, or moves layout. Use pane commands for ordinary processes. Use agent commands when Herdr must validate agent identity or interpret `idle`, `working`, `blocked`, `done`, and `unknown` lifecycle states.
+
+Agent commands accept either a unique live agent name or the pane ID currently hosting that agent. They do not accept terminal IDs or bare agent-kind labels. Names must match `[a-z][a-z0-9_-]{0,31}` and be unique among live agents. A name follows the current pane occupant and is cleared when that agent exits, is released, or is replaced.
+
+`idle` means the agent is ready for input and its tab has been seen in the focused Herdr UI. `done` is the same underlying idle state after unseen background work finishes. Focusing the tab or targeting the pane or agent with a focus command marks it seen. CLI reads do not mark it seen. `blocked` means Herdr recognized an approval or question UI. `unknown` means an agent is present but Herdr cannot classify it confidently; it does not prove completion.
+
+## Use IDs and caller context
+
+Public IDs are opaque stable handles:
+
+- workspace: `w1`
+- tab: `w1:t1`
+- pane: `w1:p1`
+
+Closed tab and pane IDs are not reused. A pane moved into another workspace receives a new workspace-qualified pane ID. After `pane move`, continue with `.result.move_result.pane.pane_id` or the live agent name. The old value is reported as `.result.move_result.previous_pane_id`; only the moved process's inherited caller context keeps resolving that old ID, so do not use it as a general agent target.
+
+Herdr injects the caller's context into each managed pane:
+
+```bash
+printf '%s\n' "$HERDR_WORKSPACE_ID" "$HERDR_TAB_ID" "$HERDR_PANE_ID"
+```
+
+Prefer `--current` when a pane command should target the calling pane. Omitting a target may use the UI-focused pane, which can belong to the user or another client.
+
+Discover live state with:
+
+```bash
+herdr workspace list
+herdr tab list --workspace "$HERDR_WORKSPACE_ID"
+herdr pane current --current
+herdr pane list --workspace "$HERDR_WORKSPACE_ID"
+herdr agent list
+```
+
+Creation responses expose the IDs to use next. `workspace create` returns `.result.workspace`, `.result.tab`, and `.result.root_pane`. `tab create` returns `.result.tab` and `.result.root_pane`. `pane split` returns the new pane as `.result.pane`.
+
+## Start and coordinate an agent
+
+Default to a sibling pane in the current tab and the current working directory. Do not create a workspace, tab, worktree, or different cwd unless the user explicitly requests that topology or location.
+
+Honor a direction requested by the user. Otherwise inspect the caller pane:
+
+```bash
+herdr pane layout --pane "$HERDR_PANE_ID"
+```
+
+Split a wide pane to the right and a narrow or tall pane down. Avoid repeated same-direction splits that create unusably narrow columns or short rows. Keep the user's focus in the calling pane and explicitly preserve the caller's working directory:
+
+```bash
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+```
+
+Replace `right` with `down` when appropriate. Read the new pane ID from `.result.pane.pane_id`.
+
+An available shell pane must be at its interactive prompt, with the shell itself in the foreground and no foreground command, editor, or agent running. Start a supported agent in that pane with a useful unique name:
+
+```bash
+herdr agent start reviewer --kind codex --pane <returned-pane-id>
+```
+
+Use the kind requested by the user. Run `herdr agent` to inspect the installed kind list and options. Pass native agent arguments only after `--`:
+
+```bash
+herdr agent start reviewer --kind codex --pane <returned-pane-id> -- <agent-args...>
+```
+
+`agent start` returns only after Herdr detects the expected agent in the same pane and considers it ready for interactive input. It defaults to a 30-second startup timeout.
+
+Submit work through the agent surface:
+
+```bash
+herdr agent prompt reviewer "Review the current diff and report only actionable findings." --wait --timeout 120000
+```
+
+`agent prompt` atomically submits text and encoded Enter while honoring the pane's live bracketed-paste mode. For normal agent work, `--wait` is enough: it waits for the first settled `idle`, `done`, or `blocked` state. Do not repeat those defaults with `--until`.
+
+A prompt sent from a non-working state must produce an observed lifecycle change within five seconds. Otherwise Herdr returns `agent_prompt_stalled` instead of waiting indefinitely. This wait tracks lifecycle state, not an individual turn; if the agent is already working, completion of the active turn may satisfy it.
+
+Use `--until` only for a state-specific workflow, such as waiting for an already-running agent to request input:
+
+```bash
+herdr agent wait reviewer --until blocked --timeout 120000
+```
+
+Without `--until`, standalone `agent wait` uses the same settled-state defaults as `agent prompt --wait`.
+
+Use logical keys for interactive agent UI controls:
+
+```bash
+herdr agent send-keys reviewer esc
+herdr agent send-keys reviewer ctrl+c
+```
+
+Herdr validates all keys before writing any bytes. Read the result through the resolved agent:
+
+```bash
+herdr agent get reviewer
+herdr agent read reviewer --source recent-unwrapped --lines 120
+```
+
+If a wait fails or returns `blocked`, inspect `agent get` and `agent read` before deciding what input to send. Use the pane surface only when raw terminal control is intentional.
+
+## Run an ordinary command in another pane
+
+Create a sibling pane with the same geometry rule, preserve the caller's working directory, and keep user focus unchanged:
+
+```bash
+herdr pane split --current --direction right --cwd "$PWD" --no-focus
+```
+
+Read the new pane ID from `.result.pane.pane_id`, then run and inspect the command:
+
+```bash
+herdr pane run <returned-pane-id> "just test"
+herdr pane wait-output <returned-pane-id> --match "test result" --timeout 120000
+herdr pane read <returned-pane-id> --source recent-unwrapped --lines 120
+```
+
+`pane run` atomically sends command text and Enter. `pane wait-output` searches the selected snapshot immediately, so output that already exists can match. Use `--match <text>` for a literal substring or `--regex <pattern>` for a Rust regular expression. Omitting `--timeout` allows an indefinite wait.
+
+Use the read source that matches the task:
+
+- `visible`: the currently rendered viewport.
+- `recent`: recent rendered output, including soft wraps.
+- `recent-unwrapped`: recent output with soft wraps joined; prefer it for logs and transcripts.
+- `detection`: the plain-text bottom-buffer snapshot used for agent detection.
+
+Use `--format ansi` when colors and terminal styling are evidence. Otherwise use text.
+
+`--lines` asks Herdr for more rows from the pane's available screen and host scrollback. If increasing it does not reveal more of a completed response, the pane is probably running the agent on the terminal's alternate screen. Rows that leave the alternate screen do not enter Herdr's host scrollback, so a larger line count cannot recover them.
+
+After that failed read, ask the agent to write its complete response as Markdown in a temporary directory and reply only with the file path, then read the file directly. Use this only as a fallback; do not request file output in the initial prompt.
+
+## Safety and coordination rules
+
+- Use `--no-focus` for background work unless the user asked to switch context.
+- Use `--current`, an explicit pane ID, or a unique agent name. Do not rely on another client's focused pane.
+- Parse IDs from JSON responses. Do not derive them from sidebar order or examples.
+- Do not close workspaces, tabs, panes, or sessions you did not create unless the user explicitly asked.
+- Never run `herdr server stop` from an active session unless the user explicitly intends to stop the server and its pane processes.
+- Never kill the main Herdr process. Use named test sessions for experiments that need an isolated server.
+- CLI server errors are JSON on stderr with exit status 1. CLI syntax errors exit with status 2.


### PR DESCRIPTION
## Summary

Adds `herdr` to the catalog so the Herdr agent skill can be installed in xcsh. xcsh already supports selectable marketplaces and this repo is already registered as `f5-sales-demo-marketplace` — the catalog simply had no `herdr` entry.

The skill teaches agents to drive Herdr from inside a Herdr-managed pane (inspect workspaces/tabs/panes, split panes, run commands without stealing focus, read pane output, coordinate sibling agents). It self-guards on `HERDR_ENV=1` and refuses to act outside Herdr.

## Related Issue

Closes #889

## Changes

- `plugins/herdr/skills/herdr/SKILL.md` — vendored **verbatim** from `ogulcancelik/herdr@81f355fa`, sha256 `0786182f02ebf92708e09d82d79e4614d1a9c30bfc337643cc2af1d0fb9db29f`
- `plugins/herdr/.xcsh-plugin/plugin.json` — manifest, v1.0.0, Apache-2.0
- `plugins/herdr/UPSTREAM.md` — provenance: upstream repo/path/commit, hash, size, license, re-vendor procedure
- `.xcsh-plugin/marketplace.json` — catalog entry (`category: development`)
- `.github/workflows/herdr-skill-freshness.yml` — fails when the vendored copy drifts from upstream

Upstream is Apache-2.0 (`LICENSE`, `Cargo.toml`), matching this marketplace's other plugins; redistributed unmodified with attribution in `UPSTREAM.md`.

The freshness job is deliberately `ubuntu-latest` (the self-hosted `code-review` runners were decommissioned) and is **not** a required check, and it carries a `paths:` filter — required + filtered would deadlock unrelated PRs, per the header note in `validate-plugins.yml`.

## Verification evidence

```
$ ./scripts/validate-plugins.sh
INFO: Checking marketplace entry: herdr
INFO:   Validating .../plugins/herdr/.xcsh-plugin/plugin.json
INFO:   Found 1 skill(s), 0 command(s), 0 agent(s)
PASSED: All validation checks passed          # exit 0

$ ./scripts/check-version-bumps.sh origin/main
check-version-bumps: 'herdr' is new (no version at base) — skipping
check-version-bumps: OK                       # exit 0

$ ./scripts/run-plugin-tests.sh
0 fail / 8 skip / 412 expect() calls
Ran 218 tests across 16 files. [3.50s]
All plugin suites passed.

$ actionlint .github/workflows/herdr-skill-freshness.yml   # exit 0
$ yamllint -c .yamllint.yaml .github/workflows/herdr-skill-freshness.yml   # exit 0
```

Freshness logic exercised **both** directions locally — a check that cannot fail is not a check:

```
upstream sha: 0786182f02ebf92708e09d82d79e4614d1a9c30bfc337643cc2af1d0fb9db29f
vendored sha: 0786182f02ebf92708e09d82d79e4614d1a9c30bfc337643cc2af1d0fb9db29f
no-drift case  -> PASS (identical)
drifted copy   -> PASS (drift correctly detected)
```

## Checklist

- [x] Linked to a GitHub issue (#889)
- [x] Feature-complete and verified — not exploratory code
- [ ] Tests written first (TDD) — n/a: this plugin ships a vendored skill document, no executable code. Enforcement is `validate-plugins.sh` plus the new freshness workflow.
- [x] Verified locally — evidence pasted above
- [ ] CI watched to green — pending, will watch after open
- [x] Follows project conventions