### PR TITLE
MEDDPICC: name no vendor in the schema, workbook or skills

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ and this project adheres to
   Renaming the input paths changes every workbook's stamp, so previously generated workbooks no
   longer read back. They are ephemeral by design: regenerate.
 
+  Two findings from the review, both confirmed. **A field set under both names is now a conflict,
+  not a decision the tool makes.** The first version deleted the legacy key so the migration would
+  terminate — and for `threeWhys.f5`, which is an object, that discarded every answer inside it to
+  make room for a possibly half-filled `threeWhys.us`. Silently dropping a value the user cannot
+  see is the exact failure this migration exists to prevent, so `migrate` now reports both paths,
+  writes nothing at all while a conflict stands, and leaves the choice to the person who made the
+  edit. **And `next` and `score` refuse a legacy deal too**, not just `validate`: `next` drives the
+  qualification workflow, and reading an unmigrated deal it found no `threeWhys.us` or
+  `team.internal` and would have called two finished sections `not_started`, walking the user back
+  through completed work without a word.
+
 - **`meddpicc`** v3.0.0 — **breaking: `fill` is gone, and F5's Deal Review Sheet is no longer
   shipped.** One spreadsheet now, generated from `workbook-spec.json`, ephemeral by design:
   produced on demand and regenerated rather than kept.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,47 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v4.0.0 — **breaking: the plugin names no vendor.** MEDDPICC is an industry-standard
+  framework and this repository is public, so the schema, the workbook and the skills no longer
+  carry one company's names. `engine/cli.ts migrate <deal.json> --apply` moves an existing deal
+  across.
+
+  | was | is |
+  | --- | --- |
+  | `threeWhys.f5` / `whyF5` | `threeWhys.us` / `whyUs` |
+  | `stakeholders[].viewOfF5` | `stakeholders[].sentiment` |
+  | `stakeholders[].f5Owner` | `stakeholders[].relationshipOwner` |
+  | `team.f5` | `team.internal` |
+  | `metadata.revenue.pAndIplusAcvx` | `metadata.revenue.subscription` |
+
+  `whyUs` is not only de-branded, it is more correct: "Why anything? Why us? Why now?" is the
+  canonical Three Whys wording. The workbook labels follow — "Why us?", "Sentiment", "Relationship
+  owner", "Internal team members", "Three Whys — Us", "Subscription" — and `skills/coach` no longer
+  instructs the agent to tie its coaching to one company's product line.
+
+  **The rename could not be made safely without a migration.** The schema sets
+  `additionalProperties: false` nowhere, so a deal using the old names does not fail validation —
+  it passes, while its values sit unreachable: present in the JSON, invisible to the workbook and
+  to scoring. Silent data loss is a worse outcome than the branding it replaces. So `validate`,
+  `generate` and `read` all **refuse** a deal that still uses the old names, listing them and
+  naming the command that fixes it, and `migrate` reports what it would move before `--apply`
+  writes anything — the same propose-then-apply posture as `read`.
+
+  There is deliberately no separate detector: a deal has legacy fields exactly when `migrateDeal`
+  reports changes, so the check cannot drift from the transform that fixes it. Renames preserve
+  each key's position too, so an applied migration reads as a rename rather than a rewrite.
+
+  Two things worth knowing. `metadata.revenue.pAndIplusAcvx` turned out to be **an addend, not a
+  total** — the workbook sums it with hardware and software — so the first generic name chosen for
+  it, `totalContractValue`, would have been actively misleading; it is `subscription`. And a new
+  guard test asserts that no schema field, label or instruction anywhere in the plugin names the
+  vendor, excluding this repository's own URL. Its first version used `\bf5\b`, which matches none
+  of `viewOfF5`, `whyF5` or `f5Owner` — camelCase leaves no word boundary — and would have passed a
+  schema still full of them. Only the test's own self-check caught it.
+
+  Renaming the input paths changes every workbook's stamp, so previously generated workbooks no
+  longer read back. They are ephemeral by design: regenerate.
+
 - **`meddpicc`** v3.0.0 — **breaking: `fill` is gone, and F5's Deal Review Sheet is no longer
   shipped.** One spreadsheet now, generated from `workbook-spec.json`, ephemeral by design:
   produced on demand and regenerated rather than kept.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to
   writes anything — the same propose-then-apply posture as `read`.
 
   There is deliberately no separate detector: a deal has legacy fields exactly when `migrateDeal`
-  reports changes, so the check cannot drift from the transform that fixes it. Renames preserve
+  reports changes or conflicts, so the check cannot drift from the transform that fixes it. Renames preserve
   each key's position too, so an applied migration reads as a rename rather than a rewrite.
 
   Two things worth knowing. `metadata.revenue.pAndIplusAcvx` turned out to be **an addend, not a

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/.xcsh-plugin/resources.json
+++ b/plugins/meddpicc/.xcsh-plugin/resources.json
@@ -6,6 +6,6 @@
   "engine": {
     "runtime": "bun",
     "entry": "engine/cli.ts",
-    "commands": ["validate", "next", "score", "hint", "check-sfdc", "check-spec", "generate", "read"]
+    "commands": ["validate", "next", "score", "hint", "check-sfdc", "check-spec", "generate", "read", "migrate"]
   }
 }

--- a/plugins/meddpicc/README.md
+++ b/plugins/meddpicc/README.md
@@ -117,11 +117,11 @@ Deals are stored as JSON files conforming to the [MEDDPICC schema](schema/meddpi
 
 - **Metadata** — deal identification, stage, financials, client interactions, Salesforce integration, completion tracking
 - **Qualification** — all 8 MEDDPICC elements with definitions, questions, responses, scores, score definitions, evidence, and notes
-- **Three Whys** — Why Anything, Why F5, Why Now (for both F5 and partner)
-- **Stakeholders** — name, title, role in deal, veto power, beliefs needed, sentiment, F5 owner
+- **Three Whys** — Why Anything, Why Us, Why Now (for both your own company and the partner)
+- **Stakeholders** — name, title, role in deal, veto power, beliefs needed, sentiment, relationship owner
 - **Sales Strategy** — differentiated value proposition and win strategy
 - **Close Plan** — milestones and critical actions with dates and owners
-- **Team** — F5 and partner team members assigned to the deal
+- **Team** — internal and partner team members assigned to the deal
 - **Scoring** — element scores, previous scores (for deltas), overall score, and rating
 
 ### File naming
@@ -205,7 +205,7 @@ The AI extracts MEDDPICC signals, presents a proposed update diff with score rec
 /meddpicc:update-deal Acme Corp
 FW: RE: API Gateway eval - internal update
 Hey John, wanted to give you a heads up. The architecture review
-board approved F5 for the shortlist. Vendor A pricing came in at
+board approved us for the shortlist. Vendor A pricing came in at
 $85K/yr vs your $120K. Legal confirmed their standard review takes
 3 weeks. Talk soon, Barney
 ```

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -23,6 +23,28 @@ async function fixture(name: string): Promise<{ deal: string; workbook: string }
   return { deal, workbook };
 }
 
+/** A copy of the example deal with every field put back to its retired name. */
+function legacyDeal(name: string): string {
+  const deal = JSON.parse(fs.readFileSync(example, 'utf8'));
+  deal.metadata.revenue.pAndIplusAcvx = deal.metadata.revenue.subscription;
+  delete deal.metadata.revenue.subscription;
+  deal.threeWhys.f5 = deal.threeWhys.us;
+  delete deal.threeWhys.us;
+  deal.threeWhys.f5.whyF5 = deal.threeWhys.f5.whyUs;
+  delete deal.threeWhys.f5.whyUs;
+  for (const s of deal.stakeholders) {
+    s.viewOfF5 = s.sentiment;
+    delete s.sentiment;
+    s.f5Owner = s.relationshipOwner;
+    delete s.relationshipOwner;
+  }
+  deal.team.f5 = deal.team.internal;
+  delete deal.team.internal;
+  const at = path.join(scratch, `${name}.json`);
+  fs.writeFileSync(at, `${JSON.stringify(deal, null, 2)}\n`);
+  return at;
+}
+
 async function run(args: string[]): Promise<{ code: number; out: string }> {
   const proc = Bun.spawn(['bun', path.join(engineDir, 'cli.ts'), ...args], { stdout: 'pipe', stderr: 'pipe' });
   const out = await new Response(proc.stdout).text();
@@ -186,5 +208,66 @@ describe('cli read', () => {
     const second = JSON.parse((await run(['read', workbook, '--deal', deal, '--apply'])).out);
     expect(second.proposals).toEqual([]);
     expect(second.applied).toBe(false);
+  });
+});
+
+describe('cli migrate', () => {
+  test('a deal using retired field names is refused by validate, generate and read', async () => {
+    // The schema tolerates them silently, so refusing is the only thing standing between an old
+    // file and a workbook full of blanks where its answers used to be.
+    const deal = legacyDeal('refused');
+    const workbook = path.join(scratch, 'refused.xlsx');
+    expect((await run(['validate', deal])).code).toBe(1);
+    expect((await run(['generate', deal, '--out', workbook])).code).toBe(1);
+    expect(fs.existsSync(workbook)).toBe(false);
+
+    // `read` needs a workbook to be handed, so build one from a current deal and read it against
+    // the legacy one: the refusal must come before any cell is compared.
+    const current = await fixture('refused-current');
+    expect((await run(['read', current.workbook, '--deal', deal])).code).toBe(1);
+  });
+
+  test('migrate lists what it would change and writes nothing', async () => {
+    const deal = legacyDeal('dry');
+    const before = fs.readFileSync(deal, 'utf8');
+    const { code, out } = await run(['migrate', deal]);
+    expect(code).toBe(0);
+    const report = JSON.parse(out);
+    expect(report.applied).toBe(false);
+    expect(report.changes.length).toBeGreaterThan(0);
+    expect(report.changes).toContain('team.f5 → team.internal');
+    expect(fs.readFileSync(deal, 'utf8')).toBe(before);
+  });
+
+  test('--apply moves every value, and the result then validates and generates', async () => {
+    const deal = legacyDeal('applied');
+    const original = JSON.parse(fs.readFileSync(deal, 'utf8'));
+    expect((await run(['migrate', deal, '--apply'])).code).toBe(0);
+
+    const after = JSON.parse(fs.readFileSync(deal, 'utf8'));
+    // Values, not just key names: a rename that lost the value would still look renamed.
+    expect(after.threeWhys.us.whyUs).toBe(original.threeWhys.f5.whyF5);
+    expect(after.stakeholders[0].sentiment).toBe(original.stakeholders[0].viewOfF5);
+    expect(after.stakeholders[0].relationshipOwner).toBe(original.stakeholders[0].f5Owner);
+    expect(after.team.internal).toEqual(original.team.f5);
+    expect(after.metadata.revenue.subscription).toBe(original.metadata.revenue.pAndIplusAcvx);
+
+    expect((await run(['validate', deal])).code).toBe(0);
+    expect((await run(['generate', deal, '--out', path.join(scratch, 'applied.xlsx')])).code).toBe(0);
+  });
+
+  test('migrating an already-current deal reports nothing and writes nothing', async () => {
+    const { deal } = await fixture('current');
+    const before = fs.readFileSync(deal, 'utf8');
+    const { code, out } = await run(['migrate', deal, '--apply']);
+    expect(code).toBe(0);
+    const report = JSON.parse(out);
+    expect(report.changes).toEqual([]);
+    expect(report.applied).toBe(false);
+    expect(fs.readFileSync(deal, 'utf8')).toBe(before);
+  });
+
+  test('migrate without a deal exits 1', async () => {
+    expect((await run(['migrate'])).code).toBe(1);
   });
 });

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -227,6 +227,30 @@ describe('cli migrate', () => {
     expect((await run(['read', current.workbook, '--deal', deal])).code).toBe(1);
   });
 
+  test('next and score refuse a legacy deal too, not just validate', async () => {
+    // `next` drives the qualification workflow. Reading a legacy deal it finds no `threeWhys.us`
+    // and no `team.internal`, so it would report two completed sections as not_started and send
+    // the user back through them with no hint that anything was wrong.
+    const deal = legacyDeal('refused-next');
+    expect((await run(['next', deal])).code).toBe(1);
+    expect((await run(['score', deal])).code).toBe(1);
+  });
+
+  test('a conflicting deal is refused and never half-applied', async () => {
+    const deal = legacyDeal('conflict');
+    const parsed = JSON.parse(fs.readFileSync(deal, 'utf8'));
+    parsed.threeWhys.us = { whyNow: 'partly filled in by hand' };
+    fs.writeFileSync(deal, `${JSON.stringify(parsed, null, 2)}\n`);
+    const before = fs.readFileSync(deal, 'utf8');
+
+    const { code, out } = await run(['migrate', deal, '--apply']);
+    expect(code).toBe(1);
+    const report = JSON.parse(out);
+    expect(report.conflicts.length).toBeGreaterThan(0);
+    expect(report.applied).toBe(false);
+    expect(fs.readFileSync(deal, 'utf8')).toBe(before);
+  });
+
   test('migrate lists what it would change and writes nothing', async () => {
     const deal = legacyDeal('dry');
     const before = fs.readFileSync(deal, 'utf8');

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { computeCompletion } from './completion';
 import { generateWorkbook, planWorkbook } from './generate';
 import { computeElementHint, computeHintOverview } from './hint';
+import { migrateDeal } from './legacy';
 import { checkSfdcMapping } from './mappings';
 import { readWorkbook } from './read-workbook';
 import { computeScore } from './score';
@@ -46,6 +47,24 @@ function flag(args: string[], name: string): string | undefined {
   return i >= 0 ? args[i + 1] : undefined;
 }
 
+/**
+ * Refuse a deal that still uses the retired field names.
+ *
+ * The schema constrains no additional properties, so an old file validates cleanly while its
+ * values sit unreachable — the workbook would show blanks and scoring would ignore them. Better to
+ * stop and say which fields, exactly as the workbook stamp refuses a workbook from another deal.
+ */
+function refuseLegacyDeal(deal: unknown, dealPath: string): number | null {
+  const { changes } = migrateDeal(deal);
+  if (changes.length === 0) return null;
+  process.stderr.write(
+    `${dealPath} uses field names this plugin has retired. Their values would be ignored rather than read.\n` +
+      `Run: cli.ts migrate ${dealPath} --apply\n`,
+  );
+  print({ ok: false, legacyFields: changes });
+  return 1;
+}
+
 async function main(): Promise<number> {
   const [command, ...rest] = process.argv.slice(2);
 
@@ -68,6 +87,8 @@ async function main(): Promise<number> {
       print({ ...result, hint });
       return 0;
     }
+    const legacy = refuseLegacyDeal(deal, dealPath);
+    if (legacy !== null) return legacy;
     const schema = await readJson(SCHEMA_PATH);
     const result = validateDeal(deal, schema);
     print(result);
@@ -114,6 +135,9 @@ async function main(): Promise<number> {
     // input. A mistyped jsonPath becomes an empty cell and a wrong type becomes a blank
     // one, and either reads as "that field is not filled in yet" instead of "the spec is
     // broken". Both checks are cheap and deterministic, so there is no reason to skip them.
+    const legacy = refuseLegacyDeal(deal, dealPath);
+    if (legacy !== null) return legacy;
+
     const specCheck = checkWorkbookSpec(schema, spec);
     if (!specCheck.ok) {
       process.stderr.write('Refusing to generate: the workbook spec does not check out.\n');
@@ -160,6 +184,9 @@ async function main(): Promise<number> {
     const schema = await readJson(SCHEMA_PATH);
     const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
     const deal = await readJson(dealPath);
+    const legacy = refuseLegacyDeal(deal, dealPath);
+    if (legacy !== null) return legacy;
+
     const bytes = new Uint8Array(await Bun.file(workbookPath).arrayBuffer());
     const report = readWorkbook(schema, spec, deal, bytes);
 
@@ -186,6 +213,25 @@ async function main(): Promise<number> {
     return report.ok ? 0 : 1;
   }
 
+  if (command === 'migrate') {
+    const dealPath = rest[0];
+    if (!dealPath) {
+      process.stderr.write('Usage: cli.ts migrate <deal.json> [--apply]\n');
+      return 1;
+    }
+    const deal = await readJson(dealPath);
+    const { deal: migrated, changes } = migrateDeal(deal);
+
+    // Same posture as `read`: say what would change and write nothing unless asked.
+    const apply = rest.includes('--apply') && changes.length > 0;
+    if (apply) await Bun.write(dealPath, `${JSON.stringify(migrated, null, 2)}\n`);
+
+    const schema = await readJson(SCHEMA_PATH);
+    const check = validateDeal(migrated, schema);
+    print({ deal: dealPath, changes, applied: apply, valid: check.valid, errors: check.errors });
+    return check.valid ? 0 : 1;
+  }
+
   if (command === 'check-spec') {
     const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
     const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
@@ -195,7 +241,7 @@ async function main(): Promise<number> {
   }
 
   process.stderr.write(
-    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, generate, read, check-sfdc, check-spec\n`,
+    `Unknown command: ${command ?? '(none)'}\nCommands: validate, next, score, hint, generate, read, migrate, check-sfdc, check-spec\n`,
   );
   return 1;
 }

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -55,13 +55,15 @@ function flag(args: string[], name: string): string | undefined {
  * stop and say which fields, exactly as the workbook stamp refuses a workbook from another deal.
  */
 function refuseLegacyDeal(deal: unknown, dealPath: string): number | null {
-  const { changes } = migrateDeal(deal);
-  if (changes.length === 0) return null;
+  const { changes, conflicts } = migrateDeal(deal);
+  if (changes.length === 0 && conflicts.length === 0) return null;
   process.stderr.write(
     `${dealPath} uses field names this plugin has retired. Their values would be ignored rather than read.\n` +
-      `Run: cli.ts migrate ${dealPath} --apply\n`,
+      (conflicts.length > 0
+        ? 'Some fields are set under BOTH names; resolve those by hand first, then migrate.\n'
+        : `Run: cli.ts migrate ${dealPath} --apply\n`),
   );
-  print({ ok: false, legacyFields: changes });
+  print({ ok: false, legacyFields: changes, conflicts });
   return 1;
 }
 
@@ -75,6 +77,11 @@ async function main(): Promise<number> {
       return 1;
     }
     const deal = await readJson(dealPath);
+    // Before `score` and `next`, not just `validate`: `computeCompletion` reads `threeWhys.us` and
+    // `team.internal`, so on an unmigrated deal `next` would call two finished sections
+    // not_started and walk the user back through them without a word.
+    const legacyBlock = refuseLegacyDeal(deal, dealPath);
+    if (legacyBlock !== null) return legacyBlock;
     if (command === 'score') {
       print(computeScore(deal));
       return 0;
@@ -87,8 +94,6 @@ async function main(): Promise<number> {
       print({ ...result, hint });
       return 0;
     }
-    const legacy = refuseLegacyDeal(deal, dealPath);
-    if (legacy !== null) return legacy;
     const schema = await readJson(SCHEMA_PATH);
     const result = validateDeal(deal, schema);
     print(result);
@@ -220,15 +225,21 @@ async function main(): Promise<number> {
       return 1;
     }
     const deal = await readJson(dealPath);
-    const { deal: migrated, changes } = migrateDeal(deal);
+    const { deal: migrated, changes, conflicts } = migrateDeal(deal);
 
-    // Same posture as `read`: say what would change and write nothing unless asked.
-    const apply = rest.includes('--apply') && changes.length > 0;
+    // Same posture as `read`: say what would change and write nothing unless asked — and write
+    // nothing at all while a field is set under both names, since applying the rest would leave a
+    // half-migrated file whose remaining conflict is easy to miss.
+    const apply = rest.includes('--apply') && changes.length > 0 && conflicts.length === 0;
     if (apply) await Bun.write(dealPath, `${JSON.stringify(migrated, null, 2)}\n`);
 
     const schema = await readJson(SCHEMA_PATH);
     const check = validateDeal(migrated, schema);
-    print({ deal: dealPath, changes, applied: apply, valid: check.valid, errors: check.errors });
+    print({ deal: dealPath, changes, conflicts, applied: apply, valid: check.valid, errors: check.errors });
+    if (conflicts.length > 0) {
+      process.stderr.write('Refusing to migrate: resolve the fields listed above, then run this again.\n');
+      return 1;
+    }
     return check.valid ? 0 : 1;
   }
 

--- a/plugins/meddpicc/engine/completion.ts
+++ b/plugins/meddpicc/engine/completion.ts
@@ -27,11 +27,11 @@ function qualStatus(el: Record<string, unknown> | undefined): SectionStatus {
 type Deal = Record<string, unknown>;
 
 function threeWhysStatus(deal: Deal): SectionStatus {
-  const tw = deal.threeWhys as { f5?: Record<string, unknown> } | undefined;
-  if (!tw?.f5) return 'not_started';
-  const f5 = tw.f5;
-  const all = nonEmptyString(f5.whyAnything) && nonEmptyString(f5.whyF5) && nonEmptyString(f5.whyNow);
-  const any = nonEmptyString(f5.whyAnything) || nonEmptyString(f5.whyF5) || nonEmptyString(f5.whyNow);
+  const tw = deal.threeWhys as { us?: Record<string, unknown> } | undefined;
+  if (!tw?.us) return 'not_started';
+  const us = tw.us;
+  const all = nonEmptyString(us.whyAnything) && nonEmptyString(us.whyUs) && nonEmptyString(us.whyNow);
+  const any = nonEmptyString(us.whyAnything) || nonEmptyString(us.whyUs) || nonEmptyString(us.whyNow);
   return all ? 'complete' : any ? 'partial' : 'not_started';
 }
 
@@ -66,11 +66,11 @@ function closePlanStatus(deal: Deal): SectionStatus {
 }
 
 function teamStatus(deal: Deal): SectionStatus {
-  const team = deal.team as { f5?: unknown; partner?: unknown } | undefined;
+  const team = deal.team as { internal?: unknown; partner?: unknown } | undefined;
   if (!team) return 'not_started';
-  const f5 = Array.isArray(team.f5) && team.f5.length > 0;
+  const internal = Array.isArray(team.internal) && team.internal.length > 0;
   const partner = Array.isArray(team.partner) && team.partner.length > 0;
-  if (f5) return 'complete';
+  if (internal) return 'complete';
   return partner ? 'partial' : 'not_started';
 }
 

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -66,7 +66,7 @@ describe('planWorkbook — form layout', () => {
       .filter((c) => c.ref.startsWith('A'))
       .map((c) => c.value);
     expect(labels).toContain('Revenue');
-    expect(labels).toContain('Three Whys — F5');
+    expect(labels).toContain('Three Whys — Us');
   });
 
   test('rows are unique and ascending — nothing lands on top of anything else', () => {
@@ -161,14 +161,14 @@ describe('planWorkbook — collections are not capped', () => {
   test('a team larger than the legacy sheet formatted still fits', () => {
     // The F5 template formats 8 team rows and silently drops the rest.
     const big = JSON.parse(JSON.stringify(deal));
-    big.team.f5 = Array.from({ length: 14 }, (_, i) => ({ name: `Person ${i + 1}`, role: 'SE' }));
+    big.team.internal = Array.from({ length: 14 }, (_, i) => ({ name: `Person ${i + 1}`, role: 'SE' }));
     const p = planWorkbook(schema, spec, big);
     const team = p.sheets.find((s) => s.name === 'Team');
     const written = Array.from(
       { length: 14 },
       (_, i) => team?.rows.find((r) => r.row === i + 2)?.cells.find((c) => c.ref === `A${i + 2}`)?.value,
     );
-    expect(written).toEqual(big.team.f5.map((m: { name: string }) => m.name));
+    expect(written).toEqual(big.team.internal.map((m: { name: string }) => m.name));
   });
 
   test('an empty collection still leaves the header and the blank rows the spec asks for', () => {

--- a/plugins/meddpicc/engine/legacy.test.ts
+++ b/plugins/meddpicc/engine/legacy.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { migrateDeal, RENAMED_FIELDS } from './legacy';
+import { validateDeal } from './validate';
+
+const here = import.meta.dir;
+const schema = JSON.parse(fs.readFileSync(path.join(here, '..', 'schema', 'meddpicc-schema.json'), 'utf8'));
+const example = JSON.parse(fs.readFileSync(path.join(here, '..', 'schema', 'example-deal.json'), 'utf8'));
+const clone = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
+
+/**
+ * Just enough shape to assert against. The codebase avoids `any`; these tests reach into a few
+ * known branches of the deal, so name those and cast once.
+ */
+interface DealShape {
+  metadata: { revenue: Record<string, number> };
+  threeWhys: Record<string, Record<string, string>>;
+  stakeholders: Array<Record<string, string>>;
+  team: Record<string, Array<Record<string, string>>>;
+}
+const shape = (deal: unknown) => deal as DealShape;
+
+/**
+ * The example deal with every field put back to its old name.
+ *
+ * Written out by hand rather than derived from `RENAMED_FIELDS`, so the fixture is independent of
+ * the table under test — driving both from one list would let a wrong entry agree with itself.
+ */
+function asLegacyDeal(): DealShape {
+  const deal = clone(example);
+  deal.metadata.revenue.pAndIplusAcvx = deal.metadata.revenue.subscription;
+  delete deal.metadata.revenue.subscription;
+  deal.threeWhys.f5 = deal.threeWhys.us;
+  delete deal.threeWhys.us;
+  deal.threeWhys.f5.whyF5 = deal.threeWhys.f5.whyUs;
+  delete deal.threeWhys.f5.whyUs;
+  for (const s of deal.stakeholders) {
+    s.viewOfF5 = s.sentiment;
+    delete s.sentiment;
+    s.f5Owner = s.relationshipOwner;
+    delete s.relationshipOwner;
+  }
+  deal.team.f5 = deal.team.internal;
+  delete deal.team.internal;
+  return deal;
+}
+
+describe('migrateDeal', () => {
+  test('a deal already using the current names is left exactly alone', () => {
+    const before = clone(example);
+    const result = migrateDeal(example);
+    expect(result.changes).toEqual([]);
+    expect(result.deal).toEqual(before);
+  });
+
+  test('every legacy field moves, and every value survives the move', () => {
+    const legacy = asLegacyDeal();
+    const result = migrateDeal(legacy);
+    // Values, not just keys: a rename that dropped the value would still change the key names.
+    expect(result.deal).toEqual(example);
+    expect(result.changes).toHaveLength(RENAMED_FIELDS.length + (example.stakeholders.length - 1) * 2);
+  });
+
+  test('the input is not mutated', () => {
+    const legacy = asLegacyDeal();
+    const untouched = clone(legacy);
+    migrateDeal(legacy);
+    expect(legacy).toEqual(untouched);
+  });
+
+  test('the renamed parent is handled before the child inside it', () => {
+    // `whyF5` lives under `threeWhys.f5`, which is itself renamed. Applied in the wrong order the
+    // child rename looks for a container that no longer exists and silently does nothing.
+    const legacy = asLegacyDeal();
+    const result = shape(migrateDeal(legacy).deal);
+    expect(result.threeWhys.us.whyUs).toBe(example.threeWhys.us.whyUs);
+    expect(result.threeWhys.us.whyF5).toBeUndefined();
+    expect(result.threeWhys.f5).toBeUndefined();
+  });
+
+  test('every stakeholder is migrated, not just the first', () => {
+    const legacy = asLegacyDeal();
+    expect(legacy.stakeholders.length).toBeGreaterThan(1);
+    const result = shape(migrateDeal(legacy).deal);
+    for (const [i, s] of result.stakeholders.entries()) {
+      expect(s.sentiment).toBe(example.stakeholders[i].sentiment);
+      expect(s.relationshipOwner).toBe(example.stakeholders[i].relationshipOwner);
+      expect(s.viewOfF5).toBeUndefined();
+      expect(s.f5Owner).toBeUndefined();
+    }
+  });
+
+  test('each change names the concrete path it moved, including the list index', () => {
+    const result = migrateDeal(asLegacyDeal());
+    expect(result.changes).toContain('threeWhys.f5 → threeWhys.us');
+    expect(result.changes).toContain('stakeholders[1].viewOfF5 → stakeholders[1].sentiment');
+    expect(result.changes).toContain('metadata.revenue.pAndIplusAcvx → metadata.revenue.subscription');
+  });
+
+  test('a key keeps its position, so the applied file is a readable diff', () => {
+    const legacy = asLegacyDeal();
+    const before = Object.keys(legacy.stakeholders[0]);
+    const result = shape(migrateDeal(legacy).deal);
+    const after = Object.keys(result.stakeholders[0]);
+    expect(after).toEqual(
+      before.map((k) => (k === 'viewOfF5' ? 'sentiment' : k === 'f5Owner' ? 'relationshipOwner' : k)),
+    );
+  });
+
+  test('when both names are present the current one wins and the legacy one is dropped', () => {
+    // Leaving the legacy key would keep the file legacy forever, so every read would go on
+    // refusing it — the migration has to terminate.
+    const legacy = asLegacyDeal();
+    legacy.stakeholders[0].sentiment = 'Negative';
+    const result = migrateDeal(legacy);
+    expect(shape(result.deal).stakeholders[0].sentiment).toBe('Negative');
+    expect(shape(result.deal).stakeholders[0].viewOfF5).toBeUndefined();
+    expect(result.changes.some((c) => c.includes('dropped') && c.includes('viewOfF5'))).toBe(true);
+  });
+
+  test('migrating twice changes nothing the second time', () => {
+    const once = migrateDeal(asLegacyDeal());
+    const twice = migrateDeal(once.deal);
+    expect(twice.changes).toEqual([]);
+    expect(twice.deal).toEqual(once.deal);
+  });
+
+  test('a migrated deal validates against the current schema', () => {
+    expect(validateDeal(migrateDeal(asLegacyDeal()).deal, schema).valid).toBe(true);
+  });
+
+  test('a legacy deal is what the current schema silently tolerates — which is why this exists', () => {
+    // No `additionalProperties: false` anywhere, so the old file passes validation while its
+    // values sit unreachable. Validation alone can never be the guard here.
+    expect(validateDeal(asLegacyDeal(), schema).valid).toBe(true);
+    expect(migrateDeal(asLegacyDeal()).changes.length).toBeGreaterThan(0);
+  });
+
+  test('an empty or partial deal is handled without throwing', () => {
+    expect(migrateDeal({}).changes).toEqual([]);
+    expect(migrateDeal({ threeWhys: {} }).changes).toEqual([]);
+    expect(migrateDeal({ stakeholders: [] }).changes).toEqual([]);
+    expect(migrateDeal({ stakeholders: 'not a list' }).changes).toEqual([]);
+    expect(migrateDeal(null).changes).toEqual([]);
+  });
+});

--- a/plugins/meddpicc/engine/legacy.test.ts
+++ b/plugins/meddpicc/engine/legacy.test.ts
@@ -108,15 +108,37 @@ describe('migrateDeal', () => {
     );
   });
 
-  test('when both names are present the current one wins and the legacy one is dropped', () => {
-    // Leaving the legacy key would keep the file legacy forever, so every read would go on
-    // refusing it — the migration has to terminate.
+  test('both names present is a conflict, and nothing is thrown away to resolve it', () => {
+    // Picking a winner here would be the very thing this module exists to prevent: discarding a
+    // value the user cannot see. Only they know which of the two is right.
     const legacy = asLegacyDeal();
     legacy.stakeholders[0].sentiment = 'Negative';
     const result = migrateDeal(legacy);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toContain('stakeholders[0].viewOfF5');
+    expect(result.conflicts[0]).toContain('stakeholders[0].sentiment');
+    // Both values are still there, untouched, for the user to adjudicate.
     expect(shape(result.deal).stakeholders[0].sentiment).toBe('Negative');
-    expect(shape(result.deal).stakeholders[0].viewOfF5).toBeUndefined();
-    expect(result.changes.some((c) => c.includes('dropped') && c.includes('viewOfF5'))).toBe(true);
+    expect(shape(result.deal).stakeholders[0].viewOfF5).toBe(shape(asLegacyDeal()).stakeholders[0].viewOfF5);
+  });
+
+  test('a conflict on a renamed parent does not discard the whole subtree', () => {
+    // The worst case: `threeWhys.f5` is a populated object. Deleting it to make room for a
+    // half-filled `threeWhys.us` would lose every answer inside it at once.
+    const legacy = asLegacyDeal();
+    const populated = shape(legacy).threeWhys.f5;
+    legacy.threeWhys.us = { whyNow: 'only this one filled in' };
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toHaveLength(1);
+    expect(shape(result.deal).threeWhys.f5).toEqual(populated);
+    expect(shape(result.deal).threeWhys.us).toEqual({ whyNow: 'only this one filled in' });
+  });
+
+  test('a conflict still counts as legacy, so callers keep refusing the file', () => {
+    const legacy = asLegacyDeal();
+    legacy.team.internal = [];
+    const result = migrateDeal(legacy);
+    expect(result.conflicts.length).toBeGreaterThan(0);
   });
 
   test('migrating twice changes nothing the second time', () => {

--- a/plugins/meddpicc/engine/legacy.ts
+++ b/plugins/meddpicc/engine/legacy.ts
@@ -1,0 +1,91 @@
+/**
+ * Field names this plugin used to use, and what they are now.
+ *
+ * The schema was written around one vendor — `threeWhys.f5`, `viewOfF5`, `f5Owner`, `team.f5`,
+ * `metadata.revenue.pAndIplusAcvx` — and MEDDPICC is a generic framework, so those names went.
+ *
+ * That rename would be harmless if an old deal file simply failed. It does not: the schema sets
+ * `additionalProperties: false` nowhere, so a file using the old names **validates cleanly while
+ * its values sit unreachable** — present in the JSON, invisible to the workbook and to scoring.
+ * Silent data loss is worse than the branding it replaced, so `validate`, `generate` and `read`
+ * all refuse a deal that still uses them, and `migrate` moves them across.
+ *
+ * There is deliberately no separate detector. A deal has legacy fields exactly when
+ * `migrateDeal` reports changes, so the check cannot drift from the transform that fixes it —
+ * the same reason one schema walker serves both the spec guard and the generator.
+ */
+import { readPath } from './json-path';
+
+/**
+ * Container path, old key, new key — applied **in order**, which is load-bearing: `threeWhys.f5`
+ * becomes `threeWhys.us` first, and the entry after it looks inside that new name. A `[]` in the
+ * container means "every element of this list".
+ */
+export const RENAMED_FIELDS = [
+  { container: 'threeWhys', from: 'f5', to: 'us' },
+  { container: 'threeWhys.us', from: 'whyF5', to: 'whyUs' },
+  { container: 'stakeholders[]', from: 'viewOfF5', to: 'sentiment' },
+  { container: 'stakeholders[]', from: 'f5Owner', to: 'relationshipOwner' },
+  { container: 'team', from: 'f5', to: 'internal' },
+  { container: 'metadata.revenue', from: 'pAndIplusAcvx', to: 'subscription' },
+] as const;
+
+const isObject = (v: unknown): v is Record<string, unknown> => typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/** Every concrete container a pattern names — one path, or one per list element. */
+function expand(deal: unknown, container: string): string[] {
+  if (!container.includes('[]')) return [container];
+  const [listPath, rest] = container.split('[]');
+  const list = readPath(deal, listPath);
+  if (!Array.isArray(list)) return [];
+  return list.map((_, i) => `${listPath}[${i}]${rest}`);
+}
+
+/**
+ * Rename a key without moving it to the end of the object.
+ *
+ * Object key order is not semantic, but this file gets written back to disk and read by a person:
+ * appending the new key turns a one-line rename into a diff that looks like a rewrite.
+ */
+function renameInPlace(holder: Record<string, unknown>, from: string, to: string): void {
+  const entries = Object.entries(holder);
+  for (const key of Object.keys(holder)) delete holder[key];
+  for (const [key, value] of entries) {
+    if (key === from) holder[to] = value;
+    else holder[key] = value;
+  }
+}
+
+export interface MigrationResult {
+  /** A copy with every legacy field moved. The input is never touched. */
+  deal: unknown;
+  /** One line per field moved or dropped, naming concrete paths. Empty means nothing to do. */
+  changes: string[];
+}
+
+export function migrateDeal(deal: unknown): MigrationResult {
+  if (deal === null || typeof deal !== 'object') return { deal, changes: [] };
+
+  const working = JSON.parse(JSON.stringify(deal)) as unknown;
+  const changes: string[] = [];
+
+  for (const rename of RENAMED_FIELDS) {
+    for (const container of expand(working, rename.container)) {
+      const holder = readPath(working, container);
+      if (!isObject(holder) || !(rename.from in holder)) continue;
+
+      if (rename.to in holder) {
+        // Both names present: the current one is authoritative and the legacy one is stale. It has
+        // to go, or the file stays legacy and every later read goes on refusing it.
+        delete holder[rename.from];
+        changes.push(`${container}.${rename.from} dropped — ${container}.${rename.to} is already set`);
+        continue;
+      }
+
+      renameInPlace(holder, rename.from, rename.to);
+      changes.push(`${container}.${rename.from} → ${container}.${rename.to}`);
+    }
+  }
+
+  return { deal: working, changes };
+}

--- a/plugins/meddpicc/engine/legacy.ts
+++ b/plugins/meddpicc/engine/legacy.ts
@@ -11,8 +11,12 @@
  * all refuse a deal that still uses them, and `migrate` moves them across.
  *
  * There is deliberately no separate detector. A deal has legacy fields exactly when
- * `migrateDeal` reports changes, so the check cannot drift from the transform that fixes it —
- * the same reason one schema walker serves both the spec guard and the generator.
+ * `migrateDeal` reports changes or conflicts, so the check cannot drift from the transform that
+ * fixes it — the same reason one schema walker serves both the spec guard and the generator.
+ *
+ * A **conflict** is a field where both the old and the new name hold a value. The migration will
+ * not pick a winner: doing so would discard a value nobody can see, which is the failure this
+ * whole module exists to prevent. It reports both paths and stops, leaving the file for a person.
  */
 import { readPath } from './json-path';
 
@@ -59,15 +63,21 @@ function renameInPlace(holder: Record<string, unknown>, from: string, to: string
 export interface MigrationResult {
   /** A copy with every legacy field moved. The input is never touched. */
   deal: unknown;
-  /** One line per field moved or dropped, naming concrete paths. Empty means nothing to do. */
+  /** One line per field moved, naming concrete paths. Empty means nothing to do. */
   changes: string[];
+  /**
+   * Fields where BOTH names hold a value. Only the person who edited the file knows which is
+   * right, so the migration reports them and refuses rather than choosing — see below.
+   */
+  conflicts: string[];
 }
 
 export function migrateDeal(deal: unknown): MigrationResult {
-  if (deal === null || typeof deal !== 'object') return { deal, changes: [] };
+  if (deal === null || typeof deal !== 'object') return { deal, changes: [], conflicts: [] };
 
   const working = JSON.parse(JSON.stringify(deal)) as unknown;
   const changes: string[] = [];
+  const conflicts: string[] = [];
 
   for (const rename of RENAMED_FIELDS) {
     for (const container of expand(working, rename.container)) {
@@ -75,10 +85,14 @@ export function migrateDeal(deal: unknown): MigrationResult {
       if (!isObject(holder) || !(rename.from in holder)) continue;
 
       if (rename.to in holder) {
-        // Both names present: the current one is authoritative and the legacy one is stale. It has
-        // to go, or the file stays legacy and every later read goes on refusing it.
-        delete holder[rename.from];
-        changes.push(`${container}.${rename.from} dropped — ${container}.${rename.to} is already set`);
+        // Both names hold a value, and nothing here can tell which one the user meant. Choosing
+        // would destroy the other — and for `threeWhys.f5`, which is a whole object, that is every
+        // answer inside it at once. Discarding a value the user cannot see is the exact failure
+        // this module exists to prevent, so it is reported and the migration stops.
+        conflicts.push(
+          `${container}.${rename.from} and ${container}.${rename.to} are both set — ` +
+            'delete whichever is wrong, then migrate again',
+        );
         continue;
       }
 
@@ -87,5 +101,5 @@ export function migrateDeal(deal: unknown): MigrationResult {
     }
   }
 
-  return { deal: working, changes };
+  return { deal: working, changes, conflicts };
 }

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/schema-path.test.ts
+++ b/plugins/meddpicc/engine/schema-path.test.ts
@@ -7,7 +7,7 @@ const schema = JSON.parse(await Bun.file(path.join(import.meta.dir, '..', 'schem
 describe('resolveSchemaPath', () => {
   test('resolves simple nested object paths', () => {
     expect(resolveSchemaPath(schema, 'metadata.accountName')).toBe(true);
-    expect(resolveSchemaPath(schema, 'metadata.revenue.pAndIplusAcvx')).toBe(true);
+    expect(resolveSchemaPath(schema, 'metadata.revenue.subscription')).toBe(true);
   });
   test('resolves through allOf + $ref + array items', () => {
     expect(resolveSchemaPath(schema, 'qualification.metrics.responses[0]')).toBe(true);

--- a/plugins/meddpicc/engine/vendor-neutral.test.ts
+++ b/plugins/meddpicc/engine/vendor-neutral.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * MEDDPICC is an industry-standard framework and this repository is public, so the plugin must not
+ * carry one company's names in the places a user reads or edits. This is the guard that keeps it
+ * that way: it is much easier to reintroduce `viewOfF5` in a schema tweak than to notice it later.
+ *
+ * The repository's own address is the one legitimate exception. `f5-sales-demo` is where this code
+ * lives, so a `$id` or documentation URL containing it is a fact about the project, not branding
+ * inside the model.
+ */
+const pluginRoot = path.join(import.meta.dir, '..');
+
+/**
+ * A plain case-insensitive substring, deliberately, and NOT `\bf5\b`.
+ *
+ * A word boundary looks more careful and is wrong here: the names this guard exists to catch are
+ * camelCase, and `\bf5\b` matches none of them — `viewOfF5` has no boundary before the `F`,
+ * `f5Owner` none after the `5`. The first version of this test used it and would have passed a
+ * schema still full of `viewOfF5`; only the self-check below caught that.
+ *
+ * Over-broad is the right trade for these files. A false positive costs one line in the exemption
+ * below and fails loudly; a false negative is the entire bug being prevented.
+ */
+const VENDOR = /f5/i;
+const ALLOWED_URL = /f5-sales-demo/g;
+
+/** Files whose *content* a user of this plugin reads, edits, or is instructed by. */
+const FILES = [
+  'schema/meddpicc-schema.json',
+  'schema/example-deal.json',
+  'engine/workbook-spec.json',
+  'README.md',
+  ...fs
+    .readdirSync(path.join(pluginRoot, 'skills'), { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .flatMap((e) => {
+      const dir = path.join('skills', e.name);
+      const out = [path.join(dir, 'SKILL.md')];
+      const refs = path.join(pluginRoot, dir, 'references');
+      if (fs.existsSync(refs)) {
+        out.push(...fs.readdirSync(refs).map((f) => path.join(dir, 'references', f)));
+      }
+      return out;
+    }),
+  ...fs.readdirSync(path.join(pluginRoot, 'commands')).map((f) => path.join('commands', f)),
+];
+
+/**
+ * Every line of `content` naming the vendor, with the repository's own URL discounted.
+ *
+ * Split out from the file reading so it can be tested against known text. Left inline, a scanner
+ * that silently matched nothing would make the whole sweep pass vacuously, and the only signal
+ * would be a suspiciously clean run.
+ */
+function vendorLinesIn(content: string, label: string): string[] {
+  return content
+    .split('\n')
+    .map((line, i) => ({ line: line.replace(ALLOWED_URL, ''), number: i + 1 }))
+    .filter(({ line }) => VENDOR.test(line))
+    .map(({ line, number }) => `${label}:${number}: ${line.trim().slice(0, 120)}`);
+}
+
+function vendorLines(relativePath: string): string[] {
+  const full = path.join(pluginRoot, relativePath);
+  if (!fs.existsSync(full)) return [];
+  return vendorLinesIn(fs.readFileSync(full, 'utf8'), relativePath);
+}
+
+describe('the plugin names no vendor', () => {
+  test('the file list actually resolves — an empty sweep would pass vacuously', () => {
+    expect(FILES.length).toBeGreaterThan(10);
+    for (const f of FILES) expect(fs.existsSync(path.join(pluginRoot, f))).toBe(true);
+  });
+
+  test('the scanner reports a violation when there is one to report', () => {
+    // The sweep below is only meaningful if this works. A scanner that returned nothing would make
+    // it pass on a schema still full of the old names.
+    const found = vendorLinesIn('{\n  "viewOfF5": "Positive",\n  "sentiment": "Positive"\n}\n', 'sample.json');
+    expect(found).toEqual(['sample.json:2: "viewOfF5": "Positive",']);
+  });
+
+  test('a line whose only mention is the repository URL is not reported', () => {
+    const line = '  "$id": "https://github.com/f5-sales-demo/marketplace/schema.json",';
+    expect(vendorLinesIn(line, 'schema.json')).toEqual([]);
+  });
+
+  test('the URL exemption stays narrow — it discounts the address, not the name', () => {
+    // Widening this to swallow every mention is the obvious way to silence a false positive, and
+    // it would switch the whole guard off without failing anything else.
+    const line = '  See https://github.com/f5-sales-demo/marketplace for the F5 owner field.';
+    expect(vendorLinesIn(line, 'README.md')).toHaveLength(1);
+  });
+
+  test('no schema field, label, or instruction names the vendor', () => {
+    const found = FILES.flatMap(vendorLines);
+    expect(found).toEqual([]);
+  });
+
+  test('the guard is looking for something — it catches every form of the name', () => {
+    // Without this a sweep that silently matched nothing would look identical to a clean one, and
+    // the camelCase cases are exactly the ones an earlier `\bf5\b` version let through.
+    for (const line of [
+      '  "viewOfF5": "Positive",',
+      '  "f5Owner": "Jane Smith",',
+      '  "whyF5": "...",',
+      '  "label": "Why F5?"',
+      '  "jsonPath": "team.f5"',
+      '  Tie guidance to the F5 Distributed Cloud sales context',
+    ]) {
+      expect(VENDOR.test(line)).toBe(true);
+    }
+    for (const line of ['  "sentiment": "Positive",', '  "relationshipOwner": "Jane Smith",']) {
+      expect(VENDOR.test(line)).toBe(false);
+    }
+  });
+
+  test('the repository URL is allowed, since that is where this code lives', () => {
+    const url = 'https://github.com/f5-sales-demo/marketplace/plugins/meddpicc';
+    expect(VENDOR.test(url.replace(ALLOWED_URL, ''))).toBe(false);
+  });
+});

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -116,9 +116,9 @@
         },
         {
           "kind": "field",
-          "id": "revenuePandI",
-          "label": "P&I + ACVx",
-          "jsonPath": "metadata.revenue.pAndIplusAcvx",
+          "id": "revenueSubscription",
+          "label": "Subscription",
+          "jsonPath": "metadata.revenue.subscription",
           "valueType": "currency"
         },
         {
@@ -146,7 +146,7 @@
           "kind": "computed",
           "id": "revenueTotal",
           "label": "Total booked value",
-          "formula": "{{ref:revenuePandI}}+{{ref:revenueHardware}}+{{ref:revenueSoftware}}",
+          "formula": "{{ref:revenueSubscription}}+{{ref:revenueHardware}}+{{ref:revenueSoftware}}",
           "valueType": "currency"
         },
         {
@@ -210,21 +210,21 @@
         },
         {
           "kind": "section",
-          "text": "Three Whys \u2014 F5"
+          "text": "Three Whys \u2014 Us"
         },
         {
           "kind": "field",
           "id": "whyAnything",
           "label": "Why anything?",
-          "jsonPath": "threeWhys.f5.whyAnything",
+          "jsonPath": "threeWhys.us.whyAnything",
           "valueType": "text",
           "height": 44
         },
         {
           "kind": "field",
-          "id": "whyF5",
-          "label": "Why F5?",
-          "jsonPath": "threeWhys.f5.whyF5",
+          "id": "whyUs",
+          "label": "Why us?",
+          "jsonPath": "threeWhys.us.whyUs",
           "valueType": "text",
           "height": 44
         },
@@ -232,7 +232,7 @@
           "kind": "field",
           "id": "whyNow",
           "label": "Why now?",
-          "jsonPath": "threeWhys.f5.whyNow",
+          "jsonPath": "threeWhys.us.whyNow",
           "valueType": "text",
           "height": 44
         },
@@ -534,19 +534,19 @@
               "width": 56
             },
             {
-              "id": "viewOfF5",
-              "header": "View of F5",
+              "id": "sentiment",
+              "header": "Sentiment",
               "role": "input",
-              "jsonPath": "viewOfF5",
+              "jsonPath": "sentiment",
               "valueType": "string",
               "width": 14,
               "validate": true
             },
             {
-              "id": "f5Owner",
-              "header": "F5 owner",
+              "id": "relationshipOwner",
+              "header": "Relationship owner",
               "role": "input",
-              "jsonPath": "f5Owner",
+              "jsonPath": "relationshipOwner",
               "valueType": "string",
               "width": 22
             }
@@ -654,10 +654,10 @@
       "kind": "table",
       "tables": [
         {
-          "id": "teamF5",
+          "id": "teamInternal",
           "source": {
             "kind": "list",
-            "jsonPath": "team.f5"
+            "jsonPath": "team.internal"
           },
           "anchorColumn": 1,
           "headerRow": 1,
@@ -964,14 +964,14 @@
           "kind": "computed",
           "id": "sentimentUnknown",
           "label": "Sentiment unknown",
-          "formula": "COUNTIF({{col:stakeholders.viewOfF5}},\"Unknown\")",
+          "formula": "COUNTIF({{col:stakeholders.sentiment}},\"Unknown\")",
           "valueType": "number"
         },
         {
           "kind": "computed",
           "id": "sentimentNegative",
           "label": "Sentiment negative",
-          "formula": "COUNTIF({{col:stakeholders.viewOfF5}},\"Negative\")",
+          "formula": "COUNTIF({{col:stakeholders.sentiment}},\"Negative\")",
           "valueType": "number"
         },
         {
@@ -1018,16 +1018,16 @@
         },
         {
           "kind": "computed",
-          "id": "teamF5Count",
-          "label": "F5 team members",
-          "formula": "COUNTA({{col:teamF5.name}})",
+          "id": "teamInternalCount",
+          "label": "Internal team members",
+          "formula": "COUNTA({{col:teamInternal.name}})",
           "valueType": "number"
         },
         {
           "kind": "computed",
-          "id": "teamF5Assigned",
-          "label": "F5 assigned to deal",
-          "formula": "COUNTIF({{col:teamF5.assignedToDeal}},TRUE)",
+          "id": "teamInternalAssigned",
+          "label": "Internal team assigned",
+          "formula": "COUNTIF({{col:teamInternal.assignedToDeal}},TRUE)",
           "valueType": "number"
         },
         {

--- a/plugins/meddpicc/engine/workbook-spec.test.ts
+++ b/plugins/meddpicc/engine/workbook-spec.test.ts
@@ -415,7 +415,7 @@ describe('checkWorkbookSpec — identity and layout', () => {
     if (sh.kind !== 'table') throw new Error('fixture drift');
     sh.tables.push({
       id: 'second',
-      source: { kind: 'list', jsonPath: 'team.f5' },
+      source: { kind: 'list', jsonPath: 'team.internal' },
       anchorColumn: 2,
       headerRow: 1,
       columns: [{ id: 'teamName', header: 'Name', role: 'input', jsonPath: 'name', valueType: 'string' }],
@@ -430,7 +430,7 @@ describe('checkWorkbookSpec — identity and layout', () => {
     if (sh.kind !== 'table') throw new Error('fixture drift');
     sh.tables.push({
       id: 'second',
-      source: { kind: 'list', jsonPath: 'team.f5' },
+      source: { kind: 'list', jsonPath: 'team.internal' },
       anchorColumn: 4,
       headerRow: 1,
       columns: [{ id: 'teamName', header: 'Name', role: 'input', jsonPath: 'name', valueType: 'string' }],
@@ -471,7 +471,7 @@ describe('the shipped workbook-spec.json', () => {
       'stakeholders',
       'closePlan.milestones',
       'closePlan.criticalActions',
-      'team.f5',
+      'team.internal',
       'team.partner',
     ]) {
       expect(tableSources).toContain(collection);

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/schema/example-deal.json
+++ b/plugins/meddpicc/schema/example-deal.json
@@ -9,14 +9,14 @@
     "winProbability": 0.5,
     "forecastStage": "Best Case",
     "revenue": {
-      "pAndIplusAcvx": 150000,
+      "subscription": 150000,
       "hardware": 0,
       "software": 85000,
       "acv": 85000
     },
     "lastClientInteraction": {
       "date": "2026-05-01",
-      "outcome": "Validated decision criteria with CTO — F5 ranked #1 on security and API protection"
+      "outcome": "Validated decision criteria with CTO — we ranked #1 on security and API protection"
     },
     "nextClientInteraction": {
       "date": "2026-05-12",
@@ -102,7 +102,7 @@
         "3": "Differentiated — Written criteria with priority ranking; competitive position mapped per criterion",
         "4": "Locked — Criteria influenced toward our strengths; key stakeholders aligned"
       },
-      "evidence": "Evaluation matrix shared by CTO 2026-04-22. F5 ranked #1 on security and API protection, #2 on multi-cloud.",
+      "evidence": "Evaluation matrix shared by CTO 2026-04-22. We ranked #1 on security and API protection, #2 on multi-cloud.",
       "notes": ""
     },
     "decisionProcess": {
@@ -191,7 +191,7 @@
       ],
       "responses": [
         "Vendor A (primary) — leading on price, positioning as simpler to deploy. Vendor B (secondary) — incumbent for CDN, trying to upsell API security.",
-        "Vendor A: strong brand, lower price point, but lacks F5's depth on API discovery and Kubernetes-native integration. Vendor B: existing relationship but their API security product is immature."
+        "Vendor A: strong brand, lower price point, but lacks our depth on API discovery and Kubernetes-native integration. Vendor B: existing relationship but their API security product is immature."
       ],
       "score": 2,
       "scoreDefinition": {
@@ -202,19 +202,19 @@
         "4": "Neutralized — Competitive proof delivered; do-nothing risk assessed; win theme validated with customer"
       },
       "evidence": "Champion shared Vendor A quote. CTO mentioned Vendor B in initial call. No formal competitive proof test done yet.",
-      "notes": "Need customer's perception of Vendor A vs F5 on key criteria. Plan competitive demo for week of May 19."
+      "notes": "Need customer's perception of Vendor A versus us on key criteria. Plan competitive demo for week of May 19."
     }
   },
   "threeWhys": {
-    "f5": {
+    "us": {
       "whyAnything": "3 API security incidents in Q1 cost $400K in SLA penalties; board mandated a fix by Q3; regulatory audit in September requires documented controls",
-      "whyF5": "Only vendor with unified app + API security that integrates natively with their Kubernetes platform; deepest API discovery and threat detection",
+      "whyUs": "Only vendor with unified app + API security that integrates natively with their Kubernetes platform; deepest API discovery and threat detection",
       "whyNow": "Board mandate deadline is Q3 2026; regulatory audit in September; every month of delay is another month of exposure to SLA penalties"
     },
     "partner": {
       "name": "PartnerCo",
       "whyAnything": "Acme needs implementation support — their platform team is at capacity with the Kubernetes migration",
-      "whyThisPartner": "PartnerCo has 3 certified F5 engineers and prior Acme relationship from the load balancer deployment",
+      "whyThisPartner": "PartnerCo has 3 certified engineers on our stack and prior Acme relationship from the load balancer deployment",
       "whyNow": "PartnerCo has a team available in June; if we wait, they're committed to another project through Q4"
     }
   },
@@ -225,9 +225,9 @@
       "roleInDeal": "Economic buyer",
       "mustSayYes": true,
       "canSayNo": true,
-      "whatTheyNeedToBelieve": "F5 will reduce security incidents by 60% within 6 months and the TCO stays under $100K/yr",
-      "viewOfF5": "Positive",
-      "f5Owner": "Jane Smith"
+      "whatTheyNeedToBelieve": "We will reduce security incidents by 60% within 6 months and the TCO stays under $100K/yr",
+      "sentiment": "Positive",
+      "relationshipOwner": "Jane Smith"
     },
     {
       "name": "David Park",
@@ -235,9 +235,9 @@
       "roleInDeal": "Decision maker",
       "mustSayYes": true,
       "canSayNo": true,
-      "whatTheyNeedToBelieve": "F5 integrates with existing Kubernetes platform without migration risk and passes architecture review",
-      "viewOfF5": "Positive",
-      "f5Owner": "Bob Johnson"
+      "whatTheyNeedToBelieve": "Our platform integrates with their existing Kubernetes platform without migration risk and passes architecture review",
+      "sentiment": "Positive",
+      "relationshipOwner": "Bob Johnson"
     },
     {
       "name": "Mike Torres",
@@ -245,9 +245,9 @@
       "roleInDeal": "Influencer",
       "mustSayYes": false,
       "canSayNo": false,
-      "whatTheyNeedToBelieve": "F5 makes his team more productive and helps him hit the MTTR target that gets him headcount",
-      "viewOfF5": "Positive",
-      "f5Owner": "Jane Smith"
+      "whatTheyNeedToBelieve": "Our platform makes his team more productive and helps him hit the MTTR target that gets him headcount",
+      "sentiment": "Positive",
+      "relationshipOwner": "Jane Smith"
     },
     {
       "name": "Lisa Wang",
@@ -255,13 +255,13 @@
       "roleInDeal": "Influencer",
       "mustSayYes": false,
       "canSayNo": true,
-      "whatTheyNeedToBelieve": "F5 meets SOC2 and regulatory requirements without creating new compliance gaps",
-      "viewOfF5": "Neutral",
-      "f5Owner": "Bob Johnson"
+      "whatTheyNeedToBelieve": "Our platform meets SOC2 and regulatory requirements without creating new compliance gaps",
+      "sentiment": "Neutral",
+      "relationshipOwner": "Bob Johnson"
     }
   ],
   "salesStrategy": {
-    "differentiatedValueProposition": "F5 is the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Acme's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
+    "differentiatedValueProposition": "We are the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Acme's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
     "winStrategy": "Lead with the pain: $400K SLA penalties and board mandate create urgency. Differentiate on Kubernetes-native integration (Vendor A can't match this). Use the POC to prove MTTR improvement quantitatively. Get EB alignment on business case before architecture review board. Neutralize Vendor A's price advantage by quantifying the cost of deploying and managing a separate API discovery tool."
   },
   "closePlan": {
@@ -314,7 +314,7 @@
     ]
   },
   "team": {
-    "f5": [
+    "internal": [
       { "name": "Jane Smith", "role": "Account Executive", "dateRequiredFrom": "2026-03-01", "assignedToDeal": true },
       { "name": "Bob Johnson", "role": "Solutions Engineer", "dateRequiredFrom": "2026-04-01", "assignedToDeal": true },
       { "name": "Amy Chen", "role": "CSM", "dateRequiredFrom": "2026-06-15", "assignedToDeal": false }

--- a/plugins/meddpicc/schema/meddpicc-schema.json
+++ b/plugins/meddpicc/schema/meddpicc-schema.json
@@ -19,7 +19,7 @@
         },
         "accountTeam": {
           "type": "string",
-          "description": "The account team owning the relationship (the sellers), e.g. \"Randy Dotson and Tyler Brown\". Distinct from `team.f5`, which is the specialist bench assigned to the deal."
+          "description": "The account team owning the relationship (the sellers), e.g. \"Randy Dotson and Tyler Brown\". Distinct from `team.internal`, which is the specialist bench assigned to the deal."
         },
         "dealName": {
           "type": "string",
@@ -54,7 +54,7 @@
           "type": "object",
           "description": "Revenue breakdown in dollars",
           "properties": {
-            "pAndIplusAcvx": { "type": "number", "default": 0, "description": "P&I + ACVx revenue" },
+            "subscription": { "type": "number", "default": 0, "description": "Subscription revenue" },
             "hardware": { "type": "number", "default": 0, "description": "Hardware revenue" },
             "software": { "type": "number", "default": 0, "description": "Software revenue" },
             "acv": { "type": "number", "default": 0, "description": "Annual Contract Value" }
@@ -300,16 +300,16 @@
     },
     "threeWhys": {
       "type": "object",
-      "description": "F5-specific: Why Anything, Why Us, Why Now — for both F5 and the partner",
+      "description": "The Three Whys — Why Anything, Why Us, Why Now — for your own company and for the partner",
       "properties": {
-        "f5": {
+        "us": {
           "type": "object",
           "properties": {
             "whyAnything": {
               "type": "string",
               "description": "Why does the client need to change from the status quo?"
             },
-            "whyF5": { "type": "string", "description": "Why is F5 the right choice over alternatives?" },
+            "whyUs": { "type": "string", "description": "Why are you the right choice over the alternatives?" },
             "whyNow": { "type": "string", "description": "Why must this happen on the current timeline?" }
           }
         },
@@ -343,14 +343,14 @@
             "type": "string",
             "description": "What this person needs to believe to say yes to the deal"
           },
-          "viewOfF5": {
+          "sentiment": {
             "type": "string",
             "enum": ["Positive", "Negative", "Neutral", "Unknown"],
-            "description": "Current sentiment toward F5"
+            "description": "Current sentiment toward you"
           },
-          "f5Owner": {
+          "relationshipOwner": {
             "type": "string",
-            "description": "F5 team member responsible for this relationship"
+            "description": "Team member responsible for this relationship"
           }
         },
         "required": ["name", "title", "roleInDeal"]
@@ -403,9 +403,9 @@
     },
     "team": {
       "type": "object",
-      "description": "F5 and partner team members assigned to the deal",
+      "description": "Internal and partner team members assigned to the deal",
       "properties": {
-        "f5": {
+        "internal": {
           "type": "array",
           "items": {
             "type": "object",

--- a/plugins/meddpicc/scripts/tests/test_engine.sh
+++ b/plugins/meddpicc/scripts/tests/test_engine.sh
@@ -104,6 +104,51 @@ test_engine_next_has_hint() {
   }
 }
 
+test_engine_migrate_refuses_and_then_fixes_a_legacy_deal() {
+  _engine_precheck || return 0
+  local tmp
+  tmp=$(mktemp -d)
+  # A deal using the retired field names. The schema tolerates them silently, so the engine has to
+  # refuse rather than read a workbook full of blanks where the answers used to be.
+  jq '
+    .metadata.revenue.pAndIplusAcvx = .metadata.revenue.subscription
+    | del(.metadata.revenue.subscription)
+    | .threeWhys.f5 = .threeWhys.us | del(.threeWhys.us)
+    | .threeWhys.f5.whyF5 = .threeWhys.f5.whyUs | del(.threeWhys.f5.whyUs)
+    | .team.f5 = .team.internal | del(.team.internal)
+  ' "$PLUGIN_ROOT/schema/example-deal.json" >"$tmp/legacy.json" || {
+    echo "could not build the legacy fixture"
+    rm -rf "$tmp"
+    return 1
+  }
+
+  if bun "$PLUGIN_ROOT/engine/cli.ts" validate "$tmp/legacy.json" >/dev/null 2>&1; then
+    echo "expected non-zero exit for a deal using retired field names"
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  # A dry run must change nothing on disk.
+  bun "$PLUGIN_ROOT/engine/cli.ts" migrate "$tmp/legacy.json" >/dev/null 2>&1
+  if ! grep -q "whyF5" "$tmp/legacy.json"; then
+    echo "migrate without --apply rewrote the file"
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  bun "$PLUGIN_ROOT/engine/cli.ts" migrate "$tmp/legacy.json" --apply >/dev/null || {
+    echo "migrate --apply exited non-zero"
+    rm -rf "$tmp"
+    return 1
+  }
+  bun "$PLUGIN_ROOT/engine/cli.ts" validate "$tmp/legacy.json" >/dev/null || {
+    echo "the migrated deal does not validate"
+    rm -rf "$tmp"
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
 test_engine_check_spec_ok() {
   _engine_precheck || return 0
   bun "$PLUGIN_ROOT/engine/cli.ts" check-spec >/dev/null || {

--- a/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
+++ b/plugins/meddpicc/scripts/tests/test_resources_manifest.sh
@@ -45,7 +45,7 @@ test_resources_manifest_advertises_engine_commands() {
   local cmd
   # Every command the engine implements, not a subset. This list once lagged the manifest by
   # two commands, so dropping either of them from the manifest would have gone unnoticed.
-  for cmd in validate next score hint check-sfdc check-spec generate read; do
+  for cmd in validate next score hint check-sfdc check-spec generate read migrate; do
     jq -e --arg c "$cmd" '.engine.commands | index($c)' "$manifest" >/dev/null || {
       echo "engine.commands does not advertise \"$cmd\""
       return 1

--- a/plugins/meddpicc/skills/coach/SKILL.md
+++ b/plugins/meddpicc/skills/coach/SKILL.md
@@ -64,7 +64,7 @@ When coaching on MEDDPICC:
 ### For general methodology questions
 
 - Explain the relevant element(s) with concrete examples
-- Tie guidance to the F5 Distributed Cloud sales context when possible
+- Tie guidance to the seller's own product and market context when the deal data makes it clear
 - Reference the appropriate reference file for deeper detail
 
 ### For deal-specific coaching

--- a/plugins/meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/meddpicc/skills/deal-qualification/SKILL.md
@@ -125,7 +125,7 @@ Stakeholders require `name`, `title`, and `roleInDeal`. Initialize
 the array if absent:
 
 ```bash
-jq --argjson item '{"name":"Jane","title":"VP","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"...","viewOfF5":"Neutral","f5Owner":"John Smith"}' \
+jq --argjson item '{"name":"Jane","title":"VP","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"...","sentiment":"Neutral","relationshipOwner":"John Smith"}' \
   'if .stakeholders then .stakeholders += [$item] else .stakeholders = [$item] end' \
   "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
 ```
@@ -162,7 +162,7 @@ User provides a deal or account name with no existing JSON file.
    - `scoring.elementScores` with all 8 keys set to `0`
    - `scoring.overallScore: 0` and `scoring.overallRating: "Red"`
    - Empty `stakeholders: []`, `closePlan: {milestones: [],
-     criticalActions: []}`, `team: {f5: [], partner: []}`
+     criticalActions: []}`, `team: {internal: [], partner: []}`
 2. Set the `DEAL_FILE` shell variable to the file path.
 3. Collect metadata: deal status, close date, competition, win
    probability, forecast stage, revenue breakdown, client

--- a/plugins/meddpicc/skills/deal-update/SKILL.md
+++ b/plugins/meddpicc/skills/deal-update/SKILL.md
@@ -120,7 +120,7 @@ Stakeholders require `name`, `title`, and `roleInDeal` (schema
 required fields). Initialize the array if absent:
 
 ```bash
-jq --argjson s '{"name":"Jane Doe","title":"CISO","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"Meets compliance","viewOfF5":"Neutral","f5Owner":"John Smith"}' \
+jq --argjson s '{"name":"Jane Doe","title":"CISO","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"Meets compliance","sentiment":"Neutral","relationshipOwner":"John Smith"}' \
   'if .stakeholders then .stakeholders += [$s] else .stakeholders = [$s] end' \
   "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
 ```
@@ -254,7 +254,7 @@ Signals: competitor vendor names (Vendor A, Vendor B, CDN providers, etc.),
 #### Also extract
 
 - **Stakeholder mentions:** new names, titles, roles, sentiments
-  toward F5
+  toward us
 - **Timeline/milestone changes:** dates, deadlines, events
 - **Action items:** next steps mentioned by customer or rep
 - **Three Whys signals:** urgency, differentiation, timing


### PR DESCRIPTION
Closes #895. MEDDPICC is an industry-standard framework and this repository is public, so the model
a user edits should not carry one company's names. #894 removed F5's *document*; this removes F5
from the *schema*, the workbook labels, the example deal and the skills.

## The renames

| was | is |
| --- | --- |
| `threeWhys.f5` / `whyF5` | `threeWhys.us` / `whyUs` |
| `stakeholders[].viewOfF5` | `stakeholders[].sentiment` |
| `stakeholders[].f5Owner` | `stakeholders[].relationshipOwner` |
| `team.f5` | `team.internal` |
| `metadata.revenue.pAndIplusAcvx` | `metadata.revenue.subscription` |

`whyUs` is not only de-branded, it is more correct: "Why anything? Why us? Why now?" is the
canonical Three Whys wording. Labels follow — "Why us?", "Sentiment", "Relationship owner",
"Internal team members", "Three Whys — Us", "Subscription" — and `skills/coach` no longer tells the
agent to tie its coaching to one company's product line, which was F5-specific *behaviour* rather
than wording.

## Why a migration was not optional

The schema sets `additionalProperties: false` **nowhere**. A deal using the old names therefore
does not fail validation — it passes, while its values sit unreachable: present in the JSON,
invisible to the workbook and to scoring. Silent data loss is a worse outcome than the branding it
replaces.

So every command that reads a deal — `validate`, `next`, `score`, `generate`, `read` — **refuses**
an unmigrated one, listing the fields and naming the fix. Only `migrate` touches it:

```bash
engine/cli.ts migrate <deal.json>            # lists what it would rename, writes nothing
engine/cli.ts migrate <deal.json> --apply    # writes it
```

There is deliberately no separate detector: a deal has legacy fields exactly when `migrateDeal`
reports changes or conflicts, so the check cannot drift from the transform that fixes it. Renames
keep each key's position, so an applied migration reads as a rename rather than a rewrite.

## Three things only found by doing it

**`pAndIplusAcvx` is an addend, not a total.** The workbook sums it with hardware and software, so
`totalContractValue` — the generic name first chosen for it — would have been actively misleading.
It also collided with the existing `revenueTotal` id, which is how I noticed. It is `subscription`.

**The recurrence guard's first version was vacuous.** It used `\bf5\b`, which matches *none* of
`viewOfF5`, `whyF5` or `f5Owner`, because camelCase leaves no word boundary — it would have passed
a schema still full of the exact fields this PR is about. Only the test's own self-check caught it.
It now uses a plain substring, with the repository's own URL discounted, and asserts that the
exemption stays narrow: widening it to swallow every mention is the obvious way to silence a false
positive and would switch the guard off silently.

**A field set under both names is a conflict, not a decision the tool makes.** The first version
deleted the legacy key so the migration would terminate. `threeWhys.f5` is an *object*, so that
discarded every answer inside it to make room for a possibly half-filled `threeWhys.us` — and
`--apply` overwrites in place. `migrate` now reports both paths, writes nothing at all while a
conflict stands, and leaves the choice to whoever made the edit.

## Verification

- `bun test engine/` — **236 pass, 0 fail** (25 new).
- `scripts/tests/run-tests.sh` — 27 passed, 1 skipped, 0 failed.
- `scripts/run-plugin-tests.sh` (the required gate) — exit 0, 364 pass, 0 failed across all plugins.
- **Excel UAT green on all five blocks**, re-run because every label changed — including round-trip
  identity and the untouched-save case.
- Every schema-derived dropdown still present, including `Positive,Negative,Neutral,Unknown` on the
  renamed `sentiment` column, which is what proves the new path resolves its enum.
- End to end from the CLI: a legacy deal is refused by all five reading commands; `migrate` reports
  12 changes and writes nothing; `--apply` fixes it and the result validates, generates and reads.
- **13 mutations across the migration and the guard, all caught.**
- Biome, codespell, shellcheck, shfmt and **textlint** clean locally.

Renaming the input paths changes every workbook's stamp, so previously generated workbooks no
longer read back. They are ephemeral by design: regenerate.

## Outside this repo

`xcsh/plugin-discovery-matrix/fixtures/*.json` are MEDDPICC deals still using the old names. I
checked: that harness is referenced by no workflow and no package script, so **nothing breaks in
CI** — but anyone running it by hand afterwards will get a refusal. Noted on xcsh#2568 with the
one-line fix per fixture. No other repository references any renamed field.

Codex reported two findings, both CONFIRMED, none refuted — the conflict deletion and the `next`
bypass, both described above. Records in `.codex-review/verify-1.json`; gate reports `done: true`.
