### PR TITLE
MEDDPICC: read a workbook back and propose deal-JSON changes (stage 3)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,50 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v2.7.0 — the workbook reads back. `engine/cli.ts read <workbook.xlsx> --deal
+  <deal.json>` reports what the spreadsheet proposes changing, and `--apply` writes it.
+
+  **Read, diff, propose — never overwrite.** The JSON stays the source of truth, so a cell that
+  differs is a *proposal*, printed with its old and new value. Nothing is written without
+  `--apply`, and `--apply` writes only a deal that validates: a partly-applied file would be
+  worse than none. The run's exit code follows the outcome, so a script can gate on it.
+
+  **The reader walks `inputCells`**, the map `planWorkbook` already returns. It has no second
+  idea of where a field lives, which is the only way the two directions cannot drift. `computed`
+  and `derived` cells are outputs and are never read — including a formula found at an input
+  address, which is refused rather than having the number beside it taken as somebody's answer.
+
+  **Every rejection names its cell.** A score of 7, a status outside the enum, prose in a
+  currency cell, `#REF!` in a text cell: each is reported as `Qualification!C8`, not as a JSON
+  pointer, because the person who has to fix it is looking at Excel. Rejections never reach the
+  deal, and the rest of the workbook still round-trips around them.
+
+  Four things that only look obvious afterwards, each of which would have made the reader
+  useless in a different way:
+
+  - **Excel rewrites the file when it saves.** The generator writes strings inline
+    (`t="inlineStr"`); Excel re-saves the same text through `sharedStrings.xml` as `t="s"`.
+    Measured: with shared strings unresolved, opening the workbook and saving it *without
+    editing anything* produced 86 phantom proposals and 18 rejections. Every unit test passed.
+  - **A date cell can only hold a day.** `2026-06-30T09:15:00Z` in the JSON against `2026-06-30`
+    in the sheet is not an edit, so dates are compared as serials. Compared as text, the reader
+    would have cried wolf on every read until nobody read it.
+  - **An unscored element is written as `0`, not blank** — deliberately, since `COUNT` over
+    blanks made a partly-qualified deal show 100%. So a `0` read back cannot be told from "not
+    assessed", and a missing score must not become a proposal to set `score: 0`.
+  - **A list may only be appended to.** The tables carry blank rows to grow into, and filling
+    the sixth row of a three-item list would write `stakeholders[5]` into an array of length 3.
+    Refused by cell address, with the row that is still empty named.
+
+  Verified in real Excel end to end: four cells of four types edited by hand, saved, and read
+  back exactly — a string through shared strings, a 0-4 score, `2026-09-15` typed as text and
+  stored as a serial, and a boolean. The UAT was itself mutation-checked, and the 86-proposal
+  measurement above is what it reports when the reader is broken.
+
+  `readPath` moved into `engine/json-path.ts` alongside the new `writePath`, so one walker
+  serves both directions. The redundant integer check in the reader's coercion is gone: whether
+  a whole number is required is the schema's call, and a second opinion could only disagree.
+
 - **`meddpicc`** v2.6.0 — the workbook is now a working spreadsheet, not just a rendered one.
 
   **Excel Tables** over all eight collections, so they filter, sort, stripe, and extend when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,23 @@ and this project adheres to
   pointer, because the person who has to fix it is looking at Excel. Rejections never reach the
   deal, and the rest of the workbook still round-trips around them.
 
-  Four things that only look obvious afterwards, each of which would have made the reader
+  **A workbook is read against the deal it came from, or not at all.** `generate` stamps each
+  file with a fingerprint of the deal's identity and its layout, kept in a custom document
+  property that Excel carries through a save; `read` refuses a workbook whose stamp does not
+  match. This is not belt-and-braces. A table's row count depends on the deal, so answering one
+  more question moves every Questions row below it, and reading a workbook from before that
+  cell by cell produced **14 confident proposals — no rejections, `ok` true** — that wrote
+  metrics' answers onto economicBuyer and economicBuyer's onto decisionCriteria. The stamp
+  covers identity and layout only, never the whole deal, so a workbook already on someone's
+  desk survives a JSON edit that moves no cell.
+
+  **Nothing is dropped in silence.** The tables are padded with blank rows and an Excel Table
+  extends further still when someone types under the last one — perfectly reasonable, and those
+  cells belong to no field. They are now reported by address rather than passed over, because
+  passing over them is the legacy sheet's own bug in a new place: it formatted eight team rows
+  and dropped the rest.
+
+  Five things that only look obvious afterwards, each of which would have made the reader
   useless in a different way:
 
   - **Excel rewrites the file when it saves.** The generator writes strings inline
@@ -50,9 +66,21 @@ and this project adheres to
   stored as a serial, and a boolean. The UAT was itself mutation-checked, and the 86-proposal
   measurement above is what it reports when the reader is broken.
 
+  - **A refused write must change nothing.** Reaching `responses[1]` in a deal with no
+    `responses` at all builds the array on the way to the leaf, and refusing the index
+    afterwards left an empty array behind in a deal reported as unchanged. `writePath` now
+    decides whether a write is possible before making it.
+
   `readPath` moved into `engine/json-path.ts` alongside the new `writePath`, so one walker
   serves both directions. The redundant integer check in the reader's coercion is gone: whether
   a whole number is required is the schema's call, and a second opinion could only disagree.
+
+  The review found all three of the above independently of the two that were found while
+  mutation-checking, and every one was reproduced before being fixed. Mutation testing was the
+  more useful of the two passes on the reader's own guards: 24 deliberate breakages, all caught,
+  and three of them changed the code rather than the tests — an error-cell test that proved
+  nothing because it used a currency cell where `NaN` already rejected the value, an integer
+  check duplicating the schema's, and a formula skip that was both untested and wrong.
 
 - **`meddpicc`** v2.6.0 — the workbook is now a working spreadsheet, not just a rendered one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ and this project adheres to
     the sixth row of a three-item list would write `stakeholders[5]` into an array of length 3.
     Refused by cell address, with the row that is still empty named.
 
-  Verified in real Excel end to end: four cells of four types edited by hand, saved, and read
+  Verified in real Excel end-to-end: four cells of four types edited by hand, saved, and read
   back exactly — a string through shared strings, a 0-4 score, `2026-09-15` typed as text and
   stored as a serial, and a boolean. The UAT was itself mutation-checked, and the 86-proposal
   measurement above is what it reports when the reader is broken.

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/.xcsh-plugin/resources.json
+++ b/plugins/meddpicc/.xcsh-plugin/resources.json
@@ -8,6 +8,6 @@
   "engine": {
     "runtime": "bun",
     "entry": "engine/cli.ts",
-    "commands": ["validate", "next", "score", "hint", "fill", "check-mappings", "check-spec", "generate"]
+    "commands": ["validate", "next", "score", "hint", "fill", "check-mappings", "check-spec", "generate", "read"]
   }
 }

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -1,8 +1,27 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 const engineDir = import.meta.dir;
 const example = path.join(engineDir, '..', 'schema', 'example-deal.json');
+
+/**
+ * A scratch directory per run. Every `read --apply` test writes a deal, so each needs its own
+ * copy — and none of them may touch a real deal file, which is edited by a person.
+ */
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'meddpicc-cli-'));
+afterAll(() => fs.rmSync(scratch, { recursive: true, force: true }));
+
+/** A private copy of the example deal, and a workbook generated from it. */
+async function fixture(name: string): Promise<{ deal: string; workbook: string }> {
+  const deal = path.join(scratch, `${name}.json`);
+  const workbook = path.join(scratch, `${name}.xlsx`);
+  fs.copyFileSync(example, deal);
+  const { code } = await run(['generate', deal, '--out', workbook]);
+  expect(code).toBe(0);
+  return { deal, workbook };
+}
 
 async function run(args: string[]): Promise<{ code: number; out: string }> {
   const proc = Bun.spawn(['bun', path.join(engineDir, 'cli.ts'), ...args], { stdout: 'pipe', stderr: 'pipe' });
@@ -60,5 +79,107 @@ describe('cli', () => {
     expect(r.nextIncompleteSection).toBe('decisionProcess');
     expect(r.hint?.element).toBe('decisionProcess');
     expect(r.hint?.questions.length).toBeGreaterThan(0);
+  });
+});
+
+describe('cli read', () => {
+  /** Retype one cell in a workbook on disk, the way a person would in Excel. */
+  async function retype(workbook: string, address: string, cellXml: string): Promise<void> {
+    const { readZip, writeZip } = await import('./zip');
+    const entries = readZip(new Uint8Array(await Bun.file(workbook).arrayBuffer()));
+    const part = [...entries.keys()].find((name) => {
+      if (!/^xl\/worksheets\/sheet\d+\.xml$/.test(name)) return false;
+      return new RegExp(`<c r="${address}"`).test(
+        new TextDecoder().decode(entries.get(name)?.data ?? new Uint8Array()),
+      );
+    });
+    if (!part) throw new Error(`no sheet holds ${address}`);
+    const xml = new TextDecoder().decode(entries.get(part)?.data as Uint8Array);
+    const updated = xml.replace(new RegExp(`<c r="${address}"(?: [^>]*)?(?:/>|>.*?</c>)`), cellXml);
+    await Bun.write(
+      workbook,
+      writeZip(
+        [...entries.values()].map((e) =>
+          e.name === part ? { name: e.name, data: new TextEncoder().encode(updated) } : { name: e.name, raw: e },
+        ),
+      ),
+    );
+  }
+
+  /** Where the generator put a jsonPath, asked of the plan rather than guessed. */
+  async function addressOf(deal: string, jsonPath: string): Promise<string> {
+    const { code, out } = await run(['generate', deal, '--plan']);
+    expect(code).toBe(0);
+    const found = (JSON.parse(out).inputCells as Array<{ jsonPath: string; address: string }>).find(
+      (c) => c.jsonPath === jsonPath,
+    );
+    if (!found) throw new Error(`no input cell for ${jsonPath}`);
+    return found.address;
+  }
+
+  test('an untouched workbook proposes nothing and exits 0', async () => {
+    const { deal, workbook } = await fixture('untouched');
+    const { code, out } = await run(['read', workbook, '--deal', deal]);
+    expect(code).toBe(0);
+    const report = JSON.parse(out);
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toEqual([]);
+    expect(report.applied).toBe(false);
+  });
+
+  test('read without --deal exits 1', async () => {
+    const { workbook } = await fixture('nodeal');
+    expect((await run(['read', workbook])).code).toBe(1);
+  });
+
+  test('an edit is proposed, and without --apply the deal on disk is untouched', async () => {
+    const { deal, workbook } = await fixture('propose');
+    const before = fs.readFileSync(deal, 'utf8');
+    const address = await addressOf(deal, 'metadata.accountName');
+    await retype(workbook, address, `<c r="${address}" t="inlineStr"><is><t>Globex</t></is></c>`);
+
+    const { code, out } = await run(['read', workbook, '--deal', deal]);
+    expect(code).toBe(0);
+    const report = JSON.parse(out);
+    expect(report.proposals).toHaveLength(1);
+    expect(report.applied).toBe(false);
+    expect(fs.readFileSync(deal, 'utf8')).toBe(before);
+  });
+
+  test('--apply writes the change, and the result still validates', async () => {
+    const { deal, workbook } = await fixture('apply');
+    const address = await addressOf(deal, 'metadata.accountName');
+    await retype(workbook, address, `<c r="${address}" t="inlineStr"><is><t>Globex</t></is></c>`);
+
+    const { code, out } = await run(['read', workbook, '--deal', deal, '--apply']);
+    expect(code).toBe(0);
+    expect(JSON.parse(out).applied).toBe(true);
+    expect(JSON.parse(fs.readFileSync(deal, 'utf8')).metadata.accountName).toBe('Globex');
+    expect((await run(['validate', deal])).code).toBe(0);
+  });
+
+  test('a rejected cell fails the run and writes nothing, even with --apply', async () => {
+    const { deal, workbook } = await fixture('reject');
+    const before = fs.readFileSync(deal, 'utf8');
+    const address = await addressOf(deal, 'qualification.champion.score');
+    await retype(workbook, address, `<c r="${address}"><v>7</v></c>`);
+
+    const { code, out } = await run(['read', workbook, '--deal', deal, '--apply']);
+    expect(code).toBe(1);
+    const report = JSON.parse(out);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.applied).toBe(false);
+    expect(fs.readFileSync(deal, 'utf8')).toBe(before);
+  });
+
+  test('applying twice is a no-op the second time', async () => {
+    const { deal, workbook } = await fixture('idempotent');
+    const address = await addressOf(deal, 'metadata.accountName');
+    await retype(workbook, address, `<c r="${address}" t="inlineStr"><is><t>Globex</t></is></c>`);
+
+    expect(JSON.parse((await run(['read', workbook, '--deal', deal, '--apply'])).out).applied).toBe(true);
+    const second = JSON.parse((await run(['read', workbook, '--deal', deal, '--apply'])).out);
+    expect(second.proposals).toEqual([]);
+    expect(second.applied).toBe(false);
   });
 });

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -6,6 +6,7 @@ import { applyFill, planFill } from './fill';
 import { generateWorkbook, planWorkbook } from './generate';
 import { computeElementHint, computeHintOverview } from './hint';
 import { checkMappings } from './mappings';
+import { readWorkbook } from './read-workbook';
 import { computeScore } from './score';
 import { QUALIFICATION_ELEMENTS } from './sections';
 import { readTemplateText } from './template';
@@ -185,6 +186,42 @@ async function main(): Promise<number> {
     return 0;
   }
 
+  if (command === 'read') {
+    const workbookPath = rest[0];
+    const dealPath = flag(rest, '--deal');
+    if (!workbookPath || !dealPath) {
+      process.stderr.write('Usage: cli.ts read <workbook.xlsx> --deal <deal.json> [--apply]\n');
+      return 1;
+    }
+    const schema = await readJson(SCHEMA_PATH);
+    const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
+    const deal = await readJson(dealPath);
+    const bytes = new Uint8Array(await Bun.file(workbookPath).arrayBuffer());
+    const report = readWorkbook(schema, spec, deal, bytes);
+
+    // The deal JSON is the source of truth, so the default is to say what the workbook
+    // proposes and change nothing. `--apply` is the only path that writes, and it writes only
+    // a deal that validates — a partly-applied file would be worse than no file.
+    const apply = rest.includes('--apply') && report.ok && report.proposals.length > 0;
+    if (apply) await Bun.write(dealPath, `${JSON.stringify(report.deal, null, 2)}\n`);
+
+    print({
+      workbook: workbookPath,
+      deal: dealPath,
+      cellsRead: report.cellsRead,
+      unchanged: report.unchanged,
+      proposals: report.proposals,
+      rejections: report.rejections,
+      valid: report.valid,
+      errors: report.errors,
+      applied: apply,
+    });
+    if (rest.includes('--apply') && !report.ok) {
+      process.stderr.write('Refusing to apply: fix the cells listed above, or edit the JSON directly.\n');
+    }
+    return report.ok ? 0 : 1;
+  }
+
   if (command === 'check-spec') {
     const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
     const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
@@ -194,7 +231,7 @@ async function main(): Promise<number> {
   }
 
   process.stderr.write(
-    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, fill, generate, check-mappings, check-spec\n`,
+    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, fill, generate, read, check-mappings, check-spec\n`,
   );
   return 1;
 }

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -11,6 +11,7 @@
  * value, with the `jsonPath` it came from. That map is the contract the round-trip reader
  * will consume, and stating it here keeps the two directions from drifting.
  */
+import { createHash } from 'node:crypto';
 import { computeCompletion } from './completion';
 import { computeElementHint } from './hint';
 import { readPath } from './json-path';
@@ -493,6 +494,30 @@ function inputPathFor(table: SpecTable, column: SpecColumn, entry: TableLayout['
   return relative.replace('*', entry.key as string);
 }
 
+/**
+ * What a workbook may be read back against: this deal, laid out this way.
+ *
+ * Both are needed, and for different reasons. The **identity** stops a workbook for one deal
+ * being applied to another — an easy mistake when every deal's file is called `meddpicc.json`
+ * in a different directory, and one that `--apply` would otherwise resolve by overwriting the
+ * second deal with the first one's figures.
+ *
+ * The **layout** stops something quieter and worse. A table's row count depends on the deal:
+ * answer one more question and every Questions row below it moves down one. The addresses in
+ * an older workbook then name a different element's answer, and reading it row by row produces
+ * a confident set of proposals that put metrics' answers onto economicBuyer. Measured on the
+ * example deal: 14 proposals, no rejections, and nothing to suggest anything was wrong.
+ *
+ * Deliberately NOT a hash of the whole deal: a workbook on someone's desk must survive an edit
+ * to the JSON that moves no cell, or the two would have to be regenerated in lockstep forever.
+ */
+export function workbookFingerprint(plan: WorkbookPlan, deal: unknown): string {
+  const identity = String(readPath(deal, 'metadata.dealId') ?? '');
+  const layout = plan.inputCells.map((c) => `${c.jsonPath}|${c.sheet}|${c.address}`).join('\n');
+  return createHash('sha256').update(`${identity}\n${layout}`).digest('hex').slice(0, 32);
+}
+
 export function generateWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown): Uint8Array {
-  return buildWorkbook(planWorkbook(schema, spec, deal).sheets);
+  const plan = planWorkbook(schema, spec, deal);
+  return buildWorkbook(plan.sheets, workbookFingerprint(plan, deal));
 }

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -13,6 +13,7 @@
  */
 import { computeCompletion } from './completion';
 import { computeElementHint } from './hint';
+import { readPath } from './json-path';
 import { schemaConstraint } from './schema-path';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
 import {
@@ -60,24 +61,6 @@ export function dateToSerial(value: unknown): number | null {
   const back = new Date(utc);
   if (back.getUTCFullYear() !== y || back.getUTCMonth() !== mo - 1 || back.getUTCDate() !== d) return null;
   return Math.round((utc - EXCEL_EPOCH_UTC) / MS_PER_DAY);
-}
-
-/** Follow a dotted/indexed path into the deal. Returns undefined rather than throwing. */
-function readPath(root: unknown, dottedPath: string): unknown {
-  let node: unknown = root;
-  for (const part of dottedPath.split('.')) {
-    const m = /^([^[\]]*)((?:\[\d+\])*)$/.exec(part);
-    const key = m?.[1] ?? part;
-    if (key) {
-      if (node === null || typeof node !== 'object') return undefined;
-      node = (node as Record<string, unknown>)[key];
-    }
-    for (const idx of m?.[2]?.match(/\d+/g) ?? []) {
-      if (!Array.isArray(node)) return undefined;
-      node = node[Number(idx)];
-    }
-  }
-  return node;
 }
 
 /** Coerce a deal value for a cell of this type. `undefined` means leave the cell blank. */

--- a/plugins/meddpicc/engine/json-path.test.ts
+++ b/plugins/meddpicc/engine/json-path.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test';
+import { readPath, writePath } from './json-path';
+
+const deal = () => ({
+  metadata: { accountName: 'Acme', revenue: { acv: 85000 } },
+  stakeholders: [{ name: 'Sarah' }, { name: 'Marcus' }],
+  qualification: { metrics: { responses: ['first', 'second'] } },
+});
+
+describe('readPath', () => {
+  test('follows properties and indexes', () => {
+    expect(readPath(deal(), 'metadata.revenue.acv')).toBe(85000);
+    expect(readPath(deal(), 'stakeholders[1].name')).toBe('Marcus');
+    expect(readPath(deal(), 'qualification.metrics.responses[0]')).toBe('first');
+  });
+
+  test('returns undefined rather than throwing on a path that is not there', () => {
+    expect(readPath(deal(), 'metadata.nope')).toBeUndefined();
+    expect(readPath(deal(), 'metadata.nope.deeper')).toBeUndefined();
+    expect(readPath(deal(), 'stakeholders[9].name')).toBeUndefined();
+    // A property read through an array, and an index read through an object: both are the
+    // wrong shape, and neither may throw — the caller is asking about a cell, not asserting.
+    expect(readPath(deal(), 'stakeholders.name')).toBeUndefined();
+    expect(readPath(deal(), 'metadata[0]')).toBeUndefined();
+  });
+});
+
+describe('writePath', () => {
+  test('sets a value that is already there', () => {
+    const d = deal();
+    expect(writePath(d, 'metadata.accountName', 'Globex')).toBeNull();
+    expect(d.metadata.accountName).toBe('Globex');
+  });
+
+  test('builds the objects on the way to a new leaf', () => {
+    const d = deal();
+    expect(writePath(d, 'metadata.lastClientInteraction.outcome', 'Agreed next steps')).toBeNull();
+    expect(readPath(d, 'metadata.lastClientInteraction.outcome')).toBe('Agreed next steps');
+  });
+
+  test('appends at the end of a list', () => {
+    const d = deal();
+    expect(writePath(d, 'stakeholders[2].name', 'Dana')).toBeNull();
+    expect(d.stakeholders.map((s) => s.name)).toEqual(['Sarah', 'Marcus', 'Dana']);
+  });
+
+  test('builds a list that does not exist yet, but only from its first row', () => {
+    const d = deal();
+    expect(writePath(d, 'closePlan.milestones[0].description', 'Signed')).toBeNull();
+    expect(readPath(d, 'closePlan.milestones[0].description')).toBe('Signed');
+
+    const other = deal();
+    expect(writePath(other, 'closePlan.milestones[2].description', 'Signed')).toMatch(/row 3.*row 1/);
+    // And the refusal built nothing: a `closePlan` left behind would be a change nobody asked
+    // for, in a deal reported as unchanged.
+    expect(other).toEqual(deal());
+  });
+
+  test('refuses to leave a hole in a list', () => {
+    const d = deal();
+    expect(writePath(d, 'stakeholders[4].name', 'Dana')).toMatch(/row 5.*row 3/);
+    expect(d).toEqual(deal());
+  });
+
+  test('refuses a path whose shape is wrong, and changes nothing', () => {
+    const d = deal();
+    expect(writePath(d, 'metadata.accountName.deeper', 'x')).toMatch(/expects an object/);
+    expect(writePath(d, 'metadata[0]', 'x')).toMatch(/expects a list/);
+    expect(writePath(d, '', 'x')).toMatch(/names nothing/);
+    expect(d).toEqual(deal());
+  });
+
+  test('clearing deletes a property outright', () => {
+    const d = deal();
+    expect(writePath(d, 'metadata.accountName', undefined)).toBeNull();
+    expect('accountName' in d.metadata).toBe(false);
+  });
+
+  test('clearing a list element keeps the positions of the others', () => {
+    // A response's position is which question it answers, so removing the element would
+    // re-attach every later answer to the wrong question.
+    const d = deal();
+    expect(writePath(d, 'qualification.metrics.responses[0]', undefined)).toBeNull();
+    expect(d.qualification.metrics.responses).toEqual(['', 'second']);
+  });
+
+  test('clearing something that is not there is a no-op, not a construction', () => {
+    const d = deal();
+    expect(writePath(d, 'metadata.nextClientInteraction.objective', undefined)).toBeNull();
+    expect(d).toEqual(deal());
+  });
+});

--- a/plugins/meddpicc/engine/json-path.ts
+++ b/plugins/meddpicc/engine/json-path.ts
@@ -54,51 +54,103 @@ export function writePath(root: unknown, dottedPath: string, value: unknown): st
   const tokens = tokenize(dottedPath);
   if (tokens.length === 0) return `"${dottedPath}" names nothing to write`;
 
+  // Decided before anything is touched, because a write that gives up halfway leaves the
+  // objects it built on the way in. Reaching `responses[1]` in a deal with no `responses` at
+  // all creates the array first; refusing the index afterwards would leave an empty array in a
+  // deal the caller was told had changed in no way.
+  const problem = checkPath(root, tokens, dottedPath, value === undefined);
+  if (problem) return problem;
+
   let node: unknown = root;
   for (let i = 0; i < tokens.length - 1; i++) {
     const token = tokens[i];
-    const nextIsIndex = typeof tokens[i + 1] === 'number';
+    const fresh = typeof tokens[i + 1] === 'number' ? [] : {};
 
     if (typeof token === 'number') {
-      if (!Array.isArray(node)) return `${dottedPath} expects a list at step ${i + 1}`;
-      if (token > node.length) {
-        return `row ${token + 1} cannot be filled in while row ${node.length + 1} is still empty`;
-      }
-      if (token === node.length) node.push(nextIsIndex ? [] : {});
-      node = node[token];
+      const list = node as unknown[];
+      if (token === list.length) list.push(fresh);
+      node = list[token];
       continue;
     }
 
-    if (node === null || typeof node !== 'object' || Array.isArray(node)) {
-      return `${dottedPath} expects an object at step ${i + 1}`;
-    }
     const holder = node as Record<string, unknown>;
+    // Clearing never builds a path: `checkPath` has already established there is nothing there.
     if (holder[token] === undefined || holder[token] === null) {
-      // Clearing a value never needs to build the path to it.
       if (value === undefined) return null;
-      holder[token] = nextIsIndex ? [] : {};
+      holder[token] = fresh;
     }
     node = holder[token];
   }
 
   const last = tokens[tokens.length - 1];
   if (typeof last === 'number') {
-    if (!Array.isArray(node)) return `${dottedPath} expects a list`;
-    if (last > node.length) {
-      return `row ${last + 1} cannot be filled in while row ${node.length + 1} is still empty`;
-    }
+    const list = node as unknown[];
     if (value === undefined) {
-      // Deleting from the middle would renumber every element after it.
-      if (last < node.length) node[last] = '';
+      // Deleting from the middle would renumber every element after it, and a response's
+      // position is which question it answers.
+      if (last < list.length) list[last] = '';
       return null;
     }
-    node[last] = value;
+    list[last] = value;
     return null;
   }
 
-  if (node === null || typeof node !== 'object' || Array.isArray(node)) return `${dottedPath} expects an object`;
   const holder = node as Record<string, unknown>;
   if (value === undefined) delete holder[last];
   else holder[last] = value;
+  return null;
+}
+
+/**
+ * Whether the write can be made, without making it.
+ *
+ * Walks the same tokens against the same data, tracking one extra thing: whether the node it
+ * is standing on is one the write would have to create. A created node is empty, so an index
+ * into it may only be 0 — which is what makes the array rule hold for a path that does not
+ * exist yet, not just for one that does.
+ */
+function checkPath(
+  root: unknown,
+  tokens: Array<string | number>,
+  dottedPath: string,
+  clearing: boolean,
+): string | null {
+  let node: unknown = root;
+  let fresh = false;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const isLast = i === tokens.length - 1;
+
+    if (typeof token === 'number') {
+      const length = fresh ? 0 : Array.isArray(node) ? node.length : -1;
+      if (length < 0) return `${dottedPath} expects a list at step ${i + 1}`;
+      if (token > length) return `row ${token + 1} cannot be filled in while row ${length + 1} is still empty`;
+      if (isLast) return null;
+      if (token === length) {
+        fresh = true;
+        node = undefined;
+      } else {
+        node = (node as unknown[])[token];
+      }
+      continue;
+    }
+
+    if (!fresh && (node === null || typeof node !== 'object' || Array.isArray(node))) {
+      return `${dottedPath} expects an object at step ${i + 1}`;
+    }
+    if (isLast) return null;
+
+    const child = fresh ? undefined : (node as Record<string, unknown>)[token];
+    if (child === undefined || child === null) {
+      if (clearing) return null;
+      fresh = true;
+      node = undefined;
+    } else {
+      fresh = false;
+      node = child;
+    }
+  }
+
   return null;
 }

--- a/plugins/meddpicc/engine/json-path.ts
+++ b/plugins/meddpicc/engine/json-path.ts
@@ -1,0 +1,104 @@
+/**
+ * Read and write a dotted/indexed path into a deal — `metadata.revenue.acv`,
+ * `stakeholders[3].name`, `qualification.metrics.responses[0]`.
+ *
+ * The generator reads these paths and the reader writes them back, so they live together:
+ * two walkers would eventually disagree about what `stakeholders[3]` means, and the
+ * disagreement would put a value somewhere nobody looked.
+ */
+
+/** Split "a.b[0].c" into its steps, keeping indexes as their own tokens. */
+function tokenize(dottedPath: string): Array<string | number> {
+  const tokens: Array<string | number> = [];
+  for (const part of dottedPath.split('.')) {
+    const m = /^([^[\]]*)((?:\[\d+\])*)$/.exec(part);
+    if (!m) {
+      tokens.push(part);
+      continue;
+    }
+    if (m[1]) tokens.push(m[1]);
+    for (const index of m[2].match(/\d+/g) ?? []) tokens.push(Number(index));
+  }
+  return tokens;
+}
+
+/** Follow a path into the deal. Returns undefined rather than throwing. */
+export function readPath(root: unknown, dottedPath: string): unknown {
+  let node: unknown = root;
+  for (const token of tokenize(dottedPath)) {
+    if (typeof token === 'number') {
+      if (!Array.isArray(node)) return undefined;
+      node = node[token];
+      continue;
+    }
+    if (node === null || typeof node !== 'object' || Array.isArray(node)) return undefined;
+    node = (node as Record<string, unknown>)[token];
+  }
+  return node;
+}
+
+/**
+ * Write a value at a path, creating the objects and array entries it passes through.
+ * Returns a message when the write cannot be made, so the caller can name the cell.
+ *
+ * `undefined` clears: an object property is deleted, an array element becomes empty — which
+ * keeps the positions of the elements around it, and those positions are what a response
+ * array means.
+ *
+ * An array may only be appended to. Writing index 5 of a 3-element array would leave holes
+ * that serialise as `null` and fail the schema, so it is refused rather than attempted: the
+ * workbook pads its tables with blank rows, and skipping two of them is an easy mistake to
+ * make in Excel.
+ */
+export function writePath(root: unknown, dottedPath: string, value: unknown): string | null {
+  const tokens = tokenize(dottedPath);
+  if (tokens.length === 0) return `"${dottedPath}" names nothing to write`;
+
+  let node: unknown = root;
+  for (let i = 0; i < tokens.length - 1; i++) {
+    const token = tokens[i];
+    const nextIsIndex = typeof tokens[i + 1] === 'number';
+
+    if (typeof token === 'number') {
+      if (!Array.isArray(node)) return `${dottedPath} expects a list at step ${i + 1}`;
+      if (token > node.length) {
+        return `row ${token + 1} cannot be filled in while row ${node.length + 1} is still empty`;
+      }
+      if (token === node.length) node.push(nextIsIndex ? [] : {});
+      node = node[token];
+      continue;
+    }
+
+    if (node === null || typeof node !== 'object' || Array.isArray(node)) {
+      return `${dottedPath} expects an object at step ${i + 1}`;
+    }
+    const holder = node as Record<string, unknown>;
+    if (holder[token] === undefined || holder[token] === null) {
+      // Clearing a value never needs to build the path to it.
+      if (value === undefined) return null;
+      holder[token] = nextIsIndex ? [] : {};
+    }
+    node = holder[token];
+  }
+
+  const last = tokens[tokens.length - 1];
+  if (typeof last === 'number') {
+    if (!Array.isArray(node)) return `${dottedPath} expects a list`;
+    if (last > node.length) {
+      return `row ${last + 1} cannot be filled in while row ${node.length + 1} is still empty`;
+    }
+    if (value === undefined) {
+      // Deleting from the middle would renumber every element after it.
+      if (last < node.length) node[last] = '';
+      return null;
+    }
+    node[last] = value;
+    return null;
+  }
+
+  if (node === null || typeof node !== 'object' || Array.isArray(node)) return `${dottedPath} expects an object`;
+  const holder = node as Record<string, unknown>;
+  if (value === undefined) delete holder[last];
+  else holder[last] = value;
+  return null;
+}

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -49,6 +49,26 @@ function withCell(bytes: Uint8Array, sheetName: string, ref: string, cellXml: st
   );
 }
 
+/** Type into a cell that does not exist yet — what Excel does when a Table grows. */
+function addCell(bytes: Uint8Array, sheetName: string, ref: string, cellXml: string): Uint8Array {
+  const entries = readZip(bytes);
+  const part = sheetPart(sheetName);
+  const entry = entries.get(part);
+  if (!entry) throw new Error(`no part ${part}`);
+  const xml = new TextDecoder().decode(entry.data);
+  if (new RegExp(`<c r="${ref}"`).test(xml)) throw new Error(`cell ${ref} already exists in ${part}`);
+  const row = /(\d+)$/.exec(ref)?.[1];
+  const existingRow = new RegExp(`<row r="${row}"(?: [^>]*)?>`).exec(xml);
+  const updated = existingRow
+    ? xml.replace(existingRow[0], `${existingRow[0]}${cellXml}`)
+    : xml.replace('</sheetData>', `<row r="${row}">${cellXml}</row></sheetData>`);
+  return writeZip(
+    [...entries.values()].map((e) =>
+      e.name === part ? { name: e.name, data: new TextEncoder().encode(updated) } : { name: e.name, raw: e },
+    ),
+  );
+}
+
 const setNumber = (bytes: Uint8Array, sheet: string, ref: string, value: number) =>
   withCell(bytes, sheet, ref, `<c r="${ref}"><v>${value}</v></c>`);
 const setText = (bytes: Uint8Array, sheet: string, ref: string, text: string) =>
@@ -505,6 +525,131 @@ describe('clearing a value', () => {
     expect(after).toHaveLength(responses.length);
     expect(after[0]).toBe('');
     expect(after[1]).toBe(responses[1]);
+  });
+});
+
+describe('a rejected cell changes nothing at all', () => {
+  test('a refused write leaves the deal byte-identical', () => {
+    // Writing `responses[1]` into a deal with no `responses` key at all has to build the array
+    // on the way to the leaf. Building it and then refusing the leaf would leave an empty
+    // array nobody asked for in a deal reported as having no proposals.
+    const deal = clone(exampleDeal);
+    delete deal.qualification.metrics.responses;
+    const { sheet, address } = addressOf(deal, 'qualification.metrics.responses[1]');
+    const report = read(deal, setText(generateWorkbook(schema, spec, deal), sheet, address, 'Second answer'));
+    expect(report.rejections).toHaveLength(1);
+    expect(report.proposals).toEqual([]);
+    expect(report.deal).toEqual(deal);
+  });
+});
+
+describe('rows typed below the ones the workbook maps', () => {
+  /** The last row an input column covers, and the column letters, for a list table. */
+  function lastMapped(deal: unknown, jsonPathPrefix: string): { sheet: string; column: string; row: number } {
+    const cells = planWorkbook(schema, spec, deal).inputCells.filter((c) => c.jsonPath.startsWith(jsonPathPrefix));
+    if (cells.length === 0) throw new Error(`no input cells under ${jsonPathPrefix}`);
+    const parsed = cells.map((c) => {
+      const m = /^([A-Z]+)(\d+)$/.exec(c.address);
+      return { sheet: c.sheet, column: m?.[1] as string, row: Number(m?.[2]) };
+    });
+    const column = parsed[0].column;
+    const inColumn = parsed.filter((p) => p.column === column);
+    return { sheet: inColumn[0].sheet, column, row: Math.max(...inColumn.map((p) => p.row)) };
+  }
+
+  test('a row below the padding is reported, not silently dropped', () => {
+    // An Excel Table extends when someone types under its last row, so this is not a hostile
+    // edit — it is the ordinary way to add a stakeholder once the padded rows are used up.
+    // Dropping it without a word is the legacy sheet's actual bug, in a new place.
+    const { sheet, column, row } = lastMapped(exampleDeal, 'stakeholders[');
+    const ref = `${column}${row + 1}`;
+    const edited = addCell(
+      generateWorkbook(schema, spec, exampleDeal),
+      sheet,
+      ref,
+      `<c r="${ref}" t="inlineStr"><is><t>One Row Too Far</t></is></c>`,
+    );
+    const report = read(exampleDeal, edited);
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0]).toMatchObject({ sheet, address: ref });
+    expect(report.rejections[0].reason).toMatch(/below/i);
+    expect(report.ok).toBe(false);
+  });
+
+  test('a formula below the padding is reported too — it is still content', () => {
+    const { sheet, column, row } = lastMapped(exampleDeal, 'stakeholders[');
+    const ref = `${column}${row + 1}`;
+    const edited = addCell(
+      generateWorkbook(schema, spec, exampleDeal),
+      sheet,
+      ref,
+      `<c r="${ref}"><f>CONCATENATE(A1," extra")</f></c>`,
+    );
+    const report = read(exampleDeal, edited);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0]).toMatchObject({ sheet, address: ref });
+    expect(report.rejections[0].reason).toMatch(/CONCATENATE/);
+  });
+
+  test('a blank cell below the padding is not reported', () => {
+    const { sheet, column, row } = lastMapped(exampleDeal, 'stakeholders[');
+    const ref = `${column}${row + 1}`;
+    const edited = addCell(generateWorkbook(schema, spec, exampleDeal), sheet, ref, `<c r="${ref}"/>`);
+    expect(read(exampleDeal, edited).rejections).toEqual([]);
+  });
+
+  test('the header row above the data is not mistaken for an unmapped edit', () => {
+    const report = read(exampleDeal, generateWorkbook(schema, spec, exampleDeal));
+    expect(report.rejections).toEqual([]);
+  });
+});
+
+describe('a workbook may only be read against the deal it came from', () => {
+  test('a workbook belonging to another deal is refused, not applied to this one', () => {
+    // Otherwise every cell of deal A reads as an edit to deal B, and `--apply` overwrites B's
+    // identity and figures with A's — a plausible mistake, since both files are called
+    // meddpicc.json in different directories.
+    const other = clone(exampleDeal);
+    other.metadata.dealId = '006XX000000OTHER';
+    const report = read(other, generateWorkbook(schema, spec, exampleDeal));
+    expect(report.ok).toBe(false);
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0].reason).toMatch(/regenerate/i);
+  });
+
+  test('a workbook whose rows have since shifted is refused, not read row by row', () => {
+    // This is the dangerous one. Answering one more question moves every Questions row below
+    // it, so the same address now names a different element's answer. Read row by row, the
+    // reader would confidently propose writing metrics' answers onto economicBuyer.
+    const grown = clone(exampleDeal);
+    (grown.qualification.metrics.responses as string[]).push('A third answer');
+    const stale = generateWorkbook(schema, spec, exampleDeal);
+    const report = read(grown, stale);
+    expect(report.ok).toBe(false);
+    expect(report.proposals).toEqual([]);
+  });
+
+  test('an unstamped workbook is refused rather than guessed at', () => {
+    const entries = readZip(generateWorkbook(schema, spec, exampleDeal));
+    const stripped = writeZip(
+      [...entries.values()].filter((e) => e.name !== 'docProps/custom.xml').map((e) => ({ name: e.name, raw: e })),
+    );
+    const report = read(exampleDeal, stripped);
+    expect(report.ok).toBe(false);
+    expect(report.proposals).toEqual([]);
+  });
+
+  test('a change that moves no cell is still readable', () => {
+    // The stamp covers the deal's identity and the layout, not its contents — editing a
+    // stakeholder's name in the JSON must not invalidate the workbook on someone's desk.
+    const edited = clone(exampleDeal);
+    edited.stakeholders[0].title = 'Chief Infrastructure Officer';
+    const report = read(edited, generateWorkbook(schema, spec, exampleDeal));
+    expect(report.rejections).toEqual([]);
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({ jsonPath: 'stakeholders[0].title' });
   });
 });
 

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -1,0 +1,539 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { dateToSerial, generateWorkbook, planWorkbook } from './generate';
+import { readWorkbook, readWorkbookCells, serialToDate } from './read-workbook';
+import { validateDeal } from './validate';
+import type { WorkbookSpec } from './workbook-spec';
+import { readZip, writeZip } from './zip';
+
+const here = import.meta.dir;
+const schema = JSON.parse(fs.readFileSync(path.join(here, '..', 'schema', 'meddpicc-schema.json'), 'utf8'));
+const spec = JSON.parse(fs.readFileSync(path.join(here, 'workbook-spec.json'), 'utf8')) as WorkbookSpec;
+const exampleDeal = JSON.parse(fs.readFileSync(path.join(here, '..', 'schema', 'example-deal.json'), 'utf8'));
+
+const clone = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
+
+/**
+ * Where a sheet's part lives, derived from the spec's own order rather than by asking the
+ * reader. The test has to locate parts independently, or a reader that resolved the wrong
+ * sheet would agree with a helper making the same mistake.
+ */
+function sheetPart(sheetName: string): string {
+  const index = spec.sheets.findIndex((s) => s.name === sheetName);
+  if (index < 0) throw new Error(`no sheet "${sheetName}" in the spec`);
+  return `xl/worksheets/sheet${index + 1}.xml`;
+}
+
+/** The address of the input cell for a jsonPath, as the generator placed it. */
+function addressOf(deal: unknown, jsonPath: string): { sheet: string; address: string } {
+  const found = planWorkbook(schema, spec, deal).inputCells.find((c) => c.jsonPath === jsonPath);
+  if (!found) throw new Error(`no input cell for ${jsonPath}`);
+  return { sheet: found.sheet, address: found.address };
+}
+
+/** Rewrite one `<c>` element in a generated workbook — a hand edit, without Excel. */
+function withCell(bytes: Uint8Array, sheetName: string, ref: string, cellXml: string): Uint8Array {
+  const entries = readZip(bytes);
+  const part = sheetPart(sheetName);
+  const entry = entries.get(part);
+  if (!entry) throw new Error(`no part ${part}`);
+  const xml = new TextDecoder().decode(entry.data);
+  const pattern = new RegExp(`<c r="${ref}"(?: [^>]*)?(?:/>|>.*?</c>)`);
+  if (!pattern.test(xml)) throw new Error(`cell ${ref} not found in ${part}`);
+  const updated = xml.replace(pattern, cellXml);
+  return writeZip(
+    [...entries.values()].map((e) =>
+      e.name === part ? { name: e.name, data: new TextEncoder().encode(updated) } : { name: e.name, raw: e },
+    ),
+  );
+}
+
+const setNumber = (bytes: Uint8Array, sheet: string, ref: string, value: number) =>
+  withCell(bytes, sheet, ref, `<c r="${ref}"><v>${value}</v></c>`);
+const setText = (bytes: Uint8Array, sheet: string, ref: string, text: string) =>
+  withCell(bytes, sheet, ref, `<c r="${ref}" t="inlineStr"><is><t>${text}</t></is></c>`);
+const setBlank = (bytes: Uint8Array, sheet: string, ref: string) => withCell(bytes, sheet, ref, `<c r="${ref}"/>`);
+
+/**
+ * Re-save the way Excel does: every inline string moves into `xl/sharedStrings.xml` and the
+ * cell becomes `t="s"` with an index.
+ *
+ * This is the difference between a reader that works on its own output and one that works on
+ * the only file that matters — the one a human edited and saved.
+ */
+function asExcelWouldSave(bytes: Uint8Array): Uint8Array {
+  const entries = readZip(bytes);
+  const strings: string[] = [];
+  const rewritten = new Map<string, string>();
+
+  for (const entry of entries.values()) {
+    if (!/^xl\/worksheets\/sheet\d+\.xml$/.test(entry.name)) continue;
+    const xml = new TextDecoder().decode(entry.data);
+    rewritten.set(
+      entry.name,
+      xml.replace(
+        /<c r="([A-Z]+\d+)"((?: [^>]*)?) t="inlineStr">.*?<t[^>]*>(.*?)<\/t>.*?<\/c>/g,
+        (_m, ref, attrs, text) => {
+          let index = strings.indexOf(text);
+          if (index < 0) {
+            strings.push(text);
+            index = strings.length - 1;
+          }
+          return `<c r="${ref}"${attrs} t="s"><v>${index}</v></c>`;
+        },
+      ),
+    );
+  }
+
+  const sharedStrings =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="${strings.length}" uniqueCount="${strings.length}">` +
+    // Excel splits a string into runs; the reader has to join every <t> inside one <si>.
+    strings.map((s) => `<si><r><t>${s.slice(0, 1)}</t></r><r><t>${s.slice(1)}</t></r></si>`).join('') +
+    `</sst>`;
+
+  const relsName = 'xl/_rels/workbook.xml.rels';
+  const rels = new TextDecoder().decode(entries.get(relsName)?.data ?? new Uint8Array());
+  const withRel = rels.replace(
+    '</Relationships>',
+    `<Relationship Id="rIdShared" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/></Relationships>`,
+  );
+  const types = new TextDecoder().decode(entries.get('[Content_Types].xml')?.data ?? new Uint8Array());
+  const withType = types.replace(
+    '</Types>',
+    `<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/></Types>`,
+  );
+
+  const enc = (s: string) => new TextEncoder().encode(s);
+  return writeZip([
+    ...[...entries.values()].map((e) => {
+      if (rewritten.has(e.name)) return { name: e.name, data: enc(rewritten.get(e.name) as string) };
+      if (e.name === relsName) return { name: e.name, data: enc(withRel) };
+      if (e.name === '[Content_Types].xml') return { name: e.name, data: enc(withType) };
+      return { name: e.name, raw: e };
+    }),
+    { name: 'xl/sharedStrings.xml', data: enc(sharedStrings) },
+  ]);
+}
+
+const read = (deal: unknown, bytes: Uint8Array) => readWorkbook(schema, spec, deal, bytes);
+
+describe('serialToDate', () => {
+  test('inverts dateToSerial', () => {
+    for (const iso of ['1900-01-01', '2026-06-30', '2026-02-28', '2099-12-31']) {
+      expect(serialToDate(dateToSerial(iso) as number)).toBe(iso);
+    }
+  });
+
+  test('a serial carrying a time of day still names its day', () => {
+    expect(serialToDate(46203.75)).toBe('2026-06-30');
+  });
+
+  test('refuses a serial that is not a date', () => {
+    expect(serialToDate(-1)).toBeNull();
+    expect(serialToDate(Number.NaN)).toBeNull();
+    expect(serialToDate(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe('readWorkbookCells', () => {
+  test('finds cells by sheet name, not by part order', () => {
+    const cells = readWorkbookCells(generateWorkbook(schema, spec, exampleDeal));
+    expect([...cells.keys()]).toEqual(spec.sheets.map((s) => s.name));
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.accountName');
+    expect(cells.get(sheet)?.get(address)?.text).toBe('Acme Corporation');
+  });
+
+  test('a formula cell is reported as a formula, with no value to mistake for one', () => {
+    const cells = readWorkbookCells(generateWorkbook(schema, spec, exampleDeal));
+    const scorecard = cells.get('Scorecard');
+    const formulas = [...(scorecard?.values() ?? [])].filter((c) => c.formula !== undefined);
+    expect(formulas.length).toBeGreaterThan(0);
+    for (const cell of formulas) expect(cell.text).toBeUndefined();
+  });
+});
+
+describe('round-trip identity', () => {
+  test('generate then read the same deal proposes nothing', () => {
+    const report = read(exampleDeal, generateWorkbook(schema, spec, exampleDeal));
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toEqual([]);
+    expect(report.ok).toBe(true);
+    expect(report.cellsRead).toBeGreaterThan(100);
+  });
+
+  test('survives the save Excel performs — shared strings, not inline', () => {
+    const saved = asExcelWouldSave(generateWorkbook(schema, spec, exampleDeal));
+    const report = read(exampleDeal, saved);
+    expect(report.rejections).toEqual([]);
+    expect(report.proposals).toEqual([]);
+  });
+
+  test('a date whose JSON value carries a time is not reported as an edit', () => {
+    // A date cell can only hold a day. Comparing the cell's `2026-06-30` against the JSON's
+    // `2026-06-30T09:15:00Z` as strings would report a phantom edit on every single read.
+    const deal = clone(exampleDeal);
+    deal.metadata.closeDate = '2026-06-30T09:15:00Z';
+    expect(validateDeal(deal, schema).valid).toBe(true);
+    const report = read(deal, generateWorkbook(schema, spec, deal));
+    expect(report.proposals).toEqual([]);
+  });
+
+  test('an element with no score reads back as unchanged, not as a proposal to set 0', () => {
+    // The generator writes an unscored element as 0 on purpose, so a 0 in the sheet cannot be
+    // told apart from "not assessed" — and must not become a proposal on every read.
+    const deal = clone(exampleDeal);
+    delete deal.qualification.champion.score;
+    const report = read(deal, generateWorkbook(schema, spec, deal));
+    expect(report.proposals).toEqual([]);
+  });
+});
+
+describe('proposals', () => {
+  test('a changed string cell proposes exactly that change', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.accountName');
+    const edited = setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Globex Corporation');
+    const report = read(exampleDeal, edited);
+    expect(report.proposals).toEqual([
+      {
+        jsonPath: 'metadata.accountName',
+        sheet,
+        address,
+        valueType: 'string',
+        kind: 'set',
+        from: 'Acme Corporation',
+        to: 'Globex Corporation',
+      },
+    ]);
+    expect(report.rejections).toEqual([]);
+  });
+
+  test('a changed score proposes the new number', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'qualification.champion.score');
+    expect(exampleDeal.qualification.champion.score).toBe(4);
+    const report = read(exampleDeal, setNumber(generateWorkbook(schema, spec, exampleDeal), sheet, address, 2));
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({
+      jsonPath: 'qualification.champion.score',
+      from: 4,
+      to: 2,
+      kind: 'set',
+    });
+  });
+
+  test('a changed date comes back as an ISO date, not a serial', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.closeDate');
+    const serial = dateToSerial('2026-09-15') as number;
+    const report = read(exampleDeal, setNumber(generateWorkbook(schema, spec, exampleDeal), sheet, address, serial));
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({ from: '2026-06-30', to: '2026-09-15' });
+  });
+
+  test('a score added where the JSON had none is an addition', () => {
+    const deal = clone(exampleDeal);
+    delete deal.qualification.champion.score;
+    const { sheet, address } = addressOf(deal, 'qualification.champion.score');
+    const report = read(deal, setNumber(generateWorkbook(schema, spec, deal), sheet, address, 3));
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({ kind: 'add', from: undefined, to: 3 });
+  });
+
+  test('a blanked cell proposes clearing the value', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.reviewer');
+    const report = read(exampleDeal, setBlank(generateWorkbook(schema, spec, exampleDeal), sheet, address));
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({ kind: 'clear', from: 'Jane Smith', to: null });
+    expect((report.deal as { metadata: Record<string, unknown> }).metadata.reviewer).toBeUndefined();
+  });
+
+  test('an edit lands in the returned deal, and the original is untouched', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.dealName');
+    const edited = setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Renewal FY27');
+    const report = read(exampleDeal, edited);
+    expect((report.deal as { metadata: { dealName: string } }).metadata.dealName).toBe('Renewal FY27');
+    expect(exampleDeal.metadata.dealName).not.toBe('Renewal FY27');
+    expect(report.valid).toBe(true);
+  });
+});
+
+describe('cells that are not inputs are never read', () => {
+  test('a hand-edited computed cell proposes nothing', () => {
+    // The Scorecard total is a formula. Typing over it in Excel replaces the formula with a
+    // number; the engine recomputes it, so taking that number into the JSON would be a lie.
+    const cells = readWorkbookCells(generateWorkbook(schema, spec, exampleDeal));
+    const formulaRef = [...(cells.get('Scorecard')?.entries() ?? [])].find(([, c]) => c.formula !== undefined)?.[0];
+    expect(formulaRef).toBeDefined();
+    const edited = setNumber(generateWorkbook(schema, spec, exampleDeal), 'Scorecard', formulaRef as string, 999);
+    expect(read(exampleDeal, edited).proposals).toEqual([]);
+  });
+
+  test('a derived cell — the rubric text — proposes nothing', () => {
+    const cells = readWorkbookCells(generateWorkbook(schema, spec, exampleDeal));
+    const qualification = cells.get('Qualification');
+    const derived = [...(qualification?.entries() ?? [])].find(([, c]) => c.text?.startsWith('Quantified'))?.[0];
+    expect(derived).toBeDefined();
+    const edited = setText(generateWorkbook(schema, spec, exampleDeal), 'Qualification', derived as string, 'nonsense');
+    expect(read(exampleDeal, edited).proposals).toEqual([]);
+  });
+});
+
+describe('rejections name the cell, and never reach the deal', () => {
+  test('a formula typed into an input cell is refused', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.revenue.acv');
+    const edited = withCell(
+      generateWorkbook(schema, spec, exampleDeal),
+      sheet,
+      address,
+      `<c r="${address}"><f>B10*2</f><v>500000</v></c>`,
+    );
+    const report = read(exampleDeal, edited);
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0]).toMatchObject({ sheet, address, jsonPath: 'metadata.revenue.acv' });
+    expect(report.rejections[0].reason).toMatch(/formula/i);
+    expect(report.ok).toBe(false);
+  });
+
+  test('a score outside the schema range is refused', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'qualification.champion.score');
+    const report = read(exampleDeal, setNumber(generateWorkbook(schema, spec, exampleDeal), sheet, address, 7));
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0]).toMatchObject({ sheet, address });
+    expect(report.rejections[0].reason).toMatch(/4/);
+  });
+
+  test('a value outside an enum is refused, and the enum is quoted back', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.dealStatus');
+    const report = read(exampleDeal, setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Maybe'));
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0].reason).toMatch(/Discovery/);
+    expect((report.deal as { metadata: { dealStatus: string } }).metadata.dealStatus).toBe(
+      exampleDeal.metadata.dealStatus,
+    );
+  });
+
+  test('prose in a currency cell is refused rather than coerced to NaN', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.revenue.acv');
+    const report = read(
+      exampleDeal,
+      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'about 500k'),
+    );
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0].reason).toMatch(/number/i);
+    expect(report.proposals).toEqual([]);
+  });
+
+  test('a fractional score is refused — 0-4 is an integer scale', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'qualification.champion.score');
+    const report = read(exampleDeal, setNumber(generateWorkbook(schema, spec, exampleDeal), sheet, address, 2.5));
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0].reason).toMatch(/whole number/i);
+  });
+
+  test('the returned deal still validates when a cell was rejected', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'qualification.champion.score');
+    const report = read(exampleDeal, setNumber(generateWorkbook(schema, spec, exampleDeal), sheet, address, 7));
+    expect(report.valid).toBe(true);
+    expect(validateDeal(report.deal, schema).valid).toBe(true);
+  });
+});
+
+describe('list rows', () => {
+  const listPath = (index: number, field: string) => `stakeholders[${index}].${field}`;
+
+  test('filling the first padded row appends a new item', () => {
+    const count = exampleDeal.stakeholders.length;
+    const { sheet, address } = addressOf(exampleDeal, listPath(count, 'name'));
+    const report = read(
+      exampleDeal,
+      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Dana Reyes'),
+    );
+    expect(report.rejections).toEqual([]);
+    const stakeholders = (report.deal as { stakeholders: Array<{ name: string }> }).stakeholders;
+    expect(stakeholders).toHaveLength(count + 1);
+    expect(stakeholders[count].name).toBe('Dana Reyes');
+  });
+
+  test('two fields of the same new row make one item, not two', () => {
+    const count = exampleDeal.stakeholders.length;
+    let bytes = generateWorkbook(schema, spec, exampleDeal);
+    const name = addressOf(exampleDeal, listPath(count, 'name'));
+    const title = addressOf(exampleDeal, listPath(count, 'title'));
+    bytes = setText(bytes, name.sheet, name.address, 'Dana Reyes');
+    bytes = setText(bytes, title.sheet, title.address, 'VP Platform');
+    const report = read(exampleDeal, bytes);
+    const stakeholders = (report.deal as { stakeholders: Array<{ name: string; title: string }> }).stakeholders;
+    expect(stakeholders).toHaveLength(count + 1);
+    expect(stakeholders[count]).toMatchObject({ name: 'Dana Reyes', title: 'VP Platform' });
+  });
+
+  test('skipping a row is refused — an array cannot have a hole', () => {
+    const count = exampleDeal.stakeholders.length;
+    const { sheet, address } = addressOf(exampleDeal, listPath(count + 1, 'name'));
+    const report = read(
+      exampleDeal,
+      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Dana Reyes'),
+    );
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0]).toMatchObject({ sheet, address });
+    expect(report.rejections[0].reason).toMatch(/row/i);
+    expect((report.deal as { stakeholders: unknown[] }).stakeholders).toHaveLength(count);
+  });
+
+  test('consecutive new rows are both appended', () => {
+    const count = exampleDeal.stakeholders.length;
+    let bytes = generateWorkbook(schema, spec, exampleDeal);
+    for (const [offset, who] of [
+      [0, 'Dana Reyes'],
+      [1, 'Sam Okafor'],
+    ] as const) {
+      const at = addressOf(exampleDeal, listPath(count + offset, 'name'));
+      bytes = setText(bytes, at.sheet, at.address, who);
+    }
+    const report = read(exampleDeal, bytes);
+    expect(report.rejections).toEqual([]);
+    const stakeholders = (report.deal as { stakeholders: Array<{ name: string }> }).stakeholders;
+    expect(stakeholders.map((s) => s.name).slice(count)).toEqual(['Dana Reyes', 'Sam Okafor']);
+  });
+
+  test('answering the last question first is refused — the answers before it are still blank', () => {
+    // The Questions sheet has a row per question the schema declares, so an element with no
+    // answers yet still shows two rows. Filling the second would write responses[1] into an
+    // empty array, and `["", "answer"]` reads as "question one was answered blankly".
+    const deal = clone(exampleDeal);
+    deal.qualification.metrics.responses = [];
+    const { sheet, address } = addressOf(deal, 'qualification.metrics.responses[1]');
+    const report = read(deal, setText(generateWorkbook(schema, spec, deal), sheet, address, 'Second answer'));
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0]).toMatchObject({ sheet, address });
+    expect(report.rejections[0].reason).toMatch(/row/i);
+  });
+
+  test('answering the first question appends to an empty answer list', () => {
+    const deal = clone(exampleDeal);
+    deal.qualification.metrics.responses = [];
+    const { sheet, address } = addressOf(deal, 'qualification.metrics.responses[0]');
+    const report = read(deal, setText(generateWorkbook(schema, spec, deal), sheet, address, 'First answer'));
+    expect(report.rejections).toEqual([]);
+    expect(
+      (report.deal as { qualification: { metrics: { responses: string[] } } }).qualification.metrics.responses,
+    ).toEqual(['First answer']);
+  });
+
+  test('an edit to an existing row changes that row and no other', () => {
+    const { sheet, address } = addressOf(exampleDeal, listPath(1, 'name'));
+    const report = read(exampleDeal, setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Renamed'));
+    const stakeholders = (report.deal as { stakeholders: Array<{ name: string }> }).stakeholders;
+    expect(stakeholders[1].name).toBe('Renamed');
+    expect(stakeholders[0].name).toBe(exampleDeal.stakeholders[0].name);
+    expect(stakeholders).toHaveLength(exampleDeal.stakeholders.length);
+  });
+});
+
+describe('what Excel does to a value on the way back', () => {
+  test('a date whose type Excel spelled out as "n" is still a date', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.closeDate');
+    const serial = dateToSerial('2026-09-15') as number;
+    const edited = withCell(
+      generateWorkbook(schema, spec, exampleDeal),
+      sheet,
+      address,
+      `<c r="${address}" t="n"><v>${serial}</v></c>`,
+    );
+    const report = read(exampleDeal, edited);
+    expect(report.rejections).toEqual([]);
+    expect(report.proposals[0]).toMatchObject({ to: '2026-09-15' });
+  });
+
+  test('a number a rounding step away from the deal is not an edit', () => {
+    // Excel re-saves 85000 as 85000.000000000001 often enough that comparing exactly would
+    // propose a change to a figure nobody touched.
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.revenue.acv');
+    const drifted = (exampleDeal.metadata.revenue.acv as number) * (1 + 1e-13);
+    expect(drifted).not.toBe(exampleDeal.metadata.revenue.acv);
+    const report = read(exampleDeal, setNumber(generateWorkbook(schema, spec, exampleDeal), sheet, address, drifted));
+    expect(report.proposals).toEqual([]);
+  });
+
+  test('a number that really moved is an edit', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.revenue.acv');
+    const report = read(exampleDeal, setNumber(generateWorkbook(schema, spec, exampleDeal), sheet, address, 85001));
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({ from: 85000, to: 85001 });
+  });
+
+  test('XML entities come back as the characters they stand for', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.dealName');
+    const edited = setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'R&amp;D &lt;Phase 3&gt;');
+    const report = read(exampleDeal, edited);
+    expect(report.proposals[0]).toMatchObject({ to: 'R&D <Phase 3>' });
+  });
+
+  test('a cell holding an Excel error is refused, not read as text', () => {
+    // On a text cell this is the only thing standing between `#REF!` and the deal JSON:
+    // nothing else about the string "#REF!" is invalid.
+    const { sheet, address } = addressOf(exampleDeal, 'metadata.reviewer');
+    const edited = withCell(
+      generateWorkbook(schema, spec, exampleDeal),
+      sheet,
+      address,
+      `<c r="${address}" t="e"><v>#REF!</v></c>`,
+    );
+    const report = read(exampleDeal, edited);
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0].reason).toMatch(/#REF!/);
+  });
+});
+
+describe('clearing a value', () => {
+  test('a cleared response keeps the positions of the answers around it', () => {
+    // Responses answer questions by position, so removing the element would silently
+    // re-attach every later answer to the wrong question.
+    const responses = exampleDeal.qualification.metrics.responses as string[];
+    expect(responses.length).toBeGreaterThan(1);
+    const { sheet, address } = addressOf(exampleDeal, 'qualification.metrics.responses[0]');
+    const report = read(exampleDeal, setBlank(generateWorkbook(schema, spec, exampleDeal), sheet, address));
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({ kind: 'clear' });
+    const after = (report.deal as { qualification: { metrics: { responses: string[] } } }).qualification.metrics
+      .responses;
+    expect(after).toHaveLength(responses.length);
+    expect(after[0]).toBe('');
+    expect(after[1]).toBe(responses[1]);
+  });
+});
+
+describe('booleans', () => {
+  test('a boolean cell round-trips both ways', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'stakeholders[0].mustSayYes');
+    expect(exampleDeal.stakeholders[0].mustSayYes).toBe(true);
+    const edited = withCell(
+      generateWorkbook(schema, spec, exampleDeal),
+      sheet,
+      address,
+      `<c r="${address}" t="b"><v>0</v></c>`,
+    );
+    const report = read(exampleDeal, edited);
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({ from: true, to: false });
+  });
+
+  test('a boolean typed as a word is understood', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'stakeholders[0].mustSayYes');
+    const report = read(exampleDeal, setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'FALSE'));
+    expect(report.rejections).toEqual([]);
+    expect(report.proposals[0]).toMatchObject({ to: false });
+  });
+
+  test('a word that is not a boolean is refused', () => {
+    const { sheet, address } = addressOf(exampleDeal, 'stakeholders[0].mustSayYes');
+    const report = read(exampleDeal, setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'sort of'));
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0].reason).toMatch(/TRUE/);
+  });
+});

--- a/plugins/meddpicc/engine/read-workbook.ts
+++ b/plugins/meddpicc/engine/read-workbook.ts
@@ -1,0 +1,371 @@
+/**
+ * Read a workbook back and say what changed — the other direction of `generate.ts`.
+ *
+ * The rule the whole file is built around: **the JSON is the source of truth, so a cell that
+ * differs is a proposal, not an update.** Nothing is written unless the caller asks, and a
+ * value the schema refuses is reported by its cell address, because the person who has to fix
+ * it is looking at Excel, not at a JSON pointer.
+ *
+ * Which cells are eligible is not decided here. `planWorkbook` already returns `inputCells` —
+ * every cell that holds a human's value, with the `jsonPath` it came from — and this walks
+ * exactly that list. A second idea of where cells live is how the two directions would drift.
+ *
+ * Three things a reader of hand-written OOXML has to get right, each learned the hard way:
+ *
+ * - **Excel rewrites the file when it saves.** The generator emits `t="inlineStr"`; Excel
+ *   re-saves the same text through `sharedStrings.xml` as `t="s"`. A reader that only
+ *   understands its own output works perfectly on a file nobody has edited.
+ * - **A formula's cached value is not a human's entry.** `<f>` is honoured by refusing the
+ *   cell, never by taking the `<v>` beside it.
+ * - **A date cell can only hold a day.** So dates are compared as serials; comparing the
+ *   cell's `2026-06-30` against a JSON `2026-06-30T09:15:00Z` as text would report a phantom
+ *   edit on every read, and the reader would cry wolf until nobody read it.
+ */
+import { dateToSerial, planWorkbook } from './generate';
+import { readPath, writePath } from './json-path';
+import { schemaConstraint } from './schema-path';
+import { type ValidationResult, validateDeal } from './validate';
+import type { ValueType, WorkbookSpec } from './workbook-spec';
+import { readZip } from './zip';
+
+const EXCEL_EPOCH_UTC = Date.UTC(1899, 11, 30);
+const MS_PER_DAY = 86_400_000;
+/** 9999-12-31. Beyond this Excel has no date, and neither has anything downstream. */
+const MAX_SERIAL = 2_958_465;
+
+/** The day an Excel serial names, or null when the number is not a date. */
+export function serialToDate(serial: number): string | null {
+  if (!Number.isFinite(serial) || serial < 0 || serial > MAX_SERIAL) return null;
+  // A serial's fraction is a time of day; a date cell's meaning is its day.
+  const date = new Date(EXCEL_EPOCH_UTC + Math.floor(serial) * MS_PER_DAY);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+}
+
+/** One cell as the file stores it, before anything is made of it. */
+export interface RawCell {
+  ref: string;
+  /**
+   * The cell's content as text, however it was stored — inline, shared, or a numeric literal.
+   * Undefined when the cell is blank, and deliberately undefined for a formula cell: a cached
+   * result must not be readable as something a person typed.
+   */
+  text?: string;
+  formula?: string;
+  /** The `t` attribute, which is how a boolean or an error is told from a number. */
+  type?: string;
+}
+
+const ENTITIES: Record<string, string> = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
+
+function unescapeXml(text: string): string {
+  return text.replace(/&(#\d+|#x[0-9a-fA-F]+|[a-z]+);/g, (whole, code: string) => {
+    if (code.startsWith('#x')) return String.fromCodePoint(Number.parseInt(code.slice(2), 16));
+    if (code.startsWith('#')) return String.fromCodePoint(Number(code.slice(1)));
+    return ENTITIES[code] ?? whole;
+  });
+}
+
+/** Every `<t>` inside one element, joined — Excel splits a string into runs. */
+function joinTextRuns(xml: string): string {
+  // Phonetic hints also live in <t>, and they are annotation, not content.
+  const withoutPhonetics = xml.replace(/<rPh[\s\S]*?<\/rPh>/g, '');
+  return [...withoutPhonetics.matchAll(/<t(?:\s[^>]*)?>([\s\S]*?)<\/t>/g)].map((m) => unescapeXml(m[1])).join('');
+}
+
+function attribute(attrs: string, name: string): string | undefined {
+  return new RegExp(`\\b${name}="([^"]*)"`).exec(attrs)?.[1];
+}
+
+/** `xl/sharedStrings.xml` as an ordered list, whatever the part is called. */
+function sharedStrings(entries: Map<string, { data: Uint8Array }>, workbookRels: Map<string, string>): string[] {
+  const target = [...workbookRels.entries()].find(([, t]) => /sharedStrings\.xml$/.test(t))?.[1];
+  const part = target ? resolvePart(target) : 'xl/sharedStrings.xml';
+  const entry = entries.get(part) ?? entries.get('xl/sharedStrings.xml');
+  if (!entry) return [];
+  const xml = new TextDecoder().decode(entry.data);
+  return [...xml.matchAll(/<si(?:\s[^>]*)?>([\s\S]*?)<\/si>/g)].map((m) => joinTextRuns(m[1]));
+}
+
+/** A relationship target, resolved to a part name inside the archive. */
+function resolvePart(target: string): string {
+  if (target.startsWith('/')) return target.slice(1);
+  return `xl/${target.replace(/^\.\//, '')}`;
+}
+
+/** Relationship id -> target, from `xl/_rels/workbook.xml.rels`. */
+function readWorkbookRels(entries: Map<string, { data: Uint8Array }>): Map<string, string> {
+  const entry = entries.get('xl/_rels/workbook.xml.rels');
+  if (!entry) throw new Error('Not a workbook: xl/_rels/workbook.xml.rels is missing');
+  const xml = new TextDecoder().decode(entry.data);
+  const rels = new Map<string, string>();
+  for (const m of xml.matchAll(/<Relationship\b([^>]*)\/>/g)) {
+    const id = attribute(m[1], 'Id');
+    const target = attribute(m[1], 'Target');
+    if (id && target) rels.set(id, target);
+  }
+  return rels;
+}
+
+/** Sheet name -> part name, in workbook order. Resolved through the relationships, because a
+ * sheet's position in the workbook says nothing about which file holds it. */
+function sheetParts(entries: Map<string, { data: Uint8Array }>, rels: Map<string, string>): Map<string, string> {
+  const entry = entries.get('xl/workbook.xml');
+  if (!entry) throw new Error('Not a workbook: xl/workbook.xml is missing');
+  const xml = new TextDecoder().decode(entry.data);
+  const parts = new Map<string, string>();
+  for (const m of xml.matchAll(/<sheet\b([^>]*)\/>/g)) {
+    const name = attribute(m[1], 'name');
+    const relId = attribute(m[1], 'r:id') ?? attribute(m[1], 'id');
+    if (!name || !relId) continue;
+    const target = rels.get(relId);
+    if (target) parts.set(unescapeXml(name), resolvePart(target));
+  }
+  return parts;
+}
+
+/** Every cell of every sheet, keyed by sheet name then by A1 reference. */
+export function readWorkbookCells(bytes: Uint8Array): Map<string, Map<string, RawCell>> {
+  const entries = readZip(bytes);
+  const rels = readWorkbookRels(entries);
+  const strings = sharedStrings(entries, rels);
+  const out = new Map<string, Map<string, RawCell>>();
+
+  for (const [sheetName, part] of sheetParts(entries, rels)) {
+    const entry = entries.get(part);
+    if (!entry) throw new Error(`Sheet "${sheetName}" points at ${part}, which the archive does not contain`);
+    const xml = new TextDecoder().decode(entry.data);
+    const cells = new Map<string, RawCell>();
+
+    for (const m of xml.matchAll(/<c\b([^>]*?)(?:\/>|>([\s\S]*?)<\/c>)/g)) {
+      const ref = attribute(m[1], 'r');
+      if (!ref) continue;
+      const type = attribute(m[1], 't');
+      const inner = m[2] ?? '';
+      const formula = /<f\b[^>]*\/>/.test(inner)
+        ? ''
+        : (/<f(?:\s[^>]*)?>([\s\S]*?)<\/f>/.exec(inner)?.[1] ?? undefined);
+
+      if (formula !== undefined) {
+        cells.set(ref, { ref, type, formula: unescapeXml(formula) });
+        continue;
+      }
+
+      let text: string | undefined;
+      if (type === 'inlineStr') text = joinTextRuns(inner);
+      else {
+        const value = /<v(?:\s[^>]*)?>([\s\S]*?)<\/v>/.exec(inner)?.[1];
+        if (value !== undefined) {
+          text = type === 's' ? (strings[Number(value)] ?? '') : unescapeXml(value);
+        }
+      }
+      cells.set(ref, { ref, type, text });
+    }
+
+    out.set(sheetName, cells);
+  }
+
+  return out;
+}
+
+/** What a cell says, or why it cannot be used. */
+type Coerced = { value: string | number | boolean | undefined } | { error: string };
+
+const BOOLEAN_WORDS: Record<string, boolean> = { TRUE: true, FALSE: false, '1': true, '0': false };
+
+function coerce(raw: RawCell | undefined, valueType: ValueType): Coerced {
+  const text = raw?.text;
+  if (text === undefined || text.trim() === '') return { value: undefined };
+
+  if (raw?.type === 'e') return { error: `holds the error ${text}; put a value there or clear the cell` };
+
+  switch (valueType) {
+    case 'string':
+    case 'text':
+    case 'rating':
+      return { value: text };
+
+    case 'boolean': {
+      const word = raw?.type === 'b' ? (text === '1' ? 'TRUE' : 'FALSE') : text.trim().toUpperCase();
+      const value = BOOLEAN_WORDS[word];
+      return value === undefined ? { error: `must be TRUE or FALSE, not "${text}"` } : { value };
+    }
+
+    case 'date': {
+      const asNumber = Number(text);
+      // A number is a serial. Excel may or may not spell the type out as `n`, and a reader
+      // that only accepted the unspelled form would call a saved date "not a date".
+      if (Number.isFinite(asNumber) && (raw?.type === undefined || raw.type === 'n')) {
+        const iso = serialToDate(asNumber);
+        return iso === null ? { error: `${text} is not a date Excel can hold` } : { value: iso };
+      }
+      const iso = dateToSerial(text.trim()) === null ? null : text.trim().slice(0, 10);
+      return iso === null ? { error: `must be a date, not "${text}"` } : { value: iso };
+    }
+
+    default: {
+      const value = Number(text);
+      if (!Number.isFinite(value)) return { error: `must be a number, not "${text}"` };
+      // Whether a whole number is required is the schema's call, not this function's —
+      // `schemaError` reads `type: integer` from the same place the validator does. Checking
+      // it here as well would be a second opinion that could disagree.
+      return { value };
+    }
+  }
+}
+
+/** Why the schema refuses this value at this path, or null. */
+function schemaError(schema: unknown, jsonPath: string, value: string | number | boolean): string | null {
+  const constraint = schemaConstraint(schema, jsonPath);
+  if (!constraint) return null;
+
+  if (constraint.enum && !constraint.enum.includes(String(value))) {
+    return `must be one of ${constraint.enum.join(', ')} — not "${value}"`;
+  }
+  if (typeof value === 'number') {
+    const { minimum, maximum } = constraint;
+    if (minimum !== undefined && value < minimum) return `must be between ${minimum} and ${maximum ?? '∞'}`;
+    if (maximum !== undefined && value > maximum) return `must be between ${minimum ?? '-∞'} and ${maximum}`;
+  }
+  if (constraint.type === 'integer' && typeof value === 'number' && !Number.isInteger(value)) {
+    return `must be a whole number, not ${value}`;
+  }
+  return null;
+}
+
+const isBlank = (v: unknown) => v === undefined || v === null || v === '';
+
+/** Numbers that came back through Excel are the same number a hair apart. */
+function nearlyEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) <= 1e-9 * Math.max(1, Math.abs(a), Math.abs(b));
+}
+
+/** Whether the cell agrees with the deal — per type, because "the same" differs by type. */
+function sameValue(current: unknown, next: string | number | boolean | undefined, valueType: ValueType): boolean {
+  // An unscored element is written as 0, so a 0 in the sheet cannot be told from "not
+  // assessed" and must not read back as a proposal to set 0 on every element that has none.
+  if (valueType === 'score') {
+    return (typeof current === 'number' ? current : 0) === (typeof next === 'number' ? next : 0);
+  }
+  if (isBlank(current) || isBlank(next)) return isBlank(current) && isBlank(next);
+  if (valueType === 'date') {
+    const a = dateToSerial(String(current));
+    const b = dateToSerial(String(next));
+    return a !== null && b !== null ? a === b : String(current) === String(next);
+  }
+  if (typeof next === 'number') return typeof current === 'number' && nearlyEqual(current, next);
+  if (typeof next === 'boolean') return current === next;
+  return String(current) === String(next);
+}
+
+export interface CellProposal {
+  jsonPath: string;
+  sheet: string;
+  address: string;
+  valueType: ValueType;
+  /** `add` when the deal has no value there, `clear` when the cell was emptied. */
+  kind: 'set' | 'add' | 'clear';
+  from: unknown;
+  to: unknown;
+}
+
+export interface CellRejection {
+  jsonPath: string;
+  sheet: string;
+  address: string;
+  reason: string;
+}
+
+export interface ReadReport {
+  /** No cell was refused and the result validates. This is what an exit code should follow. */
+  ok: boolean;
+  cellsRead: number;
+  unchanged: number;
+  proposals: CellProposal[];
+  rejections: CellRejection[];
+  /** The deal with every accepted proposal applied. A copy — the input is never mutated. */
+  deal: unknown;
+  valid: boolean;
+  errors: ValidationResult['errors'];
+}
+
+/**
+ * Compare a workbook against the deal it came from.
+ *
+ * Proposals are applied to a copy as they are accepted, in the order the cells were laid out,
+ * so that filling two consecutive blank rows of a table appends two items rather than
+ * refusing the second for a gap that the first had already closed.
+ */
+export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown, bytes: Uint8Array): ReadReport {
+  const plan = planWorkbook(schema, spec, deal);
+  const cells = readWorkbookCells(bytes);
+  const working = JSON.parse(JSON.stringify(deal)) as unknown;
+
+  const proposals: CellProposal[] = [];
+  const rejections: CellRejection[] = [];
+  let unchanged = 0;
+
+  for (const input of plan.inputCells) {
+    const { jsonPath, sheet, address, valueType } = input;
+    const reject = (reason: string) => rejections.push({ jsonPath, sheet, address, reason });
+    const sheetCells = cells.get(sheet);
+    if (!sheetCells) {
+      reject(`sheet "${sheet}" is not in this workbook`);
+      continue;
+    }
+
+    const raw = sheetCells.get(address);
+    if (raw?.formula !== undefined) {
+      reject('holds a formula, and a computed number is not an answer — type a value or edit the JSON');
+      continue;
+    }
+
+    const coerced = coerce(raw, valueType);
+    if ('error' in coerced) {
+      reject(coerced.error);
+      continue;
+    }
+
+    const current = readPath(working, jsonPath);
+    if (sameValue(current, coerced.value, valueType)) {
+      unchanged++;
+      continue;
+    }
+
+    if (coerced.value !== undefined) {
+      const problem = schemaError(schema, jsonPath, coerced.value);
+      if (problem) {
+        reject(problem);
+        continue;
+      }
+    }
+
+    const failure = writePath(working, jsonPath, coerced.value);
+    if (failure) {
+      reject(failure);
+      continue;
+    }
+
+    proposals.push({
+      jsonPath,
+      sheet,
+      address,
+      valueType,
+      kind: coerced.value === undefined ? 'clear' : isBlank(current) ? 'add' : 'set',
+      from: current,
+      to: coerced.value === undefined ? null : coerced.value,
+    });
+  }
+
+  const validation = validateDeal(working, schema);
+  return {
+    ok: rejections.length === 0 && validation.valid,
+    cellsRead: plan.inputCells.length,
+    unchanged,
+    proposals,
+    rejections,
+    deal: working,
+    valid: validation.valid,
+    errors: validation.errors,
+  };
+}

--- a/plugins/meddpicc/engine/read-workbook.ts
+++ b/plugins/meddpicc/engine/read-workbook.ts
@@ -286,9 +286,11 @@ export interface CellProposal {
 }
 
 export interface CellRejection {
-  jsonPath: string;
-  sheet: string;
-  address: string;
+  /** Absent when the cell belongs to no field — which is itself the problem being reported. */
+  jsonPath?: string;
+  /** Both absent when the whole workbook was refused, rather than one cell in it. */
+  sheet?: string;
+  address?: string;
   reason: string;
 }
 
@@ -331,7 +333,6 @@ function reportUnmappedRows(
       const content = cell.formula === undefined ? cell.text : `=${cell.formula}`;
       if (content === undefined || content.trim() === '') continue;
       rejections.push({
-        jsonPath: '',
         sheet: sheetName,
         address: cell.ref,
         reason:
@@ -384,9 +385,6 @@ export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown,
       proposals: [],
       rejections: [
         {
-          jsonPath: '',
-          sheet: '',
-          address: '',
           reason:
             stamp === null
               ? 'this workbook carries no round-trip stamp — regenerate it from this deal before reading it back'

--- a/plugins/meddpicc/engine/read-workbook.ts
+++ b/plugins/meddpicc/engine/read-workbook.ts
@@ -10,8 +10,13 @@
  * every cell that holds a human's value, with the `jsonPath` it came from — and this walks
  * exactly that list. A second idea of where cells live is how the two directions would drift.
  *
- * Three things a reader of hand-written OOXML has to get right, each learned the hard way:
+ * Four things a reader of hand-written OOXML has to get right, each learned the hard way:
  *
+ * - **An address only means something in the workbook it came from.** A table's row count
+ *   depends on the deal, so answering one more question moves every row below it. Reading an
+ *   older workbook cell by cell produced 14 confident proposals that put one element's answers
+ *   onto another, with no rejection and `ok` true. Hence the stamp, checked before anything
+ *   else: a workbook is read against the deal it was generated from, or not at all.
  * - **Excel rewrites the file when it saves.** The generator emits `t="inlineStr"`; Excel
  *   re-saves the same text through `sharedStrings.xml` as `t="s"`. A reader that only
  *   understands its own output works perfectly on a file nobody has edited.
@@ -21,11 +26,12 @@
  *   cell's `2026-06-30` against a JSON `2026-06-30T09:15:00Z` as text would report a phantom
  *   edit on every read, and the reader would cry wolf until nobody read it.
  */
-import { dateToSerial, planWorkbook } from './generate';
+import { dateToSerial, planWorkbook, workbookFingerprint } from './generate';
 import { readPath, writePath } from './json-path';
 import { schemaConstraint } from './schema-path';
 import { type ValidationResult, validateDeal } from './validate';
 import type { ValueType, WorkbookSpec } from './workbook-spec';
+import { FINGERPRINT_PROPERTY } from './xlsx';
 import { readZip } from './zip';
 
 const EXCEL_EPOCH_UTC = Date.UTC(1899, 11, 30);
@@ -122,6 +128,16 @@ function sheetParts(entries: Map<string, { data: Uint8Array }>, rels: Map<string
     if (target) parts.set(unescapeXml(name), resolvePart(target));
   }
   return parts;
+}
+
+/** The round-trip stamp a workbook was generated with, or null when it carries none. */
+export function readWorkbookFingerprint(bytes: Uint8Array): string | null {
+  const entry = readZip(bytes).get('docProps/custom.xml');
+  if (!entry) return null;
+  const xml = new TextDecoder().decode(entry.data);
+  const property = new RegExp(`<property\\b[^>]*name="${FINGERPRINT_PROPERTY}"[^>]*>([\\s\\S]*?)</property>`).exec(xml);
+  if (!property) return null;
+  return unescapeXml(/<vt:lpwstr>([\s\S]*?)<\/vt:lpwstr>/.exec(property[1])?.[1] ?? '') || null;
 }
 
 /** Every cell of every sheet, keyed by sheet name then by A1 reference. */
@@ -276,6 +292,56 @@ export interface CellRejection {
   reason: string;
 }
 
+const A1_REF = /^([A-Z]+)(\d+)$/;
+
+/**
+ * Report anything typed below the rows the workbook actually maps.
+ *
+ * The tables are padded with blank rows to grow into, and an Excel Table extends further still
+ * the moment someone types under the last one — so a seller who runs out of padded stakeholder
+ * rows just adds another, reasonably. Those cells belong to no `jsonPath`, and passing over
+ * them without a word would be the legacy sheet's own bug in a new place: it formatted eight
+ * team rows and dropped the rest. Better to refuse the run and say which cell.
+ *
+ * Only columns that hold inputs are considered, and only rows past the last input in that same
+ * column. That is already enough to leave a Table's own extended formulas alone: they land in
+ * computed columns, which hold no inputs and so are never examined. A formula in an *input*
+ * column below the range is reported like any other content, because it is content, and losing
+ * it quietly is the thing being prevented.
+ */
+function reportUnmappedRows(
+  inputCells: readonly { sheet: string; address: string }[],
+  cells: Map<string, Map<string, RawCell>>,
+  rejections: CellRejection[],
+): void {
+  const lastMapped = new Map<string, number>();
+  for (const input of inputCells) {
+    const m = A1_REF.exec(input.address);
+    if (!m) continue;
+    const key = `${input.sheet}!${m[1]}`;
+    lastMapped.set(key, Math.max(lastMapped.get(key) ?? 0, Number(m[2])));
+  }
+
+  for (const [sheetName, sheetCells] of cells) {
+    for (const cell of sheetCells.values()) {
+      const m = A1_REF.exec(cell.ref);
+      if (!m) continue;
+      const limit = lastMapped.get(`${sheetName}!${m[1]}`);
+      if (limit === undefined || Number(m[2]) <= limit) continue;
+      const content = cell.formula === undefined ? cell.text : `=${cell.formula}`;
+      if (content === undefined || content.trim() === '') continue;
+      rejections.push({
+        jsonPath: '',
+        sheet: sheetName,
+        address: cell.ref,
+        reason:
+          `holds "${content}" below row ${limit}, the last row this workbook maps — ` +
+          'add the entry to the deal JSON, then regenerate the workbook so it has room for it',
+      });
+    }
+  }
+}
+
 export interface ReadReport {
   /** No cell was refused and the result validates. This is what an exit code should follow. */
   ok: boolean;
@@ -295,15 +361,46 @@ export interface ReadReport {
  * Proposals are applied to a copy as they are accepted, in the order the cells were laid out,
  * so that filling two consecutive blank rows of a table appends two items rather than
  * refusing the second for a gap that the first had already closed.
+ *
+ * The stamp is checked first and refuses the whole workbook, rather than every cell in turn:
+ * if the addresses do not mean what this deal thinks they mean, no individual reading of one
+ * is worth reporting.
  */
 export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown, bytes: Uint8Array): ReadReport {
   const plan = planWorkbook(schema, spec, deal);
-  const cells = readWorkbookCells(bytes);
   const working = JSON.parse(JSON.stringify(deal)) as unknown;
 
   const proposals: CellProposal[] = [];
   const rejections: CellRejection[] = [];
   let unchanged = 0;
+
+  const stamp = readWorkbookFingerprint(bytes);
+  const expected = workbookFingerprint(plan, deal);
+  if (stamp !== expected) {
+    return {
+      ok: false,
+      cellsRead: 0,
+      unchanged: 0,
+      proposals: [],
+      rejections: [
+        {
+          jsonPath: '',
+          sheet: '',
+          address: '',
+          reason:
+            stamp === null
+              ? 'this workbook carries no round-trip stamp — regenerate it from this deal before reading it back'
+              : 'this workbook was generated from a different deal, or from this one before its rows moved — ' +
+                'regenerate it from the current deal before reading it back',
+        },
+      ],
+      deal: working,
+      valid: true,
+      errors: [],
+    };
+  }
+
+  const cells = readWorkbookCells(bytes);
 
   for (const input of plan.inputCells) {
     const { jsonPath, sheet, address, valueType } = input;
@@ -356,6 +453,8 @@ export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown,
       to: coerced.value === undefined ? null : coerced.value,
     });
   }
+
+  reportUnmappedRows(plan.inputCells, cells, rejections);
 
   const validation = validateDeal(working, schema);
   return {

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -449,7 +449,28 @@ function sheetXml(sheet: SheetSpec, tableIds: number[]): string {
  * absent from `[Content_Types].xml` (or missing its relationship) is the usual cause of
  * Excel's "we found a problem with some content" prompt.
  */
-export function buildWorkbook(sheets: readonly SheetSpec[]): Uint8Array {
+const NS_CUSTOM_PROPS = 'http://schemas.openxmlformats.org/officeDocument/2006/custom-properties';
+const NS_VT = 'http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes';
+/** The format id every custom document property carries; it is fixed, not ours to choose. */
+const CUSTOM_PROPS_FMTID = '{D5CDD505-2E9C-101B-9397-08002B2CF9AE}';
+
+/** The name of the custom document property carrying the round-trip stamp. */
+export const FINGERPRINT_PROPERTY = 'MeddpiccFingerprint';
+
+/**
+ * A custom document property, which is where a stamp belongs: Excel carries it through a save
+ * untouched, and it is not a cell, so nobody can retype it by accident or wonder what the
+ * hidden sheet full of hex is for.
+ */
+function customPropsXml(fingerprint: string): string {
+  return (
+    `${XML_HEADER}<Properties xmlns="${NS_CUSTOM_PROPS}" xmlns:vt="${NS_VT}">` +
+    `<property fmtid="${CUSTOM_PROPS_FMTID}" pid="2" name="${FINGERPRINT_PROPERTY}">` +
+    `<vt:lpwstr>${escapeXml(fingerprint)}</vt:lpwstr></property></Properties>`
+  );
+}
+
+export function buildWorkbook(sheets: readonly SheetSpec[], fingerprint?: string): Uint8Array {
   if (sheets.length === 0) throw new Error('A workbook needs at least one sheet');
 
   const enc = (s: string) => new TextEncoder().encode(s);
@@ -494,11 +515,17 @@ export function buildWorkbook(sheets: readonly SheetSpec[]): Uint8Array {
           `<Override PartName="/xl/tables/table${id}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"/>`,
       )
       .join('') +
+    (fingerprint === undefined
+      ? ''
+      : `<Override PartName="/docProps/custom.xml" ContentType="application/vnd.openxmlformats-officedocument.custom-properties+xml"/>`) +
     `</Types>`;
 
   const rootRels =
     `${XML_HEADER}<Relationships xmlns="${NS_REL_PKG}">` +
     `<Relationship Id="rId1" Type="${NS_REL_DOC}/officeDocument" Target="xl/workbook.xml"/>` +
+    (fingerprint === undefined
+      ? ''
+      : `<Relationship Id="rId2" Type="${NS_REL_DOC}/custom-properties" Target="docProps/custom.xml"/>`) +
     `</Relationships>`;
 
   // Sheets take rId1..rIdN; styles takes the next id after them.
@@ -543,5 +570,6 @@ export function buildWorkbook(sheets: readonly SheetSpec[]): Uint8Array {
     ...sheets.map((s, i) => ({ name: sheetPath(i), data: enc(sheetXml(s, tableIdsBySheet[i])) })),
     ...sheetRels,
     ...allTables.map(({ table, id }) => ({ name: `xl/tables/table${id}.xml`, data: enc(tableXml(table, id)) })),
+    ...(fingerprint === undefined ? [] : [{ name: 'docProps/custom.xml', data: enc(customPropsXml(fingerprint)) }]),
   ]);
 }

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
+++ b/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
@@ -43,7 +43,10 @@ test_resources_manifest_declares_reachable_keys() {
 test_resources_manifest_advertises_engine_commands() {
   local manifest="$PLUGIN_ROOT/.xcsh-plugin/resources.json"
   local cmd
-  for cmd in validate next score hint fill check-mappings; do
+  # Every command the engine implements, not a subset: `generate` and `check-spec` were both
+  # advertised in the manifest while this list still stopped at `check-mappings`, so dropping
+  # either from the manifest would have gone unnoticed.
+  for cmd in validate next score hint fill check-mappings check-spec generate read; do
     jq -e --arg c "$cmd" '.engine.commands | index($c)' "$manifest" >/dev/null || {
       echo "engine.commands does not advertise \"$cmd\""
       return 1

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -191,6 +191,129 @@ echo "PASS: keyed references follow the key, so sorting the table cannot mislabe
 
 osascript -e "tell application \"Microsoft Excel\" to close workbook \"$BOOK\" saving no" >/dev/null 2>&1
 
+# Stage 3: the round trip, through a real save.
+#
+# This is the only check that can catch what Excel does to the file on the way out. The
+# generator writes every string inline (`t="inlineStr"`); Excel re-saves the same text through
+# `sharedStrings.xml` as `t="s"`. A reader that understands only its own output passes every
+# unit test and then finds nothing in the one file that matters — the one a person edited.
+#
+# Two separate claims, in order:
+#   1. Open and save WITHOUT editing anything, and the reader must still propose nothing.
+#      Any proposal here is the reader misreading Excel's own format, not a human's edit.
+#   2. Edit four cells of four different types, save, and each edit comes back exactly.
+command -v jq >/dev/null 2>&1 || skip "jq unavailable for the round-trip case"
+
+RT_DEAL="$WORK/rt-deal.json"
+RT_OUT="$WORK/rt.xlsx"
+RT_BOOK="$(basename "$RT_OUT")"
+cp "$DEAL" "$RT_DEAL" || fail "could not copy the deal"
+bun "$PLUGIN_ROOT/engine/cli.ts" generate "$RT_DEAL" --out "$RT_OUT" >/dev/null || fail "generate failed for the round trip"
+
+# Ask the plan where each field landed. Hard-coding an address here would make this pass while
+# reading the wrong cell, which is the entire failure mode the inputCells map exists to prevent.
+rt_plan="$(bun "$PLUGIN_ROOT/engine/cli.ts" generate "$RT_DEAL" --plan)" || fail "generate --plan failed"
+at() {
+  jq -r --arg p "$1" --arg f "$2" '(.inputCells[] | select(.jsonPath == $p) | .[$f]) // "MISSING"' <<<"$rt_plan"
+}
+for field in metadata.accountName qualification.champion.score metadata.closeDate stakeholders[0].mustSayYes; do
+  [ "$(at "$field" address)" != "MISSING" ] || fail "the plan has no input cell for $field"
+done
+
+echo "==> opening the round-trip workbook in Excel"
+open -a "Microsoft Excel" "$RT_OUT" || fail "could not open the round-trip workbook"
+for _ in $(seq 1 30); do
+  if osascript -e 'tell application "Microsoft Excel" to get name of every workbook' 2>/dev/null | grep -qF "$RT_BOOK"; then
+    rt_opened=1
+    break
+  fi
+  sleep 2
+done
+[ "${rt_opened:-0}" = "1" ] || fail "Excel never listed $RT_BOOK"
+
+# Claim 1: a save with no edits at all.
+osascript <<OSA >/dev/null 2>&1
+tell application "Microsoft Excel"
+  set display alerts to false
+  save workbook "$RT_BOOK"
+  close workbook "$RT_BOOK" saving no
+  set display alerts to true
+end tell
+OSA
+untouched="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL")"
+rt_code=$?
+untouched_count="$(jq -r '.proposals | length' <<<"$untouched")"
+untouched_rejects="$(jq -r '.rejections | length' <<<"$untouched")"
+echo "    after Excel saved it untouched: $untouched_count proposal(s), $untouched_rejects rejection(s)"
+[ "$rt_code" = "0" ] || fail "read exited $rt_code on a workbook Excel had merely saved"
+[ "$untouched_count" = "0" ] || fail "Excel's own save produced $untouched_count phantom proposal(s): $(jq -c '.proposals' <<<"$untouched")"
+[ "$untouched_rejects" = "0" ] || fail "Excel's own save produced rejections: $(jq -c '.rejections' <<<"$untouched")"
+echo "PASS: a save by Excel does not read as an edit"
+
+# Claim 2: four edits, four types — a string, a 0-4 score, a date typed as text, a boolean.
+echo "==> editing four cells in Excel and saving"
+open -a "Microsoft Excel" "$RT_OUT" || fail "could not reopen the round-trip workbook"
+for _ in $(seq 1 30); do
+  if osascript -e 'tell application "Microsoft Excel" to get name of every workbook' 2>/dev/null | grep -qF "$RT_BOOK"; then
+    break
+  fi
+  sleep 2
+done
+
+# `range`, not `cell`: reads work through either, but a write through `cell` fails.
+osascript <<OSA >/dev/null 2>&1
+tell application "Microsoft Excel"
+  set display alerts to false
+  set wb to workbook "$RT_BOOK"
+  set value of range "$(at metadata.accountName address)" of worksheet "$(at metadata.accountName sheet)" of wb to "Globex Corporation"
+  set value of range "$(at qualification.champion.score address)" of worksheet "$(at qualification.champion.score sheet)" of wb to 2
+  set value of range "$(at metadata.closeDate address)" of worksheet "$(at metadata.closeDate sheet)" of wb to "2026-09-15"
+  set value of range "$(at 'stakeholders[0].mustSayYes' address)" of worksheet "$(at 'stakeholders[0].mustSayYes' sheet)" of wb to false
+  save wb
+  close wb saving no
+  set display alerts to true
+end tell
+OSA
+
+edited="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL")"
+edited_code=$?
+echo "    proposals: $(jq -c '[.proposals[] | {jsonPath, to}]' <<<"$edited")"
+[ "$edited_code" = "0" ] || fail "read exited $edited_code after four hand edits: $(jq -c '.rejections' <<<"$edited")"
+[ "$(jq -r '.rejections | length' <<<"$edited")" = "0" ] || fail "hand edits were rejected: $(jq -c '.rejections' <<<"$edited")"
+
+proposed() {
+  jq -r --arg p "$1" '(.proposals[] | select(.jsonPath == $p) | .to | tostring) // "MISSING"' <<<"$edited"
+}
+for pair in \
+  "metadata.accountName=Globex Corporation" \
+  "qualification.champion.score=2" \
+  "metadata.closeDate=2026-09-15" \
+  "stakeholders[0].mustSayYes=false"; do
+  want="${pair#*=}"
+  got="$(proposed "${pair%%=*}")"
+  echo "    ${pair%%=*}: Excel proposed [$got], expected [$want]"
+  [ "$got" = "$want" ] || fail "${pair%%=*} came back as '$got', expected '$want'"
+done
+[ "$(jq -r '.proposals | length' <<<"$edited")" = "4" ] || fail "expected exactly 4 proposals, got $(jq -r '.proposals | length' <<<"$edited")"
+
+# And applying them lands a deal that still validates.
+bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL" --apply >/dev/null || fail "read --apply exited non-zero"
+bun "$PLUGIN_ROOT/engine/cli.ts" validate "$RT_DEAL" >/dev/null || fail "the applied deal does not validate"
+applied_name="$(jq -r '.metadata.accountName' "$RT_DEAL")"
+applied_date="$(jq -r '.metadata.closeDate' "$RT_DEAL")"
+applied_score="$(jq -r '.qualification.champion.score' "$RT_DEAL")"
+applied_flag="$(jq -r '.stakeholders[0].mustSayYes' "$RT_DEAL")"
+echo "    applied: $applied_name / $applied_date / score $applied_score / mustSayYes $applied_flag"
+[ "$applied_name" = "Globex Corporation" ] || fail "the applied deal says accountName='$applied_name'"
+[ "$applied_date" = "2026-09-15" ] || fail "the applied deal says closeDate='$applied_date'"
+[ "$applied_score" = "2" ] || fail "the applied deal says champion score='$applied_score'"
+[ "$applied_flag" = "false" ] || fail "the applied deal says mustSayYes='$applied_flag'"
+
+# Applying is idempotent: with the JSON now agreeing with the sheet, there is nothing to propose.
+again="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL")" || fail "the second read exited non-zero"
+[ "$(jq -r '.proposals | length' <<<"$again")" = "0" ] || fail "a second read still proposes $(jq -c '.proposals' <<<"$again")"
+echo "PASS: edits made in Excel round-trip into the deal JSON, and applying them twice changes nothing"
+
 # The same comparison on a deal where most elements are unscored — the case that was wrong.
 #
 # MEDDPICC scores out of 32 whether or not anyone has assessed an element yet. With the

--- a/plugins/meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/meddpicc/skills/deal-qualification/SKILL.md
@@ -364,6 +364,49 @@ Rules that matter:
   sheet computes Factored Pipe from `N4` and `I5`.
 - Never target `I7`; it is the template's own formula.
 
+### The generated workbook, and reading it back
+
+`fill` above puts values into the F5 Deal Review Sheet. There is also a
+workbook the plugin builds itself, from `engine/workbook-spec.json`:
+eight sheets, a Scorecard that is entirely formulas, Excel Tables that
+grow, conditional formatting, dropdowns read from the schema — and,
+unlike the template, it reads back.
+
+```bash
+bun xcsh://plugin/meddpicc/file/engine/cli.ts generate <deal.json> \
+  --out "{accountName}-MEDDPICC-{YYYY-MM-DD}.xlsx"
+```
+
+Once someone has edited it in Excel, pull their work back into the JSON:
+
+```bash
+bun xcsh://plugin/meddpicc/file/engine/cli.ts read <workbook.xlsx> \
+  --deal <deal.json>            # says what it proposes; writes nothing
+bun xcsh://plugin/meddpicc/file/engine/cli.ts read <workbook.xlsx> \
+  --deal <deal.json> --apply    # writes it
+```
+
+**Which one to produce is the user's call, not yours.** The F5 Deal
+Review Sheet is the artefact leadership recognises; the generated
+workbook is the better tool for working the deal. If they say "render"
+or "export" without saying which, produce the template and mention the
+other exists.
+
+Rules that matter:
+
+- **Show the proposals before applying.** `read` without `--apply`
+  changes nothing, and that is the default for a reason: the JSON is
+  the source of truth and a cell that differs is a proposal.
+- **Relay a rejection by its cell address**, as the tool gives it —
+  `Qualification!C8`, not a JSON path. The user is looking at Excel.
+  A non-zero exit means something was refused; do not apply anyway.
+- **A workbook only reads back against the deal it was generated
+  from.** It carries a stamp, and `read` refuses it otherwise. If the
+  deal has gained a stakeholder or an answer since, regenerate — do
+  not try to make the old file work.
+- After applying edits that added rows, regenerate the workbook so it
+  has blank rows to grow into again.
+
 ## Coaching Behavior
 
 After presenting the scorecard:


### PR DESCRIPTION
Closes #888. Stage 3 — the last stage — of the approved modern-workbook plan, after #874
(spec + writer), #885 (generator) and #887 (tables, conditional formatting, dropdowns).

## What this adds

```
engine/cli.ts read <workbook.xlsx> --deal <deal.json> [--apply]
```

The workbook was write-only. A seller who opened `Deal.xlsx`, fixed a stakeholder's name and
raised a score had nowhere to put that work.

**Read, diff, propose — never overwrite.** The JSON stays the source of truth, so a differing
cell is a *proposal*, printed with its old and new value. Nothing is written without `--apply`,
and `--apply` writes only a deal that validates. The exit code follows the outcome.

**The reader walks `inputCells`**, the map `planWorkbook` already returned. It has no second
idea of where a field lives, which is the only way the two directions cannot drift. `computed`
and `derived` cells are never read — including a formula found at an input address, whose
cached value is not an answer anyone gave.

**Every rejection names its cell.** A score of 7, a status outside the enum, prose in a
currency cell, `#REF!` in a text cell — each reported as `Qualification!C8`, because the person
fixing it is looking at Excel, not at a JSON pointer.

## The parts that were not obvious

Six things, each of which would have made this useless in a different way. Every one was
measured, not reasoned about.

**A workbook is only meaningful against the deal it came from.** This is the one that would
have hurt. A table's row count depends on the deal, so answering one more question moves every
Questions row below it. Reading an older workbook cell by cell:

```
proposals: 14   rejections: 0   ok: true
  qualification.economicBuyer.responses[0] <= "Direct meeting held 2026-04-20…"   ← metrics' answer
  qualification.decisionCriteria.responses[0] <= "Budget approved at $90K ACV…"   ← economicBuyer's
```

Confident, silent, and `--apply` would have written all of it. `generate` now stamps each
workbook with a fingerprint of the deal's identity plus its layout, in a custom document
property; `read` refuses a workbook whose stamp does not match. The stamp covers identity and
layout only — never the whole deal — so a workbook already on someone's desk survives a JSON
edit that moves no cell.

**Excel rewrites the file when it saves.** The generator writes strings inline
(`t="inlineStr"`); Excel re-saves the same text through `sharedStrings.xml` as `t="s"`. With
that unhandled, opening the workbook and saving it *without editing anything* produced **86
phantom proposals and 18 rejections**. Every unit test passed at that point.

**Nothing is dropped in silence.** An Excel Table extends when you type under its last row, so
that is simply how you add a stakeholder once the padded rows are used up. Those cells belong to
no field, and passing over them would be the legacy sheet's own bug in a new place — it
formatted eight team rows and dropped the rest. Reported by address now.

**A date cell holds a day, not an instant.** `2026-06-30T09:15:00Z` in the JSON against
`2026-06-30` in the sheet is not an edit, so dates compare as serials. As text, the reader would
have cried wolf on every read until nobody read it.

**An unscored element is written as `0`, not blank** — stage 1c chose that deliberately, because
`COUNT` over blanks showed a partly-qualified deal as 100%. So a `0` read back cannot be
distinguished from "not assessed", and a missing score must not become a proposal to set `0`.

**A list may only be appended to.** Filling the sixth row of a three-item list would write
`stakeholders[5]` into an array of length 3 and leave holes that fail the schema. Refused,
naming the row that is still empty. And a refused write now changes nothing at all: reaching
`responses[1]` in a deal with no `responses` key used to build the array and then refuse the
index, leaving it behind in a deal reported as unchanged.

## Verification

- `bun test engine/` — **233 pass, 0 fail** (58 new).
- `scripts/tests/run-tests.sh` — 30 passed, 1 skipped, 0 failed.
- `scripts/run-plugin-tests.sh` (the required CI gate) — exit 0.
- Biome, shellcheck, shfmt, codespell — all clean.
- **Real Excel, end to end.** `scripts/uat-generate-excel.sh` opens the generated workbook,
  saves it untouched and confirms the reader proposes nothing; then edits four cells of four
  types by hand — a string, a 0-4 score, `2026-09-15` typed as text, and a boolean — saves,
  reads all four back exactly, applies them, and applies again with nothing left to do.
- **The UAT can fail.** Breaking shared-string resolution and re-running it produces the
  86-proposal figure above and stops at that assertion. A UAT that passes either way is worse
  than none.
- **24 mutations across the reader's guards, all caught.** Three of them changed the code rather
  than the tests: an error-cell test that proved nothing because it used a currency cell where
  `NaN` already rejected the value; an integer check in coercion fully redundant with the
  schema's own `type: integer`; and a formula skip that was both untested and wrong.

`codex:verified-code-review` reported three findings, all CONFIRMED, none refuted — the stamp,
the dropped rows and the partial mutation. Two of the three had already been found and fixed by
mutation-checking; the review found the stamp, which was the most serious defect in the branch.
Records in `.codex-review/verify-1.json`; the gate reports `done: true`.

## Still open, deliberately

`fill` and the legacy `cell-mapping.json` are untouched. The plan retires them in the stage that
replaces them, and this is not that stage: the F5 Deal Review Sheet is still the artefact
leadership recognises, and that call is not mine to make silently.
