### PR TITLE
MEDDPICC: put the element definitions back as hover notes (v6.1.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,4 @@ packages/typescript-edit-benchmark/runs/
 # Verified-review working artifacts (findings and verification evidence).
 # No trailing slash, so a symlink of this name is matched too.
 .codex-review
+.codex-review/

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v6.1.0 — the element definitions are back, as hover notes. Not breaking: no address
+  moved, so a v6.0.0 workbook still reads back.
+
+  They were a column until v6.0.0, and removing it is what let the tallest Qualification row drop from
+  366pt to 111pt — the same eight paragraphs in every workbook, three grid columns wide, taken from a
+  rep's own evidence and notes. But they were the only thing on the sheet telling somebody what "Paper
+  Process" means. A note costs no width and no height, because it is not in the cell.
+
+  - **Every element name carries its schema definition as a note.** Asserted the way the issue asked:
+    the same spec with the note flag removed produces byte-identical row geometry, and the acceptance
+    test asks *Excel* for the text on each of the eight cells and compares it against the schema — a
+    note that does not survive the file being opened is worth nothing.
+  - **A classic note is four parts that have to agree.** The text, a legacy VML drawing to position
+    it, the worksheet's own relationships, and two content-type declarations; `legacyDrawing` goes
+    last in the `CT_Worksheet` sequence, after the print group. Excel's response to any disagreement
+    is to drop the note and open the file anyway, which is why the check is made through the
+    application rather than by reading the package.
+  - **Three guards, each for a silence.** A note on a cell a merge hides cannot be hovered at all; two
+    notes on one cell lose one of them; a note with no text is a red triangle over nothing. The spec
+    names a kind of note rather than a function, since it is JSON, and `check-spec` refuses both a
+    kind nobody implemented and element definitions asked for on a table whose rows are not elements.
+
 - **`meddpicc`** v6.0.0 — the sheet reads as designed rather than as whatever fitted. Breaking again,
   for the same reason as v5: addresses moved, so a workbook generated before this is refused on
   read-back. Regenerate.

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/README.md
+++ b/plugins/meddpicc/README.md
@@ -240,7 +240,7 @@ Creates a customer-facing document working backward from the target close date, 
 /meddpicc:qualify-deal Acme Corp render
 ```
 
-Generates an Excel workbook from the deal JSON, built from the workbook spec: one laid-out deal-review sheet with a formula-driven scorecard, RAG conditional formatting, computed row heights for prose, and schema-derived dropdowns. `read` pulls edits back out.
+Generates an Excel workbook from the deal JSON, built from the workbook spec: one laid-out deal-review sheet with a formula-driven scorecard, RAG conditional formatting, computed row heights for prose, and schema-derived dropdowns. Each element name carries what that element means as a hover note, so the sheet explains itself without spending a column on it. `read` pulls edits back out.
 
 ### Get coaching (auto-activates)
 

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -100,6 +100,19 @@ describe('cli', () => {
     const { code } = await run(['hint', 'bogus']);
     expect(code).toBe(1);
   });
+  test('generate --plan reports every hover note and where it hangs', async () => {
+    // The acceptance test has to ask Excel whether a note is really on a cell, and it cannot ask
+    // about an address it had to work out for itself — nothing on one laid-out sheet has a fixed
+    // position. So the plan says, the same way it says where each table landed.
+    const { code, out } = await run(['generate', example, '--plan']);
+    expect(code).toBe(0);
+    const plan = JSON.parse(out) as { notes: Array<{ sheet: string; address: string; text: string }> };
+    expect(plan.notes.length).toBe(8);
+    for (const note of plan.notes) {
+      expect(note.address).toMatch(/^[A-Z]+\d+$/);
+      expect(note.text.length).toBeGreaterThan(0);
+    }
+  });
   test('next embeds the current-section hint', async () => {
     const { out } = await run(['next', example]);
     const r = JSON.parse(out);

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -207,6 +207,9 @@ async function main(): Promise<number> {
         // that needs to name a cell of a table — the Excel acceptance test above all — reads it from
         // here rather than counting rows and hoping the count still holds.
         tables: plan.tables,
+        // The hover notes, for the same reason: the acceptance test asks Excel for the text on a
+        // named cell, and it must not have to work that address out for itself.
+        notes: plan.notes,
         inputCells: plan.inputCells,
       });
       return 0;

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -901,8 +901,7 @@ describe('planWorkbook — presentation', () => {
 
 describe('planWorkbook — the element definitions ride along as hover notes', () => {
   /** The note on one cell of the one sheet, by address. */
-  const noteAt = (ref: string, of: WorkbookPlan = plan) =>
-    of.notes.find((n) => n.sheet === SHEET && n.address === ref);
+  const noteAt = (ref: string, of: WorkbookPlan = plan) => of.notes.find((n) => n.sheet === SHEET && n.address === ref);
 
   test('every element name carries its schema definition as a note', () => {
     // The definitions are what a rep without MEDDPICC training needs and everyone else has read

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -898,3 +898,68 @@ describe('planWorkbook — presentation', () => {
     }
   });
 });
+
+describe('planWorkbook — the element definitions ride along as hover notes', () => {
+  /** The note on one cell of the one sheet, by address. */
+  const noteAt = (ref: string, of: WorkbookPlan = plan) =>
+    of.notes.find((n) => n.sheet === SHEET && n.address === ref);
+
+  test('every element name carries its schema definition as a note', () => {
+    // The definitions are what a rep without MEDDPICC training needs and everyone else has read
+    // eight times. As a column they cost three grid columns and twenty lines of height; as a note
+    // they cost nothing and are still one hover away.
+    const elements = table('elements');
+    for (const [row, element] of QUALIFICATION_ELEMENTS.entries()) {
+      const definition = schema.properties.qualification.properties[element].properties.definition.const as string;
+      expect(definition, `${element} has no definition in the schema`).not.toBe('');
+      expect(noteAt(elements.ref('element', row))?.text, element).toBe(definition);
+    }
+    expect(plan.notes.length).toBe(QUALIFICATION_ELEMENTS.length);
+  });
+
+  test('the note text is nowhere in a cell', () => {
+    // The whole point is that it is not on the sheet. Written into a cell as well, it would take
+    // the width and the height back — and disagree with itself the moment one copy changed.
+    const definition = schema.properties.qualification.properties.metrics.properties.definition.const as string;
+    for (const cell of allCells()) expect(cell.value).not.toBe(definition);
+    expect(plan.proseCells.map((c) => c.text)).not.toContain(definition);
+  });
+
+  test('no row is any taller for carrying a note', () => {
+    // The acceptance criterion of the issue, asserted directly: the same spec with the note flag
+    // removed must produce exactly the same geometry.
+    const bare = clone(spec);
+    for (const sheet of bare.sheets) {
+      for (const block of sheet.blocks) {
+        if (block.kind !== 'table') continue;
+        for (const column of block.table.columns) delete (column as { note?: string }).note;
+      }
+    }
+    const without = planWorkbook(schema, bare, deal);
+    expect(without.notes).toEqual([]);
+    const heights = (of: WorkbookPlan) => of.sheets[0].rows.map((r) => `${r.row}:${r.height}`);
+    expect(heights(plan)).toEqual(heights(without));
+  });
+
+  test('the workbook ships the notes Excel can show', () => {
+    const parts = readZip(generateWorkbook(schema, spec, deal));
+    const comments = new TextDecoder().decode(parts.get('xl/comments1.xml')?.data as Uint8Array);
+    const elements = table('elements');
+    const row = QUALIFICATION_ELEMENTS.indexOf('paperProcess');
+    expect(comments).toContain(`ref="${elements.ref('element', row)}"`);
+    expect(parts.has('xl/drawings/vmlDrawing1.vml')).toBe(true);
+  });
+
+  test('a note kind the generator does not know fails loudly', () => {
+    // A silent skip would produce a workbook missing exactly the reference text this exists for,
+    // and nothing on the sheet would say so.
+    const broken = clone(spec);
+    const elements = broken.sheets
+      .flatMap((s) => s.blocks)
+      .find((b) => b.kind === 'table' && b.table.id === 'elements');
+    if (elements?.kind !== 'table') throw new Error('no elements table in the spec');
+    const column = elements.table.columns.find((c) => c.id === 'element');
+    (column as { note?: string }).note = 'somethingElse';
+    expect(() => planWorkbook(schema, broken, deal)).toThrow(/somethingElse/);
+  });
+});

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -225,6 +225,19 @@ export interface ClippedCell {
   needed: number;
 }
 
+/**
+ * A hover note the generator writes, and the cell it hangs on.
+ *
+ * Reported like the anchors and the prose cells are, because the same question applies to it: the
+ * acceptance test has to ask Excel whether the note is really there, and it cannot ask about a cell
+ * whose address it had to guess.
+ */
+export interface PlannedNote {
+  sheet: string;
+  address: string;
+  text: string;
+}
+
 /** A wrapped cell whose row height had to be computed rather than autofitted. */
 export interface ProseCell {
   sheet: string;
@@ -250,6 +263,14 @@ export interface WorkbookPlan {
   proseCells: ProseCell[];
   /** Prose that needs a taller row than Excel has, so part of it cannot be shown. */
   clippedCells: ClippedCell[];
+  /**
+   * Reference text carried as a hover note instead of as a cell.
+   *
+   * Not read back, and not an anchor: a note is not a cell, so nothing about it can move a row or
+   * disagree with the deal. It exists so the sheet explains itself to somebody meeting MEDDPICC for
+   * the first time without charging every other reader the width and the height.
+   */
+  notes: PlannedNote[];
   /** Named form cells -> `Sheet!Address`. */
   namedCells: Record<string, string>;
   /** Every table's geometry, keyed by the spec's table id. */
@@ -517,6 +538,29 @@ function resolveFormula(
   return out;
 }
 
+/**
+ * The text a column's hover note carries for one row.
+ *
+ * `source` is typed as a string rather than as {@link NoteSource} because the spec is JSON: a name
+ * nobody implemented reaches here at runtime whatever the type says. `check-spec` refuses it first;
+ * this throws if it ever gets past, because a workbook silently missing the definitions is exactly
+ * the outcome the note exists to prevent.
+ */
+function noteText(source: string, entry: TableLayout['items'][number], table: SpecTable, schema: unknown): string {
+  if (source === 'elementDefinition') {
+    if (table.source.kind !== 'elements') {
+      throw new Error(`table "${table.id}" asks for element definitions, and its rows are not elements`);
+    }
+    const element = entry.key as string;
+    const definition = computeElementHint(schema, element).definition;
+    if (definition === '') {
+      throw new Error(`the schema declares no definition for "${element}", so its note would be an empty box`);
+    }
+    return definition;
+  }
+  throw new Error(`no note text for "${source}" — the spec asks for a kind of note the generator does not know`);
+}
+
 /** The value a `derived` column shows. Everything here comes from the schema or the engine. */
 /** A formula string literal: Excel escapes a double quote by doubling it. */
 const quote = (text: string) => `"${text.replace(/"/g, '""')}"`;
@@ -641,6 +685,7 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
   const anchors: Anchor[] = [];
   const proseCells: ProseCell[] = [];
   const clippedCells: ClippedCell[] = [];
+  const notes: PlannedNote[] = [];
   const sheets: SheetSpec[] = [];
   /** `sheet!ref` for every cell the generator writes — see {@link WorkbookPlan.writtenCells}. */
   const writtenCells: string[] = [];
@@ -837,6 +882,13 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
             continue;
           }
 
+          // Before the branches, so a note is not a property of how the cell gets its value. Past the
+          // grouped-run check above, so it lands on a cell a reader can actually hover rather than on
+          // one the merge hides — which the writer refuses outright.
+          if (spec.note !== undefined) {
+            notes.push({ sheet: s.name, address: ref, text: noteText(spec.note, entry, table, schema) });
+          }
+
           if (spec.role === 'computed' && spec.formula) {
             push(dataRow, {
               ref,
@@ -918,6 +970,9 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
       }
     }
 
+    // Taken from the one collection rather than accumulated twice: the plan reports notes per
+    // workbook and the writer takes them per sheet, and two lists would be two chances to disagree.
+    const sheetNotes = notes.filter((n) => n.sheet === s.name).map(({ address, text }) => ({ ref: address, text }));
     sheets.push({
       name: s.name,
       rows: [...byRow.entries()]
@@ -931,6 +986,7 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
       ...presentation(deal),
       conditionalFormats: formats.length ? formats : undefined,
       validations: validations.length ? validations : undefined,
+      notes: sheetNotes.length ? sheetNotes : undefined,
     });
   }
 
@@ -938,6 +994,7 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
     anchors,
     proseCells,
     clippedCells,
+    notes,
     writtenCells,
     sheets,
     namedCells: Object.fromEntries([...named].map(([id, v]) => [id, `${v.sheet}!${v.address}`])),

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -403,6 +403,7 @@
                 "role": "derived",
                 "valueType": "string",
                 "span": 2,
+                "note": "elementDefinition",
                 "heading": true
               },
               {

--- a/plugins/meddpicc/engine/workbook-spec.test.ts
+++ b/plugins/meddpicc/engine/workbook-spec.test.ts
@@ -348,6 +348,23 @@ describe('checkWorkbookSpec — roles', () => {
     expect(checkWorkbookSpec(schema, spec).roles.failures.join()).toContain('colour');
   });
 
+  test('rejects a note kind the generator has no text for', () => {
+    // The spec is JSON, so a mistyped kind is a string like any other. Caught here it names the
+    // column; missed, the workbook ships without the reference text and nothing says so.
+    const spec = clone(baseSpec());
+    fixtureTable(spec, 'elements').columns[0].note = 'elementDefinitions' as never;
+    expect(checkWorkbookSpec(schema, spec).roles.failures.join()).toContain('elementDefinitions');
+  });
+
+  test('rejects element definitions on a table whose rows are not elements', () => {
+    // The text is looked up by element, so a stakeholder row has nothing to look it up by.
+    const spec = clone(baseSpec());
+    fixtureTable(spec, 'stakeholders').columns[0].note = 'elementDefinition';
+    const failures = checkWorkbookSpec(schema, spec).roles.failures.join();
+    expect(failures).toContain('stakeholders.name');
+    expect(failures).toContain('elementDefinition');
+  });
+
   test('every declared valueType has a style in the palette', () => {
     for (const [type, style] of Object.entries(VALUE_TYPE_STYLE)) {
       expect(typeof style, `${type} maps to a style name`).toBe('string');
@@ -515,6 +532,16 @@ describe('the shipped workbook-spec.json', () => {
       .filter((c) => c.kind === 'field' || c.kind === 'computed');
     expect(values.length).toBeGreaterThan(10);
     expect(values.every((c) => c.kind === 'computed')).toBe(true);
+  });
+
+  test('the eight element definitions are carried as notes, not as a column', () => {
+    // They were a column until v6.0.0 and cost three grid columns plus twenty lines of height. As
+    // notes they cost nothing — and a reader meeting "Paper Process" still has them one hover away.
+    const elements = shipped.sheets.flatMap((s) => specTables(s)).find((t) => t.id === 'elements');
+    if (!elements) throw new Error('no elements table in the shipped spec');
+    expect(elements.columns.map((c) => c.id)).not.toContain('definition');
+    const noted = elements.columns.filter((c) => c.note === 'elementDefinition');
+    expect(noted.map((c) => c.id)).toEqual(['element']);
   });
 
   test('gives every deal collection a table, so nothing is capped', () => {

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -475,7 +475,9 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
 
         if (column.note !== undefined) {
           if (!NOTE_SOURCES.includes(column.note)) {
-            roles.push(`${where}: note "${column.note}" is not one the generator knows — have ${NOTE_SOURCES.join(', ')}`);
+            roles.push(
+              `${where}: note "${column.note}" is not one the generator knows — have ${NOTE_SOURCES.join(', ')}`,
+            );
           } else if (column.note === 'elementDefinition' && table.source.kind !== 'elements') {
             // The text is per element, so there has to be an element on the row to look it up by.
             roles.push(

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -68,6 +68,22 @@ export const VALUE_TYPE_STYLE: Record<ValueType, StyleName> = {
  */
 export type CellRole = 'input' | 'computed' | 'derived';
 
+/**
+ * Reference text a column carries as a hover note rather than as a cell.
+ *
+ * `elementDefinition` is what MEDDPICC's eight elements mean. It was a column once: the same eight
+ * paragraphs in every workbook, taking three grid columns and twenty lines of height from a rep's own
+ * evidence and notes. As a note it costs neither, and somebody meeting "Paper Process" for the first
+ * time still has it one hover away.
+ *
+ * A closed set, resolved in `generate.ts`. The spec is JSON and cannot name a function, so it names a
+ * kind — and an unknown kind fails the spec check rather than quietly shipping a workbook with the
+ * reference text missing.
+ */
+export type NoteSource = 'elementDefinition';
+
+export const NOTE_SOURCES: readonly NoteSource[] = ['elementDefinition'];
+
 export interface SpecColumn {
   id: string;
   header: string;
@@ -110,6 +126,13 @@ export interface SpecColumn {
    * element instead of a column of duplicates.
    */
   groupRuns?: boolean;
+  /**
+   * Hang each of this column's cells with a hover note — see {@link NoteSource}.
+   *
+   * Only the cells a reader can hover get one: a merged run shows its first row, so that is where
+   * the note goes, and a blank row waiting to be typed into has nothing to explain.
+   */
+  note?: NoteSource;
   /** A named conditional-format preset (see xlsx.ts). Formatting is spec data, not code. */
   conditionalFormat?: CfPreset;
   /**
@@ -449,6 +472,17 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
         if (seenColumns.has(column.id)) ids.push(`${where}: duplicate column id`);
         seenColumns.add(column.id);
         checkValueType(where, column.valueType);
+
+        if (column.note !== undefined) {
+          if (!NOTE_SOURCES.includes(column.note)) {
+            roles.push(`${where}: note "${column.note}" is not one the generator knows — have ${NOTE_SOURCES.join(', ')}`);
+          } else if (column.note === 'elementDefinition' && table.source.kind !== 'elements') {
+            // The text is per element, so there has to be an element on the row to look it up by.
+            roles.push(
+              `${where}: note "elementDefinition" needs a row per MEDDPICC element, and "${table.id}" is a ${table.source.kind} table`,
+            );
+          }
+        }
 
         if (column.role === 'input') {
           if (column.formula) roles.push(`${where}: an input column cannot also carry a formula`);

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -864,3 +864,36 @@ describe('buildWorkbook — notes', () => {
     }
   });
 });
+
+describe('buildWorkbook — a note at the edge of the grid', () => {
+  /** The eight numbers of the VML anchor: left column, offset, top row, offset, then the same again. */
+  const anchorOf = (ref: string) => {
+    const vml = dec(
+      readZip(
+        buildWorkbook([
+          { name: 'Deal', rows: [{ row: 1, cells: [{ ref, value: 'edge' }] }], notes: [{ ref, text: 'x' }] },
+        ]),
+      ).get('xl/drawings/vmlDrawing1.vml')?.data as Uint8Array,
+    );
+    const numbers = /<x:Anchor>([^<]+)<\/x:Anchor>/.exec(vml)?.[1] ?? '';
+    return numbers.split(',').map((n) => Number(n.trim()));
+  };
+
+  test('the box stays inside the grid, however close to the edge the cell is', () => {
+    // The note box is anchored a few columns and rows on from its cell, and Excel's grid ends at
+    // column XFD and row 1048576. An anchor past either is not clipped — it is a malformed drawing,
+    // and Excel's answer to that is to offer to repair the file.
+    const [left, , top, , right, , bottom] = anchorOf('XFD1048576');
+    expect(right).toBeLessThanOrEqual(16383);
+    expect(bottom).toBeLessThanOrEqual(1048575);
+    // Still a box, not a line: the anchor has to keep some width and height or there is nothing to show.
+    expect(right).toBeGreaterThan(left);
+    expect(bottom).toBeGreaterThan(top);
+  });
+
+  test('an ordinary cell gets the full-size box', () => {
+    const [left, , top, , right, , bottom] = anchorOf('B20');
+    expect(right - left).toBe(4);
+    expect(bottom - top).toBe(5);
+  });
+});

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -702,3 +702,161 @@ describe('buildWorkbook — provenance properties', () => {
     expect(readZip(buildWorkbook([{ name: 'Deal', rows: [] }], {})).has('docProps/custom.xml')).toBe(false);
   });
 });
+
+describe('buildWorkbook — notes', () => {
+  /** A sheet whose B2 says "Metrics", with whatever notes and merges the test wants. */
+  const withNotes = (notes: { ref: string; text: string }[] | undefined, merges?: string[]) =>
+    readZip(
+      buildWorkbook([
+        {
+          name: 'Deal',
+          rows: [
+            {
+              row: 2,
+              cells: [
+                { ref: 'B2', value: 'Metrics', style: 'fieldLabel' },
+                { ref: 'D2', value: 3, style: 'score' },
+              ],
+            },
+          ],
+          merges,
+          notes,
+        },
+      ]),
+    );
+
+  const NOTE = { ref: 'B2', text: 'The quantified business outcome the customer is buying.' };
+
+  test('a note ships every part a classic note needs, and the text is in the comments part', () => {
+    // A note is not one part but four: the text, a legacy VML shape to position it, the
+    // worksheet's own relationships, and the two content-type declarations. Miss any one and
+    // Excel either drops the note or offers to repair the file.
+    const parts = withNotes([NOTE]);
+    expect(parts.has('xl/comments1.xml')).toBe(true);
+    expect(parts.has('xl/drawings/vmlDrawing1.vml')).toBe(true);
+    expect(parts.has('xl/worksheets/_rels/sheet1.xml.rels')).toBe(true);
+
+    const comments = dec(parts.get('xl/comments1.xml')?.data as Uint8Array);
+    expect(comments).toContain('ref="B2"');
+    expect(comments).toContain(NOTE.text);
+
+    const ct = dec(parts.get('[Content_Types].xml')?.data as Uint8Array);
+    expect(ct).toContain('Extension="vml"');
+    expect(ct).toContain('/xl/comments1.xml');
+  });
+
+  test('the worksheet points at the drawing, and the id resolves to the vml part', () => {
+    const parts = withNotes([NOTE]);
+    const sheet = dec(parts.get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+    const rels = dec(parts.get('xl/worksheets/_rels/sheet1.xml.rels')?.data as Uint8Array);
+    const id = /<legacyDrawing r:id="(rId\d+)"\/>/.exec(sheet)?.[1];
+    expect(id, 'the worksheet must declare a legacyDrawing').toBeDefined();
+    // The relationship that id names has to be the VML one; pointing it at the comments part
+    // leaves the notes present in the file and invisible in Excel.
+    const target = new RegExp(`Id="${id}"[^>]*Target="([^"]+)"`).exec(rels)?.[1];
+    expect(target).toBe('../drawings/vmlDrawing1.vml');
+    expect(rels).toContain('../comments1.xml');
+  });
+
+  test('legacyDrawing comes last, after the print group', () => {
+    // It sits at the END of the CT_Worksheet sequence — after headerFooter. Put it beside
+    // mergeCells, where it reads as if it belonged, and Excel offers to repair the file.
+    const sheet = dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'Deal',
+            rows: [{ row: 2, cells: [{ ref: 'B2', value: 'Metrics', style: 'fieldLabel' }] }],
+            print: { orientation: 'landscape', fitToWidth: true, header: ['Deal'] },
+            notes: [NOTE],
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+    for (const before of ['<sheetData', '<pageSetup', '<headerFooter']) {
+      expect(sheet.indexOf('<legacyDrawing')).toBeGreaterThan(sheet.indexOf(before));
+    }
+  });
+
+  test('the shape names the cell it hangs on, counting from zero', () => {
+    // VML counts rows and columns from zero while an A1 reference counts from one. Off by one
+    // and the note appears on the row above, still hoverable, pointing at the wrong element.
+    const vml = dec(withNotes([NOTE]).get('xl/drawings/vmlDrawing1.vml')?.data as Uint8Array);
+    expect(vml).toContain('<x:Row>1</x:Row>');
+    expect(vml).toContain('<x:Column>1</x:Column>');
+    expect(vml).toContain('ObjectType="Note"');
+    expect(vml).toContain('<x:Anchor>');
+  });
+
+  test('each note gets its own shape id', () => {
+    const vml = dec(
+      withNotes([NOTE, { ref: 'D2', text: 'A 0-4 score.' }]).get('xl/drawings/vmlDrawing1.vml')?.data as Uint8Array,
+    );
+    const ids = [...vml.matchAll(/<v:shape id="([^"]+)"/g)].map((m) => m[1]);
+    expect(ids.length).toBe(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  test('a workbook with no notes ships no note parts at all', () => {
+    const parts = withNotes(undefined);
+    expect(parts.has('xl/comments1.xml')).toBe(false);
+    expect(parts.has('xl/drawings/vmlDrawing1.vml')).toBe(false);
+    expect(parts.has('xl/worksheets/_rels/sheet1.xml.rels')).toBe(false);
+    expect(dec(parts.get('xl/worksheets/sheet1.xml')?.data as Uint8Array)).not.toContain('legacyDrawing');
+    expect(dec(parts.get('[Content_Types].xml')?.data as Uint8Array)).not.toContain('vml');
+    // An empty list is the same as none: an empty commentList would be a part Excel has to
+    // read for nothing.
+    expect(withNotes([]).has('xl/comments1.xml')).toBe(false);
+  });
+
+  test('note parts are numbered by their sheet, not by how many carry notes', () => {
+    // sheet2's note part must be comments2.xml: named comments1.xml it would collide with the
+    // first sheet's the moment that one has a note too, and Excel resolves parts by name.
+    const parts = readZip(
+      buildWorkbook([
+        { name: 'Deal', rows: [] },
+        { name: 'Qualification', rows: [{ row: 1, cells: [{ ref: 'B1', value: 'Metrics' }] }], notes: [{ ref: 'B1', text: 'x' }] },
+      ]),
+    );
+    expect(parts.has('xl/comments2.xml')).toBe(true);
+    expect(parts.has('xl/comments1.xml')).toBe(false);
+    expect(parts.has('xl/worksheets/_rels/sheet2.xml.rels')).toBe(true);
+    expect(dec(parts.get('xl/worksheets/_rels/sheet2.xml.rels')?.data as Uint8Array)).toContain(
+      '../drawings/vmlDrawing2.vml',
+    );
+  });
+
+  test('escapes the note text rather than injecting it', () => {
+    const comments = dec(
+      withNotes([{ ref: 'B2', text: 'Metrics & <targets>' }]).get('xl/comments1.xml')?.data as Uint8Array,
+    );
+    expect(comments).toContain('Metrics &amp; &lt;targets&gt;');
+    expect(comments).not.toContain('<targets>');
+  });
+
+  test('refuses two notes on one cell', () => {
+    // Excel keeps one of them, so the other text is simply gone with nothing to say so.
+    expect(() => withNotes([NOTE, { ref: 'B2', text: 'something else' }])).toThrow(/B2/);
+  });
+
+  test('refuses a note with no text', () => {
+    // A red triangle with nothing behind it is worse than no note: it invites a hover that
+    // shows an empty box.
+    expect(() => withNotes([{ ref: 'B2', text: '' }])).toThrow(/text/i);
+    expect(() => withNotes([{ ref: 'B2', text: '   ' }])).toThrow(/text/i);
+  });
+
+  test('refuses a note on a cell a merge hides', () => {
+    // Only the top-left cell of a merge is visible, and a note on any of the others cannot be
+    // hovered — the definition would be in the file and unreachable.
+    expect(() => withNotes([{ ref: 'C2', text: 'hidden' }], ['B2:C2'])).toThrow(/merge/i);
+    // The anchor of that same merge is fine, and is where the notes actually go.
+    expect(() => withNotes([NOTE], ['B2:C2'])).not.toThrow();
+  });
+
+  test('refuses anything that is not a single cell reference', () => {
+    for (const ref of ['B2:C2', '2B', 'B', '', 'b2']) {
+      expect(() => withNotes([{ ref, text: 'x' }]), ref).toThrow();
+    }
+  });
+});

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -815,7 +815,11 @@ describe('buildWorkbook — notes', () => {
     const parts = readZip(
       buildWorkbook([
         { name: 'Deal', rows: [] },
-        { name: 'Qualification', rows: [{ row: 1, cells: [{ ref: 'B1', value: 'Metrics' }] }], notes: [{ ref: 'B1', text: 'x' }] },
+        {
+          name: 'Qualification',
+          rows: [{ row: 1, cells: [{ ref: 'B1', value: 'Metrics' }] }],
+          notes: [{ ref: 'B1', text: 'x' }],
+        },
       ]),
     );
     expect(parts.has('xl/comments2.xml')).toBe(true);

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -955,7 +955,9 @@ export function buildWorkbook(sheets: readonly SheetSpec[], properties?: Workboo
     `<Default Extension="xml" ContentType="application/xml"/>` +
     // The VML drawing behind the notes. Declared by extension, as Excel does — every note part on
     // every sheet is one `.vml` file, so there is nothing per-sheet to override.
-    (!anyNotes ? '' : `<Default Extension="vml" ContentType="application/vnd.openxmlformats-officedocument.vmlDrawing"/>`) +
+    (!anyNotes
+      ? ''
+      : `<Default Extension="vml" ContentType="application/vnd.openxmlformats-officedocument.vmlDrawing"/>`) +
     `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
     `<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>` +
     sheets

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -85,6 +85,17 @@ const MAX_ROW = 1048576;
  */
 const MAX_MERGE_CELLS = 10_000;
 
+/** Parse `B14` into 1-based bounds, rejecting anything Excel would not accept as one cell. */
+function parseCell(ref: string, what: string): { column: number; row: number } {
+  const m = /^([A-Z]+)(\d+)$/.exec(ref);
+  if (!m) throw new Error(`${what} "${ref}" is not a single cell like B14`);
+  const cell = { column: columnIndex(m[1]), row: Number(m[2]) };
+  if (cell.column > MAX_COLUMN || cell.row < 1 || cell.row > MAX_ROW) {
+    throw new Error(`${what} "${ref}" is outside Excel's grid`);
+  }
+  return cell;
+}
+
 /** Parse `B2:Q7` into 1-based bounds, rejecting anything Excel would not accept as a range. */
 function parseRange(ref: string, what: string): Range {
   const m = /^([A-Z]+)(\d+):([A-Z]+)(\d+)$/.exec(ref);
@@ -283,6 +294,23 @@ export interface Validation {
   values: string[];
 }
 
+/**
+ * A note on a cell: text that shows on hover and takes no room on the sheet.
+ *
+ * The whole point is the cost. Reference text — what an element means — is wanted by whoever is
+ * reading the sheet for the first time and is noise to everyone else, and a column of it charges
+ * every reader for one reader's benefit. A note charges nobody: no width, and no row height, since
+ * it is not in the cell.
+ *
+ * Classic notes rather than threaded comments. A threaded comment is a conversation, needs a person
+ * id, and renders as somebody having said something — wrong for static reference text nobody wrote.
+ */
+export interface Note {
+  /** One cell, and the top-left of its merge — that is the only cell of a merge a reader can hover. */
+  ref: string;
+  text: string;
+}
+
 function stylesXml(): string {
   const fonts = [
     '<font><sz val="11"/><name val="Calibri"/></font>',
@@ -392,6 +420,53 @@ export interface SheetSpec {
   print?: PrintSetup;
   conditionalFormats?: ConditionalFormat[];
   validations?: Validation[];
+  /** Hover notes. Each one costs three extra parts in the package — see {@link notesParts}. */
+  notes?: Note[];
+}
+
+/**
+ * The sheet's merged ranges, parsed and bounds-checked in declaration order.
+ *
+ * Shared by everything that has to reason about a merge, so the cap and the "that is not a merge"
+ * rule are stated once. {@link expandMerges} materialises the cells; {@link hiddenByMerges} works
+ * out which of them a reader can never see.
+ */
+function mergeAreas(sheet: SheetSpec): Array<{ ref: string; area: Range }> {
+  return (sheet.merges ?? []).map((ref) => {
+    const area = parseRange(ref, `Merge on sheet "${sheet.name}"`);
+    const { c1, r1, c2, r2 } = area;
+    if (c1 === c2 && r1 === r2) {
+      throw new Error(`Merge "${ref}" on sheet "${sheet.name}" covers one cell — that is not a merge`);
+    }
+    const size = (c2 - c1 + 1) * (r2 - r1 + 1);
+    if (size > MAX_MERGE_CELLS) {
+      throw new Error(
+        `Merge "${ref}" on sheet "${sheet.name}" covers ${size} cells; the writer materialises at most ${MAX_MERGE_CELLS}`,
+      );
+    }
+    return { ref, area };
+  });
+}
+
+/**
+ * Every cell a merge covers except the top-left one, which is the only one that shows.
+ *
+ * A note on a covered cell is in the file and unreachable: there is nothing to hover, because the
+ * cell is not on screen. Same class of silence as a header past Excel's limit — the writer reports
+ * success and the reader never learns the text exists.
+ */
+function hiddenByMerges(sheet: SheetSpec): Map<string, string> {
+  const hidden = new Map<string, string>();
+  for (const { ref, area } of mergeAreas(sheet)) {
+    const anchor = A1(area.c1, area.r1);
+    for (let c = area.c1; c <= area.c2; c++) {
+      for (let r = area.r1; r <= area.r2; r++) {
+        const at = A1(c, r);
+        if (at !== anchor) hidden.set(at, ref);
+      }
+    }
+  }
+  return hidden;
 }
 
 /**
@@ -441,18 +516,8 @@ export function expandMerges(sheet: SheetSpec): RowSpec[] {
   /** ref -> the merge that already covers it, so an overlap can name both. */
   const covered = new Map<string, string>();
 
-  for (const ref of merges) {
-    const area = parseRange(ref, `Merge on sheet "${sheet.name}"`);
+  for (const { ref, area } of mergeAreas(sheet)) {
     const { c1, r1, c2, r2 } = area;
-    if (c1 === c2 && r1 === r2) {
-      throw new Error(`Merge "${ref}" on sheet "${sheet.name}" covers one cell — that is not a merge`);
-    }
-    const size = (c2 - c1 + 1) * (r2 - r1 + 1);
-    if (size > MAX_MERGE_CELLS) {
-      throw new Error(
-        `Merge "${ref}" on sheet "${sheet.name}" covers ${size} cells; the writer materialises at most ${MAX_MERGE_CELLS}`,
-      );
-    }
     const anchorRef = A1(c1, r1);
     const anchor = cellByRef.get(anchorRef);
     if (!anchor) {
@@ -558,6 +623,130 @@ function dataValidationsXml(validations: Validation[] | undefined): string {
     })
     .join('');
   return `<dataValidations count="${validations.length}">${entries}</dataValidations>`;
+}
+
+/**
+ * The relationship id the worksheet's `legacyDrawing` uses.
+ *
+ * Shared with {@link sheetRelsXml} so the two cannot disagree: pointed at the comments part instead
+ * of the drawing, the notes are in the file, valid, and invisible in Excel.
+ */
+const NOTE_VML_REL_ID = 'rId1';
+const NOTE_COMMENTS_REL_ID = 'rId2';
+
+/** Tahoma 9 with the format's own indexed colour — what Excel itself writes for a note. */
+const NOTE_RUN_PROPERTIES = '<rPr><sz val="9"/><color indexed="81"/><rFont val="Tahoma"/><family val="2"/></rPr>';
+
+/** The first legacy shape id Excel uses on a sheet; each note takes the next one. */
+const NOTE_FIRST_SHAPE_ID = 1025;
+
+function commentsXml(notes: readonly Note[]): string {
+  const list = notes
+    .map(
+      (note) =>
+        // shapeId is 0 in what Excel writes too: the shape is found through the VML drawing, not
+        // through this number.
+        `<comment ref="${note.ref}" authorId="0" shapeId="0"><text><r>${NOTE_RUN_PROPERTIES}` +
+        `<t xml:space="preserve">${escapeXml(note.text)}</t></r></text></comment>`,
+    )
+    .join('');
+  // One author, unnamed. Excel prefixes a note with its author in bold, and this text is the
+  // schema's, not a person's — an invented name would read as somebody's opinion.
+  return (
+    `${XML_HEADER}<comments xmlns="${NS_MAIN}"><authors><author/></authors>` +
+    `<commentList>${list}</commentList></comments>`
+  );
+}
+
+/**
+ * The legacy VML drawing that positions the notes.
+ *
+ * Excel has required this for classic notes since it stopped using VML for anything else, and there
+ * is no modern replacement: a comments part with no drawing produces a file whose notes never
+ * appear. The shape is hidden until hovered, which is why `visibility:hidden` is correct here rather
+ * than a mistake.
+ *
+ * No XML declaration: this part is not XML as far as Excel is concerned, and it does not write one.
+ */
+function vmlDrawingXml(notes: readonly Note[], sheetName: string): string {
+  const shapes = notes
+    .map((note, i) => {
+      // VML counts from zero where an A1 reference counts from one. Off by one puts the note on the
+      // row above — still hoverable, and explaining a different element.
+      const { column, row } = parseCell(note.ref, `Note on sheet "${sheetName}"`);
+      const col0 = column - 1;
+      const row0 = row - 1;
+      return (
+        `<v:shape id="_x0000_s${NOTE_FIRST_SHAPE_ID + i}" type="#_x0000_t202" ` +
+        `style="position:absolute;width:240pt;height:80pt;z-index:${i + 1};visibility:hidden" ` +
+        `fillcolor="#ffffe1" o:insetmode="auto">` +
+        `<v:fill color2="#ffffe1"/><v:shadow on="t" color="black" obscured="t"/><v:path o:connecttype="none"/>` +
+        `<v:textbox style="mso-direction-alt:auto"><div style="text-align:left"></div></v:textbox>` +
+        `<x:ClientData ObjectType="Note"><x:MoveWithCells/><x:SizeWithCells/>` +
+        // From one cell right of the note to four columns and five rows on: the box Excel opens.
+        `<x:Anchor>${col0 + 1}, 15, ${row0}, 2, ${col0 + 5}, 15, ${row0 + 5}, 2</x:Anchor>` +
+        `<x:AutoFill>False</x:AutoFill><x:Row>${row0}</x:Row><x:Column>${col0}</x:Column></x:ClientData></v:shape>`
+      );
+    })
+    .join('');
+  return (
+    `<xml xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" ` +
+    `xmlns:x="urn:schemas-microsoft-com:office:excel">` +
+    `<o:shapelayout v:ext="edit"><o:idmap v:ext="edit" data="1"/></o:shapelayout>` +
+    `<v:shapetype id="_x0000_t202" coordsize="21600,21600" o:spt="202" path="m,l,21600r21600,l21600,xe">` +
+    `<v:stroke joinstyle="miter"/><v:path gradientshapeok="t" o:connecttype="rect"/></v:shapetype>` +
+    `${shapes}</xml>`
+  );
+}
+
+/** The worksheet's own relationships: the drawing it points at, and the notes behind it. */
+function sheetRelsXml(sheetNumber: number): string {
+  return (
+    `${XML_HEADER}<Relationships xmlns="${NS_REL_PKG}">` +
+    `<Relationship Id="${NOTE_VML_REL_ID}" Type="${NS_REL_DOC}/vmlDrawing" ` +
+    `Target="../drawings/vmlDrawing${sheetNumber}.vml"/>` +
+    `<Relationship Id="${NOTE_COMMENTS_REL_ID}" Type="${NS_REL_DOC}/comments" ` +
+    `Target="../comments${sheetNumber}.xml"/>` +
+    `</Relationships>`
+  );
+}
+
+/**
+ * The three parts a sheet's notes need, or null when it has none.
+ *
+ * Numbered by the SHEET, not by how many sheets carry notes: `comments2.xml` belongs to sheet 2
+ * whether or not sheet 1 has any, because Excel resolves these by name and two sheets cannot share
+ * one part.
+ */
+function notesParts(sheet: SheetSpec, sheetNumber: number): { comments: string; vml: string; rels: string } | null {
+  const notes = sheet.notes ?? [];
+  if (notes.length === 0) return null;
+
+  const hidden = hiddenByMerges(sheet);
+  const seen = new Set<string>();
+  for (const note of notes) {
+    parseCell(note.ref, `Note on sheet "${sheet.name}"`);
+    if (note.text.trim() === '') {
+      throw new Error(`The note on ${sheet.name}!${note.ref} has no text — a note nobody can read is a red triangle`);
+    }
+    if (seen.has(note.ref)) {
+      throw new Error(`Two notes on ${sheet.name}!${note.ref}; Excel keeps one of them and loses the other`);
+    }
+    seen.add(note.ref);
+    const merge = hidden.get(note.ref);
+    if (merge !== undefined) {
+      throw new Error(
+        `The note on ${sheet.name}!${note.ref} sits inside merge "${merge}", which hides that cell — ` +
+          'put it on the top-left cell of the merge, the only one a reader can hover',
+      );
+    }
+  }
+
+  return {
+    comments: commentsXml(notes),
+    vml: vmlDrawingXml(notes, sheet.name),
+    rels: sheetRelsXml(sheetNumber),
+  };
 }
 
 /**
@@ -683,8 +872,10 @@ function sheetXml(sheet: SheetSpec): string {
     .join('');
   // CT_Worksheet is a sequence, not a bag: sheetPr, sheetViews, sheetFormatPr, cols,
   // sheetData, mergeCells, conditionalFormatting, dataValidations, then the print group
-  // (printOptions, pageMargins, pageSetup, headerFooter). Emitting these out of order does not
-  // warn — it makes Excel offer to repair the file, with a message that names nothing useful.
+  // (printOptions, pageMargins, pageSetup, headerFooter), and legacyDrawing after all of it.
+  // Emitting these out of order does not warn — it makes Excel offer to repair the file, with a
+  // message that names nothing useful.
+  const legacyDrawing = sheet.notes?.length ? `<legacyDrawing r:id="${NOTE_VML_REL_ID}"/>` : '';
   return (
     `${XML_HEADER}<worksheet xmlns="${NS_MAIN}" xmlns:r="${NS_REL_DOC}">` +
     sheetPr +
@@ -695,6 +886,7 @@ function sheetXml(sheet: SheetSpec): string {
     conditionalFormattingXml(sheet.conditionalFormats) +
     dataValidationsXml(sheet.validations) +
     printXml(sheet.print) +
+    legacyDrawing +
     `</worksheet>`
   );
 }
@@ -749,6 +941,10 @@ export function buildWorkbook(sheets: readonly SheetSpec[], properties?: Workboo
 
   const enc = (s: string) => new TextEncoder().encode(s);
   const sheetPath = (i: number) => `xl/worksheets/sheet${i + 1}.xml`;
+  // Validated here, before anything is written: a note the reader could never hover is a defect in
+  // the caller's layout, not something to ship quietly.
+  const notes = sheets.map((sheet, i) => notesParts(sheet, i + 1));
+  const anyNotes = notes.some((part) => part !== null);
   // An empty property set ships no part: an empty <Properties/> is legal and would make a reader
   // report the workbook as stamped when it carries nothing.
   const hasProperties = properties !== undefined && Object.keys(properties).length > 0;
@@ -757,12 +953,22 @@ export function buildWorkbook(sheets: readonly SheetSpec[], properties?: Workboo
     `${XML_HEADER}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
     `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
     `<Default Extension="xml" ContentType="application/xml"/>` +
+    // The VML drawing behind the notes. Declared by extension, as Excel does — every note part on
+    // every sheet is one `.vml` file, so there is nothing per-sheet to override.
+    (!anyNotes ? '' : `<Default Extension="vml" ContentType="application/vnd.openxmlformats-officedocument.vmlDrawing"/>`) +
     `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
     `<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>` +
     sheets
       .map(
         (_, i) =>
           `<Override PartName="/${sheetPath(i)}" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`,
+      )
+      .join('') +
+    notes
+      .map((part, i) =>
+        part === null
+          ? ''
+          : `<Override PartName="/xl/comments${i + 1}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.comments+xml"/>`,
       )
       .join('') +
     (!hasProperties
@@ -804,6 +1010,15 @@ export function buildWorkbook(sheets: readonly SheetSpec[], properties?: Workboo
     { name: 'xl/_rels/workbook.xml.rels', data: enc(workbookRels) },
     { name: 'xl/styles.xml', data: enc(stylesXml()) },
     ...sheets.map((s, i) => ({ name: sheetPath(i), data: enc(sheetXml(s)) })),
+    ...notes.flatMap((part, i) =>
+      part === null
+        ? []
+        : [
+            { name: `xl/worksheets/_rels/sheet${i + 1}.xml.rels`, data: enc(part.rels) },
+            { name: `xl/comments${i + 1}.xml`, data: enc(part.comments) },
+            { name: `xl/drawings/vmlDrawing${i + 1}.vml`, data: enc(part.vml) },
+          ],
+    ),
     ...(hasProperties ? [{ name: 'docProps/custom.xml', data: enc(customPropsXml(properties)) }] : []),
   ]);
 }

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -640,6 +640,10 @@ const NOTE_RUN_PROPERTIES = '<rPr><sz val="9"/><color indexed="81"/><rFont val="
 /** The first legacy shape id Excel uses on a sheet; each note takes the next one. */
 const NOTE_FIRST_SHAPE_ID = 1025;
 
+/** How many columns and rows the note's box covers when Excel opens it. */
+const NOTE_BOX_COLUMNS = 4;
+const NOTE_BOX_ROWS = 5;
+
 function commentsXml(notes: readonly Note[]): string {
   const list = notes
     .map(
@@ -676,6 +680,13 @@ function vmlDrawingXml(notes: readonly Note[], sheetName: string): string {
       const { column, row } = parseCell(note.ref, `Note on sheet "${sheetName}"`);
       const col0 = column - 1;
       const row0 = row - 1;
+      // The box opens one column to the right of the cell — and slides back towards the middle when
+      // the cell is close to an edge, because an anchor past column XFD or row 1048576 is not clipped
+      // by Excel: it is a malformed drawing, and Excel's answer to one of those is to offer to repair
+      // the file. Sliding keeps the box its full size; clamping the far corner would have flattened it
+      // to nothing on the last row.
+      const boxLeft = Math.min(col0 + 1, MAX_COLUMN - 1 - NOTE_BOX_COLUMNS);
+      const boxTop = Math.min(row0, MAX_ROW - 1 - NOTE_BOX_ROWS);
       return (
         `<v:shape id="_x0000_s${NOTE_FIRST_SHAPE_ID + i}" type="#_x0000_t202" ` +
         `style="position:absolute;width:240pt;height:80pt;z-index:${i + 1};visibility:hidden" ` +
@@ -683,8 +694,7 @@ function vmlDrawingXml(notes: readonly Note[], sheetName: string): string {
         `<v:fill color2="#ffffe1"/><v:shadow on="t" color="black" obscured="t"/><v:path o:connecttype="none"/>` +
         `<v:textbox style="mso-direction-alt:auto"><div style="text-align:left"></div></v:textbox>` +
         `<x:ClientData ObjectType="Note"><x:MoveWithCells/><x:SizeWithCells/>` +
-        // From one cell right of the note to four columns and five rows on: the box Excel opens.
-        `<x:Anchor>${col0 + 1}, 15, ${row0}, 2, ${col0 + 5}, 15, ${row0 + 5}, 2</x:Anchor>` +
+        `<x:Anchor>${boxLeft}, 15, ${boxTop}, 2, ${boxLeft + NOTE_BOX_COLUMNS}, 15, ${boxTop + NOTE_BOX_ROWS}, 2</x:Anchor>` +
         `<x:AutoFill>False</x:AutoFill><x:Row>${row0}</x:Row><x:Column>${col0}</x:Column></x:ClientData></v:shape>`
       );
     })

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -523,6 +523,58 @@ echo "    measured $height_checked prose cell(s) against Excel's own autofit"
 [ "$height_failures" = "0" ] || fail "$height_failures prose cell(s) are shorter than Excel needs — text is clipped"
 echo "PASS: every computed row height is at least what Excel's autofit asks for"
 
+# ── Hover notes ────────────────────────────────────────────────────────────────────────────────
+#
+# The eight element definitions are not on the sheet at all: they are notes on the element names, so
+# they cost no width and no height. That makes them the one piece of the workbook a reader can only
+# reach through the application, and the one piece no zip inspection can vouch for — a note needs a
+# comments part, a legacy VML drawing, the worksheet's own relationships and two content-type
+# declarations to agree with each other, and Excel's response to any disagreement is to drop the note
+# and open the file anyway.
+#
+# So ask Excel. And compare against the SCHEMA rather than against the plan: the plan's text and the
+# note both come from the generator, so they agree even when both are wrong.
+read_note() {
+  osascript - "$SHEET" "$BOOK" "$1" 2>&1 <<'OSA'
+on run argv
+  tell application "Microsoft Excel"
+    set ws to worksheet (item 1 of argv) of workbook (item 2 of argv)
+    -- A cell with no note raises here rather than returning empty, which is the failure this wants.
+    set theNote to Excel comment of range (item 3 of argv) of ws
+    return Excel comment text theNote
+  end tell
+end run
+OSA
+}
+
+# The elements in the order the table lays them out, from the engine — not a list written here, which
+# would go stale the day MEDDPICC's eighth letter is spelled differently.
+note_elements="$(bun "$PLUGIN_ROOT/engine/cli.ts" hint | jq -r '.elements[].element')" || fail "hint failed"
+note_planned="$(jq '.notes | length' <<<"$uat_plan")"
+note_wanted="$(wc -w <<<"$note_elements" | tr -d ' ')"
+[ "$note_planned" = "$note_wanted" ] || fail "the plan carries $note_planned note(s) for $note_wanted element(s)"
+echo "==> reading the $note_wanted element definitions back out of Excel"
+note_index=0
+for note_element in $note_elements; do
+  note_ref="$(table_cell elements element "$note_index")"
+  note_index=$((note_index + 1))
+  note_want="$(jq -r --arg e "$note_element" \
+    '.properties.qualification.properties[$e].properties.definition.const // "MISSING"' \
+    "$PLUGIN_ROOT/schema/meddpicc-schema.json")"
+  [ "$note_want" != "MISSING" ] && [ -n "$note_want" ] ||
+    fail "the schema declares no definition for $note_element, so this stage would prove nothing"
+  note_got="$(read_note "$note_ref")"
+  case "$note_got" in
+  *"execution error"* | *"syntax error"*)
+    fail "Excel has no note on $note_ref ($note_element): $note_got"
+    ;;
+  esac
+  [ "$note_got" = "$note_want" ] ||
+    fail "the note on $note_ref reads '${note_got:0:60}', the schema says '${note_want:0:60}'"
+done
+[ "$note_index" = "$note_wanted" ] || fail "checked $note_index note(s), expected $note_wanted"
+echo "PASS: Excel shows every element definition as a note on its element name"
+
 # ── Screenshots ────────────────────────────────────────────────────────────────────────────────
 #
 # Everything above proves the workbook COMPUTES. None of it can see the sheet, and the current work

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -535,7 +535,7 @@ echo "PASS: every computed row height is at least what Excel's autofit asks for"
 # So ask Excel. And compare against the SCHEMA rather than against the plan: the plan's text and the
 # note both come from the generator, so they agree even when both are wrong.
 read_note() {
-  osascript - "$SHEET" "$BOOK" "$1" 2>&1 <<'OSA'
+  osascript - "$SHEET" "$1" "$2" 2>&1 <<'OSA'
 on run argv
   tell application "Microsoft Excel"
     set ws to worksheet (item 1 of argv) of workbook (item 2 of argv)
@@ -563,7 +563,7 @@ for note_element in $note_elements; do
     "$PLUGIN_ROOT/schema/meddpicc-schema.json")"
   [ "$note_want" != "MISSING" ] && [ -n "$note_want" ] ||
     fail "the schema declares no definition for $note_element, so this stage would prove nothing"
-  note_got="$(read_note "$note_ref")"
+  note_got="$(read_note "$BOOK" "$note_ref")"
   case "$note_got" in
   *"execution error"* | *"syntax error"*)
     fail "Excel has no note on $note_ref ($note_element): $note_got"
@@ -1036,6 +1036,24 @@ done
 
 wait_until_ready "$RT_BOOK" "$(at metadata.accountName sheet)" "$(at metadata.accountName address)" ||
   fail "Excel never finished opening $RT_BOOK"
+
+# The file just reopened is Excel's OWN, saved a moment ago by its comments and VML code rather than
+# by ours. A deal review gets shared and saved, so a note that Excel drops on the way out is a note
+# nobody sees again — and this reopen is the only point in the run where anything has been through
+# Excel's writer.
+rt_note_ref="$(jq -r '.notes[0].address // "MISSING"' <<<"$rt_plan")"
+rt_note_want="$(jq -r '.notes[0].text // "MISSING"' <<<"$rt_plan")"
+[ "$rt_note_ref" != "MISSING" ] && [ "$rt_note_want" != "MISSING" ] ||
+  fail "the round-trip plan carries no notes, so this check would prove nothing"
+rt_note_got="$(read_note "$RT_BOOK" "$rt_note_ref")"
+case "$rt_note_got" in
+*"execution error"* | *"syntax error"*)
+  fail "Excel's own save dropped the note on $rt_note_ref: $rt_note_got"
+  ;;
+esac
+[ "$rt_note_got" = "$rt_note_want" ] ||
+  fail "after Excel saved it, the note on $rt_note_ref reads '${rt_note_got:0:60}', not '${rt_note_want:0:60}'"
+echo "PASS: a note survives a save by Excel itself"
 
 # Writing, saving and closing in one breath hid which of the three failed. When the save did not
 # reach disk the reader saw the untouched file, reported no proposals, and this script blamed

--- a/plugins/meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/meddpicc/skills/deal-qualification/SKILL.md
@@ -360,6 +360,11 @@ Rules that matter:
 - **Relay a rejection by its cell address**, as the tool gives it —
   `G20`, not a JSON path. The user is looking at Excel. A non-zero exit
   means something was refused; do not apply anyway.
+- **What each element means is a hover note, not a cell.** Asked on the
+  sheet what "Paper Process" or "Decision Criteria" covers, say to hover
+  the element name — the definition is there, which is why the column of
+  them is gone. `hint <element>` returns the same text if they would
+  rather read it in the conversation.
 - **A workbook only reads back against the deal it was generated
   from.** It carries a stamp, and `read` refuses it otherwise. If the
   deal has gained a stakeholder or an answer since, regenerate — do


### PR DESCRIPTION
## What this does

Closes #910. The eight MEDDPICC element definitions are back on the sheet — as hover notes on the
element names, which cost no width and no row height because they are not in a cell.

They were a column until v6.0.0, and removing it is what let the tallest Qualification row drop from
366pt to 111pt: the same eight paragraphs in every workbook, three grid columns wide, taken from a
rep's own evidence and notes. But they were also the only thing on the sheet telling somebody what
"Paper Process" means. A note gives that back for free.

**v6.1.0, not breaking** — no address moved, so a v6.0.0 workbook still reads back.

## A classic note is four parts that have to agree

`xlsx.ts` had no comment writer. One note means:

- `xl/comments1.xml` — the text, per cell
- `xl/drawings/vmlDrawing1.vml` — the legacy shape that positions it, which Excel still requires
- `xl/worksheets/_rels/sheet1.xml.rels` — the worksheet's own relationships
- a `vml` content-type default, a comments override, and `<legacyDrawing>` **last** in the
  `CT_Worksheet` sequence, after the print group

Excel's response to any disagreement between those is to drop the note and open the file anyway.
That is why the check is made through the application: an inconsistent package is not loud.

Numbered by the **sheet**, not by how many sheets carry notes — `comments2.xml` belongs to sheet 2
whether or not sheet 1 has any, because Excel resolves parts by name.

## Three guards, each for a silence

| Refused | Because |
| --- | --- |
| A note on a cell a merge hides | Only the top-left cell of a merge is on screen; there is nothing to hover |
| Two notes on one cell | Excel keeps one and loses the other, with nothing to say so |
| A note with no text | A red triangle inviting a hover that shows an empty box |

Plus one found by reading the writer rather than by a failure: a note near the right or bottom edge
anchored its box past column XFD or row 1048576. Excel does not clip a malformed drawing — it offers
to repair the file. The box now slides back towards the middle, which keeps it full size; clamping
the far corner flattened it to nothing on the last row, and a test says so.

## How the acceptance criteria were checked

- **"no row is any taller than before"** — asserted directly: the same spec with the note flag
  removed produces identical row geometry, row for row.
- **"the Excel acceptance test asks Excel itself for the note text"** — it asks for all eight and
  compares each against the **schema**, not against the plan, which comes from the same generator and
  would agree even when both are wrong.
- **"no repair prompt"** — the open stage already fails when Excel does not list the workbook, and it
  earned its keep here: a first attempt at breaking the writer left an unreferenced `legacyDrawing`
  and that stage caught it one step earlier.
- **Beyond the issue:** the workbook Excel itself saved is reopened and the note read out of *that*.
  A review gets shared and saved, so a note Excel drops on the way out is a note nobody sees again.

## Verification

- **409 engine tests**, 27 shell tests, `check-spec` clean, `run-plugin-tests.sh` — all suites passed.
- **12 mutations, 12 killed**, one per new guard: hidden-merge, duplicate, empty text, sequence
  position of `legacyDrawing`, zero-based VML addressing, per-sheet part numbering, content types,
  escaping, the rels part, note collection, unknown kind, and both edge-anchor rules.
- **The Excel acceptance test: 15 stages green, exit 0** — including `Excel shows every element
  definition as a note on its element name` and `a note survives a save by Excel itself`.
- **The new stage was proved able to fail**, by mutating the note text: `FAIL: the note on B20 reads
  'MUTANT Quantified business outcomes…', the schema says 'Quantified business outcomes…'`.
- biome, codespell, textlint (`NATURAL_LANGUAGE`), shellcheck, shfmt and `pre-commit-local.sh` clean
  from the repo root.
- `codex:verified-code-review` — **approve, no findings**, twice.
