### PR TITLE
MEDDPICC: merge and presentation primitives for a laid-out workbook

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ and this project adheres to
   a table whose range contains one. Every sheet hides the grid and prints landscape, one page wide,
   with the deal named in the header.
 
+  Three more refusals came out of review. A range outside Excel's grid (`A0`, `XFE`, row 1048577) is
+  well-formed and is not a cell. A merge overlapping an Excel table is worse than it sounds: Excel
+  drops the table and repairs the file, so the sort button, the structured references and the
+  auto-extend all vanish, leaving only a table count that fell to zero. And `A1:XFD1048576` is valid,
+  in bounds and seventeen billion cells — without a cap the writer did not fail, it stopped
+  responding.
+
+  Chasing that last one turned up the real defect: cells were looked up by walking every row from
+  inside the expansion loop, making the whole thing quadratic. A 200,000-cell merge did not finish in
+  two minutes. Measured at the new cap, rescanning against indexing: `A1:B5000` 700ms against 9ms,
+  `A1:A9999` 942ms against 7ms. The cap bounds the damage; the index makes it free.
+
   Verified against real Excel: the file opens with no repair prompt, and Excel confirms the merge, the
   preserved anchor value, the absence of any merge inside a table range, the hidden grid, and the
   landscape fit-to-width setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ and this project adheres to
   269-character header. It is now truncated with an ellipsis, in whole encoded units so a cut can
   never split a `&&` pair and leave a dangling `&` to swallow what follows it.
 
+  And truncating the *joined* string was not good enough either — a third pass caught that. The parts
+  are ordered account-then-deal, so a 300-character account name consumed the whole budget and emitted
+  a header with no deal name in it, which makes every deal for that account print identically.
+  `PrintSetup.header` now takes parts and shares the budget across them, with a part that does not
+  need its share releasing the surplus to the ones that do.
+
   Verified against real Excel: the file opens with no repair prompt, and Excel confirms the merge, the
   preserved anchor value, the absence of any merge inside a table range, the hidden grid, and the
   landscape fit-to-width setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v4.3.0 — the workbook writer can lay a sheet out: merged ranges, a hidden grid, and
+  a print setup.
+
+  The generated workbook was functionally complete but presented as a data dump — a grid of cells
+  with no heading that spanned anything. There was no way to express a banner, because the writer had
+  no merge support at all.
+
+  `SheetSpec` gains `merges`, `hideGridlines`, `zoom` and `print`. A merge is declared as a range and
+  anchored by its top-left cell, and the writer fills every other covered cell with that cell's
+  style — which is what Excel needs, because it paints a merged range from the styles of all its
+  cells. Styling the anchor alone stops a banner's fill after its first column and leaves its border
+  box open.
+
+  Five things are refused rather than emitted for Excel to repair: a range that is malformed, one
+  written bottom-right first, one covering a single cell, two that overlap, and one that would hide a
+  value the caller wrote. The last is the one worth having — a merge silently swallowing a field is
+  how two sections that overlap by a row look fine and lose data.
+
+  The palette moves to the stock modern Office theme the manual sheet uses — `#0E2841` navy banners,
+  `#156082` teal labels, `#0F9ED5` sub-headers — and two orphaned entries are gone. A new test binds
+  each style name to the font and fill a person would actually see, so the positional-index mistake
+  this writer has always been exposed to now fails loudly instead of quietly painting a banner in
+  italic grey.
+
+  Titles and section headers span the form width; table sheets declare no merges, because Excel drops
+  a table whose range contains one. Every sheet hides the grid and prints landscape, one page wide,
+  with the deal named in the header.
+
+  Verified against real Excel: the file opens with no repair prompt, and Excel confirms the merge, the
+  preserved anchor value, the absence of any merge inside a table range, the hidden grid, and the
+  landscape fit-to-width setup.
+
 - **`meddpicc`** v4.2.0 — a row typed **under** a table is now read as a new list entry instead of
   merely being reported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,9 +63,21 @@ and this project adheres to
   `PrintSetup.header` now takes parts and shares the budget across them, with a part that does not
   need its share releasing the surplus to the ones that do.
 
+  The header also now carries `dealId`, and falls back to a constant when a deal names nothing at all.
+  The schema requires `dealId`, `accountName` and `dealName` but bounds none of them, so all three can
+  be empty strings and still validate — filed as #901, because that laxness reaches further than
+  headers.
+
   Verified against real Excel: the file opens with no repair prompt, and Excel confirms the merge, the
   preserved anchor value, the absence of any merge inside a table range, the hidden grid, and the
   landscape fit-to-width setup.
+
+  One UAT honesty fix came out of a real failure during that verification. The round-trip block wrote
+  four cells, saved and closed in a single AppleScript, so when a save did not reach disk the reader
+  saw the untouched file, found nothing to propose, and the script reported that
+  `metadata.accountName` "came back as MISSING" — an accurate symptom pointing at the wrong component.
+  The write is now checked in the open workbook, and the save is checked against the file on disk,
+  each naming itself. Three consecutive runs, eight blocks each, green.
 
 - **`meddpicc`** v4.2.0 — a row typed **under** a table is now read as a new list entry instead of
   merely being reported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to
   two minutes. Measured at the new cap, rescanning against indexing: `A1:B5000` 700ms against 9ms,
   `A1:A9999` 942ms against 7ms. The cap bounds the damage; the index makes it free.
 
+  One more from a second review pass: Excel caps a print header at 255 characters and **drops** one
+  that is longer rather than complaining, so a printout would come out unidentified while generation
+  reported success. Nothing bounds a deal name, and the ampersand doubling grows the string on the way
+  in — 200 ampersands encode to 400 characters. Measured: two 130-character names produced a
+  269-character header. It is now truncated with an ellipsis, in whole encoded units so a cut can
+  never split a `&&` pair and leave a dangling `&` to swallow what follows it.
+
   Verified against real Excel: the file opens with no repair prompt, and Excel confirms the merge, the
   preserved anchor value, the absence of any merge inside a table range, the hidden grid, and the
   landscape fit-to-width setup.

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -5,7 +5,7 @@ import { computeCompletion } from './completion';
 import { dateToSerial, generateWorkbook, planWorkbook } from './generate';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
 import type { WorkbookSpec } from './workbook-spec';
-import { COMPLETION_STATUSES } from './xlsx';
+import { A1, COMPLETION_STATUSES } from './xlsx';
 import { readZip } from './zip';
 
 const here = import.meta.dir;
@@ -410,5 +410,40 @@ describe('planWorkbook — where a list can grow', () => {
     // equal to ['name'] and this assertion could not fail if the computed column slipped through.
     expect(growth[0].columns).toHaveLength(1);
     expect(growth[0].columns.map((c) => c.relativePath)).toStrictEqual(['name']);
+  });
+});
+
+describe('planWorkbook — presentation', () => {
+  test('every sheet hides the grid and carries a print setup', () => {
+    for (const s of plan.sheets) {
+      expect(s.hideGridlines, `${s.name} shows the grid`).toBe(true);
+      expect(s.print?.orientation, `${s.name} print orientation`).toBe('landscape');
+      expect(s.print?.fitToWidth, `${s.name} fit-to-width`).toBe(true);
+    }
+  });
+
+  test('the print header names the deal, so a printout is identifiable', () => {
+    const header = plan.sheets[0].print?.header ?? '';
+    expect(header).toContain(String(deal.metadata.accountName));
+    expect(header).toContain(String(deal.metadata.dealName));
+  });
+
+  test('a title and every section banner span the form width', () => {
+    // A banner that stops at the label column reads as a mislabelled cell, not a heading.
+    const deals = sheet('Deal');
+    const width = deals.columns?.reduce((w, c) => Math.max(w, c.max), 0) ?? 0;
+    expect(width).toBeGreaterThan(1);
+    const banners = deals.rows.filter((r) => r.cells.some((c) => c.style === 'title' || c.style === 'sectionHeader'));
+    expect(banners.length).toBeGreaterThan(1);
+    for (const row of banners) {
+      expect(deals.merges ?? []).toContain(`${A1(1, row.row)}:${A1(width, row.row)}`);
+    }
+  });
+
+  test('a table sheet declares no merges, because a merge would break its table', () => {
+    // Excel drops a table whose range contains a merged cell, and repairs the file to say so.
+    for (const s of plan.sheets.filter((x) => x.tables?.length)) {
+      expect(s.merges, `${s.name} merges`).toBeUndefined();
+    }
   });
 });

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -423,9 +423,12 @@ describe('planWorkbook — presentation', () => {
   });
 
   test('the print header names the deal, so a printout is identifiable', () => {
-    const header = plan.sheets[0].print?.header ?? '';
-    expect(header).toContain(String(deal.metadata.accountName));
-    expect(header).toContain(String(deal.metadata.dealName));
+    // Parts, so the writer can budget each one: a joined string lets a long account name crowd
+    // the deal name out entirely.
+    expect(plan.sheets[0].print?.header).toStrictEqual([
+      String(deal.metadata.accountName),
+      String(deal.metadata.dealName),
+    ]);
   });
 
   test('a title and every section banner span the form width', () => {

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -428,7 +428,18 @@ describe('planWorkbook — presentation', () => {
     expect(plan.sheets[0].print?.header).toStrictEqual([
       String(deal.metadata.accountName),
       String(deal.metadata.dealName),
+      String(deal.metadata.dealId),
     ]);
+  });
+
+  test('the header falls back to the deal id, then to a constant, so it is never absent', () => {
+    // The schema requires accountName, dealName and dealId but bounds none of them, so all three
+    // can be empty strings and still validate. A printout with no header cannot be filed.
+    const nameless = { ...deal, metadata: { ...deal.metadata, accountName: '', dealName: '' } };
+    expect(planWorkbook(schema, spec, nameless).sheets[0].print?.header).toStrictEqual([String(deal.metadata.dealId)]);
+
+    const anonymous = { ...deal, metadata: { ...deal.metadata, accountName: '', dealName: '', dealId: '' } };
+    expect(planWorkbook(schema, spec, anonymous).sheets[0].print?.header).toStrictEqual(['MEDDPICC Deal Review']);
   });
 
   test('a title and every section banner span the form width', () => {

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -349,12 +349,15 @@ function derivedValue(
  * between this and a sheet somebody laid out by hand.
  */
 function presentation(deal: unknown): Pick<SheetSpec, 'hideGridlines' | 'print'> {
-  const account = readPath(deal, 'metadata.accountName');
-  const name = readPath(deal, 'metadata.dealName');
-  const header = [account, name].filter((p): p is string => typeof p === 'string' && p !== '').join(' — ');
+  // Parts, not one joined string: the writer shares Excel's 255-character header budget across
+  // them, so a very long account name cannot crowd the deal name out and leave every deal for
+  // that account printing identically.
+  const header = ['metadata.accountName', 'metadata.dealName']
+    .map((path) => readPath(deal, path))
+    .filter((part): part is string => typeof part === 'string' && part !== '');
   return {
     hideGridlines: true,
-    print: { orientation: 'landscape', fitToWidth: true, header: header || undefined },
+    print: { orientation: 'landscape', fitToWidth: true, header: header.length ? header : undefined },
   };
 }
 

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -340,6 +340,9 @@ function derivedValue(
   return undefined;
 }
 
+/** What the header says when the deal names nothing — see {@link presentation}. */
+const FALLBACK_HEADER = 'MEDDPICC Deal Review';
+
 /**
  * Presentation settings every sheet shares: no grid, and a print setup that puts the deal on
  * paper the way a review expects rather than spread over six portrait pages.
@@ -350,14 +353,24 @@ function derivedValue(
  */
 function presentation(deal: unknown): Pick<SheetSpec, 'hideGridlines' | 'print'> {
   // Parts, not one joined string: the writer shares Excel's 255-character header budget across
-  // them, so a very long account name cannot crowd the deal name out and leave every deal for
-  // that account printing identically.
-  const header = ['metadata.accountName', 'metadata.dealName']
+  // them, so a very long account name cannot crowd a later part out and leave every deal for that
+  // account printing identically.
+  //
+  // `dealId` is in there because it is the only part guaranteed to identify the deal. The schema
+  // requires all three of these but bounds none of them, so a deal whose account and deal names
+  // are both empty strings still validates — and a printout of it would carry nothing to file it
+  // by. The id is short, so per-part budgeting always lets it through.
+  const header = ['metadata.accountName', 'metadata.dealName', 'metadata.dealId']
     .map((path) => readPath(deal, path))
     .filter((part): part is string => typeof part === 'string' && part !== '');
   return {
     hideGridlines: true,
-    print: { orientation: 'landscape', fitToWidth: true, header: header.length ? header : undefined },
+    print: {
+      orientation: 'landscape',
+      fitToWidth: true,
+      // Never nothing: an unlabelled printout is worse than a generic one.
+      header: header.length ? header : [FALLBACK_HEADER],
+    },
   };
 }
 

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -340,6 +340,24 @@ function derivedValue(
   return undefined;
 }
 
+/**
+ * Presentation settings every sheet shares: no grid, and a print setup that puts the deal on
+ * paper the way a review expects rather than spread over six portrait pages.
+ *
+ * The grid is what makes a generated workbook read as a data dump. Hiding it costs nothing —
+ * the cells and their borders are unchanged — and is the single largest visual difference
+ * between this and a sheet somebody laid out by hand.
+ */
+function presentation(deal: unknown): Pick<SheetSpec, 'hideGridlines' | 'print'> {
+  const account = readPath(deal, 'metadata.accountName');
+  const name = readPath(deal, 'metadata.dealName');
+  const header = [account, name].filter((p): p is string => typeof p === 'string' && p !== '').join(' — ');
+  return {
+    hideGridlines: true,
+    print: { orientation: 'landscape', fitToWidth: true, header: header || undefined },
+  };
+}
+
 export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown): WorkbookPlan {
   const { named, tables, formRows } = layout(schema, spec, deal);
   const completion = computeCompletion(deal).completionStatus as Record<string, string>;
@@ -349,6 +367,9 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
   for (const s of spec.sheets) {
     if (s.kind === 'form') {
       const rows: RowSpec[] = [];
+      const merges: string[] = [];
+      // A form is label-then-value, so its width is however many columns the spec sizes.
+      const formWidth = s.columns?.reduce((widest, c) => Math.max(widest, c.max), 0) ?? 0;
       for (const { block, row } of formRows.get(s.name) ?? []) {
         const cells: CellSpec[] = [];
 
@@ -373,6 +394,11 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
         }
 
         if (cells.length > 0) rows.push({ row, cells, height: 'height' in block ? block.height : undefined });
+        // A banner that stops at the label column reads as a mislabelled cell rather than a
+        // heading, so a title or section spans the width the sheet actually uses.
+        if ((block.kind === 'title' || block.kind === 'section') && formWidth > 1) {
+          merges.push(`${A1(1, row)}:${A1(formWidth, row)}`);
+        }
       }
       const formFormats: ConditionalFormat[] = [];
       const formValidations: Validation[] = [];
@@ -391,6 +417,8 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
         rows,
         columns: s.columns,
         freezeAtRow: 1,
+        merges: merges.length ? merges : undefined,
+        ...presentation(deal),
         conditionalFormats: formFormats.length ? formFormats : undefined,
         validations: formValidations.length ? formValidations : undefined,
       });
@@ -487,6 +515,7 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
       rows: [...byRow.entries()].sort(([a], [b]) => a - b).map(([row, cells]) => ({ row, cells })),
       columns,
       freezeAtRow: 1,
+      ...presentation(deal),
       tables: tableParts.length ? tableParts : undefined,
       conditionalFormats: tableFormats.length ? tableFormats : undefined,
       validations: tableValidations.length ? tableValidations : undefined,

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { A1, buildWorkbook, columnIndex, columnLetter, STYLE_IDS } from './xlsx';
+import { A1, buildWorkbook, columnIndex, columnLetter, expandMerges, STYLE_IDS } from './xlsx';
 import { readZip } from './zip';
 
 const dec = (b: Uint8Array) => new TextDecoder().decode(b);
@@ -392,6 +392,71 @@ describe('buildWorkbook — merges', () => {
     for (const bad of ['B2:A2', 'B2:B1']) {
       expect(() => merged([bad])).toThrow(/runs backwards/);
     }
+  });
+
+  test("refuses a range outside Excel's grid", () => {
+    // Syntax and direction are not enough: A0, XFE and row 1048577 are all well-formed and
+    // are not cells, and the writer would materialise them into a file Excel must repair.
+    for (const bad of ['A0:B0', 'XFE1:XFF1', 'A1048576:A1048577']) {
+      expect(() => merged([bad]), bad).toThrow(/outside Excel's grid/);
+    }
+  });
+
+  test('refuses a merge too large to materialise, rather than not responding', () => {
+    // A1:XFD1048576 is valid, in bounds, and seventeen billion cells. Without a cap the writer
+    // does not fail — it stops responding, which is the one failure mode with no message.
+    expect(() => merged(['A1:XFD1048576'])).toThrow(/covers 17179869184 cells/);
+  });
+
+  test('refuses a merge that overlaps an Excel table', () => {
+    // Excel does not merely dislike this: it drops the table and repairs the file, so the sort
+    // button, the structured references and the auto-extend all vanish with nothing to notice.
+    expect(() =>
+      buildWorkbook([
+        {
+          name: 'Data',
+          merges: ['A2:B2'],
+          rows: [
+            {
+              row: 1,
+              cells: [
+                { ref: 'A1', value: 'Name' },
+                { ref: 'B1', value: 'Score' },
+              ],
+            },
+            { row: 2, cells: [{ ref: 'A2', value: 'x' }] },
+            { row: 3, cells: [{ ref: 'A3' }, { ref: 'B3' }] },
+          ],
+          tables: [{ name: 'people', displayName: 'people', ref: 'A1:B3', columns: ['Name', 'Score'] }],
+        },
+      ]),
+    ).toThrow(/overlaps table "people"/);
+  });
+
+  test('refuses a sheet that declares the same row twice', () => {
+    expect(() =>
+      buildWorkbook([
+        {
+          name: 'S',
+          merges: ['A1:B1'],
+          rows: [
+            { row: 1, cells: [{ ref: 'A1', value: 'x' }] },
+            { row: 1, cells: [{ ref: 'C1', value: 'y' }] },
+          ],
+        },
+      ]),
+    ).toThrow(/row 1 twice/);
+  });
+
+  test("leaves the caller's cells untouched", () => {
+    // The rows and their arrays are copied; the cell objects are not, so a fill that mutated
+    // one in place would edit the spec the caller still holds.
+    const anchor = { ref: 'B2', value: 'Banner', style: 'sectionHeader' as const };
+    const blank = { ref: 'C2', style: 'default' as const };
+    const spec = { name: 'Deal', merges: ['B2:C2'], rows: [{ row: 2, cells: [anchor, blank] }] };
+    expandMerges(spec);
+    expect(blank).toStrictEqual({ ref: 'C2', style: 'default' });
+    expect(spec.rows[0].cells).toHaveLength(2);
   });
 
   test('a single-cell range is not a merge', () => {

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -512,6 +512,39 @@ describe('buildWorkbook — presentation', () => {
     expect(sheet).toContain('fitToPage="1"');
   });
 
+  test("a header over Excel's limit is truncated, not dropped", () => {
+    // Excel does not complain about a header past 255 characters — it drops it, so a printout
+    // comes out unidentified while generation reports success. Nothing bounds a deal name.
+    const headerOf = (text: string) => {
+      const odd =
+        /<oddHeader>(.*?)<\/oddHeader>/s.exec(presented({ print: { orientation: 'landscape', header: text } }))?.[1] ??
+        '';
+      // Count what Excel counts: the header string itself, format codes included.
+      return odd.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+    };
+
+    const long = `${'A'.repeat(130)} — ${'B'.repeat(130)}`;
+    const truncated = headerOf(long);
+    expect(truncated.length).toBeLessThanOrEqual(255);
+    expect(truncated).toContain('…');
+    expect(truncated.startsWith('&L' + 'A'.repeat(50))).toBe(true);
+
+    // An ampersand encodes to two characters, so 200 of them would emit a 406-character header.
+    const amps = headerOf('&'.repeat(200));
+    expect(amps.length).toBeLessThanOrEqual(255);
+    // Every literal ampersand must still be a pair: a lone trailing & would eat the &R after it.
+    const body = amps.replace(/^&L/, '').replace(/&R&D$/, '').replace(/…$/, '');
+    expect(body.length % 2).toBe(0);
+    expect(/(^|[^&])&([^&]|$)/.test(body)).toBe(false);
+  });
+
+  test('a header inside the limit is emitted whole', () => {
+    const odd = /<oddHeader>(.*?)<\/oddHeader>/s.exec(
+      presented({ print: { orientation: 'landscape', header: 'Visa, Inc. — XC WAF-API' } }),
+    )?.[1];
+    expect(odd).toBe('&amp;LVisa, Inc. — XC WAF-API&amp;R&amp;D');
+  });
+
   test('parts appear in CT_Worksheet sequence order', () => {
     // CT_Worksheet is a sequence, not a bag. Out of order, Excel offers to repair the file
     // and names nothing useful — so assert the ORDER, not merely the presence.

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -495,7 +495,7 @@ describe('buildWorkbook — presentation', () => {
   });
 
   test('emits print setup, escaping the header text', () => {
-    const sheet = presented({ print: { orientation: 'landscape', fitToWidth: true, header: 'Visa & Co' } });
+    const sheet = presented({ print: { orientation: 'landscape', fitToWidth: true, header: ['Visa & Co'] } });
     expect(sheet).toContain('<pageSetup');
     expect(sheet).toContain('orientation="landscape"');
     expect(sheet).toContain('fitToWidth="1"');
@@ -517,8 +517,9 @@ describe('buildWorkbook — presentation', () => {
     // comes out unidentified while generation reports success. Nothing bounds a deal name.
     const headerOf = (text: string) => {
       const odd =
-        /<oddHeader>(.*?)<\/oddHeader>/s.exec(presented({ print: { orientation: 'landscape', header: text } }))?.[1] ??
-        '';
+        /<oddHeader>(.*?)<\/oddHeader>/s.exec(
+          presented({ print: { orientation: 'landscape', header: [text] } }),
+        )?.[1] ?? '';
       // Count what Excel counts: the header string itself, format codes included.
       return odd.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
     };
@@ -538,9 +539,44 @@ describe('buildWorkbook — presentation', () => {
     expect(/(^|[^&])&([^&]|$)/.test(body)).toBe(false);
   });
 
+  test('every header part survives truncation, however long an earlier one is', () => {
+    // Composed account-first, a 300-character account name would consume the whole budget and
+    // emit a header with no deal name in it — so two deals for that account print identically.
+    const odd =
+      /<oddHeader>(.*?)<\/oddHeader>/s.exec(
+        presented({ print: { orientation: 'landscape', header: ['A'.repeat(300), 'DISTINCT-DEAL'] } }),
+      )?.[1] ?? '';
+    const header = odd.replace(/&amp;/g, '&');
+    expect(header.length).toBeLessThanOrEqual(255);
+    expect(header).toContain('DISTINCT-DEAL');
+    expect(header).toContain('…');
+  });
+
+  test('an empty part is dropped rather than leaving a dangling separator', () => {
+    const oddOf = (header: string[]) =>
+      /<oddHeader>(.*?)<\/oddHeader>/s.exec(presented({ print: { orientation: 'landscape', header } }))?.[1];
+    expect(oddOf(['Visa', ''])).toBe('&amp;LVisa&amp;R&amp;D');
+    expect(oddOf(['', 'XC WAF-API'])).toBe('&amp;LXC WAF-API&amp;R&amp;D');
+    // Nothing to say: no header element at all, rather than an empty one.
+    expect(presented({ print: { orientation: 'landscape', header: ['', ''] } })).not.toContain('headerFooter');
+    expect(presented({ print: { orientation: 'landscape', header: [] } })).not.toContain('headerFooter');
+  });
+
+  test('a part short enough to fit gives its surplus budget to the others', () => {
+    const odd =
+      /<oddHeader>(.*?)<\/oddHeader>/s.exec(
+        presented({ print: { orientation: 'landscape', header: ['Visa', 'D'.repeat(300)] } }),
+      )?.[1] ?? '';
+    const header = odd.replace(/&amp;/g, '&');
+    expect(header.length).toBeLessThanOrEqual(255);
+    expect(header).toContain('Visa');
+    // Visa needed 4 of its ~124 share, so the deal name should get far more than half.
+    expect((/D+/.exec(header)?.[0] ?? '').length).toBeGreaterThan(200);
+  });
+
   test('a header inside the limit is emitted whole', () => {
     const odd = /<oddHeader>(.*?)<\/oddHeader>/s.exec(
-      presented({ print: { orientation: 'landscape', header: 'Visa, Inc. — XC WAF-API' } }),
+      presented({ print: { orientation: 'landscape', header: ['Visa, Inc.', 'XC WAF-API'] } }),
     )?.[1];
     expect(odd).toBe('&amp;LVisa, Inc. — XC WAF-API&amp;R&amp;D');
   });
@@ -557,7 +593,7 @@ describe('buildWorkbook — presentation', () => {
             zoom: 75,
             freezeAtRow: 1,
             merges: ['B1:D1'],
-            print: { orientation: 'landscape', fitToWidth: true, header: 'Deal' },
+            print: { orientation: 'landscape', fitToWidth: true, header: ['Deal'] },
             rows: [
               { row: 1, cells: [{ ref: 'B1', value: 'Element', style: 'columnHeader' }] },
               { row: 2, cells: [{ ref: 'B2', value: 1, style: 'score' }] },

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { A1, buildWorkbook, columnLetter, STYLE_IDS } from './xlsx';
+import { A1, buildWorkbook, columnIndex, columnLetter, STYLE_IDS } from './xlsx';
 import { readZip } from './zip';
 
 const dec = (b: Uint8Array) => new TextDecoder().decode(b);
@@ -284,5 +284,277 @@ describe('buildWorkbook — tables, conditional formatting and validation', () =
     expect(sheet).not.toContain('dataValidations');
     expect(sheet).not.toContain('tableParts');
     expect(readZip(minimal()).has('xl/tables/table1.xml')).toBe(false);
+  });
+});
+
+describe('buildWorkbook — merges', () => {
+  const merged = (merges: string[], extra: Parameters<typeof buildWorkbook>[0][number]['rows'] = []) =>
+    dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'Deal',
+            merges,
+            rows: [{ row: 2, cells: [{ ref: 'B2', value: 'MEDDPICC Deal Review', style: 'sectionHeader' }] }, ...extra],
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+
+  test('declares the range once, with a count', () => {
+    const sheet = merged(['B2:Q2']);
+    expect(sheet).toContain('<mergeCells count="1"><mergeCell ref="B2:Q2"/></mergeCells>');
+  });
+
+  test('every covered cell carries the anchor style, and only the anchor carries the value', () => {
+    // Excel paints a merged range from the styles of all its cells, not the top-left alone:
+    // style only the anchor and the banner's fill stops after one column and its border box
+    // is left open. The sample workbook writes all sixteen cells of B2:Q2 with the same s=.
+    const sheet = merged(['B2:E2']);
+    const row = /<row r="2".*?<\/row>/s.exec(sheet)?.[0] ?? '';
+    const cells = [...row.matchAll(/<c r="([A-Z]+2)"([^>]*?)(\/>|>(.*?)<\/c>)/g)].map((m) => ({
+      ref: m[1],
+      attrs: m[2],
+      body: m[4] ?? '',
+    }));
+    expect(cells.map((c) => c.ref)).toEqual(['B2', 'C2', 'D2', 'E2']);
+    const anchorStyle = `s="${STYLE_IDS.sectionHeader}"`;
+    for (const c of cells) expect(c.attrs).toContain(anchorStyle);
+    expect(cells[0].body).toContain('MEDDPICC Deal Review');
+    for (const c of cells.slice(1)) expect(c.body).toBe('');
+  });
+
+  test('a vertical merge fills the rows below, creating them if the caller did not', () => {
+    const sheet = merged(['B2:B4']);
+    expect(sheet).toContain('<row r="3"');
+    expect(sheet).toContain('<row r="4"');
+    for (const ref of ['B3', 'B4']) expect(sheet).toContain(`<c r="${ref}" s="${STYLE_IDS.sectionHeader}"/>`);
+  });
+
+  test('rows stay in ascending order once a merge has created some', () => {
+    // sheetData is a sequence: Excel repairs a file whose rows descend.
+    const sheet = merged(['B2:B6'], [{ row: 9, cells: [{ ref: 'B9', value: 'later' }] }]);
+    const order = [...sheet.matchAll(/<row r="(\d+)"/g)].map((m) => Number(m[1]));
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    expect(order).toContain(9);
+  });
+
+  test('cells stay in ascending column order once merges have added some', () => {
+    // A merge declared after one further right appends its filled cells behind them, so the
+    // row ends up C after D unless it is re-sorted. Excel repairs a row whose cells descend.
+    const sheet = dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'Deal',
+            merges: ['D2:E2', 'B2:C2'],
+            rows: [
+              {
+                row: 2,
+                cells: [
+                  { ref: 'B2', value: 'left', style: 'fieldLabel' },
+                  { ref: 'D2', value: 'right', style: 'fieldLabel' },
+                ],
+              },
+            ],
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+    const row = /<row r="2".*?<\/row>/s.exec(sheet)?.[0] ?? '';
+    const cols = [...row.matchAll(/<c r="([A-Z]+)2"/g)].map((m) => columnIndex(m[1]));
+    expect(cols).toEqual([2, 3, 4, 5]);
+  });
+
+  test('refuses a merge with no cell to anchor it', () => {
+    expect(() => merged(['D8:F8'])).toThrow(/D8:F8/);
+  });
+
+  test('refuses two merges that overlap, naming both', () => {
+    expect(() => merged(['B2:E2', 'D2:G2'])).toThrow(/B2:E2[\s\S]*D2:G2|D2:G2[\s\S]*B2:E2/);
+  });
+
+  test('refuses a merge that would hide a value the caller wrote', () => {
+    // A value in a covered cell is invisible once merged. Silently dropping it is how two
+    // sections that overlap by one row look fine and lose a field.
+    expect(() => merged(['B2:B3'], [{ row: 3, cells: [{ ref: 'B3', value: 'hidden' }] }])).toThrow(/B3/);
+  });
+
+  test('refuses a malformed range', () => {
+    for (const bad of ['B2', 'B2:', 'not-a-ref', '2B:4C']) {
+      expect(() => merged([bad])).toThrow(/is not a range/);
+    }
+  });
+
+  test('refuses a range written bottom-right first', () => {
+    // Assert the REASON, not merely that it threw: an inverted range whose anchor happens to
+    // be absent throws the anchor error instead, which let a missing bounds check survive.
+    for (const bad of ['B2:A2', 'B2:B1']) {
+      expect(() => merged([bad])).toThrow(/runs backwards/);
+    }
+  });
+
+  test('a single-cell range is not a merge', () => {
+    expect(() => merged(['B2:B2'])).toThrow(/B2:B2/);
+  });
+});
+
+describe('buildWorkbook — presentation', () => {
+  const presented = (extra: Partial<Parameters<typeof buildWorkbook>[0][number]>) =>
+    dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'Deal',
+            rows: [{ row: 1, cells: [{ ref: 'B1', value: 'Deal Review', style: 'sectionHeader' }] }],
+            ...extra,
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+
+  test('hides the grid on request, and leaves it alone otherwise', () => {
+    expect(presented({ hideGridlines: true })).toContain('showGridLines="0"');
+    expect(presented({})).not.toContain('showGridLines');
+  });
+
+  test('opens at the requested zoom so the full width is visible', () => {
+    const sheet = presented({ zoom: 75 });
+    expect(sheet).toContain('zoomScale="75"');
+    expect(sheet).toContain('zoomScaleNormal="75"');
+    expect(presented({})).not.toContain('zoomScale');
+  });
+
+  test('refuses a zoom Excel would reject', () => {
+    for (const bad of [0, 9, 401, 1.5]) expect(() => presented({ zoom: bad })).toThrow(/zoom/i);
+  });
+
+  test('emits print setup, escaping the header text', () => {
+    const sheet = presented({ print: { orientation: 'landscape', fitToWidth: true, header: 'Visa & Co' } });
+    expect(sheet).toContain('<pageSetup');
+    expect(sheet).toContain('orientation="landscape"');
+    expect(sheet).toContain('fitToWidth="1"');
+    expect(sheet).toContain('<pageMargins');
+    // "&" opens a format code in a header (&D is the date), so a literal ampersand has to be
+    // doubled before the usual XML escaping — otherwise Excel eats the " C" after it.
+    expect(sheet).toContain('Visa &amp;&amp; Co');
+    expect(presented({})).not.toContain('pageSetup');
+  });
+
+  test('fit-to-width needs the sheet-level flag Excel actually reads', () => {
+    // pageSetup fitToWidth is ignored unless sheetPr says the page setup is fit-to-page.
+    const sheet = presented({ print: { orientation: 'landscape', fitToWidth: true } });
+    expect(sheet).toContain('fitToPage="1"');
+  });
+
+  test('parts appear in CT_Worksheet sequence order', () => {
+    // CT_Worksheet is a sequence, not a bag. Out of order, Excel offers to repair the file
+    // and names nothing useful — so assert the ORDER, not merely the presence.
+    const sheet = dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'Deal',
+            hideGridlines: true,
+            zoom: 75,
+            freezeAtRow: 1,
+            merges: ['B1:D1'],
+            print: { orientation: 'landscape', fitToWidth: true, header: 'Deal' },
+            rows: [
+              { row: 1, cells: [{ ref: 'B1', value: 'Element', style: 'columnHeader' }] },
+              { row: 2, cells: [{ ref: 'B2', value: 1, style: 'score' }] },
+            ],
+            conditionalFormats: [{ sqref: 'B2:B2', preset: 'score' }],
+            validations: [{ sqref: 'B2:B2', values: ['0', '1'] }],
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+    const expected = [
+      '<sheetPr',
+      '<sheetViews',
+      '<sheetFormatPr',
+      '<sheetData',
+      '<mergeCells',
+      '<conditionalFormatting',
+      '<dataValidations',
+      '<printOptions',
+      '<pageMargins',
+      '<pageSetup',
+      '<headerFooter',
+    ];
+    const found = expected.map((tag) => ({ tag, at: sheet.indexOf(tag) }));
+    for (const { tag, at } of found) expect(at, `${tag} missing`).toBeGreaterThan(-1);
+    expect(found.map(({ at }) => at)).toEqual([...found.map(({ at }) => at)].sort((a, b) => a - b));
+  });
+});
+
+describe('styles.xml — a named style resolves to the look it promises', () => {
+  /** The font and fill XML that a style name actually lands on, via its cellXf. */
+  const lookOf = (name: keyof typeof STYLE_IDS) => {
+    const styles = dec(readZip(minimal()).get('xl/styles.xml')?.data as Uint8Array);
+    const fonts = [...styles.matchAll(/<font>.*?<\/font>/gs)].map((m) => m[0]);
+    const fills = [...styles.matchAll(/<fill>.*?<\/fill>/gs)].map((m) => m[0]);
+    const xfs = [...styles.slice(styles.indexOf('<cellXfs')).matchAll(/<xf [^>]*?(?:\/>|>.*?<\/xf>)/gs)].map(
+      (m) => m[0],
+    );
+    const xf = xfs[STYLE_IDS[name]];
+    const fontId = Number(/fontId="(\d+)"/.exec(xf)?.[1]);
+    const fillId = Number(/fillId="(\d+)"/.exec(xf)?.[1]);
+    expect(fonts[fontId], `${name} fontId ${fontId} is past the end of <fonts>`).toBeDefined();
+    expect(fills[fillId], `${name} fillId ${fillId} is past the end of <fills>`).toBeDefined();
+    return { xf, font: fonts[fontId], fill: fills[fillId] };
+  };
+
+  // Indexes into <fonts> and <fills> are positional, so a renumber that misses one silently
+  // paints a banner in italic grey and no other test notices. Bind each name to what a person
+  // would SEE, not to a number.
+  test('the banner styles are white bold text on the dark fill', () => {
+    for (const name of ['title', 'sectionHeader'] as const) {
+      const { font, fill } = lookOf(name);
+      expect(font, name).toContain('<b/>');
+      expect(font, name).toContain('FFFFFFFF');
+      expect(fill, name).toContain('FF0E2841');
+    }
+  });
+
+  test('the header and label styles are white bold on teal or light blue', () => {
+    expect(lookOf('columnHeader').fill).toContain('FF156082');
+    expect(lookOf('fieldLabel').fill).toContain('FF156082');
+    expect(lookOf('groupHeader').fill).toContain('FF0F9ED5');
+    for (const name of ['columnHeader', 'fieldLabel', 'groupHeader'] as const) {
+      expect(lookOf(name).font, name).toContain('FFFFFFFF');
+    }
+  });
+
+  test('the RAG styles keep their own three fills, all different', () => {
+    const fills = (['ragRed', 'ragAmber', 'ragGreen'] as const).map((n) => lookOf(n).fill);
+    expect(new Set(fills).size).toBe(3);
+    expect(fills[0]).toContain('FFF8CBAD');
+    expect(fills[1]).toContain('FFFFE699');
+    expect(fills[2]).toContain('FFC6E0B4');
+  });
+
+  test('plain styles carry no fill, so they do not paint over the page', () => {
+    for (const name of ['default', 'text', 'label', 'currency', 'date'] as const) {
+      expect(lookOf(name).fill, name).toContain('patternType="none"');
+    }
+  });
+
+  test('every declared font and fill is reachable from some style', () => {
+    // An entry nothing points at is either a mistake or a leftover; the two reserved
+    // placeholders Excel requires are the only exceptions.
+    const styles = dec(readZip(minimal()).get('xl/styles.xml')?.data as Uint8Array);
+    const cellXfs = styles.slice(styles.indexOf('<cellXfs'));
+    const usedFonts = new Set([...cellXfs.matchAll(/fontId="(\d+)"/g)].map((m) => Number(m[1])));
+    const usedFills = new Set([...cellXfs.matchAll(/fillId="(\d+)"/g)].map((m) => Number(m[1])));
+    const fontCount = Number(/<fonts count="(\d+)"/.exec(styles)?.[1]);
+    const fillCount = Number(/<fills count="(\d+)"/.exec(styles)?.[1]);
+    for (let i = 0; i < fontCount; i++) expect(usedFonts.has(i), `font ${i} is unreachable`).toBe(true);
+    // Fill 1 is the format-reserved gray125 placeholder, which nothing may use.
+    for (let i = 0; i < fillCount; i++) {
+      if (i === 1) continue;
+      expect(usedFills.has(i), `fill ${i} is unreachable`).toBe(true);
+    }
   });
 });

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -600,13 +600,45 @@ function dataValidationsXml(validations: Validation[] | undefined): string {
  *
  * `pageMargins` is not optional decoration: Excel wants it present before `pageSetup`.
  */
+/** Excel's cap on a header string, format codes and all. One character over and it is dropped. */
+const HEADER_LIMIT = 255;
+
+/** The codes wrapped around the caller's text: left-align it, and put the date on the right. */
+const HEADER_CODES = '&L&R&D';
+
+/**
+ * Encode a header, fitting it inside Excel's limit.
+ *
+ * Two things conspire here. A deal name has no length bound — nothing stops an account being
+ * called something 200 characters long — and "&" has to be doubled because it opens a format
+ * code, so an ampersand-heavy name grows on the way in: 200 of them encode to 400. Excel does
+ * not complain about a header over the limit, it drops it, so a printout would come out
+ * unidentified while generation reported success.
+ *
+ * Truncating is the right answer rather than refusing: the header is a convenience, the deal
+ * name is not ours to shorten, and an ellipsis says plainly that there was more. Whole encoded
+ * units only, so a truncation can never split a `&&` pair and leave a dangling `&` that would
+ * swallow whatever follows it as a format code.
+ */
+function fitHeader(text: string): string {
+  const budget = HEADER_LIMIT - HEADER_CODES.length;
+  const encode = (c: string) => (c === '&' ? '&&' : c);
+  const full = [...text].map(encode).join('');
+  if (full.length <= budget) return full;
+  let out = '';
+  for (const ch of text) {
+    const unit = encode(ch);
+    if (out.length + unit.length > budget - 1) break; // one unit back for the ellipsis
+    out += unit;
+  }
+  return `${out}…`;
+}
+
 function printXml(print: PrintSetup | undefined): string {
   if (!print) return '';
   const fit = print.fitToWidth ? ' fitToWidth="1" fitToHeight="0"' : '';
-  // In a header, "&" opens a format code (&D is the date, &P the page) — so a literal
-  // ampersand in the deal name has to be doubled, on top of the usual XML escaping.
   const header = print.header
-    ? `<headerFooter><oddHeader>&amp;L${escapeXml(print.header.replace(/&/g, '&&'))}&amp;R&amp;D</oddHeader></headerFooter>`
+    ? `<headerFooter><oddHeader>&amp;L${escapeXml(fitHeader(print.header))}&amp;R&amp;D</oddHeader></headerFooter>`
     : '';
   return (
     `<printOptions horizontalCentered="1"/>` +

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -357,8 +357,13 @@ export interface PrintSetup {
   orientation: 'landscape' | 'portrait';
   /** Squeeze the used width onto one page. Needs `fitToPage` on the sheet, which we emit. */
   fitToWidth?: boolean;
-  /** Left-hand header text. The date is added on the right. */
-  header?: string;
+  /**
+   * Left-hand header parts, joined with an em dash. The date is added on the right.
+   *
+   * Parts rather than one string so that a long first part cannot crowd out a later one: see
+   * {@link fitHeader}.
+   */
+  header?: string[];
 }
 
 export interface SheetSpec {
@@ -606,39 +611,79 @@ const HEADER_LIMIT = 255;
 /** The codes wrapped around the caller's text: left-align it, and put the date on the right. */
 const HEADER_CODES = '&L&R&D';
 
-/**
- * Encode a header, fitting it inside Excel's limit.
- *
- * Two things conspire here. A deal name has no length bound — nothing stops an account being
- * called something 200 characters long — and "&" has to be doubled because it opens a format
- * code, so an ampersand-heavy name grows on the way in: 200 of them encode to 400. Excel does
- * not complain about a header over the limit, it drops it, so a printout would come out
- * unidentified while generation reported success.
- *
- * Truncating is the right answer rather than refusing: the header is a convenience, the deal
- * name is not ours to shorten, and an ellipsis says plainly that there was more. Whole encoded
- * units only, so a truncation can never split a `&&` pair and leave a dangling `&` that would
- * swallow whatever follows it as a format code.
- */
-function fitHeader(text: string): string {
-  const budget = HEADER_LIMIT - HEADER_CODES.length;
-  const encode = (c: string) => (c === '&' ? '&&' : c);
-  const full = [...text].map(encode).join('');
-  if (full.length <= budget) return full;
+/** What joins the header parts, and counts against the budget like anything else. */
+const HEADER_SEPARATOR = ' — ';
+
+/** `&` opens a format code, so a literal one has to be doubled — and then costs two. */
+const encodeHeaderChar = (c: string) => (c === '&' ? '&&' : c);
+
+/** Encoded length, which is what Excel counts — not the source length. */
+function encodedLength(text: string): number {
+  let n = 0;
+  for (const ch of text) n += encodeHeaderChar(ch).length;
+  return n;
+}
+
+/** Encode up to `budget` characters, appending an ellipsis if anything was left behind. */
+function elide(text: string, budget: number): string {
+  if (encodedLength(text) <= budget) return [...text].map(encodeHeaderChar).join('');
   let out = '';
   for (const ch of text) {
-    const unit = encode(ch);
+    const unit = encodeHeaderChar(ch);
     if (out.length + unit.length > budget - 1) break; // one unit back for the ellipsis
     out += unit;
   }
   return `${out}…`;
 }
 
+/**
+ * Encode the header parts, fitting them inside Excel's limit with every part represented.
+ *
+ * Three things conspire. Nothing bounds a deal or account name. "&" doubles on the way in, so
+ * 200 ampersands encode to 400 characters. And Excel does not complain about a header past the
+ * limit — it drops it, so a printout comes out unidentified while generation reports success.
+ *
+ * Truncating beats refusing: the header is a convenience and the account name is not ours to
+ * shorten. But truncating the *joined* string is not good enough, because the parts are ordered
+ * account-then-deal and a 300-character account name would then consume the whole budget and
+ * emit a header with no deal name in it — so every deal for that account prints identically.
+ * Each part gets its own share instead, and a part that does not need its share releases the
+ * surplus to the ones that do.
+ */
+function fitHeader(parts: string[]): string {
+  const kept = parts.filter((p) => p !== '');
+  if (kept.length === 0) return '';
+  const budget = HEADER_LIMIT - HEADER_CODES.length - HEADER_SEPARATOR.length * (kept.length - 1);
+  if (budget < kept.length) return '';
+
+  // Redistribute in passes: each pass gives the parts still over their share the budget freed by
+  // the parts under it. It settles once nothing is under its share, at most one pass per part.
+  const shares = new Array(kept.length).fill(0);
+  let pool = budget;
+  let open = kept.map((_, i) => i);
+  while (open.length > 0 && pool > 0) {
+    const share = Math.floor(pool / open.length);
+    if (share === 0) break;
+    const settled = open.filter((i) => encodedLength(kept[i]) <= share);
+    if (settled.length === 0) {
+      for (const i of open) shares[i] = share;
+      break;
+    }
+    for (const i of settled) {
+      shares[i] = encodedLength(kept[i]);
+      pool -= shares[i];
+    }
+    open = open.filter((i) => !settled.includes(i));
+  }
+  return kept.map((part, i) => elide(part, shares[i])).join(HEADER_SEPARATOR);
+}
+
 function printXml(print: PrintSetup | undefined): string {
   if (!print) return '';
   const fit = print.fitToWidth ? ' fitToWidth="1" fitToHeight="0"' : '';
-  const header = print.header
-    ? `<headerFooter><oddHeader>&amp;L${escapeXml(fitHeader(print.header))}&amp;R&amp;D</oddHeader></headerFooter>`
+  const headerText = print.header?.length ? fitHeader(print.header) : '';
+  const header = headerText
+    ? `<headerFooter><oddHeader>&amp;L${escapeXml(headerText)}&amp;R&amp;D</oddHeader></headerFooter>`
     : '';
   return (
     `<printOptions horizontalCentered="1"/>` +

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -70,6 +70,20 @@ interface Range {
   r2: number;
 }
 
+/** The last cell Excel has: column XFD, row 1048576. Anything past it is not a cell at all. */
+const MAX_COLUMN = 16384;
+const MAX_ROW = 1048576;
+
+/**
+ * How many cells one merge may materialise.
+ *
+ * A full-width banner is sixteen cells and the tallest prose block is a few hundred, so this is
+ * three orders of magnitude of headroom. It exists because `A1:XFD1048576` is a syntactically
+ * valid, in-bounds range covering seventeen billion cells: without a cap the writer does not
+ * fail, it stops responding, which is the one failure mode with no error message.
+ */
+const MAX_MERGE_CELLS = 10_000;
+
 /** Parse `B2:Q7` into 1-based bounds, rejecting anything Excel would not accept as a range. */
 function parseRange(ref: string, what: string): Range {
   const m = /^([A-Z]+)(\d+):([A-Z]+)(\d+)$/.exec(ref);
@@ -78,7 +92,20 @@ function parseRange(ref: string, what: string): Range {
   if (range.c2 < range.c1 || range.r2 < range.r1) {
     throw new Error(`${what} "${ref}" runs backwards — write it top-left first, as B2:Q7`);
   }
+  for (const [axis, low, high, limit] of [
+    ['row', range.r1, range.r2, MAX_ROW],
+    ['column', range.c1, range.c2, MAX_COLUMN],
+  ] as const) {
+    if (low < 1 || high > limit) {
+      throw new Error(`${what} "${ref}" is outside Excel's grid — ${axis}s run from 1 to ${limit}`);
+    }
+  }
   return range;
+}
+
+/** Do two ranges share a cell? */
+function overlaps(a: Range, b: Range): boolean {
+  return a.c1 <= b.c2 && b.c1 <= a.c2 && a.r1 <= b.r2 && b.r1 <= a.r2;
 }
 
 /**
@@ -373,32 +400,67 @@ export function expandMerges(sheet: SheetSpec): RowSpec[] {
   const rows = sheet.rows.map((r) => ({ ...r, cells: [...r.cells] }));
   if (merges.length === 0) return rows;
 
-  const cellAt = (ref: string) => {
-    for (const row of rows) {
-      const found = row.cells.find((c) => c.ref === ref);
-      if (found) return found;
+  // Indexed once, not scanned per cell. Looking a cell up by walking every row inside the
+  // expansion loop makes this quadratic: a 200,000-cell merge did not finish in two minutes.
+  //
+  // Measured at MAX_MERGE_CELLS, rescanning against indexing: A1:B5000 700ms vs 9ms, A1:A9999
+  // 942ms vs 7ms. So the cap is what bounds the damage and the index is what makes it free.
+  // No test asserts the timing — at these sizes a threshold either cannot fail or flakes.
+  const rowByNumber = new Map<number, RowSpec>();
+  for (const row of rows) {
+    if (rowByNumber.has(row.row)) {
+      throw new Error(
+        `Sheet "${sheet.name}" declares row ${row.row} twice — Excel repairs a sheet with a repeated row`,
+      );
     }
-    return undefined;
-  };
+    rowByNumber.set(row.row, row);
+  }
+  const cellByRef = new Map<string, CellSpec>();
+  for (const row of rows) for (const cell of row.cells) cellByRef.set(cell.ref, cell);
+
   const rowAt = (n: number) => {
-    let row = rows.find((r) => r.row === n);
+    let row = rowByNumber.get(n);
     if (!row) {
       row = { row: n, cells: [] };
+      rowByNumber.set(n, row);
       rows.push(row);
     }
     return row;
   };
 
+  const tableRanges = (sheet.tables ?? []).map((t) => ({
+    name: t.name,
+    range: parseRange(t.ref, `Table "${t.name}" on sheet "${sheet.name}"`),
+  }));
+
   /** ref -> the merge that already covers it, so an overlap can name both. */
   const covered = new Map<string, string>();
 
   for (const ref of merges) {
-    const { c1, r1, c2, r2 } = parseRange(ref, `Merge on sheet "${sheet.name}"`);
+    const area = parseRange(ref, `Merge on sheet "${sheet.name}"`);
+    const { c1, r1, c2, r2 } = area;
     if (c1 === c2 && r1 === r2) {
       throw new Error(`Merge "${ref}" on sheet "${sheet.name}" covers one cell — that is not a merge`);
     }
+    const size = (c2 - c1 + 1) * (r2 - r1 + 1);
+    if (size > MAX_MERGE_CELLS) {
+      throw new Error(
+        `Merge "${ref}" on sheet "${sheet.name}" covers ${size} cells; the writer materialises at most ${MAX_MERGE_CELLS}`,
+      );
+    }
+    // Excel does not merely dislike a merge inside a table — it drops the table and repairs the
+    // file, so the sort button, the structured references and the auto-extend all disappear
+    // with nothing to notice but a table count that fell to zero.
+    for (const table of tableRanges) {
+      if (overlaps(area, table.range)) {
+        throw new Error(
+          `Merge "${ref}" on sheet "${sheet.name}" overlaps table "${table.name}" (${sheet.tables?.find((t) => t.name === table.name)?.ref}) — ` +
+            'Excel drops a table whose range contains a merged cell',
+        );
+      }
+    }
     const anchorRef = A1(c1, r1);
-    const anchor = cellAt(anchorRef);
+    const anchor = cellByRef.get(anchorRef);
     if (!anchor) {
       throw new Error(
         `Merge "${ref}" on sheet "${sheet.name}" has no cell at ${anchorRef} to anchor it — ` +
@@ -415,18 +477,21 @@ export function expandMerges(sheet: SheetSpec): RowSpec[] {
         covered.set(at, ref);
         if (at === anchorRef) continue;
 
-        const existing = cellAt(at);
+        const existing = cellByRef.get(at);
         if (existing && (existing.value !== undefined || existing.formula !== undefined)) {
           throw new Error(
             `Merge "${ref}" on sheet "${sheet.name}" would hide the value at ${at} — ` +
               'a merged range shows only its top-left cell',
           );
         }
+        // Replace, never mutate: the cell objects still belong to the caller's spec, and only
+        // the rows and their arrays were copied.
         const row = rowAt(r);
         const index = row.cells.findIndex((cell) => cell.ref === at);
         const filled: CellSpec = { ref: at, style: anchor.style };
         if (index === -1) row.cells.push(filled);
         else row.cells[index] = filled;
+        cellByRef.set(at, filled);
       }
     }
   }

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -58,6 +58,29 @@ export function A1(col: number, row: number): string {
   return `${columnLetter(col)}${row}`;
 }
 
+/** "A" -> 1, "AA" -> 27. The inverse of {@link columnLetter}. */
+export function columnIndex(letters: string): number {
+  return [...letters].reduce((n, c) => n * 26 + (c.charCodeAt(0) - 64), 0);
+}
+
+interface Range {
+  c1: number;
+  r1: number;
+  c2: number;
+  r2: number;
+}
+
+/** Parse `B2:Q7` into 1-based bounds, rejecting anything Excel would not accept as a range. */
+function parseRange(ref: string, what: string): Range {
+  const m = /^([A-Z]+)(\d+):([A-Z]+)(\d+)$/.exec(ref);
+  if (!m) throw new Error(`${what} "${ref}" is not a range like B2:Q7`);
+  const range = { c1: columnIndex(m[1]), r1: Number(m[2]), c2: columnIndex(m[3]), r2: Number(m[4]) };
+  if (range.c2 < range.c1 || range.r2 < range.r1) {
+    throw new Error(`${what} "${ref}" runs backwards — write it top-left first, as B2:Q7`);
+  }
+  return range;
+}
+
 /**
  * The style palette, in `cellXfs` order — the index of each name IS its `s=` attribute.
  *
@@ -69,7 +92,9 @@ const STYLE_ORDER = [
   'default',
   'title',
   'sectionHeader',
+  'groupHeader',
   'columnHeader',
+  'fieldLabel',
   'label',
   'text',
   'number',
@@ -93,18 +118,19 @@ export const STYLE_IDS: Record<StyleName, number> = Object.fromEntries(
 /** Font index per style, into the `<fonts>` list below. */
 const FONT_DEFAULT = 0;
 const FONT_BOLD = 1;
-const FONT_TITLE = 2;
-const FONT_WHITE_BOLD = 3;
-const FONT_ITALIC_GREY = 4;
+const FONT_WHITE_BOLD = 2;
+const FONT_ITALIC_GREY = 3;
+const FONT_WHITE_TITLE = 4;
 
 /** Fill index per style, into the `<fills>` list below. */
 const FILL_NONE = 0;
 // index 1 is the format-reserved gray125 placeholder; Excel expects it present and unused
 const FILL_DARK = 2;
-const FILL_HEADER = 3;
-const FILL_RED = 4;
-const FILL_AMBER = 5;
-const FILL_GREEN = 6;
+const FILL_RED = 3;
+const FILL_AMBER = 4;
+const FILL_GREEN = 5;
+const FILL_TEAL = 6;
+const FILL_ACCENT = 7;
 
 interface StyleDef {
   font: number;
@@ -112,13 +138,17 @@ interface StyleDef {
   numFmt: number;
   wrap?: boolean;
   center?: boolean;
+  /** Sit the text in the middle of the row. Banners are twice the height of their text. */
+  middle?: boolean;
 }
 
 const STYLE_DEFS: Record<StyleName, StyleDef> = {
   default: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: 0 },
-  title: { font: FONT_TITLE, fill: FILL_NONE, numFmt: 0 },
-  sectionHeader: { font: FONT_WHITE_BOLD, fill: FILL_DARK, numFmt: 0 },
-  columnHeader: { font: FONT_BOLD, fill: FILL_HEADER, numFmt: 0 },
+  title: { font: FONT_WHITE_TITLE, fill: FILL_DARK, numFmt: 0, center: true, middle: true },
+  sectionHeader: { font: FONT_WHITE_BOLD, fill: FILL_DARK, numFmt: 0, center: true, middle: true },
+  groupHeader: { font: FONT_WHITE_BOLD, fill: FILL_ACCENT, numFmt: 0, center: true, middle: true },
+  columnHeader: { font: FONT_WHITE_BOLD, fill: FILL_TEAL, numFmt: 0, center: true, middle: true, wrap: true },
+  fieldLabel: { font: FONT_WHITE_BOLD, fill: FILL_TEAL, numFmt: 0, middle: true, wrap: true },
   label: { font: FONT_BOLD, fill: FILL_NONE, numFmt: 0 },
   text: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: 0, wrap: true },
   number: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: 0 },
@@ -226,18 +256,22 @@ function stylesXml(): string {
   const fonts = [
     '<font><sz val="11"/><name val="Calibri"/></font>',
     '<font><b/><sz val="11"/><name val="Calibri"/></font>',
-    '<font><b/><sz val="16"/><name val="Calibri"/></font>',
     '<font><b/><sz val="11"/><color rgb="FFFFFFFF"/><name val="Calibri"/></font>',
     '<font><i/><sz val="10"/><color rgb="FF6B6B6B"/><name val="Calibri"/></font>',
+    '<font><b/><sz val="16"/><color rgb="FFFFFFFF"/><name val="Calibri"/></font>',
   ];
+  // Navy, teal and light blue are dk2, accent1 and accent4 of the stock modern Office theme —
+  // resolved to literal RGB rather than referenced by theme index, because we ship no theme
+  // part and a `theme=` reference with nothing to resolve against renders as black on black.
   const fills = [
     '<fill><patternFill patternType="none"/></fill>',
     '<fill><patternFill patternType="gray125"/></fill>',
-    '<fill><patternFill patternType="solid"><fgColor rgb="FF1F3864"/><bgColor indexed="64"/></patternFill></fill>',
-    '<fill><patternFill patternType="solid"><fgColor rgb="FFD9E2F3"/><bgColor indexed="64"/></patternFill></fill>',
+    '<fill><patternFill patternType="solid"><fgColor rgb="FF0E2841"/><bgColor indexed="64"/></patternFill></fill>',
     '<fill><patternFill patternType="solid"><fgColor rgb="FFF8CBAD"/><bgColor indexed="64"/></patternFill></fill>',
     '<fill><patternFill patternType="solid"><fgColor rgb="FFFFE699"/><bgColor indexed="64"/></patternFill></fill>',
     '<fill><patternFill patternType="solid"><fgColor rgb="FFC6E0B4"/><bgColor indexed="64"/></patternFill></fill>',
+    '<fill><patternFill patternType="solid"><fgColor rgb="FF156082"/><bgColor indexed="64"/></patternFill></fill>',
+    '<fill><patternFill patternType="solid"><fgColor rgb="FF0F9ED5"/><bgColor indexed="64"/></patternFill></fill>',
   ];
   const border =
     '<border><left style="thin"><color rgb="FFD0D0D0"/></left><right style="thin"><color rgb="FFD0D0D0"/></right>' +
@@ -245,9 +279,10 @@ function stylesXml(): string {
 
   const xfs = STYLE_ORDER.map((name) => {
     const d = STYLE_DEFS[name];
+    const vertical = d.middle ? ' vertical="center"' : d.wrap ? ' vertical="top"' : '';
     const align =
-      d.wrap || d.center
-        ? `<alignment${d.wrap ? ' wrapText="1" vertical="top"' : ''}${d.center ? ' horizontal="center"' : ''}/>`
+      d.wrap || d.center || d.middle
+        ? `<alignment${d.wrap ? ' wrapText="1"' : ''}${vertical}${d.center ? ' horizontal="center"' : ''}/>`
         : '';
     const applies = `${d.numFmt ? ' applyNumberFormat="1"' : ''}${d.font ? ' applyFont="1"' : ''}${d.fill ? ' applyFill="1"' : ''}${align ? ' applyAlignment="1"' : ''}`;
     return `<xf numFmtId="${d.numFmt}" fontId="${d.font}" fillId="${d.fill}" borderId="1" xfId="0"${applies}>${align}</xf>`;
@@ -290,6 +325,15 @@ export interface RowSpec {
   height?: number;
 }
 
+/** How the sheet prints. Omitted entirely, Excel uses its own defaults. */
+export interface PrintSetup {
+  orientation: 'landscape' | 'portrait';
+  /** Squeeze the used width onto one page. Needs `fitToPage` on the sheet, which we emit. */
+  fitToWidth?: boolean;
+  /** Left-hand header text. The date is added on the right. */
+  header?: string;
+}
+
 export interface SheetSpec {
   name: string;
   rows: RowSpec[];
@@ -297,9 +341,104 @@ export interface SheetSpec {
   columns?: { min: number; max: number; width: number }[];
   /** Freeze everything above this row (a header freeze). */
   freezeAtRow?: number;
+  /**
+   * Merged ranges, as `B2:Q2`. Write the value into the top-left cell only; the writer fills
+   * the rest of the range with that cell's style, which is what Excel needs to paint a fill
+   * or a border across a merge.
+   */
+  merges?: string[];
+  /** Hide the grid, so the sheet reads as a designed page rather than a spreadsheet. */
+  hideGridlines?: boolean;
+  /** Opening zoom percentage. Excel accepts 10 to 400. */
+  zoom?: number;
+  print?: PrintSetup;
   tables?: TablePart[];
   conditionalFormats?: ConditionalFormat[];
   validations?: Validation[];
+}
+
+/**
+ * Fill every cell a merge covers with the anchor's style, and return the rows sorted.
+ *
+ * Excel paints a merged range from the styles of ALL its cells, not the top-left alone: style
+ * only the anchor and a banner's fill stops after its first column with its border box left
+ * open. Real Excel files write every covered cell — the sample deal-review sheet writes all
+ * sixteen cells of `B2:Q2` with the same `s=`. So the caller declares the range and writes one
+ * cell; keeping the other fifteen in step is this function's job, not theirs.
+ *
+ * Pure: the caller's rows and cells are never mutated.
+ */
+export function expandMerges(sheet: SheetSpec): RowSpec[] {
+  const merges = sheet.merges ?? [];
+  const rows = sheet.rows.map((r) => ({ ...r, cells: [...r.cells] }));
+  if (merges.length === 0) return rows;
+
+  const cellAt = (ref: string) => {
+    for (const row of rows) {
+      const found = row.cells.find((c) => c.ref === ref);
+      if (found) return found;
+    }
+    return undefined;
+  };
+  const rowAt = (n: number) => {
+    let row = rows.find((r) => r.row === n);
+    if (!row) {
+      row = { row: n, cells: [] };
+      rows.push(row);
+    }
+    return row;
+  };
+
+  /** ref -> the merge that already covers it, so an overlap can name both. */
+  const covered = new Map<string, string>();
+
+  for (const ref of merges) {
+    const { c1, r1, c2, r2 } = parseRange(ref, `Merge on sheet "${sheet.name}"`);
+    if (c1 === c2 && r1 === r2) {
+      throw new Error(`Merge "${ref}" on sheet "${sheet.name}" covers one cell — that is not a merge`);
+    }
+    const anchorRef = A1(c1, r1);
+    const anchor = cellAt(anchorRef);
+    if (!anchor) {
+      throw new Error(
+        `Merge "${ref}" on sheet "${sheet.name}" has no cell at ${anchorRef} to anchor it — ` +
+          'the top-left cell carries the value and the style for the whole range',
+      );
+    }
+    for (let c = c1; c <= c2; c++) {
+      for (let r = r1; r <= r2; r++) {
+        const at = A1(c, r);
+        const already = covered.get(at);
+        if (already !== undefined) {
+          throw new Error(`Merges "${already}" and "${ref}" on sheet "${sheet.name}" both cover ${at}`);
+        }
+        covered.set(at, ref);
+        if (at === anchorRef) continue;
+
+        const existing = cellAt(at);
+        if (existing && (existing.value !== undefined || existing.formula !== undefined)) {
+          throw new Error(
+            `Merge "${ref}" on sheet "${sheet.name}" would hide the value at ${at} — ` +
+              'a merged range shows only its top-left cell',
+          );
+        }
+        const row = rowAt(r);
+        const index = row.cells.findIndex((cell) => cell.ref === at);
+        const filled: CellSpec = { ref: at, style: anchor.style };
+        if (index === -1) row.cells.push(filled);
+        else row.cells[index] = filled;
+      }
+    }
+  }
+
+  // sheetData is a sequence: Excel repairs a file whose rows do not ascend, and a vertical
+  // merge creates rows wherever its range reaches.
+  rows.sort((a, b) => a.row - b.row);
+  for (const row of rows)
+    row.cells.sort(
+      (a, b) => columnIndex(/^[A-Z]+/.exec(a.ref)?.[0] ?? '') - columnIndex(/^[A-Z]+/.exec(b.ref)?.[0] ?? ''),
+    );
+  return rows;
 }
 
 function cellXml(cell: CellSpec): string {
@@ -331,10 +470,9 @@ function headerTextsFor(sheet: SheetSpec, ref: string): string[] {
   if (lastRow <= headerRow) {
     throw new Error(`Table ref "${ref}" on sheet "${sheet.name}" has no data row — Excel rejects a header-only table`);
   }
-  const colIndex = (letters: string) => [...letters].reduce((n, c) => n * 26 + (c.charCodeAt(0) - 64), 0);
   const row = sheet.rows.find((r) => r.row === headerRow);
   const out: string[] = [];
-  for (let c = colIndex(firstCol); c <= colIndex(lastCol); c++) {
+  for (let c = columnIndex(firstCol); c <= columnIndex(lastCol); c++) {
     const cell = row?.cells.find((x) => x.ref === A1(c, headerRow));
     out.push(typeof cell?.value === 'string' ? cell.value : '');
   }
@@ -392,6 +530,27 @@ function dataValidationsXml(validations: Validation[] | undefined): string {
   return `<dataValidations count="${validations.length}">${entries}</dataValidations>`;
 }
 
+/**
+ * `printOptions`, `pageMargins`, `pageSetup` and `headerFooter`, in that order.
+ *
+ * `pageMargins` is not optional decoration: Excel wants it present before `pageSetup`.
+ */
+function printXml(print: PrintSetup | undefined): string {
+  if (!print) return '';
+  const fit = print.fitToWidth ? ' fitToWidth="1" fitToHeight="0"' : '';
+  // In a header, "&" opens a format code (&D is the date, &P the page) — so a literal
+  // ampersand in the deal name has to be doubled, on top of the usual XML escaping.
+  const header = print.header
+    ? `<headerFooter><oddHeader>&amp;L${escapeXml(print.header.replace(/&/g, '&&'))}&amp;R&amp;D</oddHeader></headerFooter>`
+    : '';
+  return (
+    `<printOptions horizontalCentered="1"/>` +
+    `<pageMargins left="0.4" right="0.4" top="0.6" bottom="0.6" header="0.3" footer="0.3"/>` +
+    `<pageSetup paperSize="9" orientation="${print.orientation}"${fit}/>` +
+    header
+  );
+}
+
 function sheetXml(sheet: SheetSpec, tableIds: number[]): string {
   const cols = sheet.columns?.length
     ? `<cols>${sheet.columns.map((c) => `<col min="${c.min}" max="${c.max}" width="${c.width}" customWidth="1"/>`).join('')}</cols>`
@@ -399,7 +558,22 @@ function sheetXml(sheet: SheetSpec, tableIds: number[]): string {
   const pane = sheet.freezeAtRow
     ? `<pane ySplit="${sheet.freezeAtRow}" topLeftCell="A${sheet.freezeAtRow + 1}" activePane="bottomLeft" state="frozen"/>`
     : '';
-  const rows = sheet.rows
+  if (sheet.zoom !== undefined && (!Number.isInteger(sheet.zoom) || sheet.zoom < 10 || sheet.zoom > 400)) {
+    throw new Error(
+      `Sheet "${sheet.name}" asks for zoom ${sheet.zoom}; Excel accepts whole percentages from 10 to 400`,
+    );
+  }
+  const viewAttrs =
+    `${sheet.hideGridlines ? ' showGridLines="0"' : ''}` +
+    `${sheet.zoom === undefined ? '' : ` zoomScale="${sheet.zoom}" zoomScaleNormal="${sheet.zoom}"`}`;
+  // fitToWidth on pageSetup is ignored unless the sheet itself says its page setup is
+  // fit-to-page, which is a sheetPr child and so has to come before everything else.
+  const sheetPr = sheet.print?.fitToWidth ? `<sheetPr><pageSetUpPr fitToPage="1"/></sheetPr>` : '';
+  const merged = expandMerges(sheet);
+  const mergeCells = sheet.merges?.length
+    ? `<mergeCells count="${sheet.merges.length}">${sheet.merges.map((ref) => `<mergeCell ref="${ref}"/>`).join('')}</mergeCells>`
+    : '';
+  const rows = merged
     .map(
       (r) =>
         `<row r="${r.row}"${r.height ? ` ht="${r.height}" customHeight="1"` : ''}>${r.cells.map(cellXml).join('')}</row>`,
@@ -426,16 +600,21 @@ function sheetXml(sheet: SheetSpec, tableIds: number[]): string {
     ? `<tableParts count="${tableIds.length}">${tableIds.map((_, i) => `<tablePart r:id="rId${i + 1}"/>`).join('')}</tableParts>`
     : '';
 
-  // CT_Worksheet is a sequence, not a bag: sheetData, then conditionalFormatting, then
-  // dataValidations, with tableParts last. Emitting these out of order does not warn — it
-  // makes Excel offer to repair the file, with a message that names nothing useful.
+  // CT_Worksheet is a sequence, not a bag: sheetPr, sheetViews, sheetFormatPr, cols,
+  // sheetData, mergeCells, conditionalFormatting, dataValidations, then the print group
+  // (printOptions, pageMargins, pageSetup, headerFooter), with tableParts last. Emitting
+  // these out of order does not warn — it makes Excel offer to repair the file, with a
+  // message that names nothing useful.
   return (
     `${XML_HEADER}<worksheet xmlns="${NS_MAIN}" xmlns:r="${NS_REL_DOC}">` +
-    `<sheetViews><sheetView workbookViewId="0">${pane}</sheetView></sheetViews>` +
+    sheetPr +
+    `<sheetViews><sheetView${viewAttrs} workbookViewId="0">${pane}</sheetView></sheetViews>` +
     `<sheetFormatPr defaultRowHeight="15"/>${cols}` +
     `<sheetData>${rows}</sheetData>` +
+    mergeCells +
     conditionalFormattingXml(sheet.conditionalFormats) +
     dataValidationsXml(sheet.validations) +
+    printXml(sheet.print) +
     tableParts +
     `</worksheet>`
   );

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -365,14 +365,34 @@ done
 wait_until_ready "$RT_BOOK" "$(at metadata.accountName sheet)" "$(at metadata.accountName address)" ||
   fail "Excel never finished opening $RT_BOOK"
 
+# Writing, saving and closing in one breath hid which of the three failed. When the save did not
+# reach disk the reader saw the untouched file, reported no proposals, and this script blamed
+# `metadata.accountName` for "coming back as MISSING" — an accurate symptom pointing at the wrong
+# component. So each step is now checked on its own terms.
+#
 # `range`, not `cell`: reads work through either, but a write through `cell` fails.
 excel_do "the four hand edits" "  set wb to workbook \"$RT_BOOK\"
   set value of range \"$(at metadata.accountName address)\" of worksheet \"$(at metadata.accountName sheet)\" of wb to \"Globex Corporation\"
   set value of range \"$(at qualification.champion.score address)\" of worksheet \"$(at qualification.champion.score sheet)\" of wb to 2
   set value of range \"$(at metadata.closeDate address)\" of worksheet \"$(at metadata.closeDate sheet)\" of wb to \"2026-09-15\"
   set value of range \"$(at 'stakeholders[0].mustSayYes' address)\" of worksheet \"$(at 'stakeholders[0].mustSayYes' sheet)\" of wb to false
+  if ((get value of range \"$(at metadata.accountName address)\" of worksheet \"$(at metadata.accountName sheet)\" of wb) as string) is not \"Globex Corporation\" then error \"the accountName write did not take in the open workbook\""
+
+# What the file looked like before Excel was asked to save it.
+rt_before="$(stat -f '%m %z' "$RT_OUT")"
+
+excel_do "saving and closing the edited workbook" "  set wb to workbook \"$RT_BOOK\"
   save wb
   close wb saving no"
+
+# Excel reports a successful `save` before the bytes are necessarily on disk, and a workbook that
+# closes without flushing leaves the reader looking at the file as it was.
+for _ in $(seq 1 30); do
+  [ "$(stat -f '%m %z' "$RT_OUT")" != "$rt_before" ] && break
+  sleep 1
+done
+[ "$(stat -f '%m %z' "$RT_OUT")" != "$rt_before" ] ||
+  fail "Excel reported saving $RT_BOOK but the file on disk is unchanged ($rt_before) — the edits never reached it"
 
 edited="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL")"
 edited_code=$?

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -217,6 +217,47 @@ echo "    score dropdown: Excel=[$got_scores]"
 [ "$got_scores" = "0,1,2,3,4" ] || fail "the score dropdown is '$got_scores', expected 0,1,2,3,4"
 echo "PASS: Excel recognises the tables, the conditional formats and the schema-derived dropdowns"
 
+# The presentation primitives are the ones a unit test can least vouch for: a merge Excel
+# rejects, a print setup it ignores, a gridline flag in the wrong place — all of them produce a
+# file that still opens. So ask Excel what it made of them.
+merged_title="$(ask "merge cells of range \"A1:B1\" of worksheet \"Deal\" of workbook \"$BOOK\"")"
+echo "    Deal!A1:B1 merged: ${merged_title:-<none>}"
+[ "$merged_title" = "true" ] || fail "expected the title banner to be merged, Excel reports '$merged_title'"
+
+# The value belongs to the top-left cell; a merge that lost it would read back empty.
+merged_text="$(ask "value of range \"A1\" of worksheet \"Deal\" of workbook \"$BOOK\"")"
+echo "    Deal!A1 reads: ${merged_text:-<empty>}"
+[ -n "$merged_text" ] || fail "the merged title cell is empty — the merge swallowed its value"
+
+# A table sheet must have NO merge anywhere in its table range: Excel silently drops a table
+# that contains one, and the drop is only visible as the table count falling to zero.
+merged_in_table="$(ask "merge cells of range \"A1:H2\" of worksheet \"Stakeholders\" of workbook \"$BOOK\"")"
+echo "    Stakeholders!A1:H2 merged: ${merged_in_table:-<none>}"
+[ "$merged_in_table" = "false" ] || fail "a merge inside the Stakeholders table range would make Excel drop the table"
+
+gridlines="$(
+  osascript <<OSA 2>/dev/null
+tell application "Microsoft Excel"
+  activate object worksheet "Deal" of workbook "$BOOK"
+  return (display gridlines of active window) as string
+end tell
+OSA
+)"
+echo "    gridlines shown on Deal: ${gridlines:-<none>}"
+[ "$gridlines" = "false" ] || fail "expected gridlines hidden on Deal, Excel reports '$gridlines'"
+
+# `page orientation`, not `orientation` — the latter is a different property that reads back
+# "missing value" for a worksheet page setup, which looks exactly like Excel ignoring us.
+orientation="$(ask "page orientation of page setup object of worksheet \"Deal\" of workbook \"$BOOK\"")"
+fit_wide="$(ask "fit to pages wide of page setup object of worksheet \"Deal\" of workbook \"$BOOK\"")"
+fit_tall="$(ask "fit to pages tall of page setup object of worksheet \"Deal\" of workbook \"$BOOK\"")"
+echo "    print orientation: ${orientation:-<none>}, fit to pages wide/tall: ${fit_wide:-<none>}/${fit_tall:-<none>}"
+[ "$orientation" = "landscape" ] || fail "expected landscape print orientation, Excel reports '$orientation'"
+# One page wide, unlimited tall: a deal review is read by scrolling, not shrunk to nothing.
+[ "$fit_wide" = "1" ] || fail "expected fit to 1 page wide, Excel reports '$fit_wide'"
+[ "$fit_tall" = "0" ] || fail "expected unlimited page height, Excel reports '$fit_tall'"
+echo "PASS: Excel accepts the merges, hides the grid and honours the print setup"
+
 # Putting a Table on Qualification hands the user a sort button, and a formula written as
 # `Qualification!C8` means "champion" only until they press it. Moving the key to another row
 # is what a sort does; the Scorecard must follow the key, not the address.


### PR DESCRIPTION
Closes #900

First of five changes taking the generated MEDDPICC workbook from functionally complete to
presentable. This one adds only the drawing primitives — the layout itself follows.

## What the writer could not do

It could not express a heading. There was no merge support at all, so a section banner was a single
cell in column A with the rest of the row empty, and the sheet read as a data dump.

## What it does now

`SheetSpec` gains `merges`, `hideGridlines`, `zoom` and `print`. A merge is declared as a range and
anchored by its top-left cell; the writer fills every other covered cell with that cell's style.
That last part is not an optimisation — Excel paints a merged range from the styles of **all** its
cells, so styling the anchor alone stops a banner's fill after its first column and leaves its
border box open. The manual sheet this is modelled on writes all sixteen cells of `B2:Q2` with the
same `s=`.

The palette moves to the stock modern Office theme that sheet uses — `#0E2841` navy banners,
`#156082` teal labels, `#0F9ED5` sub-headers. Being Excel's own default theme, it is faithful to the
sample and vendor-neutral at the same time.

Titles and section headers now span the form width. Table sheets declare no merges, because Excel
drops a table whose range contains one. Every sheet hides the grid and prints landscape, one page
wide, with the deal named in the header.

## What it refuses

Nine things, rather than emitting a file for Excel to repair: a malformed range, one written
bottom-right first, one covering a single cell, two that overlap, one that would hide a value the
caller wrote, one outside Excel's grid, one too large to materialise, one overlapping a table, and a
sheet declaring the same row twice.

The hidden-value one is the one worth having: a merge silently swallowing a field is how two
sections that overlap by a row look fine and lose data.

## Review found four things, and one of them was underneath

Four rounds of `codex:verified-code-review`, every finding confirmed with a failing test first:

| | |
| --- | --- |
| A merge overlapping a table | Excel drops the table and repairs the file, so the sort button, structured references and auto-extend all vanish — leaving only a table count that fell to zero |
| Coordinates past Excel's grid | `A0`, `XFE`, row 1048577 are well-formed and are not cells |
| `A1:XFD1048576` | Valid, in bounds, seventeen billion cells: the writer did not fail, it stopped responding |
| A header over 255 characters | Excel drops it rather than complaining, so a printout comes out unidentified while generation reports success |

Chasing the third exposed the real defect: cells were looked up by walking every row from inside the
expansion loop, making expansion **quadratic**. A 200,000-cell merge did not finish in two minutes.
Both lookups are indexed now. Measured at the new cap, rescanning against indexing: `A1:B5000` 700ms
against 9ms, `A1:A9999` 942ms against 7ms.

The header took three passes to get right. Truncating the joined string was not enough — the parts
are ordered account-then-deal, so a long account name consumed the whole budget and emitted a header
with no deal name in it, and then every deal for that account prints identically. `PrintSetup.header`
takes parts and shares the budget across them. It also carries `dealId` now, because that is the only
part guaranteed to identify the deal; the schema requires all three of these fields and bounds none
of them, so a deal with three empty strings validates. That laxness reaches further than headers, so
it is filed separately as #901.

## Verification

- 290 unit tests, 27 plugin tests, biome, codespell, shellcheck, shfmt, textlint — all clean.
- **Every new guard mutation-checked** — 27 mutations, 27 caught. Two of those mutations were caught
  only after fixing weak tests: a bare `toThrow()` accepted the wrong error, and a timing assertion
  could not fail at all. The timing test was removed rather than loosened — at these sizes a
  threshold either cannot fail or flakes, so the cap is what a test can hold and the measurement
  lives in a comment.
- **Real Excel**, three consecutive runs of eight PASS blocks: opens with no repair prompt, and Excel
  itself confirms the merge, the preserved anchor value, the absence of any merge inside a table
  range, the hidden grid, and the landscape fit-to-width setup.

One of those runs failed, which is how a reporting bug in the UAT surfaced: the round-trip block
wrote four cells, saved and closed in one AppleScript, so when a save did not reach disk the reader
saw the untouched file and the script announced that `metadata.accountName` "came back as MISSING" —
an accurate symptom pointing at the wrong component. The write is now verified in the open workbook
and the save against the file on disk, each failing in its own words.

## What this does not do yet

`zoom` is unit-tested but not emitted by the generator: it is meaningful once the sheet is wide, which
is the next change. Row-height computation, the one-sheet layout, and localisation are all still to
come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)