### PR TITLE
MEDDPICC migrate: settle the conflicts that are not actually ambiguous

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,17 @@ and this project adheres to
   and the conflicting leaf is named — a half-merged subtree would look migrated while burying the
   disagreement that stopped it.
 
-  Mutation testing found the simplification, for the third time in this series: `isEmpty` also
-  treated a recursively-blank object as empty, which turned out to be unobservable — for every
-  reachable input the key-by-key merge reaches the same answer. Two rules to keep in agreement where
-  one would do, so it is gone.
+  **Every value that moves is reported, and that is load-bearing.** Callers decide whether a deal
+  needs migrating by asking whether anything was reported, so a settlement that changed the deal
+  while saying nothing would tell them the file was already current — and its legacy values would go
+  on being ignored. Reaching that failure from inside the code written to prevent it is exactly what
+  happened during this change: `isEmpty` had also treated a recursively-blank object as empty, and
+  mutation testing said that branch was unobservable, so I removed it. It was unobservable in the
+  merged *values* and not in the *reports* — with `{}` now falling to the merge, a disjoint key was
+  copied across with no line against it, and `validate` accepted the unmigrated file. Found by the
+  review. Fixed at the root: every key taken from the legacy side is named, and a settled field
+  always emits at least one line, so "a legacy key was removed" and "something was reported" cannot
+  come apart.
 
 - **`meddpicc`** v4.0.0 — **breaking: the plugin names no vendor.** MEDDPICC is an industry-standard
   framework and this repository is public, so the schema, the workbook and the skills no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v4.1.0 — `migrate` now settles the conflicts that were never actually ambiguous.
+
+  v4.0.0 refused whenever a field was set under both its old and its new name, on the grounds that
+  only a human knows which value is right. True for a genuine disagreement, needlessly obstructive
+  for everything else — and everything else is the common case. The realistic conflict is a partial
+  hand-edit: someone adds the new field and leaves the old one. Measured on the example deal, that
+  case has **no ambiguous field at all** — two keys exist on one side only and the third is
+  identical — and the previous version refused the whole subtree and made the user merge it by hand.
+
+  The rule that makes settling it safe: **resolve only when the value being dropped carries no
+  information the kept value lacks.**
+
+  | case | resolution |
+  | --- | --- |
+  | the values are deep-equal | keep either — nothing is lost |
+  | the legacy value is empty | keep the current one |
+  | the current value is empty | move the legacy one across |
+  | both are objects | merge key by key, recursing with these same rules |
+  | both non-empty and different | still a **conflict**, still refused |
+
+  `0` and `false` are not empty: a zero score and a "no" are answers, and treating them as absence
+  would overwrite them with whatever the other side held. **Lists are never merged** — two non-empty
+  team lists cannot be combined without inventing which entries are the same person and what order
+  they belong in, so concatenating them would silently duplicate people.
+
+  **Nothing is settled silently.** Every resolution is reported with its path and the reason it was
+  safe, separately from plain renames, so an applied migration can be audited line by line. And
+  merging stays atomic per field: if any leaf inside an object conflicts, neither side is touched
+  and the conflicting leaf is named — a half-merged subtree would look migrated while burying the
+  disagreement that stopped it.
+
+  Mutation testing found the simplification, for the third time in this series: `isEmpty` also
+  treated a recursively-blank object as empty, which turned out to be unobservable — for every
+  reachable input the key-by-key merge reaches the same answer. Two rules to keep in agreement where
+  one would do, so it is gone.
+
 - **`meddpicc`** v4.0.0 — **breaking: the plugin names no vendor.** MEDDPICC is an industry-standard
   framework and this repository is public, so the schema, the workbook and the skills no longer
   carry one company's names. `engine/cli.ts migrate <deal.json> --apply` moves an existing deal

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -55,15 +55,15 @@ function flag(args: string[], name: string): string | undefined {
  * stop and say which fields, exactly as the workbook stamp refuses a workbook from another deal.
  */
 function refuseLegacyDeal(deal: unknown, dealPath: string): number | null {
-  const { changes, conflicts } = migrateDeal(deal);
-  if (changes.length === 0 && conflicts.length === 0) return null;
+  const { changes, resolved, conflicts } = migrateDeal(deal);
+  if (changes.length === 0 && resolved.length === 0 && conflicts.length === 0) return null;
   process.stderr.write(
     `${dealPath} uses field names this plugin has retired. Their values would be ignored rather than read.\n` +
       (conflicts.length > 0
         ? 'Some fields are set under BOTH names; resolve those by hand first, then migrate.\n'
         : `Run: cli.ts migrate ${dealPath} --apply\n`),
   );
-  print({ ok: false, legacyFields: changes, conflicts });
+  print({ ok: false, legacyFields: changes, resolved, conflicts });
   return 1;
 }
 
@@ -225,17 +225,17 @@ async function main(): Promise<number> {
       return 1;
     }
     const deal = await readJson(dealPath);
-    const { deal: migrated, changes, conflicts } = migrateDeal(deal);
+    const { deal: migrated, changes, resolved, conflicts } = migrateDeal(deal);
 
     // Same posture as `read`: say what would change and write nothing unless asked — and write
     // nothing at all while a field is set under both names, since applying the rest would leave a
     // half-migrated file whose remaining conflict is easy to miss.
-    const apply = rest.includes('--apply') && changes.length > 0 && conflicts.length === 0;
+    const apply = rest.includes('--apply') && changes.length + resolved.length > 0 && conflicts.length === 0;
     if (apply) await Bun.write(dealPath, `${JSON.stringify(migrated, null, 2)}\n`);
 
     const schema = await readJson(SCHEMA_PATH);
     const check = validateDeal(migrated, schema);
-    print({ deal: dealPath, changes, conflicts, applied: apply, valid: check.valid, errors: check.errors });
+    print({ deal: dealPath, changes, resolved, conflicts, applied: apply, valid: check.valid, errors: check.errors });
     if (conflicts.length > 0) {
       process.stderr.write('Refusing to migrate: resolve the fields listed above, then run this again.\n');
       return 1;

--- a/plugins/meddpicc/engine/legacy.test.ts
+++ b/plugins/meddpicc/engine/legacy.test.ts
@@ -227,6 +227,36 @@ describe('migrateDeal', () => {
     for (const line of result.resolved) expect(line).toMatch(/stakeholders\[[01]\]/);
   });
 
+  test('a legacy key present ALWAYS produces a report — that is what makes callers refuse', () => {
+    // The invariant the refusal depends on. Merging correctly in memory while reporting nothing
+    // makes `refuseLegacyDeal` accept the file, so the workbook goes on ignoring the legacy value:
+    // the exact silent loss this module exists to prevent, reached by the code meant to prevent it.
+    for (const deal of [
+      { threeWhys: { f5: { whyAnything: 'legacy answer' }, us: {} } },
+      { threeWhys: { f5: { whyAnything: 'a' }, us: { whyNow: 'b' } } },
+      { threeWhys: { f5: {}, us: { whyNow: 'b' } } },
+      { team: { f5: [{ name: 'A' }], internal: [] } },
+    ]) {
+      const result = migrateDeal(deal);
+      const reported = result.changes.length + result.resolved.length + result.conflicts.length;
+      expect(reported).toBeGreaterThan(0);
+    }
+  });
+
+  test('each key taken from the legacy side is named', () => {
+    const result = migrateDeal({ threeWhys: { f5: { whyAnything: 'a' }, us: { whyNow: 'b' } } });
+    expect(result.conflicts).toEqual([]);
+    expect(result.resolved.some((r) => r.includes('threeWhys.f5.whyAnything'))).toBe(true);
+    expect(shape(result.deal).threeWhys.us).toEqual({ whyNow: 'b', whyAnything: 'a' });
+  });
+
+  test('a legacy key that held nothing is still reported before being removed', () => {
+    const result = migrateDeal({ threeWhys: { f5: {}, us: { whyNow: 'b' } } });
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0]).toContain('threeWhys.f5');
+    expect(shape(result.deal).threeWhys.f5).toBeUndefined();
+  });
+
   test('migrating twice changes nothing the second time', () => {
     const once = migrateDeal(asLegacyDeal());
     const twice = migrateDeal(once.deal);

--- a/plugins/meddpicc/engine/legacy.test.ts
+++ b/plugins/meddpicc/engine/legacy.test.ts
@@ -108,37 +108,123 @@ describe('migrateDeal', () => {
     );
   });
 
-  test('both names present is a conflict, and nothing is thrown away to resolve it', () => {
-    // Picking a winner here would be the very thing this module exists to prevent: discarding a
-    // value the user cannot see. Only they know which of the two is right.
+  test('identical values on both sides resolve — there is nothing to weigh', () => {
+    const legacy = asLegacyDeal();
+    legacy.stakeholders[0].sentiment = legacy.stakeholders[0].viewOfF5;
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toEqual([]);
+    expect(shape(result.deal).stakeholders[0].sentiment).toBe(shape(asLegacyDeal()).stakeholders[0].viewOfF5);
+    expect(result.resolved.some((r) => r.includes('stakeholders[0]') && /identical/.test(r))).toBe(true);
+  });
+
+  test('an empty value on the current side resolves to the legacy one', () => {
+    const legacy = asLegacyDeal();
+    legacy.stakeholders[0].sentiment = '   ';
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toEqual([]);
+    expect(shape(result.deal).stakeholders[0].sentiment).toBe(shape(asLegacyDeal()).stakeholders[0].viewOfF5);
+    expect(result.resolved.length).toBeGreaterThan(0);
+  });
+
+  test('an empty legacy value resolves to the current one', () => {
+    const legacy = asLegacyDeal();
+    legacy.stakeholders[0].viewOfF5 = '';
+    legacy.stakeholders[0].sentiment = 'Negative';
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toEqual([]);
+    expect(shape(result.deal).stakeholders[0].sentiment).toBe('Negative');
+    expect(shape(result.deal).stakeholders[0].viewOfF5).toBeUndefined();
+  });
+
+  test('a partly hand-migrated subtree merges key by key, with nothing left to adjudicate', () => {
+    // The realistic case: someone added `threeWhys.us` by hand and left `threeWhys.f5` in place.
+    // Two keys exist on one side only and the third is identical, so none of it is ambiguous.
+    const legacy = asLegacyDeal();
+    const populated = { ...shape(legacy).threeWhys.f5 };
+    legacy.threeWhys.us = { whyNow: populated.whyNow };
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toEqual([]);
+    expect(shape(result.deal).threeWhys.f5).toBeUndefined();
+    expect(shape(result.deal).threeWhys.us).toEqual({
+      whyNow: populated.whyNow,
+      whyAnything: populated.whyAnything,
+      whyUs: populated.whyF5,
+    });
+  });
+
+  test('an object whose every answer is blank counts as empty', () => {
+    // A hand-added stub like `{whyNow: ""}` holds no answers, so the populated legacy subtree wins
+    // outright rather than being merged key by key against nothing.
+    const legacy = asLegacyDeal();
+    const populated = { ...shape(legacy).threeWhys.f5 };
+    legacy.threeWhys.us = { whyAnything: '', whyNow: '   ' };
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toEqual([]);
+    expect(shape(result.deal).threeWhys.us.whyAnything).toBe(populated.whyAnything);
+    expect(shape(result.deal).threeWhys.us.whyUs).toBe(populated.whyF5);
+    expect(shape(result.deal).threeWhys.us.whyNow).toBe(populated.whyNow);
+  });
+
+  test('two different non-empty values are still a conflict, and neither is touched', () => {
     const legacy = asLegacyDeal();
     legacy.stakeholders[0].sentiment = 'Negative';
     const result = migrateDeal(legacy);
     expect(result.conflicts).toHaveLength(1);
     expect(result.conflicts[0]).toContain('stakeholders[0].viewOfF5');
-    expect(result.conflicts[0]).toContain('stakeholders[0].sentiment');
-    // Both values are still there, untouched, for the user to adjudicate.
     expect(shape(result.deal).stakeholders[0].sentiment).toBe('Negative');
     expect(shape(result.deal).stakeholders[0].viewOfF5).toBe(shape(asLegacyDeal()).stakeholders[0].viewOfF5);
   });
 
-  test('a conflict on a renamed parent does not discard the whole subtree', () => {
-    // The worst case: `threeWhys.f5` is a populated object. Deleting it to make room for a
-    // half-filled `threeWhys.us` would lose every answer inside it at once.
+  test('0 and false are answers, not emptiness', () => {
+    // Treating them as empty would silently overwrite a deliberate zero score or a deliberate no.
     const legacy = asLegacyDeal();
-    const populated = shape(legacy).threeWhys.f5;
-    legacy.threeWhys.us = { whyNow: 'only this one filled in' };
+    legacy.metadata.revenue.pAndIplusAcvx = 0;
+    legacy.metadata.revenue.subscription = 150000;
     const result = migrateDeal(legacy);
     expect(result.conflicts).toHaveLength(1);
-    expect(shape(result.deal).threeWhys.f5).toEqual(populated);
-    expect(shape(result.deal).threeWhys.us).toEqual({ whyNow: 'only this one filled in' });
+    expect(shape(result.deal).metadata.revenue.pAndIplusAcvx).toBe(0);
+    expect(shape(result.deal).metadata.revenue.subscription).toBe(150000);
   });
 
-  test('a conflict still counts as legacy, so callers keep refusing the file', () => {
+  test('two non-empty lists are never merged — that would invent people', () => {
+    // Concatenating would duplicate whoever appears in both, and no order is defensible.
+    const legacy = asLegacyDeal();
+    legacy.team.internal = [{ name: 'Someone Else', role: 'AE' }];
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toHaveLength(1);
+    expect(shape(result.deal).team.internal).toEqual([{ name: 'Someone Else', role: 'AE' }]);
+    expect(shape(result.deal).team.f5).toEqual(shape(asLegacyDeal()).team.f5);
+  });
+
+  test('an empty list on one side does resolve', () => {
     const legacy = asLegacyDeal();
     legacy.team.internal = [];
     const result = migrateDeal(legacy);
-    expect(result.conflicts.length).toBeGreaterThan(0);
+    expect(result.conflicts).toEqual([]);
+    expect(shape(result.deal).team.internal).toEqual(shape(asLegacyDeal()).team.f5);
+  });
+
+  test('a subtree with one conflicting leaf leaves BOTH sides alone', () => {
+    // A half-merged object is the worst outcome: it looks migrated, and the disagreement that
+    // stopped it is now buried inside instead of being reported.
+    const legacy = asLegacyDeal();
+    const populated = { ...shape(legacy).threeWhys.f5 };
+    legacy.threeWhys.us = { whyNow: 'a different answer entirely' };
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toHaveLength(1);
+    expect(result.conflicts[0]).toContain('whyNow');
+    expect(shape(result.deal).threeWhys.f5).toEqual(populated);
+    expect(shape(result.deal).threeWhys.us).toEqual({ whyNow: 'a different answer entirely' });
+  });
+
+  test('every resolution is reported, so nothing is dropped without saying so', () => {
+    const legacy = asLegacyDeal();
+    legacy.stakeholders[0].sentiment = legacy.stakeholders[0].viewOfF5;
+    legacy.stakeholders[1].sentiment = '';
+    const result = migrateDeal(legacy);
+    expect(result.conflicts).toEqual([]);
+    expect(result.resolved).toHaveLength(2);
+    for (const line of result.resolved) expect(line).toMatch(/stakeholders\[[01]\]/);
   });
 
   test('migrating twice changes nothing the second time', () => {

--- a/plugins/meddpicc/engine/legacy.ts
+++ b/plugins/meddpicc/engine/legacy.ts
@@ -130,6 +130,9 @@ function settle(legacy: unknown, current: unknown, path: string, legacyPath: str
     for (const [key, legacyValue] of Object.entries(legacy)) {
       if (!(key in current)) {
         merged[key] = legacyValue;
+        // Reported, not just copied. A value that moves without a line against it leaves the
+        // caller believing the file was already current — see the invariant in `migrateDeal`.
+        resolved.push(`${legacyPath}.${key} moved to ${path}.${key}`);
         continue;
       }
       const inner = settle(legacyValue, current[key], `${path}.${key}`, `${legacyPath}.${key}`);
@@ -177,7 +180,16 @@ export function migrateDeal(deal: unknown): MigrationResult {
         }
         holder[rename.to] = settled.value;
         delete holder[rename.from];
-        resolved.push(...settled.resolved);
+        // A removed legacy key must ALWAYS leave a line behind. Callers decide whether a deal needs
+        // migrating by asking whether anything was reported, so a silent settlement would tell them
+        // the file is current while its legacy values stay unread — which is the whole failure this
+        // module exists to stop, arrived at from the inside. An empty object is the one case that
+        // reaches here with nothing of its own to say.
+        resolved.push(
+          ...(settled.resolved.length > 0
+            ? settled.resolved
+            : [`${container}.${rename.from} removed — it held nothing ${container}.${rename.to} lacks`]),
+        );
         continue;
       }
 

--- a/plugins/meddpicc/engine/legacy.ts
+++ b/plugins/meddpicc/engine/legacy.ts
@@ -14,11 +14,20 @@
  * `migrateDeal` reports changes or conflicts, so the check cannot drift from the transform that
  * fixes it — the same reason one schema walker serves both the spec guard and the generator.
  *
- * A **conflict** is a field where both the old and the new name hold a value. The migration will
- * not pick a winner: doing so would discard a value nobody can see, which is the failure this
- * whole module exists to prevent. It reports both paths and stops, leaving the file for a person.
+ * A field can end up set under BOTH names — someone adds the new one by hand and leaves the old
+ * one in place. Most of those are not actually ambiguous, and the rule for telling the difference
+ * is: **resolve only when the value being dropped carries no information the kept value lacks.**
+ * Identical values, an empty value on either side, and objects that differ only in which keys they
+ * carry all qualify. Two non-empty values that disagree do not, and neither do two non-empty lists,
+ * which cannot be combined without inventing an identity and an order for their elements.
+ *
+ * What is left is a genuine disagreement, and the migration will not pick a winner: doing so would
+ * discard a value nobody can see, the failure this module exists to prevent. Those are reported and
+ * left for a person. Every automatic resolution is reported too, with the reason it was safe —
+ * nothing is dropped silently.
  */
 import { readPath } from './json-path';
+import { deepEqual } from './validate';
 
 /**
  * Container path, old key, new key — applied **in order**, which is load-bearing: `threeWhys.f5`
@@ -65,18 +74,87 @@ export interface MigrationResult {
   deal: unknown;
   /** One line per field moved, naming concrete paths. Empty means nothing to do. */
   changes: string[];
+  /** Fields that were set under both names and could be settled, with the reason each was safe. */
+  resolved: string[];
   /**
-   * Fields where BOTH names hold a value. Only the person who edited the file knows which is
-   * right, so the migration reports them and refuses rather than choosing — see below.
+   * Fields set under both names with genuinely different values. Only the person who edited the
+   * file knows which is right, so these are reported and both sides left untouched.
    */
   conflicts: string[];
 }
 
+/**
+ * Whether a value carries no information, so dropping it loses nothing.
+ *
+ * `0` and `false` are emphatically NOT empty: a zero score and a "no" are answers, and treating
+ * them as absence would overwrite them with whatever the other side happened to hold.
+ */
+function isEmpty(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  if (typeof value === 'string') return value.trim() === '';
+  if (Array.isArray(value)) return value.length === 0;
+  // Objects are deliberately never "empty" here: an object with nothing in it is handled by the
+  // key-by-key merge below, which reaches the same answer. Asking twice would be two rules to keep
+  // in agreement, and mutation testing showed the second one could not be observed at all.
+  return false;
+}
+
+interface Settlement {
+  value: unknown;
+  resolved: string[];
+  conflicts: string[];
+}
+
+/**
+ * Settle one field that exists under both names, or report why it cannot be settled.
+ *
+ * Objects are merged key by key with these same rules, which is what makes the common case work:
+ * a hand-added `threeWhys.us` holding one of three answers merges with the `threeWhys.f5` holding
+ * all three, because two keys exist on one side only and the third is identical.
+ */
+function settle(legacy: unknown, current: unknown, path: string, legacyPath: string): Settlement {
+  if (deepEqual(legacy, current)) {
+    return { value: current, resolved: [`${legacyPath} dropped — identical to ${path}`], conflicts: [] };
+  }
+  if (isEmpty(legacy)) {
+    return { value: current, resolved: [`${legacyPath} dropped — it was empty and ${path} is set`], conflicts: [] };
+  }
+  if (isEmpty(current)) {
+    return { value: legacy, resolved: [`${legacyPath} moved to ${path} — ${path} was empty`], conflicts: [] };
+  }
+
+  if (isObject(legacy) && isObject(current)) {
+    const merged: Record<string, unknown> = { ...current };
+    const resolved: string[] = [];
+    const conflicts: string[] = [];
+    for (const [key, legacyValue] of Object.entries(legacy)) {
+      if (!(key in current)) {
+        merged[key] = legacyValue;
+        continue;
+      }
+      const inner = settle(legacyValue, current[key], `${path}.${key}`, `${legacyPath}.${key}`);
+      merged[key] = inner.value;
+      resolved.push(...inner.resolved);
+      conflicts.push(...inner.conflicts);
+    }
+    return { value: merged, resolved, conflicts };
+  }
+
+  // Two non-empty values that disagree — including two lists, which cannot be combined without
+  // inventing which elements are the same person and what order they belong in.
+  return {
+    value: current,
+    resolved: [],
+    conflicts: [`${legacyPath} and ${path} are both set and differ — delete whichever is wrong, then migrate again`],
+  };
+}
+
 export function migrateDeal(deal: unknown): MigrationResult {
-  if (deal === null || typeof deal !== 'object') return { deal, changes: [], conflicts: [] };
+  if (deal === null || typeof deal !== 'object') return { deal, changes: [], resolved: [], conflicts: [] };
 
   const working = JSON.parse(JSON.stringify(deal)) as unknown;
   const changes: string[] = [];
+  const resolved: string[] = [];
   const conflicts: string[] = [];
 
   for (const rename of RENAMED_FIELDS) {
@@ -85,14 +163,21 @@ export function migrateDeal(deal: unknown): MigrationResult {
       if (!isObject(holder) || !(rename.from in holder)) continue;
 
       if (rename.to in holder) {
-        // Both names hold a value, and nothing here can tell which one the user meant. Choosing
-        // would destroy the other — and for `threeWhys.f5`, which is a whole object, that is every
-        // answer inside it at once. Discarding a value the user cannot see is the exact failure
-        // this module exists to prevent, so it is reported and the migration stops.
-        conflicts.push(
-          `${container}.${rename.from} and ${container}.${rename.to} are both set — ` +
-            'delete whichever is wrong, then migrate again',
+        const settled = settle(
+          holder[rename.from],
+          holder[rename.to],
+          `${container}.${rename.to}`,
+          `${container}.${rename.from}`,
         );
+        if (settled.conflicts.length > 0) {
+          // Leave BOTH sides exactly as they are. A half-merged object looks migrated while burying
+          // the disagreement that stopped it, which is worse than not starting.
+          conflicts.push(...settled.conflicts);
+          continue;
+        }
+        holder[rename.to] = settled.value;
+        delete holder[rename.from];
+        resolved.push(...settled.resolved);
         continue;
       }
 
@@ -101,5 +186,5 @@ export function migrateDeal(deal: unknown): MigrationResult {
     }
   }
 
-  return { deal: working, changes, conflicts };
+  return { deal: working, changes, resolved, conflicts };
 }

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/validate.ts
+++ b/plugins/meddpicc/engine/validate.ts
@@ -30,7 +30,8 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
-function deepEqual(a: unknown, b: unknown): boolean {
+/** Structural equality for JSON values. Exported so the migration compares the same way. */
+export function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (Array.isArray(a) && Array.isArray(b)) {
     return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Closes #897. `migrate` (#896) refused whenever a field was set under both its old and its new name.
That is right for a genuine disagreement and needlessly obstructive for everything else — and
everything else is the common case.

## What was actually ambiguous

The realistic conflict is a partial hand-edit: someone adds the new field and leaves the old one.

```
threeWhys.f5 = { whyAnything: "…", whyF5: "…", whyNow: "Renewal in Q3" }
threeWhys.us = {                               whyNow: "Renewal in Q3" }
```

Two keys exist on one side only — nothing to weigh. The third is identical — nothing to lose either
way. Ambiguous fields: **none**. The previous version refused the whole subtree and made the user
merge it by hand.

## The rule

**Resolve only when the value being dropped carries no information the kept value lacks.**

| case | resolution |
| --- | --- |
| the values are deep-equal | keep either |
| the legacy value is empty | keep the current one |
| the current value is empty | move the legacy one across |
| both are objects | merge key by key, recursing with these rules |
| both non-empty and different | still a **conflict**, still refused |

Two deliberate refusals inside that. **`0` and `false` are not empty** — a zero score and a "no" are
answers, and treating them as absence would overwrite them. **Lists are never merged** — two
non-empty team lists cannot be combined without inventing which entries are the same person and what
order they belong in, so concatenating would silently duplicate people.

Measured on one file carrying both kinds:

```
renames  : 10
resolved : threeWhys.f5.whyNow dropped — identical to threeWhys.us.whyNow
conflicts: stakeholders[0].viewOfF5 and stakeholders[0].sentiment are both set and differ
applied  : false
```

## Reporting is load-bearing, which I learned the hard way

Callers decide whether a deal needs migrating by asking whether `migrateDeal` reported anything. A
settlement that changes the deal while saying nothing therefore tells them the file is already
current, and its legacy values go on being ignored — the silent loss this module exists to prevent,
reached from inside the code written to prevent it.

That is exactly what happened mid-change. `isEmpty` had also treated a recursively-blank object as
empty; mutation testing reported that branch as unobservable, so I removed it. It **was**
unobservable in the merged *values* and not in the *reports*: with `{}` falling to the merge, a
disjoint key was copied with no line against it, and `validate` accepted an unmigrated file. I had
compared values and never compared reports, so the sweep could not see the difference.

The review caught it. Fixed at the root rather than by restoring the branch — which would have left
the general disjoint case unreported — so every key taken from the legacy side is named and a settled
field always emits at least one line. The invariant now has its own test over four shapes: *a legacy
key was removed* and *something was reported* cannot come apart.

## Verification

- `bun test engine/` — **247 pass, 0 fail**.
- `scripts/tests/run-tests.sh` — 27 passed, 1 skipped, 0 failed.
- **12 mutations across the settlement rules and the reporting invariant, all caught.**
- **Excel UAT green on all six blocks.**
- End to end: the previously-blocked partial hand-edit migrates with 0 conflicts and every answer
  preserved; a real disagreement still refuses and writes nothing; `validate` exits 1 on each of the
  three shapes that previously slipped through.
- Biome, codespell, shellcheck, shfmt and textlint clean locally.

`deepEqual` is exported from `validate.ts` rather than written a second time, so the migration
compares values the same way the validator does.

Codex reported one finding, CONFIRMED, none refuted — the unreported merge above. Record in
`.codex-review/verify-1.json`; gate reports `done: true`.
