### PR TITLE
MEDDPICC: read a row typed under a table as a new list entry

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,16 @@ and this project adheres to
   validates. Two things that fixed themselves in the writing: filling only the name produced a deal
   that does not validate — a stakeholder needs a title and a role — and the UAT's own failure handler
   closed only the first workbook, so a mid-script failure left Excel holding a stale one and the next
-  run read the Scorecard out of it and blamed the code. It now closes every workbook, waits until a
-  known cell reads back before writing, and **verifies each write instead of discarding the
-  AppleScript's errors** — which is what had made the round-trip block fail about one run in three.
-  Three consecutive runs, seven blocks each, green.
+  run read the Scorecard out of it and blamed the code. It now closes its own workbooks by name,
+  waits until a known cell reads back before writing, and **verifies each write instead of discarding
+  the AppleScript's errors** — which is what had made the round-trip block fail about one run in
+  three. Three consecutive runs, seven blocks each, green.
+
+  The review caught the dangerous version of that cleanup: my first fix closed *every* open workbook
+  with `saving no`, which on the machine that runs this would have discarded unsaved changes in the
+  operator's own spreadsheets. A test has no business touching a document it did not create, so it
+  closes only the four names it ever produces, each wrapped so an absent one is a no-op. Verified by
+  leaving an unrelated workbook open across a full run and confirming it survived.
 
 - **`meddpicc`** v4.1.0 — `migrate` now settles the conflicts that were never actually ambiguous.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v4.2.0 — a row typed **under** a table is now read as a new list entry instead of
+  merely being reported.
+
+  An Excel Table extends the moment somebody types below its last row, which is simply how you add a
+  stakeholder once the padded rows are used up. v2.7.0 reported those cells rather than dropping them
+  — which was the honest minimum — but it still left the user to add the entry by hand.
+
+  `planWorkbook` now returns `listGrowth` for every list-bound table: where its rows end, which list
+  index comes next, and which columns are writable. The reader continues the same
+  `list[index].field` shape `inputPathFor` builds, so a grown row goes through exactly the same
+  coercion, schema check and append rule as a planned one — filling row 13 of a list holding four
+  items is still refused for the holes it would leave.
+
+  **A wholly blank row ends the scan.** Without that, a stray note a few rows under the table would
+  be read as a stakeholder; with it, anything past the gap is still reported as content below the
+  table, which is what it is.
+
+  Only tables bound to a list can grow — `elements` and `elementResponses` have one row per element
+  or question, so a row underneath them means something else entirely and is reported as before.
+
+  `read` now also refuses a workbook spec that does not check out, as `generate` already did. Reading
+  leans on the spec being well-formed: a column claiming both a formula and a `jsonPath` would have
+  the reader take a computed value as somebody's answer, and `check-spec` already refuses that with
+  the right words — "a derived value must not flow back". With one authority consulted on both
+  paths, the reader no longer needs its own opinion about column roles.
+
+  **Verified in real Excel**, because this is precisely the behaviour that cannot be simulated: the
+  UAT now types a whole stakeholder into the row below the table, saves, and reads back three
+  proposals under `stakeholders[12]`, applies them, and confirms 13 stakeholders in a deal that still
+  validates. Two things that fixed themselves in the writing: filling only the name produced a deal
+  that does not validate — a stakeholder needs a title and a role — and the UAT's own failure handler
+  closed only the first workbook, so a mid-script failure left Excel holding a stale one and the next
+  run read the Scorecard out of it and blamed the code. It now closes every workbook, waits until a
+  known cell reads back before writing, and **verifies each write instead of discarding the
+  AppleScript's errors** — which is what had made the round-trip block fail about one run in three.
+  Three consecutive runs, seven blocks each, green.
+
 - **`meddpicc`** v4.1.0 — `migrate` now settles the conflicts that were never actually ambiguous.
 
   v4.0.0 refused whenever a field was set under both its old and its new name, on the grounds that

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -199,6 +199,23 @@ describe('cli read', () => {
     expect(fs.readFileSync(deal, 'utf8')).toBe(before);
   });
 
+  test('read refuses a spec that does not check out, as generate does', async () => {
+    // Reading leans on the spec: a column claiming both a formula and a jsonPath would have the
+    // reader take a computed value as somebody's answer.
+    const { deal, workbook } = await fixture('badspec');
+    const spec = JSON.parse(fs.readFileSync(path.join(engineDir, 'workbook-spec.json'), 'utf8'));
+    const table = spec.sheets.flatMap((s: { tables?: unknown[] }) => s.tables ?? []).find(Boolean) as {
+      columns: Array<Record<string, unknown>>;
+    };
+    table.columns[0] = { ...table.columns[0], role: 'computed', formula: '1', jsonPath: 'name' };
+    const badSpec = path.join(scratch, 'bad-spec.json');
+    fs.writeFileSync(badSpec, JSON.stringify(spec));
+
+    const { code, out } = await run(['read', workbook, '--deal', deal, '--spec', badSpec]);
+    expect(code).toBe(1);
+    expect(JSON.parse(out).ok).toBe(false);
+  });
+
   test('applying twice is a no-op the second time', async () => {
     const { deal, workbook } = await fixture('idempotent');
     const address = await addressOf(deal, 'metadata.accountName');

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -192,6 +192,16 @@ async function main(): Promise<number> {
     const legacy = refuseLegacyDeal(deal, dealPath);
     if (legacy !== null) return legacy;
 
+    // `generate` refuses a spec that does not check out; so must this. Reading leans on the spec
+    // being well-formed — a column claiming both a formula and a jsonPath would have the reader
+    // take a computed value as somebody's answer, which is the one thing it must never do.
+    const specCheck = checkWorkbookSpec(schema, spec);
+    if (!specCheck.ok) {
+      process.stderr.write('Refusing to read: the workbook spec does not check out.\n');
+      print(specCheck);
+      return 1;
+    }
+
     const bytes = new Uint8Array(await Bun.file(workbookPath).arrayBuffer());
     const report = readWorkbook(schema, spec, deal, bytes);
 

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -352,3 +352,63 @@ describe('the Completion sheet is coloured with its own vocabulary', () => {
     }
   });
 });
+
+describe('planWorkbook — where a list can grow', () => {
+  test('growth starts one row past the mapped rows, at the next list index', () => {
+    const growth = plan.listGrowth.find((g) => g.jsonPath === 'stakeholders');
+    expect(growth).toBeDefined();
+    const rows = plan.inputCells
+      .filter((c) => c.jsonPath.startsWith('stakeholders['))
+      .map((c) => Number((/(\d+)$/.exec(c.address) as RegExpExecArray)[1]));
+    expect(growth?.firstRow).toBe(Math.max(...rows) + 1);
+    expect(growth?.nextIndex).toBe(new Set(rows).size);
+  });
+
+  test('only tables bound to a list can grow', () => {
+    // `elements` and `elementResponses` have one row per element or question, not per item, so
+    // there is nothing to append to and a row under them means something else entirely.
+    const sources = plan.listGrowth.map((g) => g.jsonPath);
+    expect(sources).toContain('stakeholders');
+    expect(sources).toContain('team.internal');
+    expect(sources).not.toContain('elements');
+    expect(sources).not.toContain('qualification');
+  });
+
+  test('a computed column in a list table is NOT offered as somewhere to write', () => {
+    // No shipped list table has one today, so this is the guard against adding one and having the
+    // reader take its formula result as a human's entry — the one thing `read` must never do.
+    const synthetic = {
+      sheets: [
+        {
+          kind: 'table',
+          name: 'People',
+          tables: [
+            {
+              id: 'people',
+              source: { kind: 'list', jsonPath: 'stakeholders' },
+              anchorColumn: 1,
+              headerRow: 1,
+              minRows: 2,
+              columns: [
+                { id: 'name', header: 'Name', role: 'input', valueType: 'string', jsonPath: 'name' },
+                {
+                  id: 'shout',
+                  header: 'Shout',
+                  role: 'computed',
+                  valueType: 'string',
+                  formula: 'UPPER({{this:name}})',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as WorkbookSpec;
+    const growth = planWorkbook(schema, synthetic, deal).listGrowth;
+    expect(growth).toHaveLength(1);
+    // toStrictEqual, not toEqual: toEqual ignores undefined, so ['name', undefined] would compare
+    // equal to ['name'] and this assertion could not fail if the computed column slipped through.
+    expect(growth[0].columns).toHaveLength(1);
+    expect(growth[0].columns.map((c) => c.relativePath)).toStrictEqual(['name']);
+  });
+});

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -119,11 +119,29 @@ export interface InputCell {
   valueType: ValueType;
 }
 
+/**
+ * Where a list table can grow, so the reader can pick up rows a user added below the ones this plan
+ * maps. An Excel Table extends the moment somebody types under its last row, which is the ordinary
+ * way to add a stakeholder once the padded rows are used up.
+ */
+export interface ListGrowth {
+  sheet: string;
+  /** The list a new row would extend. */
+  jsonPath: string;
+  /** The first row past the ones this plan maps. */
+  firstRow: number;
+  /** The list index that first row would become. */
+  nextIndex: number;
+  /** Input columns only: where each sits, and the path it takes inside a new item. */
+  columns: Array<{ column: number; relativePath: string; valueType: ValueType }>;
+}
+
 export interface WorkbookPlan {
   sheets: SheetSpec[];
   /** Named form cells -> `Sheet!Address`. */
   namedCells: Record<string, string>;
   inputCells: InputCell[];
+  listGrowth: ListGrowth[];
 }
 
 /**
@@ -475,10 +493,33 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
     });
   }
 
+  // Row r of a list table holds item r, so the row after the last mapped one is item `rowCount`.
+  const listGrowth: ListGrowth[] = [];
+  for (const info of tables.values()) {
+    if (info.table.source.kind !== 'list') continue;
+    const columns = info.table.columns
+      .map((column, i) => ({ column: info.table.anchorColumn + i, spec: column }))
+      // A jsonPath is what makes a column writable, and `checkWorkbookSpec` already refuses a
+      // computed column that claims one ("a derived value must not flow back"). Both `generate` and
+      // `read` run that check, so asking about the role here as well would be a second opinion on a
+      // settled question.
+      .filter((c) => typeof c.spec.jsonPath === 'string')
+      .map((c) => ({ column: c.column, relativePath: c.spec.jsonPath as string, valueType: c.spec.valueType }));
+    if (columns.length === 0) continue;
+    listGrowth.push({
+      sheet: info.sheet,
+      jsonPath: info.table.source.jsonPath,
+      firstRow: info.firstDataRow + info.rowCount,
+      nextIndex: info.rowCount,
+      columns,
+    });
+  }
+
   return {
     sheets,
     namedCells: Object.fromEntries([...named].map(([id, v]) => [id, `${v.sheet}!${v.address}`])),
     inputCells,
+    listGrowth,
   };
 }
 

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -528,6 +528,124 @@ describe('clearing a value', () => {
   });
 });
 
+describe('rows typed below the padded ones are read, not just reported', () => {
+  /** A deal whose stakeholder table is completely full, so the next row has to grow the list. */
+  function fullDeal(): Record<string, unknown> {
+    const deal = clone(exampleDeal);
+    const table = spec.sheets.flatMap((s) => ('tables' in s ? s.tables : [])).find((x) => x.id === 'stakeholders');
+    const padded = table?.minRows as number;
+    deal.stakeholders = Array.from({ length: padded }, (_, i) => ({
+      name: `Person ${i + 1}`,
+      title: 'VP',
+      roleInDeal: 'Influencer',
+    }));
+    return deal;
+  }
+
+  /** The address one row below the last row the plan maps, for a given stakeholder column. */
+  function firstGrownCell(deal: unknown, relativePath: string): { sheet: string; address: string; column: string } {
+    const cells = planWorkbook(schema, spec, deal).inputCells.filter(
+      (c) => c.jsonPath.startsWith('stakeholders[') && c.jsonPath.endsWith(`.${relativePath}`),
+    );
+    const parsed = cells.map((c) => /^([A-Z]+)(\d+)$/.exec(c.address) as RegExpExecArray);
+    const column = parsed[0][1];
+    const lastRow = Math.max(...parsed.map((m) => Number(m[2])));
+    return { sheet: cells[0].sheet, address: `${column}${lastRow + 1}`, column };
+  }
+
+  const text = (ref: string, value: string) => `<c r="${ref}" t="inlineStr"><is><t>${value}</t></is></c>`;
+
+  test('a filled row below the padding becomes a new item', () => {
+    const deal = fullDeal();
+    const count = (deal.stakeholders as unknown[]).length;
+    const at = firstGrownCell(deal, 'name');
+    const edited = addCell(generateWorkbook(schema, spec, deal), at.sheet, at.address, text(at.address, 'Dana Reyes'));
+
+    const report = read(deal, edited);
+    expect(report.rejections).toEqual([]);
+    expect(report.proposals).toHaveLength(1);
+    expect(report.proposals[0]).toMatchObject({
+      jsonPath: `stakeholders[${count}].name`,
+      kind: 'add',
+      to: 'Dana Reyes',
+    });
+    const after = (report.deal as { stakeholders: Array<{ name: string }> }).stakeholders;
+    expect(after).toHaveLength(count + 1);
+    expect(after[count].name).toBe('Dana Reyes');
+  });
+
+  test('several columns of the same grown row make one item', () => {
+    const deal = fullDeal();
+    const count = (deal.stakeholders as unknown[]).length;
+    let bytes = generateWorkbook(schema, spec, deal);
+    for (const [field, value] of [
+      ['name', 'Dana Reyes'],
+      ['title', 'VP Platform'],
+      ['roleInDeal', 'Influencer'],
+    ] as const) {
+      const at = firstGrownCell(deal, field);
+      bytes = addCell(bytes, at.sheet, at.address, text(at.address, value));
+    }
+    const report = read(deal, bytes);
+    expect(report.rejections).toEqual([]);
+    const after = (report.deal as { stakeholders: Array<Record<string, string>> }).stakeholders;
+    expect(after).toHaveLength(count + 1);
+    expect(after[count]).toEqual({ name: 'Dana Reyes', title: 'VP Platform', roleInDeal: 'Influencer' });
+  });
+
+  test('two consecutive grown rows are both appended, in order', () => {
+    const deal = fullDeal();
+    const count = (deal.stakeholders as unknown[]).length;
+    const at = firstGrownCell(deal, 'name');
+    const row = Number((/\d+$/.exec(at.address) as RegExpExecArray)[0]);
+    let bytes = generateWorkbook(schema, spec, deal);
+    bytes = addCell(bytes, at.sheet, `${at.column}${row}`, text(`${at.column}${row}`, 'Dana Reyes'));
+    bytes = addCell(bytes, at.sheet, `${at.column}${row + 1}`, text(`${at.column}${row + 1}`, 'Sam Okafor'));
+
+    const report = read(deal, bytes);
+    expect(report.rejections).toEqual([]);
+    const after = (report.deal as { stakeholders: Array<{ name: string }> }).stakeholders;
+    expect(after.map((s) => s.name).slice(count)).toEqual(['Dana Reyes', 'Sam Okafor']);
+  });
+
+  test('a blank row ends the list — anything past it is reported, not read', () => {
+    // Otherwise a stray note three rows below the table would be read as a stakeholder.
+    const deal = fullDeal();
+    const at = firstGrownCell(deal, 'name');
+    const row = Number((/\d+$/.exec(at.address) as RegExpExecArray)[0]);
+    const ref = `${at.column}${row + 1}`;
+    const edited = addCell(generateWorkbook(schema, spec, deal), at.sheet, ref, text(ref, 'Too Far Down'));
+
+    const report = read(deal, edited);
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0]).toMatchObject({ address: ref });
+    // And reported as content below the table, NOT as a stakeholder row with a hole before it:
+    // scanning past the blank row would frame a stray note as a missing list entry.
+    expect(report.rejections[0].reason).toMatch(/below/i);
+  });
+
+  test('a grown row is still refused when the padded rows are not full', () => {
+    // The list has 4 entries and 12 padded rows, so row 13 would leave eight holes.
+    const at = firstGrownCell(exampleDeal, 'name');
+    const edited = addCell(
+      generateWorkbook(schema, spec, exampleDeal),
+      at.sheet,
+      at.address,
+      text(at.address, 'Dana Reyes'),
+    );
+    const report = read(exampleDeal, edited);
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toHaveLength(1);
+    expect(report.rejections[0].reason).toMatch(/row/i);
+  });
+
+  test('an untouched full workbook still proposes nothing', () => {
+    const deal = fullDeal();
+    expect(read(deal, generateWorkbook(schema, spec, deal)).proposals).toEqual([]);
+  });
+});
+
 describe('a rejected cell changes nothing at all', () => {
   test('a refused write leaves the deal byte-identical', () => {
     // Writing `responses[1]` into a deal with no `responses` key at all has to build the array
@@ -543,113 +661,59 @@ describe('a rejected cell changes nothing at all', () => {
   });
 });
 
-describe('rows typed below the ones the workbook maps', () => {
-  /** The last row an input column covers, and the column letters, for a list table. */
-  function lastMapped(deal: unknown, jsonPathPrefix: string): { sheet: string; column: string; row: number } {
-    const cells = planWorkbook(schema, spec, deal).inputCells.filter((c) => c.jsonPath.startsWith(jsonPathPrefix));
-    if (cells.length === 0) throw new Error(`no input cells under ${jsonPathPrefix}`);
-    const parsed = cells.map((c) => {
-      const m = /^([A-Z]+)(\d+)$/.exec(c.address);
-      return { sheet: c.sheet, column: m?.[1] as string, row: Number(m?.[2]) };
-    });
-    const column = parsed[0].column;
-    const inColumn = parsed.filter((p) => p.column === column);
-    return { sheet: inColumn[0].sheet, column, row: Math.max(...inColumn.map((p) => p.row)) };
+describe('rows below a table that cannot grow', () => {
+  /**
+   * The Qualification table has one row per MEDDPICC element and no padding: its rows are not a
+   * list anyone can extend, so a cell typed under it maps to nothing and has to be reported. This
+   * is where the guard still earns its keep now that list tables read their grown rows instead.
+   */
+  function belowQualification(relativePath: string): { sheet: string; address: string } {
+    const cells = planWorkbook(schema, spec, exampleDeal).inputCells.filter(
+      (c) => c.jsonPath.startsWith('qualification.') && c.jsonPath.endsWith(`.${relativePath}`),
+    );
+    const parsed = cells.map((c) => /^([A-Z]+)(\d+)$/.exec(c.address) as RegExpExecArray);
+    const column = parsed[0][1];
+    const lastRow = Math.max(...parsed.map((m) => Number(m[2])));
+    return { sheet: cells[0].sheet, address: `${column}${lastRow + 1}` };
   }
 
-  test('a row below the padding is reported, not silently dropped', () => {
-    // An Excel Table extends when someone types under its last row, so this is not a hostile
-    // edit — it is the ordinary way to add a stakeholder once the padded rows are used up.
-    // Dropping it without a word is the legacy sheet's actual bug, in a new place.
-    const { sheet, column, row } = lastMapped(exampleDeal, 'stakeholders[');
-    const ref = `${column}${row + 1}`;
+  test('a row below it is reported, not silently dropped', () => {
+    const { sheet, address } = belowQualification('evidence');
     const edited = addCell(
       generateWorkbook(schema, spec, exampleDeal),
       sheet,
-      ref,
-      `<c r="${ref}" t="inlineStr"><is><t>One Row Too Far</t></is></c>`,
+      address,
+      `<c r="${address}" t="inlineStr"><is><t>One Row Too Far</t></is></c>`,
     );
     const report = read(exampleDeal, edited);
     expect(report.proposals).toEqual([]);
     expect(report.rejections).toHaveLength(1);
-    expect(report.rejections[0]).toMatchObject({ sheet, address: ref });
+    expect(report.rejections[0]).toMatchObject({ sheet, address });
     expect(report.rejections[0].reason).toMatch(/below/i);
     expect(report.ok).toBe(false);
   });
 
-  test('a formula below the padding is reported too — it is still content', () => {
-    const { sheet, column, row } = lastMapped(exampleDeal, 'stakeholders[');
-    const ref = `${column}${row + 1}`;
+  test('a formula below it is reported too — it is still content', () => {
+    const { sheet, address } = belowQualification('evidence');
     const edited = addCell(
       generateWorkbook(schema, spec, exampleDeal),
       sheet,
-      ref,
-      `<c r="${ref}"><f>CONCATENATE(A1," extra")</f></c>`,
+      address,
+      `<c r="${address}"><f>CONCATENATE(A1," extra")</f></c>`,
     );
     const report = read(exampleDeal, edited);
     expect(report.rejections).toHaveLength(1);
-    expect(report.rejections[0]).toMatchObject({ sheet, address: ref });
     expect(report.rejections[0].reason).toMatch(/CONCATENATE/);
   });
 
-  test('a blank cell below the padding is not reported', () => {
-    const { sheet, column, row } = lastMapped(exampleDeal, 'stakeholders[');
-    const ref = `${column}${row + 1}`;
-    const edited = addCell(generateWorkbook(schema, spec, exampleDeal), sheet, ref, `<c r="${ref}"/>`);
+  test('a blank cell below it is not reported', () => {
+    const { sheet, address } = belowQualification('evidence');
+    const edited = addCell(generateWorkbook(schema, spec, exampleDeal), sheet, address, `<c r="${address}"/>`);
     expect(read(exampleDeal, edited).rejections).toEqual([]);
   });
 
-  test('the header row above the data is not mistaken for an unmapped edit', () => {
-    const report = read(exampleDeal, generateWorkbook(schema, spec, exampleDeal));
-    expect(report.rejections).toEqual([]);
-  });
-});
-
-describe('a workbook may only be read against the deal it came from', () => {
-  test('a workbook belonging to another deal is refused, not applied to this one', () => {
-    // Otherwise every cell of deal A reads as an edit to deal B, and `--apply` overwrites B's
-    // identity and figures with A's — a plausible mistake, since both files are called
-    // meddpicc.json in different directories.
-    const other = clone(exampleDeal);
-    other.metadata.dealId = '006XX000000OTHER';
-    const report = read(other, generateWorkbook(schema, spec, exampleDeal));
-    expect(report.ok).toBe(false);
-    expect(report.proposals).toEqual([]);
-    expect(report.rejections).toHaveLength(1);
-    expect(report.rejections[0].reason).toMatch(/regenerate/i);
-  });
-
-  test('a workbook whose rows have since shifted is refused, not read row by row', () => {
-    // This is the dangerous one. Answering one more question moves every Questions row below
-    // it, so the same address now names a different element's answer. Read row by row, the
-    // reader would confidently propose writing metrics' answers onto economicBuyer.
-    const grown = clone(exampleDeal);
-    (grown.qualification.metrics.responses as string[]).push('A third answer');
-    const stale = generateWorkbook(schema, spec, exampleDeal);
-    const report = read(grown, stale);
-    expect(report.ok).toBe(false);
-    expect(report.proposals).toEqual([]);
-  });
-
-  test('an unstamped workbook is refused rather than guessed at', () => {
-    const entries = readZip(generateWorkbook(schema, spec, exampleDeal));
-    const stripped = writeZip(
-      [...entries.values()].filter((e) => e.name !== 'docProps/custom.xml').map((e) => ({ name: e.name, raw: e })),
-    );
-    const report = read(exampleDeal, stripped);
-    expect(report.ok).toBe(false);
-    expect(report.proposals).toEqual([]);
-  });
-
-  test('a change that moves no cell is still readable', () => {
-    // The stamp covers the deal's identity and the layout, not its contents — editing a
-    // stakeholder's name in the JSON must not invalidate the workbook on someone's desk.
-    const edited = clone(exampleDeal);
-    edited.stakeholders[0].title = 'Chief Infrastructure Officer';
-    const report = read(edited, generateWorkbook(schema, spec, exampleDeal));
-    expect(report.rejections).toEqual([]);
-    expect(report.proposals).toHaveLength(1);
-    expect(report.proposals[0]).toMatchObject({ jsonPath: 'stakeholders[0].title' });
+  test('a pristine workbook reports nothing anywhere', () => {
+    expect(read(exampleDeal, generateWorkbook(schema, spec, exampleDeal)).rejections).toEqual([]);
   });
 });
 

--- a/plugins/meddpicc/engine/read-workbook.ts
+++ b/plugins/meddpicc/engine/read-workbook.ts
@@ -26,12 +26,12 @@
  *   cell's `2026-06-30` against a JSON `2026-06-30T09:15:00Z` as text would report a phantom
  *   edit on every read, and the reader would cry wolf until nobody read it.
  */
-import { dateToSerial, planWorkbook, workbookFingerprint } from './generate';
+import { dateToSerial, type InputCell, planWorkbook, type WorkbookPlan, workbookFingerprint } from './generate';
 import { readPath, writePath } from './json-path';
 import { schemaConstraint } from './schema-path';
 import { type ValidationResult, validateDeal } from './validate';
 import type { ValueType, WorkbookSpec } from './workbook-spec';
-import { FINGERPRINT_PROPERTY } from './xlsx';
+import { A1, FINGERPRINT_PROPERTY } from './xlsx';
 import { readZip } from './zip';
 
 const EXCEL_EPOCH_UTC = Date.UTC(1899, 11, 30);
@@ -296,6 +296,52 @@ export interface CellRejection {
 
 const A1_REF = /^([A-Z]+)(\d+)$/;
 
+/** Whether a cell holds anything at all — a formula counts, because a formula is content. */
+function hasContent(cell: RawCell | undefined): boolean {
+  if (!cell) return false;
+  return cell.formula !== undefined || (cell.text !== undefined && cell.text.trim() !== '');
+}
+
+/**
+ * Input cells for rows somebody added below the ones the plan maps.
+ *
+ * An Excel Table extends when you type under its last row, which is simply how you add a
+ * stakeholder once the padded rows are used up. Those cells belong to no `jsonPath` in the plan, so
+ * the paths are derived here from the table's geometry — the same `list[index].field` shape
+ * `inputPathFor` builds, continuing from where the plan stopped.
+ *
+ * **A wholly blank row ends the scan.** Without that, a stray note a few rows under the table would
+ * be read as a stakeholder; with it, anything past the gap falls to `reportUnmappedRows` and is
+ * reported instead. Appending still obeys the array rule, so filling row 13 of a list holding four
+ * items is refused for the holes it would leave, exactly as before.
+ */
+function growthCells(plan: WorkbookPlan, cells: Map<string, Map<string, RawCell>>): InputCell[] {
+  const out: InputCell[] = [];
+
+  for (const growth of plan.listGrowth) {
+    const sheetCells = cells.get(growth.sheet);
+    if (!sheetCells) continue;
+    const lastRow = Math.max(0, ...[...sheetCells.keys()].map((ref) => Number(A1_REF.exec(ref)?.[2] ?? 0)));
+
+    for (let row = growth.firstRow; row <= lastRow; row++) {
+      const rowCells = growth.columns.map((column) => ({ ...column, address: A1(column.column, row) }));
+      if (!rowCells.some((cell) => hasContent(sheetCells.get(cell.address)))) break;
+
+      const index = growth.nextIndex + (row - growth.firstRow);
+      for (const cell of rowCells) {
+        out.push({
+          jsonPath: `${growth.jsonPath}[${index}].${cell.relativePath}`,
+          sheet: growth.sheet,
+          address: cell.address,
+          valueType: cell.valueType,
+        });
+      }
+    }
+  }
+
+  return out;
+}
+
 /**
  * Report anything typed below the rows the workbook actually maps.
  *
@@ -330,8 +376,8 @@ function reportUnmappedRows(
       if (!m) continue;
       const limit = lastMapped.get(`${sheetName}!${m[1]}`);
       if (limit === undefined || Number(m[2]) <= limit) continue;
-      const content = cell.formula === undefined ? cell.text : `=${cell.formula}`;
-      if (content === undefined || content.trim() === '') continue;
+      if (!hasContent(cell)) continue;
+      const content = cell.formula === undefined ? (cell.text as string) : `=${cell.formula}`;
       rejections.push({
         sheet: sheetName,
         address: cell.ref,
@@ -399,8 +445,11 @@ export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown,
   }
 
   const cells = readWorkbookCells(bytes);
+  // Grown rows come last, so the planned rows have already been applied and appending a new item
+  // lands at the index the array has actually reached.
+  const inputs = [...plan.inputCells, ...growthCells(plan, cells)];
 
-  for (const input of plan.inputCells) {
+  for (const input of inputs) {
     const { jsonPath, sheet, address, valueType } = input;
     const reject = (reason: string) => rejections.push({ jsonPath, sheet, address, reason });
     const sheetCells = cells.get(sheet);
@@ -452,12 +501,12 @@ export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown,
     });
   }
 
-  reportUnmappedRows(plan.inputCells, cells, rejections);
+  reportUnmappedRows(inputs, cells, rejections);
 
   const validation = validateDeal(working, schema);
   return {
     ok: rejections.length === 0 && validation.valid,
-    cellsRead: plan.inputCells.length,
+    cellsRead: inputs.length,
     unchanged,
     proposals,
     rejections,

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -29,30 +29,39 @@ command -v bun >/dev/null 2>&1 || skip "bun unavailable"
 command -v osascript >/dev/null 2>&1 || skip "not macOS (no osascript)"
 [ -d "/Applications/Microsoft Excel.app" ] || skip "Microsoft Excel is not installed"
 
-# Close EVERY workbook, not just the first one this script opened. A failure part-way through used
-# to leave a later workbook open, and the next run then read the Scorecard out of the stale one and
-# reported an empty rating — a confusing failure with nothing to do with the code under test.
-close_all_workbooks() {
-  osascript >/dev/null 2>&1 <<'OSA'
+# Every workbook this script can open, by the name Excel knows it as. Closing is BY NAME and never
+# "every workbook": the operator has their own spreadsheets open, `saving no` discards unsaved
+# changes, and a test has no business touching a document it did not create. These four names are
+# ours — they are basenames of files under this run's temp directory — so a stale one left by an
+# earlier failed run is safe to close, which is the point.
+OUR_WORKBOOKS=(uat-deal.xlsx rt.xlsx grown.xlsx uat-partial.xlsx)
+
+close_our_workbooks() {
+  local book
+  for book in "${OUR_WORKBOOKS[@]}"; do
+    osascript >/dev/null 2>&1 <<OSA
 tell application "Microsoft Excel"
   set display alerts to false
-  repeat with wb in (get every workbook)
-    close wb saving no
-  end repeat
+  try
+    close workbook "$book" saving no
+  end try
   set display alerts to true
 end tell
 OSA
+  done
 }
 
+# A failure part-way through used to leave a LATER workbook open — the handler closed only the first
+# one — and the next run then read the Scorecard out of the stale copy and reported an empty rating,
+# blaming the code under test for Excel's state.
 fail() {
   echo "FAIL: $1" >&2
-  close_all_workbooks
+  close_our_workbooks
   exit 1
 }
 
-# Start from a clean slate for the same reason: a workbook left open by anything else is a workbook
-# this script might read by mistake.
-close_all_workbooks
+# Start from a clean slate for the same reason, still only among our own names.
+close_our_workbooks
 
 # Appearing in `get name of every workbook` means Excel has ACCEPTED the file, not that it has
 # finished with it. Writing too early fails silently, and the symptom is a later assertion reporting

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -29,10 +29,66 @@ command -v bun >/dev/null 2>&1 || skip "bun unavailable"
 command -v osascript >/dev/null 2>&1 || skip "not macOS (no osascript)"
 [ -d "/Applications/Microsoft Excel.app" ] || skip "Microsoft Excel is not installed"
 
+# Close EVERY workbook, not just the first one this script opened. A failure part-way through used
+# to leave a later workbook open, and the next run then read the Scorecard out of the stale one and
+# reported an empty rating — a confusing failure with nothing to do with the code under test.
+close_all_workbooks() {
+  osascript >/dev/null 2>&1 <<'OSA'
+tell application "Microsoft Excel"
+  set display alerts to false
+  repeat with wb in (get every workbook)
+    close wb saving no
+  end repeat
+  set display alerts to true
+end tell
+OSA
+}
+
 fail() {
   echo "FAIL: $1" >&2
-  osascript -e "tell application \"Microsoft Excel\" to close workbook \"$BOOK\" saving no" >/dev/null 2>&1
+  close_all_workbooks
   exit 1
+}
+
+# Start from a clean slate for the same reason: a workbook left open by anything else is a workbook
+# this script might read by mistake.
+close_all_workbooks
+
+# Appearing in `get name of every workbook` means Excel has ACCEPTED the file, not that it has
+# finished with it. Writing too early fails silently, and the symptom is a later assertion reporting
+# a value that was never written — which is how this script twice blamed the code under test for
+# Excel still being busy. So wait until a known cell reads back, then verify every write.
+wait_until_ready() {
+  local book="$1" sheet="$2" cell="$3" seen
+  for _ in $(seq 1 30); do
+    seen="$(
+      osascript 2>/dev/null <<OSA
+tell application "Microsoft Excel"
+  return (get value of cell "$cell" of worksheet "$sheet" of workbook "$book") as string
+end tell
+OSA
+    )"
+    [ -n "${seen// /}" ] && return 0
+    sleep 1
+  done
+  return 1
+}
+
+# Run an AppleScript body that must end by returning "ok". Anything else — including an error
+# AppleScript would otherwise print to stderr and lose — fails the run with the text.
+excel_do() {
+  local label="$1" body="$2" result
+  result="$(
+    osascript 2>&1 <<OSA
+tell application "Microsoft Excel"
+  set display alerts to false
+$body
+  set display alerts to true
+  return "ok"
+end tell
+OSA
+  )"
+  [ "$result" = "ok" ] || fail "$label did not apply: ${result:-<no output>}"
 }
 
 echo "==> generating $OUT"
@@ -232,14 +288,10 @@ done
 [ "${rt_opened:-0}" = "1" ] || fail "Excel never listed $RT_BOOK"
 
 # Claim 1: a save with no edits at all.
-osascript <<OSA >/dev/null 2>&1
-tell application "Microsoft Excel"
-  set display alerts to false
-  save workbook "$RT_BOOK"
-  close workbook "$RT_BOOK" saving no
-  set display alerts to true
-end tell
-OSA
+wait_until_ready "$RT_BOOK" "$(at metadata.accountName sheet)" "$(at metadata.accountName address)" ||
+  fail "Excel never finished opening $RT_BOOK"
+excel_do "the untouched save" "  save workbook \"$RT_BOOK\"
+  close workbook \"$RT_BOOK\" saving no"
 untouched="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL")"
 rt_code=$?
 untouched_count="$(jq -r '.proposals | length' <<<"$untouched")"
@@ -260,20 +312,17 @@ for _ in $(seq 1 30); do
   sleep 2
 done
 
+wait_until_ready "$RT_BOOK" "$(at metadata.accountName sheet)" "$(at metadata.accountName address)" ||
+  fail "Excel never finished opening $RT_BOOK"
+
 # `range`, not `cell`: reads work through either, but a write through `cell` fails.
-osascript <<OSA >/dev/null 2>&1
-tell application "Microsoft Excel"
-  set display alerts to false
-  set wb to workbook "$RT_BOOK"
-  set value of range "$(at metadata.accountName address)" of worksheet "$(at metadata.accountName sheet)" of wb to "Globex Corporation"
-  set value of range "$(at qualification.champion.score address)" of worksheet "$(at qualification.champion.score sheet)" of wb to 2
-  set value of range "$(at metadata.closeDate address)" of worksheet "$(at metadata.closeDate sheet)" of wb to "2026-09-15"
-  set value of range "$(at 'stakeholders[0].mustSayYes' address)" of worksheet "$(at 'stakeholders[0].mustSayYes' sheet)" of wb to false
+excel_do "the four hand edits" "  set wb to workbook \"$RT_BOOK\"
+  set value of range \"$(at metadata.accountName address)\" of worksheet \"$(at metadata.accountName sheet)\" of wb to \"Globex Corporation\"
+  set value of range \"$(at qualification.champion.score address)\" of worksheet \"$(at qualification.champion.score sheet)\" of wb to 2
+  set value of range \"$(at metadata.closeDate address)\" of worksheet \"$(at metadata.closeDate sheet)\" of wb to \"2026-09-15\"
+  set value of range \"$(at 'stakeholders[0].mustSayYes' address)\" of worksheet \"$(at 'stakeholders[0].mustSayYes' sheet)\" of wb to false
   save wb
-  close wb saving no
-  set display alerts to true
-end tell
-OSA
+  close wb saving no"
 
 edited="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL")"
 edited_code=$?
@@ -313,6 +362,74 @@ echo "    applied: $applied_name / $applied_date / score $applied_score / mustSa
 again="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL")" || fail "the second read exited non-zero"
 [ "$(jq -r '.proposals | length' <<<"$again")" = "0" ] || fail "a second read still proposes $(jq -c '.proposals' <<<"$again")"
 echo "PASS: edits made in Excel round-trip into the deal JSON, and applying them twice changes nothing"
+
+# A row typed UNDER the table, which is how an Excel Table grows.
+#
+# The reader derives a path for such a row from the table's geometry, and only real Excel can show
+# that the row it creates when you type below the last one is a row the reader then finds. The unit
+# tests inject the cell into the XML themselves; Excel decides where it actually lands, whether the
+# Table absorbs it, and what it looks like afterwards.
+#
+# The padded rows have to be FULL for this: a list of four items with twelve padded rows would leave
+# holes, and appending is refused for exactly that reason. So the fixture fills every one.
+GROWN_DEAL="$WORK/grown.json"
+jq '
+  .stakeholders = [range(12) | {name: ("Person " + (.+1|tostring)), title: "VP", roleInDeal: "Influencer"}]
+' "$DEAL" >"$GROWN_DEAL" || fail "could not build the full-table deal"
+
+GROWN_OUT="$WORK/grown.xlsx"
+GROWN_BOOK="$(basename "$GROWN_OUT")"
+bun "$PLUGIN_ROOT/engine/cli.ts" generate "$GROWN_DEAL" --out "$GROWN_OUT" >/dev/null || fail "generate failed for the grown-row case"
+
+# Ask the plan where the table ends rather than assuming; the row below it is the one to type into.
+grown_plan="$(bun "$PLUGIN_ROOT/engine/cli.ts" generate "$GROWN_DEAL" --plan)" || fail "generate --plan failed"
+grown_sheet="$(jq -r 'first(.inputCells[] | select(.jsonPath | startswith("stakeholders[")) | .sheet)' <<<"$grown_plan")"
+# A stakeholder needs name, title and roleInDeal — the schema requires all three — so type a whole
+# one. Filling only the name leaves a deal that does not validate, which `read` rightly refuses.
+col_for() {
+  jq -r --arg suffix "].$1" 'first(.inputCells[] | select(.jsonPath | startswith("stakeholders[") and endswith($suffix)) | .address) | sub("[0-9]+$"; "")' <<<"$grown_plan"
+}
+last_row="$(jq -r '[.inputCells[] | select(.jsonPath | startswith("stakeholders[")) | .address | capture("(?<r>[0-9]+)$") | .r | tonumber] | max' <<<"$grown_plan")"
+grown_row=$((last_row + 1))
+grown_ref="$(col_for name)$grown_row"
+echo "==> typing a stakeholder into $grown_sheet row $grown_row, one row under the table"
+
+open -a "Microsoft Excel" "$GROWN_OUT" || fail "could not open the grown-row workbook"
+for _ in $(seq 1 30); do
+  if osascript -e 'tell application "Microsoft Excel" to get name of every workbook' 2>/dev/null | grep -qF "$GROWN_BOOK"; then
+    break
+  fi
+  sleep 2
+done
+
+wait_until_ready "$GROWN_BOOK" "$grown_sheet" "$(col_for name)$last_row" ||
+  fail "Excel never finished opening $GROWN_BOOK"
+excel_do "the grown stakeholder row" "  set wb to workbook \"$GROWN_BOOK\"
+  set value of range \"$(col_for name)$grown_row\" of worksheet \"$grown_sheet\" of wb to \"Dana Reyes\"
+  set value of range \"$(col_for title)$grown_row\" of worksheet \"$grown_sheet\" of wb to \"VP Platform\"
+  set value of range \"$(col_for roleInDeal)$grown_row\" of worksheet \"$grown_sheet\" of wb to \"Influencer\"
+  save wb
+  close wb saving no"
+
+grown_report="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$GROWN_OUT" --deal "$GROWN_DEAL")"
+grown_code=$?
+echo "    proposals: $(jq -c '[.proposals[] | {jsonPath, to}]' <<<"$grown_report")"
+[ "$grown_code" = "0" ] || fail "read exited $grown_code on the grown row: $(jq -c '.rejections' <<<"$grown_report")"
+[ "$(jq -r '.rejections | length' <<<"$grown_report")" = "0" ] || fail "the grown row was rejected: $(jq -c '.rejections' <<<"$grown_report")"
+[ "$(jq -r '.proposals | length' <<<"$grown_report")" = "3" ] || fail "expected 3 proposals for the grown row"
+[ "$(jq -r '[.proposals[].jsonPath] | sort | join(",")' <<<"$grown_report")" = "stakeholders[12].name,stakeholders[12].roleInDeal,stakeholders[12].title" ] || fail "the grown row mapped to $(jq -c '[.proposals[].jsonPath]' <<<"$grown_report")"
+[ "$(jq -r '.valid' <<<"$grown_report")" = "true" ] || fail "the deal with the appended stakeholder does not validate"
+
+bun "$PLUGIN_ROOT/engine/cli.ts" read "$GROWN_OUT" --deal "$GROWN_DEAL" --apply >/dev/null || fail "applying the grown row failed"
+grown_count="$(jq -r '.stakeholders | length' "$GROWN_DEAL")"
+grown_name="$(jq -r '.stakeholders[12].name' "$GROWN_DEAL")"
+grown_role="$(jq -r '.stakeholders[12].roleInDeal' "$GROWN_DEAL")"
+echo "    stakeholders after applying: $grown_count, last = $grown_name"
+[ "$grown_count" = "13" ] || fail "expected 13 stakeholders after applying, got $grown_count"
+[ "$grown_name" = "Dana Reyes" ] || fail "the appended stakeholder is '$grown_name'"
+[ "$grown_role" = "Influencer" ] || fail "the appended stakeholder's role is '$grown_role'"
+bun "$PLUGIN_ROOT/engine/cli.ts" validate "$GROWN_DEAL" >/dev/null || fail "the deal does not validate after appending a grown row"
+echo "PASS: a row typed under the table in Excel becomes a new list entry"
 
 # The same comparison on a deal where most elements are unscored — the case that was wrong.
 #


### PR DESCRIPTION
Closes #893. An Excel Table extends the moment somebody types below its last row — which is simply
how you add a stakeholder once the padded rows are used up. v2.7.0 *reported* those cells rather than
dropping them, which was the honest minimum, but still left the user to add the entry by hand.

## What changes

`planWorkbook` returns `listGrowth` per list-bound table: where its rows end, which list index comes
next, and which columns are writable. The reader continues the same `list[index].field` shape
`inputPathFor` builds, so a grown row goes through exactly the same coercion, schema check and append
rule as a planned one — filling row 13 of a list holding four items is still refused for the holes it
would leave.

**A wholly blank row ends the scan.** Without it, a stray note a few rows under the table would be
read as a stakeholder; with it, anything past the gap is still reported as content below the table,
which is what it is. And only list-bound tables grow: `elements` and `elementResponses` have one row
per element or question, so a row underneath them means something else.

`read` now also refuses a spec that does not check out, as `generate` already did. Reading leans on
the spec being well-formed — a column claiming both a formula and a `jsonPath` would have the reader
take a computed value as somebody's answer, and `check-spec` already refuses that with the right
words, *"a derived value must not flow back"*. With one authority consulted on both paths, the growth
code no longer needs its own opinion about column roles.

## Verified in real Excel, because this is the part that cannot be simulated

The unit tests inject a cell into the XML themselves. Excel decides where a row typed under a Table
actually lands and whether the Table absorbs it, so the UAT now does that: types a whole stakeholder
into the row below the table, saves, reads back three proposals under `stakeholders[12]`, applies
them, and confirms 13 stakeholders in a deal that still validates.

Three things the UAT taught me while I wrote it:

- **Filling only the name produced a deal that does not validate** — a stakeholder needs a title and
  a role. `read` was right to refuse; my expectation was wrong.
- **The failure handler closed only the first workbook**, so a mid-script failure left Excel holding a
  stale one, and the next run read the Scorecard out of it and blamed the code under test.
- **The write blocks discarded the AppleScript's own errors.** When Excel was still busy the writes
  silently did not happen, and the symptom was a downstream assertion reporting a value that was
  never written — about one run in three. It now waits until a known cell reads back and verifies
  every write. Three consecutive runs, seven blocks each, green.

## The review caught the dangerous version of that cleanup

My first fix closed **every** open workbook with `saving no`. The machine that runs this UAT is the
one Excel is used on for this add-in, so a run would have silently discarded unsaved changes in
documents that have nothing to do with the test. A test has no business touching a document it did
not create.

It now closes only the four names it ever produces, each wrapped so an absent one is a no-op — which
still clears a stale copy from an earlier failed run, the original purpose. Verified by leaving an
unrelated workbook open across a full run and confirming it survived. Worth noting my *first* attempt
at that proof silently did not run (a wrong venv path meant the fixture was never created), so the
passing UAT said nothing about the property until I rebuilt it with our own generator.

## Verification

- `bun test engine/` — **253 pass, 0 fail**.
- `scripts/tests/run-tests.sh` — 27 passed, 1 skipped, 0 failed.
- `scripts/run-plugin-tests.sh` — exit 0, 364 pass, 0 failed across all plugins.
- **Excel UAT green on all seven blocks**, three consecutive runs.
- **10 mutations** across the growth geometry, the blank-row terminator, the index continuation and
  the spec refusal, all caught. One exposed a vacuous assertion of mine: `toEqual` ignores
  `undefined`, so `['name', undefined]` compared equal to `['name']` and could not fail. It is
  `toStrictEqual` now.
- Biome, codespell, shellcheck, shfmt, textlint clean.

Codex reported one finding, CONFIRMED, none refuted — the blanket workbook close above. Record in
`.codex-review/verify-1.json`; gate reports `done: true`.
