### PR TITLE
MEDDPICC: align every label on a slot grid, and show the score rather than the arithmetic (v6.0.0)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "5.0.0",
+      "version": "6.0.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,20 @@ and this project adheres to
   - **The per-element definition column is gone.** It was the same eight paragraphs in every workbook,
     taking three columns from a rep's own evidence. `engine hint <element>` still returns them, and the
     follow-up issue proposes putting them back as hover notes, which cost no height at all.
-  - **Score, Previous and Change now read as one trio** — all three centred, where Change alone had
-    been left-aligned, and the delta is coloured by its sign. Up is good, down is not, and nought stays
-    uncoloured: an amber "nothing moved" looks like a warning in a column somebody scans for problems.
+  - **The elements table shows the score and nothing a reader could work out.** Previous and Change were
+    both on display — eight previous scores and eight deltas, two columns across the table so that
+    somebody could see 3 beside 1 and be told the difference is 2. The score itself, colour-coded, is
+    the at-a-glance signal; the arithmetic is not. Neither column is in the sample, incidentally: its
+    177 cells mention no score, previous, change, rubric, evidence or notes at all. That width went to
+    **Evidence and Notes**, which hold what a stakeholder actually reads out in a forecast call, and
+    which were the narrowest columns on the sheet. Movement survives where it earns its place: one
+    Previous Total and one Change on the scorecard, the Change coloured by its sign, and the total now
+    computed by the engine since the column it used to sum is gone.
+  - Two intermittent failures in the Excel acceptance test, both root-caused rather than retried away.
+    A write can be silently discarded while Excel is still busy with the workbook, and a dependent
+    formula is not calculated by the time the next question arrives — so writes are confirmed and
+    dependent reads are polled, with a distinct message for each so the next failure names the right
+    thing. The error-value detector reports the offending cell's address now, not just its sheet.
 
 - **`meddpicc`** v5.0.0 — **the workbook is one laid-out deal-review sheet.** Breaking: the shape
   changed, so a workbook generated before this is refused on read-back. They are ephemeral —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v6.0.0 — the sheet reads as designed rather than as whatever fitted. Breaking again,
+  for the same reason as v5: addresses moved, so a workbook generated before this is refused on
+  read-back. Regenerate.
+
+  Opened side by side with the manual sheet, the palette and the grid matched — and the coloured
+  labels staircased down the page. They were starting at **nine different columns** (B, F, G, H, I, J,
+  L, M, N), because each row had been cut to fit its own content. Every row was individually sensible;
+  together they looked like a mistake.
+
+  - **Four slots, at B, F, J and N.** Every label starts on one and is exactly two columns wide; a
+    value fills the rest of its slot, or runs on through the slots after it when they carry no label.
+    So a row of four short pairs lines up with a row of two wide ones. `check-spec` enforces it, which
+    is the part that keeps it true — the alignment is now a rule, not a tidy-up.
+  - **The Qualification rows were three times taller than they needed to be.** Measured rather than
+    guessed: Notes held up to 543 characters in the *narrowest* column on the sheet, 27.8 characters
+    wide, wrapping to twenty lines. Widest content now gets the widest column, and the tallest row went
+    from 366pt to 141pt — all eight elements fit on a screen where two and a half did.
+  - **The per-element definition column is gone.** It was the same eight paragraphs in every workbook,
+    taking three columns from a rep's own evidence. `engine hint <element>` still returns them, and the
+    follow-up issue proposes putting them back as hover notes, which cost no height at all.
+  - **Score, Previous and Change now read as one trio** — all three centred, where Change alone had
+    been left-aligned, and the delta is coloured by its sign. Up is good, down is not, and nought stays
+    uncoloured: an amber "nothing moved" looks like a warning in a column somebody scans for problems.
+
 - **`meddpicc`** v5.0.0 — **the workbook is one laid-out deal-review sheet.** Breaking: the shape
   changed, so a workbook generated before this is refused on read-back. They are ephemeral —
   regenerate.

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -310,12 +310,17 @@ describe('planWorkbook — formula references resolve to addresses', () => {
   });
 
   test('{{this:…}} resolves to the same row of the same table', () => {
-    // The elements table's `change` column is score - previousScore, per row.
+    // The elements table's `change` column used to be the case for this — score minus previousScore,
+    // per row. Both columns are gone from the display: a reader comparing two adjacent single digits
+    // does not need a third column to do it for them, and the width went to their own evidence and
+    // notes instead. So this is asserted on the rubric, which still resolves `{{this:score}}` to its
+    // own row's score cell — the property that matters, whichever column exercises it.
     const elements = table('elements');
     for (const offset of [0, elements.rows - 1]) {
-      expect(cellAt(elements.ref('change', offset))?.formula).toBe(
-        `${elements.ref('score', offset)}-${elements.ref('previousScore', offset)}`,
-      );
+      expect(cellAt(elements.ref('rubric', offset))?.formula).toContain(elements.ref('score', offset));
+      // …and NOT another row's score, which is the mistake `{{this:…}}` exists to prevent.
+      const otherRow = offset === 0 ? 1 : 0;
+      expect(cellAt(elements.ref('rubric', offset))?.formula).not.toContain(elements.ref('score', otherRow));
     }
   });
 });
@@ -640,6 +645,61 @@ describe('the rubric follows the score in Excel, not just at generation time', (
     const width = spanWidthOf(t.column('rubric'), 'rubric');
     const height = theSheet().rows.find((r) => r.row === t.firstDataRow + row)?.height ?? 0;
     expect(height).toBeGreaterThanOrEqual(estimateRowHeight(longest, width, 24));
+  });
+});
+
+describe('the elements table shows the score and nothing the reader could work out', () => {
+  // Previous and Change were both on display: eight previous scores and eight deltas, taking two
+  // columns across the table so that a reader could see 3 beside 1 and be told the difference is 2.
+  // The score itself, colour-coded, is the at-a-glance signal; the arithmetic is not. Those two columns
+  // went to Evidence and Notes, which hold a rep's own words and were the narrowest on the sheet.
+  test('no per-element previous score or delta column', () => {
+    const columns = Object.keys(table('elements').columns);
+    expect(columns).not.toContain('previousScore');
+    expect(columns).not.toContain('change');
+    expect(columns).toEqual(['element', 'score', 'rubric', 'evidence', 'notes']);
+  });
+
+  test('the score column is still colour-coded, which is the part worth keeping', () => {
+    const declared = spec.sheets.flatMap(specTables).find((t) => t.id === 'elements');
+    expect(declared?.columns.find((c) => c.id === 'score')?.conditionalFormat).toBe('score');
+  });
+
+  test('movement survives as one summary cell, and agrees with the deal', () => {
+    // The previous total used to be a SUM over the column that is now gone, so the generator works it
+    // out. Compared against the deal by a different route: summing the scores the engine recorded.
+    const previous = deal.scoring.previousElementScores as Record<string, number>;
+    const expected = QUALIFICATION_ELEMENTS.reduce((n, el) => n + (previous[el] ?? 0), 0);
+    expect(expected).toBeGreaterThan(0);
+    expect(cellAt(plan.namedCells.scorePreviousTotal.split('!')[1] ?? '')?.value).toBe(expected);
+  });
+
+  test('a stray key in the previous scores cannot inflate the total', () => {
+    // Summed over the elements MEDDPICC scores, not over whatever keys the object happens to carry. A
+    // retired element left behind by an older engine, or a typo, would otherwise be added to a total
+    // the sheet presents as the last review's — and it is compared against the current score, so an
+    // inflated one reads as a regression that never happened.
+    const withStray = clone(deal);
+    withStray.scoring.previousElementScores.retiredElement = 4;
+    const p = planWorkbook(schema, spec, withStray);
+    expect(cellOf(p, p.namedCells.scorePreviousTotal.split('!')[1] ?? '')?.value).toBe(
+      cellAt(plan.namedCells.scorePreviousTotal.split('!')[1] ?? '')?.value,
+    );
+  });
+
+  test('a deal with no previous scores leaves the cell empty rather than claiming zero', () => {
+    // Nought is a real total — every element unscored last time. "We have never scored this" is not,
+    // and a 0 there would read as a regression from nothing.
+    const fresh = clone(deal);
+    delete fresh.scoring.previousElementScores;
+    const p = planWorkbook(schema, spec, fresh);
+    expect(cellOf(p, p.namedCells.scorePreviousTotal.split('!')[1] ?? '')?.value).toBeUndefined();
+  });
+
+  test('the change cell is coloured by its sign', () => {
+    const sheet = theSheet();
+    const ref = plan.namedCells.scoreChange.split('!')[1] ?? '';
+    expect(sheet.conditionalFormats?.some((f) => f.sqref === ref && f.preset === 'delta')).toBe(true);
   });
 });
 

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -186,12 +186,16 @@ describe('planWorkbook — values by type', () => {
 });
 
 describe('planWorkbook — derived cells come from the schema, not from prose', () => {
-  test('each element row carries the definition the schema declares', () => {
+  test('the element column carries the name, and no column repeats static reference text', () => {
+    // The per-element definition used to sit here. It is the same eight paragraphs in every workbook,
+    // and it was taking three columns from Evidence and Notes — where a rep's own words, measured at
+    // up to 543 characters, were being squeezed into the narrowest column on the sheet and wrapping to
+    // twenty lines. `engine hint <element>` still returns the definitions; see the follow-up issue for
+    // putting them back as hover notes, which cost no height at all.
     const elements = table('elements');
+    expect(Object.keys(elements.columns)).not.toContain('definition');
     const row = QUALIFICATION_ELEMENTS.indexOf('metrics');
-    const definition = cellAt(elements.ref('definition', row))?.value;
-    expect(typeof definition).toBe('string');
-    expect(definition).toContain('Quantified business outcomes');
+    expect(cellAt(elements.ref('element', row))?.value).toBe(sectionLabel('metrics'));
   });
 
   test('the rubric cell selects the wording for that element at its own score', () => {

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -423,7 +423,7 @@ function layout(
         let column = contentStart;
         for (const cell of block.cells) {
           columns.push(column);
-          if (cell.kind === 'field' || cell.kind === 'computed') {
+          if (cell.kind === 'field' || cell.kind === 'computed' || cell.kind === 'derived') {
             named.set(cell.id, { sheet: s.name, address: A1(column, row) });
           }
           column += cell.span;
@@ -731,6 +731,12 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
           }
 
           const style = VALUE_TYPE_STYLE[cell.valueType];
+          if (cell.kind === 'derived') {
+            const value = derivedRowValue(cell.id, deal);
+            push(row, { ref, value, style });
+            if (cell.conditionalFormat) formats.push({ sqref: ref, preset: cell.conditionalFormat });
+            return;
+          }
           if (cell.kind === 'field') {
             const value = displayValue(
               schema,
@@ -945,6 +951,28 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
       columns: Object.fromEntries(info.columns),
     })),
   };
+}
+
+/**
+ * A named row cell the generator works out, where the sheet has nothing to work it out from.
+ *
+ * Deliberately a closed set with a throw on anything else: a silent `undefined` here would render as an
+ * empty cell, which reads as "not filled in yet" rather than "the spec names something that does not
+ * exist".
+ */
+function derivedRowValue(id: string, deal: unknown): number | undefined {
+  if (id === 'scorePreviousTotal') {
+    const previous = readPath(deal, 'scoring.previousElementScores');
+    if (previous === undefined || previous === null) return undefined;
+    if (typeof previous !== 'object') return undefined;
+    // Summed over the elements MEDDPICC actually scores, not over whatever keys the object carries, so
+    // a stray key cannot inflate the total the sheet compares against.
+    return QUALIFICATION_ELEMENTS.reduce((total, element) => {
+      const score = (previous as Record<string, unknown>)[element];
+      return total + (typeof score === 'number' && Number.isFinite(score) ? score : 0);
+    }, 0);
+  }
+  throw new Error(`no derived value for row cell "${id}"`);
 }
 
 /** The concrete deal path an input column writes for one row. */

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -573,7 +573,6 @@ function derivedValue(
     const element = entry.key as string;
     const hint = computeElementHint(schema, element);
     if (column.id === 'element') return sectionLabel(element);
-    if (column.id === 'definition') return hint.definition;
     if (column.id === 'rubric') {
       const score = readPath(deal, `qualification.${element}.score`);
       return hint.scoreDefinition[String(typeof score === 'number' ? score : 0)] ?? '';

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -5,6 +5,7 @@ import { BOOLEAN_NO, BOOLEAN_YES, dateToSerial, generateWorkbook, planWorkbook }
 import { readPath } from './json-path';
 import { enumLabel } from './labels';
 import { readWorkbook, readWorkbookCells, readWorkbookProperty, serialToDate } from './read-workbook';
+import { sectionLabel } from './sections';
 import { validateDeal } from './validate';
 import { specTables, type WorkbookSpec } from './workbook-spec';
 import { buildWorkbook, columnLetter } from './xlsx';
@@ -302,12 +303,12 @@ describe('cells that are not inputs are never read', () => {
     expect(read(exampleDeal, edited).proposals).toEqual([]);
   });
 
-  test('a derived cell — an element definition — proposes nothing, and says so', () => {
+  test('a derived cell — an element name — proposes nothing, and says so', () => {
     // It proposes nothing because the workbook is REFUSED: a derived cell is an anchor, so text that
     // is not the text the generator wrote means either the rows moved or somebody typed over it.
     // Asserting only "no proposals" would go on passing if the cell were quietly ignored instead.
     const cells = readWorkbookCells(generateWorkbook(schema, spec, exampleDeal));
-    const derived = [...(cells.get(SHEET)?.entries() ?? [])].find(([, c]) => c.text?.startsWith('Quantified'))?.[0];
+    const derived = [...(cells.get(SHEET)?.entries() ?? [])].find(([, c]) => c.text === sectionLabel('metrics'))?.[0];
     expect(derived).toBeDefined();
     const edited = setText(generateWorkbook(schema, spec, exampleDeal), SHEET, derived as string, 'nonsense');
     const report = read(exampleDeal, edited);
@@ -927,7 +928,7 @@ describe('a workbook whose rows have moved is refused, not read', () => {
     // the deal. Passing over it without a word would be this plugin's oldest bug in a new place.
     const t = planWorkbook(schema, spec, exampleDeal).tables.find((x) => x.id === 'elements');
     if (!t) throw new Error('no elements table');
-    const definition = `${columnLetter(t.columns.definition)}${t.firstDataRow}`;
+    const definition = `${columnLetter(t.columns.element)}${t.firstDataRow}`;
     const report = read(
       exampleDeal,
       setText(generateWorkbook(schema, spec, exampleDeal), SHEET, definition, 'My own words'),

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -98,7 +98,7 @@
             },
             {
               "kind": "field",
-              "span": 3,
+              "span": 2,
               "id": "dealStatus",
               "jsonPath": "metadata.dealStatus",
               "valueType": "string",
@@ -111,7 +111,7 @@
             },
             {
               "kind": "field",
-              "span": 3,
+              "span": 2,
               "id": "forecastStage",
               "jsonPath": "metadata.forecastStage",
               "valueType": "string",
@@ -124,10 +124,22 @@
             },
             {
               "kind": "field",
-              "span": 4,
+              "span": 2,
               "id": "closeDate",
               "jsonPath": "metadata.closeDate",
               "valueType": "date"
+            },
+            {
+              "kind": "label",
+              "span": 2,
+              "text": "Win Probability"
+            },
+            {
+              "kind": "field",
+              "span": 2,
+              "id": "winProbability",
+              "jsonPath": "metadata.winProbability",
+              "valueType": "percent"
             }
           ]
         },
@@ -136,24 +148,12 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
-              "text": "Win Probability (%)"
-            },
-            {
-              "kind": "field",
-              "span": 2,
-              "id": "winProbability",
-              "jsonPath": "metadata.winProbability",
-              "valueType": "percent"
-            },
-            {
-              "kind": "label",
               "span": 2,
               "text": "Reviewer"
             },
             {
               "kind": "field",
-              "span": 4,
+              "span": 6,
               "id": "reviewer",
               "jsonPath": "metadata.reviewer",
               "valueType": "string"
@@ -165,7 +165,7 @@
             },
             {
               "kind": "field",
-              "span": 3,
+              "span": 6,
               "id": "reviewDate",
               "jsonPath": "metadata.reviewDate",
               "valueType": "date"
@@ -254,7 +254,7 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Total Booked Value"
             },
             {
@@ -266,7 +266,7 @@
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Factored Pipeline"
             },
             {
@@ -278,15 +278,19 @@
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Days To Close"
             },
             {
               "kind": "computed",
-              "span": 3,
+              "span": 2,
               "id": "daysToClose",
               "formula": "IF({{ref:closeDate}}=\"\",\"\",{{ref:closeDate}}-TODAY())",
               "valueType": "number"
+            },
+            {
+              "kind": "blank",
+              "span": 4
             }
           ]
         },
@@ -302,8 +306,8 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
-              "text": "Last Client Interaction"
+              "span": 2,
+              "text": "Last Interaction"
             },
             {
               "kind": "field",
@@ -314,8 +318,8 @@
             },
             {
               "kind": "label",
-              "span": 3,
-              "text": "Next Client Interaction"
+              "span": 2,
+              "text": "Next Interaction"
             },
             {
               "kind": "field",
@@ -326,7 +330,7 @@
             },
             {
               "kind": "label",
-              "span": 4,
+              "span": 2,
               "text": "Days Since Last"
             },
             {
@@ -335,6 +339,10 @@
               "id": "daysSinceLastInteraction",
               "formula": "IF({{ref:lastInteractionDate}}=\"\",\"\",TODAY()-{{ref:lastInteractionDate}})",
               "valueType": "number"
+            },
+            {
+              "kind": "blank",
+              "span": 4
             }
           ]
         },
@@ -343,12 +351,12 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Outcome"
             },
             {
               "kind": "field",
-              "span": 13,
+              "span": 14,
               "id": "lastInteractionOutcome",
               "jsonPath": "metadata.lastClientInteraction.outcome",
               "valueType": "text"
@@ -360,12 +368,12 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Objective"
             },
             {
               "kind": "field",
-              "span": 13,
+              "span": 14,
               "id": "nextInteractionObjective",
               "jsonPath": "metadata.nextClientInteraction.objective",
               "valueType": "text"
@@ -398,13 +406,6 @@
                 "heading": true
               },
               {
-                "id": "definition",
-                "header": "What This Element Means",
-                "role": "derived",
-                "valueType": "text",
-                "span": 3
-              },
-              {
                 "id": "score",
                 "header": "Score",
                 "role": "input",
@@ -429,8 +430,9 @@
                 "header": "Change",
                 "role": "computed",
                 "formula": "{{this:score}}-{{this:previousScore}}",
-                "valueType": "number",
-                "span": 1
+                "valueType": "score",
+                "span": 1,
+                "conditionalFormat": "delta"
               },
               {
                 "id": "rubric",
@@ -454,7 +456,7 @@
                 "role": "input",
                 "jsonPath": "qualification.*.notes",
                 "valueType": "text",
-                "span": 2
+                "span": 5
               }
             ]
           }
@@ -990,12 +992,12 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Total Score"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "scoreTotal",
               "formula": "SUM({{col:elements.score}})",
               "valueType": "number"
@@ -1007,7 +1009,7 @@
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "scoreMaximum",
               "formula": "COUNTA({{col:elements.element}})*4",
               "valueType": "number"
@@ -1031,7 +1033,7 @@
             },
             {
               "kind": "computed",
-              "span": 3,
+              "span": 2,
               "id": "scoreRating",
               "formula": "IF({{ref:scoreTotal}}>=26,\"Green\",IF({{ref:scoreTotal}}>=14,\"Yellow\",\"Red\"))",
               "valueType": "rating",
@@ -1044,12 +1046,12 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Previous Total"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "scorePreviousTotal",
               "formula": "SUM({{col:elements.previousScore}})",
               "valueType": "number"
@@ -1061,26 +1063,26 @@
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "scoreChange",
               "formula": "{{ref:scoreTotal}}-{{ref:scorePreviousTotal}}",
               "valueType": "number"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Elements At Zero"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "elementsAtZero",
               "formula": "COUNTIF({{col:elements.score}},0)",
               "valueType": "number"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Below Three"
             },
             {
@@ -1097,36 +1099,36 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Weakest Element"
             },
             {
               "kind": "computed",
-              "span": 5,
+              "span": 6,
               "id": "lowestElement",
               "formula": "INDEX({{col:elements.element}},MATCH(MIN({{col:elements.score}}),{{col:elements.score}},0))",
               "valueType": "string"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Economic Buyer"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "economicBuyerScore",
               "formula": "{{row:elements.score@economicBuyer}}",
               "valueType": "score"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Champion"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "championScore",
               "formula": "{{row:elements.score@champion}}",
               "valueType": "score"
@@ -1138,12 +1140,12 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Sections Complete"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "sectionsComplete",
               "formula": "COUNTIF({{col:sections.status}},{{word:statusComplete}})",
               "valueType": "number"
@@ -1151,18 +1153,18 @@
             {
               "kind": "label",
               "span": 2,
-              "text": "Tracked"
+              "text": "Sections Tracked"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "sectionsTracked",
               "formula": "COUNTA({{col:sections.section}})",
               "valueType": "number"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Completion"
             },
             {
@@ -1172,6 +1174,15 @@
               "formula": "IF({{ref:sectionsTracked}}=0,0,{{ref:sectionsComplete}}/{{ref:sectionsTracked}})",
               "valueType": "percent"
             },
+            {
+              "kind": "blank",
+              "span": 4
+            }
+          ]
+        },
+        {
+          "kind": "row",
+          "cells": [
             {
               "kind": "label",
               "span": 2,
@@ -1183,58 +1194,41 @@
               "id": "questionsAsked",
               "formula": "COUNTA({{col:responses.question}})",
               "valueType": "number"
-            }
-          ]
-        },
-        {
-          "kind": "row",
-          "cells": [
+            },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Questions Answered"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "questionsAnswered",
               "formula": "COUNTA({{col:responses.response}})",
               "valueType": "number"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Stakeholders"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "stakeholdersMapped",
               "formula": "COUNTA({{col:stakeholders.name}})",
               "valueType": "number"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Must Say Yes"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "mustSayYesCount",
               "formula": "COUNTIF({{col:stakeholders.mustSayYes}},{{word:booleanYes}})",
-              "valueType": "number"
-            },
-            {
-              "kind": "label",
-              "span": 3,
-              "text": "Can Say No"
-            },
-            {
-              "kind": "computed",
-              "span": 1,
-              "id": "canSayNoCount",
-              "formula": "COUNTIF({{col:stakeholders.canSayNo}},{{word:booleanYes}})",
               "valueType": "number"
             }
           ]
@@ -1244,50 +1238,95 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
+              "text": "Can Say No"
+            },
+            {
+              "kind": "computed",
+              "span": 2,
+              "id": "canSayNoCount",
+              "formula": "COUNTIF({{col:stakeholders.canSayNo}},{{word:booleanYes}})",
+              "valueType": "number"
+            },
+            {
+              "kind": "label",
+              "span": 2,
               "text": "Sentiment Unknown"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "sentimentUnknown",
               "formula": "COUNTIF({{col:stakeholders.sentiment}},\"Unknown\")",
               "valueType": "number"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Sentiment Negative"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "sentimentNegative",
               "formula": "COUNTIF({{col:stakeholders.sentiment}},\"Negative\")",
               "valueType": "number"
             },
             {
+              "kind": "blank",
+              "span": 4
+            }
+          ]
+        },
+        {
+          "kind": "row",
+          "cells": [
+            {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Milestones"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "milestonesTotal",
               "formula": "COUNTA({{col:milestones.description}})",
               "valueType": "number"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Milestones Complete"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "milestonesComplete",
               "formula": "COUNTIF({{col:milestones.status}},{{word:statusComplete}})",
+              "valueType": "number"
+            },
+            {
+              "kind": "label",
+              "span": 2,
+              "text": "Actions Open"
+            },
+            {
+              "kind": "computed",
+              "span": 2,
+              "id": "actionsOpen",
+              "formula": "COUNTA({{col:actions.action}})-COUNTIF({{col:actions.status}},{{word:statusComplete}})",
+              "valueType": "number"
+            },
+            {
+              "kind": "label",
+              "span": 2,
+              "text": "Actions Overdue"
+            },
+            {
+              "kind": "computed",
+              "span": 2,
+              "id": "actionsOverdue",
+              "formula": "SUMPRODUCT(({{col:actions.dueDate}}<>\"\")*({{col:actions.dueDate}}<TODAY())*({{col:actions.status}}<>{{word:statusComplete}}))",
               "valueType": "number"
             }
           ]
@@ -1297,36 +1336,12 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
-              "text": "Actions Open"
-            },
-            {
-              "kind": "computed",
-              "span": 1,
-              "id": "actionsOpen",
-              "formula": "COUNTA({{col:actions.action}})-COUNTIF({{col:actions.status}},{{word:statusComplete}})",
-              "valueType": "number"
-            },
-            {
-              "kind": "label",
-              "span": 3,
-              "text": "Actions Overdue"
-            },
-            {
-              "kind": "computed",
-              "span": 1,
-              "id": "actionsOverdue",
-              "formula": "SUMPRODUCT(({{col:actions.dueDate}}<>\"\")*({{col:actions.dueDate}}<TODAY())*({{col:actions.status}}<>{{word:statusComplete}}))",
-              "valueType": "number"
-            },
-            {
-              "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Internal Team"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "teamInternalCount",
               "formula": "COUNTA({{col:teamInternal.name}})",
               "valueType": "number"
@@ -1334,39 +1349,30 @@
             {
               "kind": "label",
               "span": 2,
-              "text": "Assigned"
+              "text": "Team Assigned"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "teamInternalAssigned",
               "formula": "COUNTIF({{col:teamInternal.assignedToDeal}},{{word:booleanYes}})",
               "valueType": "number"
             },
             {
-              "kind": "blank",
-              "span": 1
-            }
-          ]
-        },
-        {
-          "kind": "row",
-          "cells": [
-            {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Partner Team"
             },
             {
               "kind": "computed",
-              "span": 1,
+              "span": 2,
               "id": "teamPartnerCount",
               "formula": "COUNTA({{col:teamPartner.name}})",
               "valueType": "number"
             },
             {
               "kind": "blank",
-              "span": 12
+              "span": 4
             }
           ]
         },
@@ -1419,12 +1425,12 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Opportunity ID"
             },
             {
               "kind": "field",
-              "span": 3,
+              "span": 2,
               "id": "salesforceOpportunityId",
               "jsonPath": "metadata.salesforce.opportunityId",
               "valueType": "string"
@@ -1436,7 +1442,7 @@
             },
             {
               "kind": "field",
-              "span": 3,
+              "span": 2,
               "id": "salesforceAccountId",
               "jsonPath": "metadata.salesforce.accountId",
               "valueType": "string"
@@ -1448,10 +1454,14 @@
             },
             {
               "kind": "field",
-              "span": 3,
+              "span": 2,
               "id": "salesforceOwnerId",
               "jsonPath": "metadata.salesforce.ownerId",
               "valueType": "string"
+            },
+            {
+              "kind": "blank",
+              "span": 4
             }
           ]
         },
@@ -1460,19 +1470,19 @@
           "cells": [
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Stage Name"
             },
             {
               "kind": "field",
-              "span": 4,
+              "span": 6,
               "id": "salesforceStageName",
               "jsonPath": "metadata.salesforce.stageName",
               "valueType": "string"
             },
             {
               "kind": "label",
-              "span": 3,
+              "span": 2,
               "text": "Last Sync"
             },
             {

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -416,25 +416,6 @@
                 "span": 1
               },
               {
-                "id": "previousScore",
-                "header": "Previous",
-                "role": "input",
-                "jsonPath": "scoring.previousElementScores.*",
-                "valueType": "score",
-                "conditionalFormat": "score",
-                "validate": true,
-                "span": 1
-              },
-              {
-                "id": "change",
-                "header": "Change",
-                "role": "computed",
-                "formula": "{{this:score}}-{{this:previousScore}}",
-                "valueType": "score",
-                "span": 1,
-                "conditionalFormat": "delta"
-              },
-              {
                 "id": "rubric",
                 "header": "What This Score Means",
                 "role": "derived",
@@ -448,7 +429,7 @@
                 "role": "input",
                 "jsonPath": "qualification.*.evidence",
                 "valueType": "text",
-                "span": 3
+                "span": 4
               },
               {
                 "id": "notes",
@@ -456,7 +437,7 @@
                 "role": "input",
                 "jsonPath": "qualification.*.notes",
                 "valueType": "text",
-                "span": 5
+                "span": 6
               }
             ]
           }
@@ -1050,10 +1031,9 @@
               "text": "Previous Total"
             },
             {
-              "kind": "computed",
+              "kind": "derived",
               "span": 2,
               "id": "scorePreviousTotal",
-              "formula": "SUM({{col:elements.previousScore}})",
               "valueType": "number"
             },
             {
@@ -1066,7 +1046,8 @@
               "span": 2,
               "id": "scoreChange",
               "formula": "{{ref:scoreTotal}}-{{ref:scorePreviousTotal}}",
-              "valueType": "number"
+              "valueType": "number",
+              "conditionalFormat": "delta"
             },
             {
               "kind": "label",

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -52,6 +52,9 @@ export const VALUE_TYPE_STYLE: Record<ValueType, StyleName> = {
   percent: 'percent',
   date: 'date',
   boolean: 'default',
+  // Bold and centred. Also carries the score DELTA in the elements table: it is the same visual class
+  // as the two columns beside it, and a matched trio of numbers reading left, centre, centre is the
+  // kind of small wrongness the eye notices before the mind does.
   score: 'score',
   rating: 'default',
 };
@@ -547,6 +550,16 @@ function checkReferences(collected: Collected): { checked: number; failures: str
   return { checked, failures };
 }
 
+/**
+ * The grid label cells sit on: a slot every four content columns, each label two columns of it.
+ *
+ * Four slots across a sixteen-column sheet. A value fills the rest of its slot, or runs on through the
+ * slots after it when they carry no label of their own — so two wide pairs put their labels in the same
+ * bands as slots one and three of a four-across row.
+ */
+const LABEL_SLOT_WIDTH = 4;
+const LABEL_SPAN = 2;
+
 function checkLayout(spec: WorkbookSpec): string[] {
   const failures: string[] = [];
   const seen = new Set<string>();
@@ -577,6 +590,38 @@ function checkLayout(spec: WorkbookSpec): string[] {
             failures.push(`tables "${spans[i].id}" and "${spans[j].id}" share rows and columns on "${sheet.name}"`);
           }
         }
+      }
+    }
+
+    // Every label starts on a slot boundary, and is exactly two columns wide.
+    //
+    // Without this the labels drifted to nine different columns — B, F, G, H, I, J, L, M, N — and the
+    // coloured blocks staircased down the sheet. Each row was individually sensible; together they
+    // looked like a mistake. Four bands is what makes a dense grid read as designed rather than as
+    // whatever fitted, and a row of four short pairs lines up with a row of two wide ones because both
+    // put their labels on the same slots.
+    const contentStart = (sheet.columns[0]?.max ?? 1) + 1;
+    for (const [index, block] of sheet.blocks.entries()) {
+      if (block.kind !== 'row') continue;
+      let column = contentStart;
+      for (const cell of block.cells) {
+        if (cell.kind === 'label') {
+          const offset = column - contentStart;
+          if (offset % LABEL_SLOT_WIDTH !== 0) {
+            failures.push(
+              `"${sheet.name}" block ${index}: label "${cell.text}" starts ${offset} columns into the ` +
+                `content, which is not a multiple of ${LABEL_SLOT_WIDTH} — it would not line up with the ` +
+                'labels above and below it',
+            );
+          }
+          if (cell.span !== LABEL_SPAN) {
+            failures.push(
+              `"${sheet.name}" block ${index}: label "${cell.text}" spans ${cell.span}, not ${LABEL_SPAN} — ` +
+                'a wider label pushes its value off the slot grid',
+            );
+          }
+        }
+        column += cell.span;
       }
     }
   }

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -175,6 +175,23 @@ export type SpecRowCell =
       formula: string;
       valueType: ValueType;
       conditionalFormat?: CfPreset;
+    }
+  /**
+   * A value the generator works out, where the sheet has nothing to work it out from.
+   *
+   * The previous review's total is the case this exists for. Its eight per-element scores used to sit
+   * in the elements table where a formula could sum them, and they were noise: a reader comparing this
+   * review to the last one wants one number, not eight, and can see the current score right beside it.
+   * So the column went and the total is computed from the deal instead.
+   *
+   * Like a derived table column, it is not a formula and is never read back — the engine recomputes it.
+   */
+  | {
+      kind: 'derived';
+      span: number;
+      id: string;
+      valueType: ValueType;
+      conditionalFormat?: CfPreset;
     };
 
 export type SpecBlock =
@@ -395,7 +412,7 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
     for (const block of sheet.blocks) {
       if (block.kind !== 'row') continue;
       for (const cell of block.cells) {
-        if (cell.kind !== 'field' && cell.kind !== 'computed') continue;
+        if (cell.kind !== 'field' && cell.kind !== 'computed' && cell.kind !== 'derived') continue;
         const where = `${sheet.name}.${cell.id}`;
         if (out.namedCells.has(cell.id)) {
           ids.push(`duplicate cell id "${cell.id}" (${out.namedCells.get(cell.id)?.sheet} and ${sheet.name})`);
@@ -412,9 +429,11 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
             out.inputs.push({ where, paths: [cell.jsonPath] });
             if (cell.validate) out.validated.push({ where, path: cell.jsonPath, valueType: cell.valueType });
           }
-        } else {
+        } else if (cell.kind === 'computed') {
           out.formulas.push({ where, formula: cell.formula, table: null });
         }
+        // A `derived` cell holds no formula and no path: the generator works it out, and `generate`
+        // throws on an id it does not know. Named all the same, so a formula may point at it.
       }
     }
 

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -249,6 +249,42 @@ describe('buildWorkbook — conditional formatting and validation', () => {
   });
 });
 
+describe('the delta preset colours movement, not stillness', () => {
+  // A change since the last review reads at a glance: up is good, down is not. Nought is neither, so
+  // it stays uncoloured — an amber "nothing moved" would look like a warning in a column somebody
+  // scans for problems.
+  const sheet = () => {
+    const parts = readZip(
+      buildWorkbook([
+        {
+          name: 'Data',
+          rows: [
+            { row: 1, cells: [{ ref: 'A1', value: 2, style: 'score' }] },
+            { row: 2, cells: [{ ref: 'A2', value: 0, style: 'score' }] },
+          ],
+          conditionalFormats: [{ sqref: 'A1:A2', preset: 'delta' }],
+        },
+      ]),
+    );
+    return dec(parts.get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+  };
+
+  test('two rules, one each way, and nothing for zero', () => {
+    const xml = sheet();
+    const rules = [...xml.matchAll(/<cfRule[^>]*operator="([a-zA-Z]+)"[^>]*>\s*<formula>([^<]*)<\/formula>/g)].map(
+      (m) => `${m[1]} ${m[2]}`,
+    );
+    expect(rules).toEqual(['greaterThan 0', 'lessThan 0']);
+  });
+
+  test('the two rules use different colours, or the sign is not readable', () => {
+    const xml = sheet();
+    const ids = [...xml.matchAll(/<cfRule[^>]*dxfId="(\d+)"/g)].map((m) => m[1]);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+});
+
 describe('buildWorkbook — merges', () => {
   const merged = (merges: string[], extra: Parameters<typeof buildWorkbook>[0][number]['rows'] = []) =>
     dec(

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -215,7 +215,7 @@ export const DXF_IDS: Record<DxfName, number> = Object.fromEntries(DXF_ORDER.map
  * `%FIRST%` is replaced with the first cell of the range, which is how an expression rule
  * refers to "this cell" — Excel evaluates it relatively across the range.
  */
-export type CfPreset = 'score' | 'ragText' | 'statusText' | 'completionText' | 'overdueDate';
+export type CfPreset = 'score' | 'delta' | 'ragText' | 'statusText' | 'completionText' | 'overdueDate';
 
 /**
  * The section statuses `computeCompletion` emits.
@@ -260,6 +260,13 @@ const CF_PRESETS: Record<CfPreset, CfRule[]> = {
     { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('complete')}"`], dxf: 'green' },
     { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('in_progress')}"`], dxf: 'amber' },
     { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('pending')}"`], dxf: 'red' },
+  ],
+  // A change since the last review: up is good, down is not, and nought is neither. Deliberately no
+  // amber — a delta of zero is not a warning, and colouring it would make "nothing moved" look like a
+  // problem in a column read at a glance.
+  delta: [
+    { type: 'cellIs', operator: 'greaterThan', formulas: ['0'], dxf: 'green' },
+    { type: 'cellIs', operator: 'lessThan', formulas: ['0'], dxf: 'red' },
   ],
   // Past its date and not blank. A blank cell is "no date set", not "overdue since 1900".
   overdueDate: [{ type: 'expression', formulas: ['AND(%FIRST%<>"",%FIRST%<TODAY())'], dxf: 'red' }],

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -224,23 +224,38 @@ echo "PASS: every scorecard count Excel computes agrees with the deal JSON"
 # So the detector now proves itself on every run instead of being trusted: clean, then with a
 # deliberate =1/0, then clean again. An assertion nobody has watched fail is not an assertion.
 error_values() {
-  osascript <<OSA 2>&1
-tell application "Microsoft Excel"
-  set errs to ""
-  set n to count of worksheets of workbook "$BOOK"
-  repeat with i from 1 to n
-    set ws to worksheet i of workbook "$BOOK"
-    set vals to (get string value of (get used range of ws))
-    repeat with rw in vals
-      repeat with v in rw
-        if (v as string) is in {"#REF!", "#VALUE!", "#DIV/0!", "#N/A", "#NAME?", "#NULL!", "#NUM!"} then
-          set errs to errs & (get name of ws) & ":" & (v as string) & " "
-        end if
+  # Reports the ADDRESS of every error cell, not just the sheet. "MEDDPICC Deal Review:#DIV/0!" was
+  # true and useless: it could not distinguish a formula that is wrong from the sentinel this stage
+  # plants on purpose, and I spent three runs guessing which.
+  osascript - "$BOOK" <<'OSA' 2>&1
+on run argv
+  set bookName to item 1 of argv
+  tell application "Microsoft Excel"
+    set errs to ""
+    set n to count of worksheets of workbook bookName
+    repeat with i from 1 to n
+      set ws to worksheet i of workbook bookName
+      set usedRange to (get used range of ws)
+      set vals to (get string value of usedRange)
+      set firstRow to (first row index of usedRange)
+      set firstCol to (first column index of usedRange)
+      set r to 0
+      repeat with rw in vals
+        set r to r + 1
+        set c to 0
+        repeat with v in rw
+          set c to c + 1
+          set sv to (v as string)
+          if sv is in {"#REF!", "#VALUE!", "#DIV/0!", "#N/A", "#NAME?", "#NULL!", "#NUM!"} then
+            set cellRef to (get address of cell (r + firstRow - 1) of column (c + firstCol - 1) of ws)
+            set errs to errs & (get name of ws) & "!" & cellRef & "=" & sv & " "
+          end if
+        end repeat
       end repeat
     end repeat
-  end repeat
-  return errs
-end tell
+    return errs
+  end tell
+end run
 OSA
 }
 
@@ -257,6 +272,26 @@ assert_no_error_values() {
   [ -z "${errors// /}" ] || fail "Excel error values present ($when): $errors"
 }
 
+# The same check, but waiting for a change just made to take effect.
+#
+# Excel does not finish with a write before AppleScript asks the next question. Asserting straight
+# after clearing the planted sentinel reported the #DIV/0! still present on one run in three — the code
+# was right and the assertion was early, which is the worst kind of failing test because it points at
+# the wrong thing. Only used where a mutation is known to be pending; the plain form above stays
+# immediate, so a genuine error is not hidden behind a delay.
+assert_error_values_clear() {
+  local when="$1" errors i
+  for i in $(seq 1 40); do
+    errors="$(error_values)"
+    case "$errors" in
+    *"execution error"* | *"syntax error"*) fail "the error-value check could not run ($when): $errors" ;;
+    esac
+    [ -n "${errors// /}" ] || return 0
+    sleep 0.25
+  done
+  fail "Excel error values still present after waiting ($when): $errors"
+}
+
 assert_no_error_values "before planting one"
 
 # Now break it on purpose. A detector that has never fired is indistinguishable from one that cannot.
@@ -271,7 +306,7 @@ case "$planted" in
 *) fail "the error-value detector did not notice a deliberate #DIV/0! in $SHEET!$SENTINEL_CELL: [${planted}]" ;;
 esac
 excel_do "clearing the deliberate error value" "  clear contents range \"$SENTINEL_CELL\" of worksheet \"$SHEET\" of workbook \"$BOOK\""
-assert_no_error_values "after clearing the planted one"
+assert_error_values_clear "after clearing the planted one"
 echo "    no Excel error values on any sheet (detector verified: it catches a planted #DIV/0!)"
 
 echo "PASS: Excel opened the generated workbook and its scorecard agrees with the engine"
@@ -776,32 +811,71 @@ echo "PASS: keyed references follow the key, so re-ordering the rows cannot misl
 #
 # So: change a score in Excel and ask Excel what the rubric now says. Only the application can answer
 # that, because the answer is a formula it evaluates.
+#
+# **Waits for the recalculation.** AppleScript writes and reads faster than Excel recalculates, so
+# reading straight after the write returns the value from before it — and then both readings match and
+# the stage reports "the rubric is not following the score", which is a different diagnosis from the
+# truth. This failed once and passed on the next run, which is the shape of a race and not of a bug.
+# So each write is followed by `calculate` and a bounded poll, and a timeout says so in its own words.
 rubric_cell="$(table_cell elements rubric 0)"
 rubric_score="$(table_cell elements score 0)"
-rubric_element="$(table_cell elements element 0)"
-echo "==> changing $rubric_score and reading $rubric_cell back"
+echo "==> changing $rubric_score and reading $rubric_cell back, waiting for each recalculation"
 rubric_seen="$(
-  osascript - "$SHEET" "$BOOK" "$rubric_score" "$rubric_cell" "$rubric_element" 2>&1 <<'OSA'
+  osascript - "$SHEET" "$BOOK" "$rubric_score" "$rubric_cell" 2>&1 <<'OSA'
 on run argv
+  set sheetName to item 1 of argv
+  set bookName to item 2 of argv
+  set scoreRef to item 3 of argv
+  set rubricRef to item 4 of argv
   tell application "Microsoft Excel"
-    set ws to worksheet (item 1 of argv) of workbook (item 2 of argv)
-    set scoreCell to range (item 3 of argv) of ws
-    set rubricCell to range (item 4 of argv) of ws
+    set ws to worksheet sheetName of workbook bookName
+    set scoreCell to range scoreRef of ws
+    set rubricCell to range rubricRef of ws
     set was to (get value of rubricCell) as string
     set original to (get value of scoreCell)
-    set value of scoreCell to 0
-    set atZero to (get value of rubricCell) as string
-    set value of scoreCell to 4
-    set atFour to (get value of rubricCell) as string
-    set value of scoreCell to original
-    set restored to (get value of rubricCell) as string
+    set atZero to my scoreThenRead(ws, scoreCell, rubricCell, 0, was)
+    set atFour to my scoreThenRead(ws, scoreCell, rubricCell, 4, atZero)
+    set restored to my scoreThenRead(ws, scoreCell, rubricCell, original, atFour)
     return was & "|" & atZero & "|" & atFour & "|" & restored
   end tell
 end run
+
+-- Write the score, confirm the write TOOK, then wait for the rubric to follow it.
+--
+-- Both halves are needed and they fail differently. Excel accepts a workbook before it has finished
+-- with it, so an early write is discarded with no error — the symptom is a later assertion reporting a
+-- value that was never written, which is how this stage once claimed the rubric was not following the
+-- score when the score had never changed. And a write that does take is not calculated by the time the
+-- next question arrives. So: retry the write until the cell holds it, then poll for the dependent cell,
+-- and say which of the two gave up.
+--
+-- `before` cannot be a parameter name here: AppleScript reserves it for positional references, and the
+-- parse error — "Expected expression but found )" — points at the call rather than the handler.
+on scoreThenRead(ws, scoreCell, rubricCell, newScore, priorText)
+  tell application "Microsoft Excel"
+    repeat 40 times
+      set value of scoreCell to newScore
+      calculate ws
+      if (get value of scoreCell) = newScore then
+        repeat 40 times
+          calculate ws
+          set nowText to (get value of rubricCell) as string
+          if nowText is not priorText then return nowText
+          delay 0.1
+        end repeat
+        return "TIMEOUT-rubric-did-not-follow-the-score"
+      end if
+      delay 0.25
+    end repeat
+    return "TIMEOUT-score-write-never-took"
+  end tell
+end scoreThenRead
 OSA
 )"
 case "$rubric_seen" in
 *"execution error"* | *"syntax error"*) fail "the rubric check could not run: $rubric_seen" ;;
+*"TIMEOUT-score-write-never-took"*) fail "Excel discarded the score write — it was still busy: $rubric_seen" ;;
+*"TIMEOUT-rubric-did-not-follow-the-score"*) fail "the score changed and the rubric did not follow it: $rubric_seen" ;;
 esac
 rub_was="$(cut -d'|' -f1 <<<"$rubric_seen")"
 rub_zero="$(cut -d'|' -f2 <<<"$rubric_seen")"


### PR DESCRIPTION
Closes #909.

Opened side by side with the manual sheet, the palette and the grid matched — and the coloured
labels staircased down the page. Reviewed by looking at it, on the operator's own deal.

**Breaking**, for the same reason as v5: addresses moved, so a workbook generated before this is
refused on read-back. They are ephemeral.

## The labels were starting at nine different columns

B, F, G, H, I, J, L, M and N. Each row had been cut to fit its own content, so every row was
individually sensible and together they looked like a mistake — which is the first thing a reader
notices about a dense grid, before any of the content.

**Four slots, at B, F, J and N.** Every label starts on one and spans exactly two columns; a value
fills the rest of its slot, or runs on through the slots after it when they carry no label of their
own. So a row of four short pairs lines up with a row of two wide ones. `checkLayout` enforces it —
verified by shifting one label off the grid and watching `check-spec` refuse the spec — so the
alignment is a rule now, not a tidy-up.

The re-cut was scripted against the existing spec, carrying every value cell over by id, and asserts
that all 65 are placed exactly once. All tests passed unchanged afterwards, because they name cells
by table and column id rather than by position.

## The Qualification rows were three times taller than they needed to be

`generate --prose-heights` said why rather than my guessing: **Notes held up to 543 characters in the
narrowest column on the sheet** — two grid columns, 27.8 characters — wrapping to twenty lines.

The two columns that freed the width were **Previous** and **Change**: eight previous scores and
eight deltas, so that a reader could see 3 beside 1 and be told the difference is 2. Neither is in the
sample — its 177 non-empty cells mention no score, previous, change, rubric, evidence or notes at all
— and neither survives the question "what does this tell a human that they cannot see?" The score
itself, colour-coded, is the at-a-glance signal.

That width went to **Evidence and Notes**, which are what a stakeholder reads out in a forecast call
and were the two narrowest columns while carrying the longest content. The per-element definition
column went too: the same eight paragraphs in every workbook, and #910 proposes putting them back as
hover notes, which cost no height at all.

Elements is now `element 2, score 1, rubric 3, evidence 4, notes 6`. The tallest row went from 366pt
to 111pt, and all eight elements fit on a screen where two and a half did.

Movement survives where one cell earns its place: Previous Total and Change on the scorecard, the
Change coloured by its sign. The previous total used to be a `SUM` over the column that is now gone,
so a new `derived` row-cell kind lets the generator work it out from the deal. It sums over the eight
elements MEDDPICC scores rather than whatever keys the object carries, and an absent
`previousElementScores` leaves the cell empty rather than claiming nought — nought is a real total,
"never scored" is not.

## Two intermittent Excel failures, root-caused rather than retried away

These matter more than the layout: a flaky acceptance gate teaches you to ignore it.

- **A write is silently discarded while Excel is still busy with the workbook.** The symptom was "the
  rubric says the same thing at score 0 and score 4" — the code was right, the score had never
  changed, and the assertion pointed at the wrong component. Writes are confirmed now before anything
  reads a cell that depends on them.
- **A dependent formula is not calculated by the time the next question arrives**, so dependent reads
  poll with `calculate` instead of reading once.
- Each has its own timeout message, so the next failure names which half gave up. `error_values` now
  reports the offending cell's **address**, not just its sheet — the old form could not tell a wrong
  formula from the sentinel that stage plants on purpose.

## Verification

- 386 engine tests, 27 shell tests, `check-spec` clean, every lint gate clean.
- **Five consecutive Excel acceptance runs, 13 stages each, no failures** — including the row heights
  re-measured against Excel's own autofit across 75 prose cells.
- Every new guard mutation-checked. One survived its first test and the test was wrong, not the guard:
  it spoiled a cell before the pair it was testing, so an earlier clause skipped the column either way.
- Rendered on the operator's own deal and reviewed side by side with the sample at matched zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)