### PR TITLE
MEDDPICC: colour only what needs attention (v6.2.0)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,14 @@ and this project adheres to
     start, and the old "under 2" rule painted them identically.
   - **A blank cell that something depends on is washed.** An element's evidence, a question's response,
     the three whys, the two strategy cells, the identifying metadata, and a stakeholder's name, title
-    and role. Deliberately not `notes`, not the partner-side whys, and never a list's pre-allocated
-    rows: those exist to be empty until somebody needs them, and shading them would ask for work that
-    is not owed.
+    and role. Deliberately not `notes` and not the partner-side whys: those are legitimately empty.
+  - **A row somebody has started is washed even if it was a spare one.** A list keeps blank rows below
+    its entries so there is somewhere to type, and a conditional-format range does not grow when one is
+    used — so a wash stopping at the last existing entry was absent from the case it is most use, a
+    stakeholder halfway through being entered whose blank title is schema-required. Covering those rows
+    unconditionally would ask for work nobody owes, so the rule carries the condition instead: empty
+    **and** something else on this row, over the table's own columns rather than the width of the page,
+    because two tables share a band of rows. Found by the second-opinion review.
   - **The Excel stage reads each rule's own resolved fill back out of the application** and checks it is
     warm and faint — red at least green at least blue, no channel far from white. That is the assertion
     that fails if green returns anywhere, and it is a property worth asserting where a hex is not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,15 @@ and this project adheres to
   - **The score column is a ladder now** — 0 red, 1 orange, 2 yellow, 3 and 4 clear — rather than three
     bands with the top one shouting. An element nobody has scored and one scored 1 are a gap and a
     start, and the old "under 2" rule painted them identically.
-  - **A blank cell that something depends on is washed.** An element's evidence, a question's response,
-    the three whys, the two strategy cells, the identifying metadata, and a stakeholder's name, title
-    and role. Deliberately not `notes` and not the partner-side whys: those are legitimately empty.
+  - **A blank cell that something depends on is washed, at one of two levels.** `required` — a
+    completion rule or the schema needs a value, so blank is a gap: an element's evidence, the three
+    whys, the two strategy cells, the identifying metadata, a stakeholder's name, title and role.
+    `wanted` — nothing requires it and a blank one is still worth seeing: a discovery question nobody has
+    answered, which drops to the faintest tint. `qualStatus` is satisfied by any ONE answer, so calling
+    the others missing would raise a false alarm on an element that is genuinely complete — and an
+    unanswered question is still among the most actionable things on the sheet, so it drops a level
+    rather than disappearing. Deliberately nothing at all on `notes` or the partner-side whys, which are
+    legitimately empty. The level distinction came out of the second-opinion review.
   - **A row somebody has started is washed even if it was a spare one.** A list keeps blank rows below
     its entries so there is somewhere to type, and a conditional-format range does not grow when one is
     used — so a wash stopping at the last existing entry was absent from the case it is most use, a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v6.2.0 — colour marks what needs attention, and nothing else. Not breaking: no
+  address, width or height changes, so a v6.1.0 workbook still reads back.
+
+  The sheet used to paint something on every cell it evaluated, including every cell that was fine —
+  green at score 3-4, green on "Green", green on "Complete", green on any improvement. On a page read at
+  a glance the eye should land on the gaps; it was landing on whatever had the most fill, which on a
+  well-qualified deal is the good news.
+
+  - **Three faint warm washes, named for the attention they ask for rather than for their hue.**
+    `urgent` — nothing there: an unscored element, an untouched section, an overdue date, a "Red"
+    rating. `warn` — barely begun, or a step backwards. `watch` — nearly there: partial, in progress, a
+    score of 2. **Anything finished carries no fill at all.**
+  - **The score column is a ladder now** — 0 red, 1 orange, 2 yellow, 3 and 4 clear — rather than three
+    bands with the top one shouting. An element nobody has scored and one scored 1 are a gap and a
+    start, and the old "under 2" rule painted them identically.
+  - **A blank cell that something depends on is washed.** An element's evidence, a question's response,
+    the three whys, the two strategy cells, the identifying metadata, and a stakeholder's name, title
+    and role. Deliberately not `notes`, not the partner-side whys, and never a list's pre-allocated
+    rows: those exist to be empty until somebody needs them, and shading them would ask for work that
+    is not owed.
+  - **The Excel stage reads each rule's own resolved fill back out of the application** and checks it is
+    warm and faint — red at least green at least blue, no channel far from white. That is the assertion
+    that fails if green returns anywhere, and it is a property worth asserting where a hex is not.
+  - The three `ragRed` / `ragAmber` / `ragGreen` **cell** styles are gone with it. Nothing had
+    referenced them since the conditional formats took the colouring over.
+
 - **`meddpicc`** v6.1.0 — the element definitions are back, as hover notes. Not breaking: no address
   moved, so a v6.0.0 workbook still reads back.
 

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/README.md
+++ b/plugins/meddpicc/README.md
@@ -240,7 +240,7 @@ Creates a customer-facing document working backward from the target close date, 
 /meddpicc:qualify-deal Acme Corp render
 ```
 
-Generates an Excel workbook from the deal JSON, built from the workbook spec: one laid-out deal-review sheet with a formula-driven scorecard, RAG conditional formatting, computed row heights for prose, and schema-derived dropdowns. Each element name carries what that element means as a hover note, so the sheet explains itself without spending a column on it. `read` pulls edits back out.
+Generates an Excel workbook from the deal JSON, built from the workbook spec: one laid-out deal-review sheet with a formula-driven scorecard, computed row heights for prose, and schema-derived dropdowns. Colour marks only what needs attention — a faint warm wash on an unscored element, an untouched section, an overdue date, or a cell a completion rule needs and nobody has filled in — and anything finished carries no fill at all. Each element name carries what that element means as a hover note, so the sheet explains itself without spending a column on it. `read` pulls edits back out.
 
 ### Get coaching (auto-activates)
 

--- a/plugins/meddpicc/README.md
+++ b/plugins/meddpicc/README.md
@@ -240,7 +240,13 @@ Creates a customer-facing document working backward from the target close date, 
 /meddpicc:qualify-deal Acme Corp render
 ```
 
-Generates an Excel workbook from the deal JSON, built from the workbook spec: one laid-out deal-review sheet with a formula-driven scorecard, computed row heights for prose, and schema-derived dropdowns. Colour marks only what needs attention — a faint warm wash on an unscored element, an untouched section, an overdue date, or a cell a completion rule needs and nobody has filled in — and anything finished carries no fill at all. Each element name carries what that element means as a hover note, so the sheet explains itself without spending a column on it. `read` pulls edits back out.
+Generates an Excel workbook from the deal JSON, built from the workbook spec: one laid-out
+deal-review sheet with a formula-driven scorecard, computed row heights for prose, and
+schema-derived dropdowns. Colour marks only what needs attention — a faint warm wash on an
+unscored element, an untouched section, an overdue date, or a cell a completion rule needs and
+nobody has filled in — and anything finished carries no fill at all. Each element name carries
+what that element means as a hover note, so the sheet explains itself without spending a column
+on it. `read` pulls edits back out.
 
 ### Get coaching (auto-activates)
 

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -8,7 +8,7 @@ import { ENUM_LABELS, enumLabel } from './labels';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER, sectionLabel, statusLabel } from './sections';
 import { estimateRowHeight, MAX_ROW_HEIGHT } from './text-metrics';
 import { specTables, type WorkbookSpec } from './workbook-spec';
-import { A1, COMPLETION_STATUSES, columnIndex } from './xlsx';
+import { A1, COMPLETION_STATUSES, columnIndex, columnLetter } from './xlsx';
 import { readZip } from './zip';
 
 const here = import.meta.dir;
@@ -967,32 +967,48 @@ describe('planWorkbook — a blank cell something depends on is shaded', () => {
   const formatsOn = (ref: string, of: WorkbookPlan = plan) =>
     (of.sheets[0].conditionalFormats ?? []).filter((f) => f.sqref.split(':')[0] === ref);
 
-  test('the evidence column carries the missing wash, and the notes column does not', () => {
+  test('the evidence column carries the wash, and the notes column does not', () => {
     const elements = table('elements');
     const evidence = formatsOn(elements.ref('evidence', 0));
-    expect(evidence.map((f) => f.preset)).toEqual(['missing']);
+    expect(evidence.map((f) => f.preset)).toEqual(['missingInRow']);
+    // The row range is the table's own columns, not the sheet's width: two tables share a band of rows,
+    // and a range spanning the page would let one decide whether the other's row had been started.
+    const elementsSpec = spec.sheets.flatMap(specTables).find((t) => t.id === 'elements');
+    const width = (elementsSpec?.columns ?? []).reduce((n, c) => n + (c.span ?? 1), 0);
+    const last = columnLetter((elementsSpec?.anchorColumn ?? 0) + width - 1);
+    expect(evidence[0]?.rowRange).toBe(`$B${elements.firstDataRow}:$${last}${elements.firstDataRow}`);
     expect(formatsOn(elements.ref('notes', 0))).toEqual([]);
   });
 
-  test('a list is shaded over the entries it has, never over its spare rows', () => {
-    // The blank rows under a list are capacity, not gaps: shading them would ask somebody to fill in
-    // rows that exist only so there is somewhere to type.
+  test('a stakeholder typed into a spare row is warned about its blank required fields', () => {
+    // The pre-allocated rows are the supported way to add somebody, and a conditional-format range does
+    // not grow when a person starts typing in one. Stopping the range at the last existing entry meant
+    // the wash was missing in exactly the case it is most use: a half-entered row, whose blank title is
+    // then refused on read-back with a schema error instead of shown as a gap while it is being typed.
     const stakeholders = table('stakeholders');
     const entries = (deal.stakeholders as unknown[]).length;
-    expect(entries).toBeGreaterThan(0);
     expect(stakeholders.rows).toBeGreaterThan(entries);
     const [format] = formatsOn(stakeholders.ref('name', 0));
-    expect(format?.preset).toBe('missing');
-    expect(format?.sqref).toBe(`${stakeholders.ref('name', 0)}:${stakeholders.ref('name', entries - 1)}`);
+    expect(format?.sqref).toBe(`${stakeholders.ref('name', 0)}:${stakeholders.ref('name', stakeholders.rows - 1)}`);
   });
 
-  test('a list with no entries at all is not shaded', () => {
-    // Nothing to be missing yet, and a column of washes on an empty list is noise on every new deal.
+  test('a spare row nobody has touched is left alone', () => {
+    // Both things have to be true at once: the rule reaches the spare rows, and it does not fire until
+    // the row has been started. Otherwise a new deal opens as a column of washes asking for work that is
+    // not owed yet.
+    const stakeholders = table('stakeholders');
+    const [format] = formatsOn(stakeholders.ref('name', 0));
+    expect(format?.preset).toBe('missingInRow');
+    expect(format?.rowRange).toBeDefined();
+  });
+
+  test('an empty list is covered, and still shows nothing', () => {
     const empty = clone(deal);
     empty.stakeholders = [];
     const p = planWorkbook(schema, spec, empty);
     const stakeholders = table('stakeholders', p);
-    expect(formatsOn(stakeholders.ref('name', 0), p)).toEqual([]);
+    const [format] = formatsOn(stakeholders.ref('name', 0), p);
+    expect(format?.preset).toBe('missingInRow');
   });
 
   test('a form field the schema requires is shaded when empty', () => {
@@ -1009,5 +1025,81 @@ describe('planWorkbook — a blank cell something depends on is shaded', () => {
       byCell.set(first, (byCell.get(first) ?? 0) + 1);
     }
     expect([...byCell.entries()].filter(([, n]) => n > 1)).toEqual([]);
+  });
+});
+
+describe('planWorkbook — the row a wash asks about is its own table’s row', () => {
+  /** A sheet with two narrow lists side by side, the way the Close Plan and the Team are laid out. */
+  const sideBySide = (): WorkbookSpec =>
+    ({
+      version: 1,
+      sheets: [
+        {
+          kind: 'grid',
+          name: 'Lists',
+          columns: [
+            { min: 1, max: 1, width: 3.5 },
+            { min: 2, max: 17, width: 14 },
+          ],
+          blocks: [
+            {
+              kind: 'table',
+              table: {
+                id: 'left',
+                source: { kind: 'list', jsonPath: 'closePlan.milestones' },
+                anchorColumn: 2,
+                minRows: 3,
+                columns: [
+                  { id: 'title', header: 'Milestone', role: 'input', valueType: 'string', jsonPath: 'title', span: 4 },
+                  {
+                    id: 'owner',
+                    header: 'Owner',
+                    role: 'input',
+                    valueType: 'string',
+                    jsonPath: 'owner',
+                    span: 4,
+                    shadeWhenEmpty: true,
+                  },
+                ],
+              },
+            },
+            {
+              kind: 'table',
+              table: {
+                id: 'right',
+                source: { kind: 'list', jsonPath: 'team.internal' },
+                anchorColumn: 10,
+                minRows: 3,
+                columns: [
+                  { id: 'name', header: 'Name', role: 'input', valueType: 'string', jsonPath: 'name', span: 4 },
+                  {
+                    id: 'role',
+                    header: 'Role',
+                    role: 'input',
+                    valueType: 'string',
+                    jsonPath: 'role',
+                    span: 4,
+                    shadeWhenEmpty: true,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    }) as unknown as WorkbookSpec;
+
+  test('a narrow table asks about its own columns, not the width of the sheet', () => {
+    // Two lists share a band of rows. A row range spanning the page would let the milestones decide
+    // whether a team member's row had been started — and they are different lists, so a milestone
+    // typed on that row would suppress the wash on an empty name beside it, or raise one on a row
+    // nobody had touched.
+    const p = planWorkbook(schema, sideBySide(), deal);
+    const formats = p.sheets[0].conditionalFormats ?? [];
+    const left = table('left', p);
+    const right = table('right', p);
+    const rangeOf = (ref: string) => formats.find((f) => f.sqref.startsWith(`${ref}:`))?.rowRange;
+    expect(rangeOf(left.ref('owner', 0))).toBe(`$B${left.firstDataRow}:$I${left.firstDataRow}`);
+    expect(rangeOf(right.ref('role', 0))).toBe(`$J${right.firstDataRow}:$Q${right.firstDataRow}`);
   });
 });

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -967,6 +967,25 @@ describe('planWorkbook — a blank cell something depends on is shaded', () => {
   const formatsOn = (ref: string, of: WorkbookPlan = plan) =>
     (of.sheets[0].conditionalFormats ?? []).filter((f) => f.sqref.split(':')[0] === ref);
 
+  test('an unanswered question is wanted, not missing', () => {
+    // `qualStatus` calls an element complete when ANY of its responses is non-empty, so with two
+    // questions and one answer the element IS complete — and washing the blank sibling row the same red
+    // as a missing evidence cell claims something mandatory is absent when nothing requires it. The row
+    // is still worth seeing, so it drops a level rather than disappearing: "needs more information"
+    // rather than "nothing there".
+    const oneOfTwo = clone(deal);
+    const metrics = oneOfTwo.qualification.metrics as { responses: string[] };
+    metrics.responses = [metrics.responses[0], ''];
+    expect(computeCompletion(oneOfTwo).completionStatus.metrics).toBe('complete');
+
+    const p = planWorkbook(schema, spec, oneOfTwo);
+    const responses = table('responses', p);
+    const [format] = (p.sheets[0].conditionalFormats ?? []).filter(
+      (f) => f.sqref.split(':')[0] === responses.ref('response', 0),
+    );
+    expect(format?.preset).toBe('wantedInRow');
+  });
+
   test('the evidence column carries the wash, and the notes column does not', () => {
     const elements = table('elements');
     const evidence = formatsOn(elements.ref('evidence', 0));

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -962,3 +962,52 @@ describe('planWorkbook — the element definitions ride along as hover notes', (
     expect(() => planWorkbook(schema, broken, deal)).toThrow(/somethingElse/);
   });
 });
+
+describe('planWorkbook — a blank cell something depends on is shaded', () => {
+  const formatsOn = (ref: string, of: WorkbookPlan = plan) =>
+    (of.sheets[0].conditionalFormats ?? []).filter((f) => f.sqref.split(':')[0] === ref);
+
+  test('the evidence column carries the missing wash, and the notes column does not', () => {
+    const elements = table('elements');
+    const evidence = formatsOn(elements.ref('evidence', 0));
+    expect(evidence.map((f) => f.preset)).toEqual(['missing']);
+    expect(formatsOn(elements.ref('notes', 0))).toEqual([]);
+  });
+
+  test('a list is shaded over the entries it has, never over its spare rows', () => {
+    // The blank rows under a list are capacity, not gaps: shading them would ask somebody to fill in
+    // rows that exist only so there is somewhere to type.
+    const stakeholders = table('stakeholders');
+    const entries = (deal.stakeholders as unknown[]).length;
+    expect(entries).toBeGreaterThan(0);
+    expect(stakeholders.rows).toBeGreaterThan(entries);
+    const [format] = formatsOn(stakeholders.ref('name', 0));
+    expect(format?.preset).toBe('missing');
+    expect(format?.sqref).toBe(`${stakeholders.ref('name', 0)}:${stakeholders.ref('name', entries - 1)}`);
+  });
+
+  test('a list with no entries at all is not shaded', () => {
+    // Nothing to be missing yet, and a column of washes on an empty list is noise on every new deal.
+    const empty = clone(deal);
+    empty.stakeholders = [];
+    const p = planWorkbook(schema, spec, empty);
+    const stakeholders = table('stakeholders', p);
+    expect(formatsOn(stakeholders.ref('name', 0), p)).toEqual([]);
+  });
+
+  test('a form field the schema requires is shaded when empty', () => {
+    const address = plan.namedCells.accountName?.split('!')[1] ?? '';
+    expect(address).not.toBe('');
+    expect(formatsOn(address).map((f) => f.preset)).toEqual(['missing']);
+  });
+
+  test('no cell carries two washes', () => {
+    // Two rules over one cell means one paints over the other, decided by a priority nobody chose.
+    const byCell = new Map<string, number>();
+    for (const format of plan.sheets[0].conditionalFormats ?? []) {
+      const first = format.sqref.split(':')[0];
+      byCell.set(first, (byCell.get(first) ?? 0) + 1);
+    }
+    expect([...byCell.entries()].filter(([, n]) => n > 1)).toEqual([]);
+  });
+});

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -32,9 +32,9 @@ import {
 import {
   A1,
   buildWorkbook,
-  columnLetter,
   type CellSpec,
   type ConditionalFormat,
+  columnLetter,
   ENGINE_VERSION_PROPERTY,
   FINGERPRINT_PROPERTY,
   LOCALE_PROPERTY,

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -32,6 +32,7 @@ import {
 import {
   A1,
   buildWorkbook,
+  columnLetter,
   type CellSpec,
   type ConditionalFormat,
   ENGINE_VERSION_PROPERTY,
@@ -136,14 +137,6 @@ interface TableLayout {
   headerRow: number;
   firstDataRow: number;
   rowCount: number;
-  /**
-   * How many of those rows are entries.
-   *
-   * For a keyed table every row is one; for a list the rest are pre-allocated capacity. The two
-   * differ wherever a wash or a rule should stop at the data — shading a spare row asks somebody to
-   * fill in a row that exists only so there is somewhere to type.
-   */
-  entryCount: number;
   /** Column id -> 1-based column index. */
   columns: Map<string, number>;
   /** For a keyed source, the key at each data row. */
@@ -363,15 +356,18 @@ function resolveRows(table: SpecTable, deal: unknown, schema: unknown): TableLay
 }
 
 /**
- * How many of a table's rows are entries rather than room to grow.
+ * The row a cell sits on, across the columns of its own table — what `%ROW%` resolves to.
  *
- * Only a `list` pads: {@link resolveRows} returns `max(entries, minRows)` for one, and every row of a
- * keyed table or a question table is real.
+ * Columns absolute and the row relative, so Excel moves the reference down the range and never
+ * sideways. Scoped to the table rather than to the sheet because two tables share a band of rows: a
+ * range spanning the width would let the milestones decide whether a critical action's row had been
+ * started, and they are different lists.
  */
-function countEntries(table: SpecTable, deal: unknown, items: TableLayout['items']): number {
-  if (table.source.kind !== 'list') return items.length;
-  const list = readPath(deal, table.source.jsonPath);
-  return Array.isArray(list) ? list.length : 0;
+function tableRowRange(table: SpecTable, row: number): string {
+  const width = table.columns.reduce((total, column) => total + (column.span ?? 1), 0);
+  const from = columnLetter(table.anchorColumn);
+  const to = columnLetter(table.anchorColumn + width - 1);
+  return `$${from}${row}:$${to}${row}`;
 }
 
 /**
@@ -439,7 +435,6 @@ function layout(
           column += c.span ?? 1;
         }
         const items = resolveRows(table, deal, schema);
-        const entryCount = countEntries(table, deal, items);
         // At least one data row, and at least `minRows` so the list has room to grow into.
         const depth = 1 + Math.max(items.length, table.minRows ?? 1);
         tables.set(table.id, {
@@ -448,7 +443,6 @@ function layout(
           headerRow,
           firstDataRow: headerRow + 1,
           rowCount: items.length,
-          entryCount,
           columns,
           rowKeys: keysOf(table.source),
           items,
@@ -984,12 +978,14 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
         const lastRow = info.firstDataRow + padded - 1;
         const sqref = `${A1(column, info.firstDataRow)}:${A1(column, lastRow)}`;
         if (spec.conditionalFormat) formats.push({ sqref, preset: spec.conditionalFormat });
-        // Over the entries only. The other formats deliberately cover the padded rows — a value typed
-        // into one should colour like any other — but a wash for emptiness would be painting rows whose
-        // whole purpose is to be empty until somebody needs them.
-        if (spec.shadeWhenEmpty && info.entryCount > 0) {
-          const lastEntry = info.firstDataRow + info.entryCount - 1;
-          formats.push({ sqref: `${A1(column, info.firstDataRow)}:${A1(column, lastEntry)}`, preset: 'missing' });
+        // Over the whole capacity, including the rows kept spare — and the rule itself decides, by
+        // asking whether anything else is on the row. A range stopping at the last existing entry left
+        // the wash absent from the case it is most use: a stakeholder somebody is halfway through
+        // typing into a spare row, whose blank title is refused on read-back rather than shown as a gap
+        // while it is being filled in. Painting those rows unconditionally would be the opposite
+        // mistake, so `%ROW%` carries the condition.
+        if (spec.shadeWhenEmpty) {
+          formats.push({ sqref, preset: 'missingInRow', rowRange: tableRowRange(table, info.firstDataRow) });
         }
         if (spec.role === 'input' && spec.validate && spec.jsonPath) {
           // Any row's path resolves to the same schema node, so the first one answers for all.

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -136,6 +136,14 @@ interface TableLayout {
   headerRow: number;
   firstDataRow: number;
   rowCount: number;
+  /**
+   * How many of those rows are entries.
+   *
+   * For a keyed table every row is one; for a list the rest are pre-allocated capacity. The two
+   * differ wherever a wash or a rule should stop at the data — shading a spare row asks somebody to
+   * fill in a row that exists only so there is somewhere to type.
+   */
+  entryCount: number;
   /** Column id -> 1-based column index. */
   columns: Map<string, number>;
   /** For a keyed source, the key at each data row. */
@@ -355,6 +363,18 @@ function resolveRows(table: SpecTable, deal: unknown, schema: unknown): TableLay
 }
 
 /**
+ * How many of a table's rows are entries rather than room to grow.
+ *
+ * Only a `list` pads: {@link resolveRows} returns `max(entries, minRows)` for one, and every row of a
+ * keyed table or a question table is real.
+ */
+function countEntries(table: SpecTable, deal: unknown, items: TableLayout['items']): number {
+  if (table.source.kind !== 'list') return items.length;
+  const list = readPath(deal, table.source.jsonPath);
+  return Array.isArray(list) ? list.length : 0;
+}
+
+/**
  * The sheet's vertical rhythm, in points, measured off the manual deal-review sheet.
  *
  * A banner is roughly twice the height of its text and a standard row a little over one line, which
@@ -419,6 +439,7 @@ function layout(
           column += c.span ?? 1;
         }
         const items = resolveRows(table, deal, schema);
+        const entryCount = countEntries(table, deal, items);
         // At least one data row, and at least `minRows` so the list has room to grow into.
         const depth = 1 + Math.max(items.length, table.minRows ?? 1);
         tables.set(table.id, {
@@ -427,6 +448,7 @@ function layout(
           headerRow,
           firstDataRow: headerRow + 1,
           rowCount: items.length,
+          entryCount,
           columns,
           rowKeys: keysOf(table.source),
           items,
@@ -799,6 +821,7 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
               const values = validationValues(schema, cell.jsonPath, cell.valueType);
               if (values) validations.push({ sqref: ref, values });
             }
+            if (cell.shadeWhenEmpty) formats.push({ sqref: ref, preset: 'missing' });
           } else {
             push(row, { ref, formula: resolveFormula(cell.formula, { sheet: s.name }, named, tables), style });
           }
@@ -961,6 +984,13 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
         const lastRow = info.firstDataRow + padded - 1;
         const sqref = `${A1(column, info.firstDataRow)}:${A1(column, lastRow)}`;
         if (spec.conditionalFormat) formats.push({ sqref, preset: spec.conditionalFormat });
+        // Over the entries only. The other formats deliberately cover the padded rows — a value typed
+        // into one should colour like any other — but a wash for emptiness would be painting rows whose
+        // whole purpose is to be empty until somebody needs them.
+        if (spec.shadeWhenEmpty && info.entryCount > 0) {
+          const lastEntry = info.firstDataRow + info.entryCount - 1;
+          formats.push({ sqref: `${A1(column, info.firstDataRow)}:${A1(column, lastEntry)}`, preset: 'missing' });
+        }
         if (spec.role === 'input' && spec.validate && spec.jsonPath) {
           // Any row's path resolves to the same schema node, so the first one answers for all.
           const values = validationValues(schema, inputPathFor(table, spec, info.items[0] ?? {}), spec.valueType);

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -815,7 +815,9 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
               const values = validationValues(schema, cell.jsonPath, cell.valueType);
               if (values) validations.push({ sqref: ref, values });
             }
-            if (cell.shadeWhenEmpty) formats.push({ sqref: ref, preset: 'missing' });
+            if (cell.shadeWhenEmpty) {
+              formats.push({ sqref: ref, preset: cell.shadeWhenEmpty === 'wanted' ? 'wanted' : 'missing' });
+            }
           } else {
             push(row, { ref, formula: resolveFormula(cell.formula, { sheet: s.name }, named, tables), style });
           }
@@ -985,7 +987,11 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
         // while it is being filled in. Painting those rows unconditionally would be the opposite
         // mistake, so `%ROW%` carries the condition.
         if (spec.shadeWhenEmpty) {
-          formats.push({ sqref, preset: 'missingInRow', rowRange: tableRowRange(table, info.firstDataRow) });
+          formats.push({
+            sqref,
+            preset: spec.shadeWhenEmpty === 'wanted' ? 'wantedInRow' : 'missingInRow',
+            rowRange: tableRowRange(table, info.firstDataRow),
+          });
         }
         if (spec.role === 'input' && spec.validate && spec.jsonPath) {
           // Any row's path resolves to the same schema node, so the first one answers for all.

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -44,7 +44,7 @@
               "id": "accountName",
               "jsonPath": "metadata.accountName",
               "valueType": "string",
-              "shadeWhenEmpty": true
+              "shadeWhenEmpty": "required"
             },
             {
               "kind": "label",
@@ -57,7 +57,7 @@
               "id": "dealId",
               "jsonPath": "metadata.dealId",
               "valueType": "string",
-              "shadeWhenEmpty": true
+              "shadeWhenEmpty": "required"
             }
           ]
         },
@@ -75,7 +75,7 @@
               "id": "dealName",
               "jsonPath": "metadata.dealName",
               "valueType": "string",
-              "shadeWhenEmpty": true
+              "shadeWhenEmpty": "required"
             },
             {
               "kind": "label",
@@ -433,7 +433,7 @@
                 "role": "input",
                 "jsonPath": "qualification.*.evidence",
                 "valueType": "text",
-                "shadeWhenEmpty": true,
+                "shadeWhenEmpty": "required",
                 "span": 4
               },
               {
@@ -481,7 +481,7 @@
                 "role": "input",
                 "jsonPath": "qualification.*.responses[]",
                 "valueType": "text",
-                "shadeWhenEmpty": true,
+                "shadeWhenEmpty": "wanted",
                 "span": 9
               }
             ]
@@ -521,7 +521,7 @@
               "id": "whyAnything",
               "jsonPath": "threeWhys.us.whyAnything",
               "valueType": "text",
-              "shadeWhenEmpty": true
+              "shadeWhenEmpty": "required"
             },
             {
               "kind": "label",
@@ -551,7 +551,7 @@
               "id": "whyUs",
               "jsonPath": "threeWhys.us.whyUs",
               "valueType": "text",
-              "shadeWhenEmpty": true
+              "shadeWhenEmpty": "required"
             },
             {
               "kind": "label",
@@ -581,7 +581,7 @@
               "id": "whyNow",
               "jsonPath": "threeWhys.us.whyNow",
               "valueType": "text",
-              "shadeWhenEmpty": true
+              "shadeWhenEmpty": "required"
             },
             {
               "kind": "label",
@@ -642,7 +642,7 @@
                 "role": "input",
                 "jsonPath": "name",
                 "valueType": "string",
-                "shadeWhenEmpty": true,
+                "shadeWhenEmpty": "required",
                 "span": 2
               },
               {
@@ -651,7 +651,7 @@
                 "role": "input",
                 "jsonPath": "title",
                 "valueType": "string",
-                "shadeWhenEmpty": true,
+                "shadeWhenEmpty": "required",
                 "span": 3
               },
               {
@@ -660,7 +660,7 @@
                 "role": "input",
                 "jsonPath": "roleInDeal",
                 "valueType": "string",
-                "shadeWhenEmpty": true,
+                "shadeWhenEmpty": "required",
                 "validate": true,
                 "span": 2
               },
@@ -739,7 +739,7 @@
               "id": "differentiatedValueProposition",
               "jsonPath": "salesStrategy.differentiatedValueProposition",
               "valueType": "text",
-              "shadeWhenEmpty": true
+              "shadeWhenEmpty": "required"
             },
             {
               "kind": "field",
@@ -747,7 +747,7 @@
               "id": "winStrategy",
               "jsonPath": "salesStrategy.winStrategy",
               "valueType": "text",
-              "shadeWhenEmpty": true
+              "shadeWhenEmpty": "required"
             }
           ]
         },

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -43,7 +43,8 @@
               "span": 6,
               "id": "accountName",
               "jsonPath": "metadata.accountName",
-              "valueType": "string"
+              "valueType": "string",
+              "shadeWhenEmpty": true
             },
             {
               "kind": "label",
@@ -55,7 +56,8 @@
               "span": 6,
               "id": "dealId",
               "jsonPath": "metadata.dealId",
-              "valueType": "string"
+              "valueType": "string",
+              "shadeWhenEmpty": true
             }
           ]
         },
@@ -72,7 +74,8 @@
               "span": 6,
               "id": "dealName",
               "jsonPath": "metadata.dealName",
-              "valueType": "string"
+              "valueType": "string",
+              "shadeWhenEmpty": true
             },
             {
               "kind": "label",
@@ -430,6 +433,7 @@
                 "role": "input",
                 "jsonPath": "qualification.*.evidence",
                 "valueType": "text",
+                "shadeWhenEmpty": true,
                 "span": 4
               },
               {
@@ -477,6 +481,7 @@
                 "role": "input",
                 "jsonPath": "qualification.*.responses[]",
                 "valueType": "text",
+                "shadeWhenEmpty": true,
                 "span": 9
               }
             ]
@@ -515,7 +520,8 @@
               "span": 6,
               "id": "whyAnything",
               "jsonPath": "threeWhys.us.whyAnything",
-              "valueType": "text"
+              "valueType": "text",
+              "shadeWhenEmpty": true
             },
             {
               "kind": "label",
@@ -544,7 +550,8 @@
               "span": 6,
               "id": "whyUs",
               "jsonPath": "threeWhys.us.whyUs",
-              "valueType": "text"
+              "valueType": "text",
+              "shadeWhenEmpty": true
             },
             {
               "kind": "label",
@@ -573,7 +580,8 @@
               "span": 6,
               "id": "whyNow",
               "jsonPath": "threeWhys.us.whyNow",
-              "valueType": "text"
+              "valueType": "text",
+              "shadeWhenEmpty": true
             },
             {
               "kind": "label",
@@ -634,6 +642,7 @@
                 "role": "input",
                 "jsonPath": "name",
                 "valueType": "string",
+                "shadeWhenEmpty": true,
                 "span": 2
               },
               {
@@ -642,6 +651,7 @@
                 "role": "input",
                 "jsonPath": "title",
                 "valueType": "string",
+                "shadeWhenEmpty": true,
                 "span": 3
               },
               {
@@ -650,6 +660,7 @@
                 "role": "input",
                 "jsonPath": "roleInDeal",
                 "valueType": "string",
+                "shadeWhenEmpty": true,
                 "validate": true,
                 "span": 2
               },
@@ -727,14 +738,16 @@
               "span": 8,
               "id": "differentiatedValueProposition",
               "jsonPath": "salesStrategy.differentiatedValueProposition",
-              "valueType": "text"
+              "valueType": "text",
+              "shadeWhenEmpty": true
             },
             {
               "kind": "field",
               "span": 8,
               "id": "winStrategy",
               "jsonPath": "salesStrategy.winStrategy",
-              "valueType": "text"
+              "valueType": "text",
+              "shadeWhenEmpty": true
             }
           ]
         },

--- a/plugins/meddpicc/engine/workbook-spec.test.ts
+++ b/plugins/meddpicc/engine/workbook-spec.test.ts
@@ -365,6 +365,18 @@ describe('checkWorkbookSpec — roles', () => {
     expect(failures).toContain('elementDefinition');
   });
 
+  test('rejects a shade level nobody implemented', () => {
+    // The spec is JSON, so `true` or a typo is a string like any other. Unchecked, the generator would
+    // silently fall back to the strongest wash — the loudest possible outcome from a mistake.
+    const spec = clone(baseSpec());
+    const evidence = fixtureTable(spec, 'elements').columns.find((c) => c.role === 'input');
+    if (!evidence) throw new Error('fixture drift');
+    evidence.shadeWhenEmpty = 'nice-to-have' as never;
+    const failures = checkWorkbookSpec(schema, spec).roles.failures.join();
+    expect(failures).toContain('nice-to-have');
+    expect(failures).toContain('required, wanted');
+  });
+
   test('rejects shading-when-empty on a cell nobody types into', () => {
     // A derived or computed cell is empty because the engine or a formula made it so; a wash there
     // would blame a person for the generator's output.
@@ -372,7 +384,7 @@ describe('checkWorkbookSpec — roles', () => {
     const elements = fixtureTable(spec, 'elements');
     const derived = elements.columns.find((c) => c.role === 'derived');
     if (!derived) throw new Error('fixture drift');
-    derived.shadeWhenEmpty = true;
+    derived.shadeWhenEmpty = 'required';
     const failures = checkWorkbookSpec(schema, spec).roles.failures.join();
     expect(failures).toContain(derived.id);
     expect(failures).toContain('shadeWhenEmpty');
@@ -384,7 +396,7 @@ describe('checkWorkbookSpec — roles', () => {
     const spec = clone(baseSpec());
     const score = fixtureTable(spec, 'elements').columns.find((c) => c.id === 'score');
     if (!score) throw new Error('fixture drift');
-    score.shadeWhenEmpty = true;
+    score.shadeWhenEmpty = 'required';
     score.conditionalFormat = 'score';
     const failures = checkWorkbookSpec(schema, spec).roles.failures.join();
     expect(failures).toContain('elements.score');

--- a/plugins/meddpicc/engine/workbook-spec.test.ts
+++ b/plugins/meddpicc/engine/workbook-spec.test.ts
@@ -365,6 +365,32 @@ describe('checkWorkbookSpec — roles', () => {
     expect(failures).toContain('elementDefinition');
   });
 
+  test('rejects shading-when-empty on a cell nobody types into', () => {
+    // A derived or computed cell is empty because the engine or a formula made it so; a wash there
+    // would blame a person for the generator's output.
+    const spec = clone(baseSpec());
+    const elements = fixtureTable(spec, 'elements');
+    const derived = elements.columns.find((c) => c.role === 'derived');
+    if (!derived) throw new Error('fixture drift');
+    derived.shadeWhenEmpty = true;
+    const failures = checkWorkbookSpec(schema, spec).roles.failures.join();
+    expect(failures).toContain(derived.id);
+    expect(failures).toContain('shadeWhenEmpty');
+  });
+
+  test('rejects shading-when-empty beside a conditional format on the same cell', () => {
+    // Two rules over one cell means one paints over the other, and which one wins is a priority
+    // number nobody set deliberately.
+    const spec = clone(baseSpec());
+    const score = fixtureTable(spec, 'elements').columns.find((c) => c.id === 'score');
+    if (!score) throw new Error('fixture drift');
+    score.shadeWhenEmpty = true;
+    score.conditionalFormat = 'score';
+    const failures = checkWorkbookSpec(schema, spec).roles.failures.join();
+    expect(failures).toContain('elements.score');
+    expect(failures).toContain('shadeWhenEmpty');
+  });
+
   test('every declared valueType has a style in the palette', () => {
     for (const [type, style] of Object.entries(VALUE_TYPE_STYLE)) {
       expect(typeof style, `${type} maps to a style name`).toBe('string');
@@ -542,6 +568,18 @@ describe('the shipped workbook-spec.json', () => {
     expect(elements.columns.map((c) => c.id)).not.toContain('definition');
     const noted = elements.columns.filter((c) => c.note === 'elementDefinition');
     expect(noted.map((c) => c.id)).toEqual(['element']);
+  });
+
+  test('shades the cells a completion rule consults, and leaves the optional ones alone', () => {
+    // Blank evidence is a gap the engine's own rule cares about — `complete` needs a non-empty
+    // response AND non-empty evidence. Blank notes are a choice.
+    const tables = shipped.sheets.flatMap((s) => specTables(s));
+    const shaded = (tableId: string) =>
+      (tables.find((t) => t.id === tableId)?.columns ?? []).filter((c) => c.shadeWhenEmpty).map((c) => c.id);
+    expect(shaded('elements')).toEqual(['evidence']);
+    expect(shaded('responses')).toEqual(['response']);
+    // The schema requires all three of these, so an empty one is not a deal in progress but a gap.
+    expect(shaded('stakeholders').sort()).toEqual(['name', 'roleInDeal', 'title']);
   });
 
   test('gives every deal collection a table, so nothing is capped', () => {

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -136,6 +136,18 @@ export interface SpecColumn {
   /** A named conditional-format preset (see xlsx.ts). Formatting is spec data, not code. */
   conditionalFormat?: CfPreset;
   /**
+   * Wash this column's cells when they are empty — see the `missing` preset in `xlsx.ts`.
+   *
+   * Only where blankness is a **gap** rather than a choice: the cells a completion rule consults
+   * (an element's evidence, a question's response) and the ones the schema requires (a stakeholder's
+   * name, title and role). Not `notes`, not the partner-side whys — those are legitimately empty, and
+   * shading them would nag about a decision instead of showing a hole.
+   *
+   * Input cells only, and never on a cell that already carries a `conditionalFormat`: two rules over
+   * one cell means one paints over the other, decided by a priority number nobody chose.
+   */
+  shadeWhenEmpty?: boolean;
+  /**
    * Offer a dropdown of the values the schema allows. The list is READ from the schema, never
    * written here — that is the whole point, since a hand-copied list drifts the moment someone
    * adds an enum member and the workbook goes on offering the old set.
@@ -189,6 +201,8 @@ export type SpecRowCell =
       jsonPath: string;
       valueType: ValueType;
       conditionalFormat?: CfPreset;
+      /** Wash the cell when it is empty — see {@link SpecColumn.shadeWhenEmpty}. */
+      shadeWhenEmpty?: boolean;
       validate?: boolean;
     }
   | {
@@ -451,6 +465,11 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
           } else {
             out.inputs.push({ where, paths: [cell.jsonPath] });
             if (cell.validate) out.validated.push({ where, path: cell.jsonPath, valueType: cell.valueType });
+            if (cell.shadeWhenEmpty && cell.conditionalFormat) {
+              roles.push(
+                `${where}: shadeWhenEmpty and conditionalFormat "${cell.conditionalFormat}" both paint this cell — one would cover the other`,
+              );
+            }
           }
         } else if (cell.kind === 'computed') {
           out.formulas.push({ where, formula: cell.formula, table: null });
@@ -472,6 +491,19 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
         if (seenColumns.has(column.id)) ids.push(`${where}: duplicate column id`);
         seenColumns.add(column.id);
         checkValueType(where, column.valueType);
+
+        if (column.shadeWhenEmpty) {
+          // An empty derived or computed cell is the engine's or a formula's doing, so a wash there
+          // would blame a person for the generator's output.
+          if (column.role !== 'input') {
+            roles.push(`${where}: shadeWhenEmpty belongs on an input column; this one is ${column.role}`);
+          }
+          if (column.conditionalFormat) {
+            roles.push(
+              `${where}: shadeWhenEmpty and conditionalFormat "${column.conditionalFormat}" both paint this cell — one would cover the other`,
+            );
+          }
+        }
 
         if (column.note !== undefined) {
           if (!NOTE_SOURCES.includes(column.note)) {

--- a/plugins/meddpicc/engine/workbook-spec.ts
+++ b/plugins/meddpicc/engine/workbook-spec.ts
@@ -82,6 +82,20 @@ export type CellRole = 'input' | 'computed' | 'derived';
  */
 export type NoteSource = 'elementDefinition';
 
+/**
+ * How much attention a blank cell should ask for — see {@link SpecColumn.shadeWhenEmpty}.
+ *
+ * `required` — a completion rule or the schema needs a value here, so blank is a gap: an element's
+ * evidence, a stakeholder's name, the three whys. The strongest wash.
+ *
+ * `wanted` — nothing requires it and a blank one is still worth seeing: a discovery question nobody has
+ * answered. One level down, because `qualStatus` is satisfied by any ONE answer, so calling the others
+ * missing would raise a false alarm on an element that is genuinely complete.
+ */
+export type ShadeLevel = 'required' | 'wanted';
+
+export const SHADE_LEVELS: readonly ShadeLevel[] = ['required', 'wanted'];
+
 export const NOTE_SOURCES: readonly NoteSource[] = ['elementDefinition'];
 
 export interface SpecColumn {
@@ -146,7 +160,7 @@ export interface SpecColumn {
    * Input cells only, and never on a cell that already carries a `conditionalFormat`: two rules over
    * one cell means one paints over the other, decided by a priority number nobody chose.
    */
-  shadeWhenEmpty?: boolean;
+  shadeWhenEmpty?: ShadeLevel;
   /**
    * Offer a dropdown of the values the schema allows. The list is READ from the schema, never
    * written here — that is the whole point, since a hand-copied list drifts the moment someone
@@ -202,7 +216,7 @@ export type SpecRowCell =
       valueType: ValueType;
       conditionalFormat?: CfPreset;
       /** Wash the cell when it is empty — see {@link SpecColumn.shadeWhenEmpty}. */
-      shadeWhenEmpty?: boolean;
+      shadeWhenEmpty?: ShadeLevel;
       validate?: boolean;
     }
   | {
@@ -492,6 +506,11 @@ function collect(spec: WorkbookSpec, roles: string[], ids: string[]): Collected 
         seenColumns.add(column.id);
         checkValueType(where, column.valueType);
 
+        if (column.shadeWhenEmpty !== undefined && !SHADE_LEVELS.includes(column.shadeWhenEmpty)) {
+          roles.push(
+            `${where}: shadeWhenEmpty "${column.shadeWhenEmpty}" is not a level — have ${SHADE_LEVELS.join(', ')}`,
+          );
+        }
         if (column.shadeWhenEmpty) {
           // An empty derived or computed cell is the engine's or a formula's doing, so a wash there
           // would blame a person for the generator's output.

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -970,3 +970,34 @@ describe('the colour rules paint only what needs attention', () => {
     expect(Object.keys(STYLE_IDS)).not.toContain('ragGreen');
   });
 });
+
+describe('a rule and its row range have to agree', () => {
+  const build = (format: { sqref: string; preset: CfPreset; rowRange?: string }) =>
+    buildWorkbook([
+      {
+        name: 'Data',
+        rows: [{ row: 2, cells: [{ ref: 'B2', value: 'x' }] }],
+        conditionalFormats: [format],
+      },
+    ]);
+
+  test('a rule that asks about the row cannot be emitted without one', () => {
+    // Left to resolve to nothing it would emit `COUNTA()>0`, which Excel takes as a formula error and
+    // shows as a rule that simply never fires — a wash that is missing with nothing to say why.
+    expect(() => build({ sqref: 'B2:B5', preset: 'missingInRow' })).toThrow(/rowRange/);
+  });
+
+  test('a row range on a rule that does not use it is refused', () => {
+    // Data nothing reads is data that lies: it would look as though the rule had been scoped.
+    expect(() => build({ sqref: 'B2:B5', preset: 'missing', rowRange: '$B2:$Q2' })).toThrow(/rowRange/);
+  });
+
+  test('given one, it is substituted into the formula as written', () => {
+    const xml = dec(
+      readZip(build({ sqref: 'B2:B5', preset: 'missingInRow', rowRange: '$B2:$Q2' })).get('xl/worksheets/sheet1.xml')
+        ?.data as Uint8Array,
+    );
+    expect(xml).toContain('COUNTA($B2:$Q2)');
+    expect(xml).not.toContain('%ROW%');
+  });
+});

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { A1, buildWorkbook, columnIndex, columnLetter, expandMerges, STYLE_IDS } from './xlsx';
+import { enumLabel } from './labels';
+import { A1, buildWorkbook, type CfPreset, columnIndex, columnLetter, DXF_IDS, expandMerges, STYLE_IDS } from './xlsx';
 import { readZip } from './zip';
 
 const dec = (b: Uint8Array) => new TextDecoder().decode(b);
@@ -249,39 +250,32 @@ describe('buildWorkbook — conditional formatting and validation', () => {
   });
 });
 
-describe('the delta preset colours movement, not stillness', () => {
-  // A change since the last review reads at a glance: up is good, down is not. Nought is neither, so
-  // it stays uncoloured — an amber "nothing moved" would look like a warning in a column somebody
-  // scans for problems.
-  const sheet = () => {
-    const parts = readZip(
-      buildWorkbook([
-        {
-          name: 'Data',
-          rows: [
-            { row: 1, cells: [{ ref: 'A1', value: 2, style: 'score' }] },
-            { row: 2, cells: [{ ref: 'A2', value: 0, style: 'score' }] },
-          ],
-          conditionalFormats: [{ sqref: 'A1:A2', preset: 'delta' }],
-        },
-      ]),
+describe('the delta preset colours a step backwards and nothing else', () => {
+  // A change since the last review. Up used to be green and it is now unpainted, along with every
+  // other piece of good news on the sheet: nought is not a warning either, so one rule is the whole
+  // preset and a column of improvements reads as quiet.
+  const rules = () => {
+    const xml = dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'Data',
+            rows: [
+              { row: 1, cells: [{ ref: 'A1', value: 2, style: 'score' }] },
+              { row: 2, cells: [{ ref: 'A2', value: 0, style: 'score' }] },
+            ],
+            conditionalFormats: [{ sqref: 'A1:A2', preset: 'delta' }],
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
     );
-    return dec(parts.get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
-  };
-
-  test('two rules, one each way, and nothing for zero', () => {
-    const xml = sheet();
-    const rules = [...xml.matchAll(/<cfRule[^>]*operator="([a-zA-Z]+)"[^>]*>\s*<formula>([^<]*)<\/formula>/g)].map(
+    return [...xml.matchAll(/<cfRule[^>]*operator="([a-zA-Z]+)"[^>]*>\s*<formula>([^<]*)<\/formula>/g)].map(
       (m) => `${m[1]} ${m[2]}`,
     );
-    expect(rules).toEqual(['greaterThan 0', 'lessThan 0']);
-  });
+  };
 
-  test('the two rules use different colours, or the sign is not readable', () => {
-    const xml = sheet();
-    const ids = [...xml.matchAll(/<cfRule[^>]*dxfId="(\d+)"/g)].map((m) => m[1]);
-    expect(ids).toHaveLength(2);
-    expect(new Set(ids).size).toBe(2);
+  test('one rule, for movement downwards', () => {
+    expect(rules()).toEqual(['lessThan 0']);
   });
 });
 
@@ -634,14 +628,6 @@ describe('styles.xml — a named style resolves to the look it promises', () => 
     }
   });
 
-  test('the RAG styles keep their own three fills, all different', () => {
-    const fills = (['ragRed', 'ragAmber', 'ragGreen'] as const).map((n) => lookOf(n).fill);
-    expect(new Set(fills).size).toBe(3);
-    expect(fills[0]).toContain('FFF8CBAD');
-    expect(fills[1]).toContain('FFFFE699');
-    expect(fills[2]).toContain('FFC6E0B4');
-  });
-
   test('plain styles carry no fill, so they do not paint over the page', () => {
     for (const name of ['default', 'text', 'label', 'currency', 'date'] as const) {
       expect(lookOf(name).fill, name).toContain('patternType="none"');
@@ -895,5 +881,92 @@ describe('buildWorkbook — a note at the edge of the grid', () => {
     const [left, , top, , right, , bottom] = anchorOf('B20');
     expect(right - left).toBe(4);
     expect(bottom - top).toBe(5);
+  });
+});
+
+describe('the colour rules paint only what needs attention', () => {
+  /** Every rule of one preset, as `operator formula -> dxfName`. */
+  const rulesOf = (preset: CfPreset) => {
+    const xml = dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'Data',
+            rows: [{ row: 1, cells: [{ ref: 'A1', value: 1 }] }],
+            conditionalFormats: [{ sqref: 'A1:A2', preset }],
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+    const byId = Object.fromEntries(Object.entries(DXF_IDS).map(([name, id]) => [String(id), name]));
+    return [
+      ...xml.matchAll(/<cfRule type="([a-zA-Z]+)"(?: operator="([a-zA-Z]+)")? dxfId="(\d+)"[^>]*>(.*?)<\/cfRule>/g),
+    ].map((m) => ({
+      type: m[1],
+      operator: m[2] ?? '',
+      formula: /<formula>([^<]*)<\/formula>/.exec(m[4])?.[1] ?? '',
+      dxf: byId[m[3]],
+    }));
+  };
+
+  test('the score column is a ladder that runs out before the good scores', () => {
+    // 0 is nothing, 1 is barely, 2 is nearly — and 3 or 4 is done, so it carries no fill at all.
+    // Colouring the top of the range meant a well-qualified deal was the loudest thing on the sheet.
+    expect(rulesOf('score')).toEqual([
+      { type: 'cellIs', operator: 'equal', formula: '0', dxf: 'urgent' },
+      { type: 'cellIs', operator: 'equal', formula: '1', dxf: 'warn' },
+      { type: 'cellIs', operator: 'equal', formula: '2', dxf: 'watch' },
+    ]);
+  });
+
+  test('no preset paints a fill for a value that is finished, good, or improved', () => {
+    // The whole rule of the palette, asserted once: nothing in any preset may fire on the words and
+    // numbers that mean "done". A green fill anywhere is what this is here to catch.
+    const good = [enumLabel('complete'), 'Green', '3', '4'];
+    for (const preset of ['score', 'delta', 'ragText', 'statusText', 'completionText', 'missing'] as CfPreset[]) {
+      for (const rule of rulesOf(preset)) {
+        for (const word of good) {
+          expect(rule.formula, `${preset}: ${rule.operator} ${rule.formula}`).not.toContain(word);
+        }
+      }
+    }
+    // Movement upwards is not painted either, so only a step backwards draws the eye.
+    expect(rulesOf('delta').map((r) => r.operator)).toEqual(['lessThan']);
+  });
+
+  test('a blank cell a rule needs is shaded, and the rule is about emptiness alone', () => {
+    const [rule, ...rest] = rulesOf('missing');
+    expect(rest).toEqual([]);
+    expect(rule.type).toBe('expression');
+    expect(rule.dxf).toBe('urgent');
+    // Whitespace is not content: a cell holding a space is as empty as one holding nothing.
+    expect(rule.formula).toContain('TRIM');
+    expect(rule.formula).toContain('A1');
+  });
+
+  test('all three fills are faint and warm, and none of them is green', () => {
+    // "Subtle" and "warm" are the two properties worth asserting; the exact hexes are a matter of
+    // taste and belong in the render the operator looks at. Red at least green at least blue is what
+    // makes a wash warm — and it is what fails if somebody reaches for green again.
+    const styles = dec(readZip(minimal()).get('xl/styles.xml')?.data as Uint8Array);
+    const dxfs = styles.slice(styles.indexOf('<dxfs'), styles.indexOf('</dxfs>'));
+    const colours = [...dxfs.matchAll(/bgColor rgb="FF([0-9A-F]{6})"/g)].map((m) => m[1]);
+    expect(colours).toHaveLength(Object.keys(DXF_IDS).length);
+    expect(new Set(colours).size).toBe(colours.length);
+    for (const hex of colours) {
+      const [r, g, b] = [0, 2, 4].map((i) => Number.parseInt(hex.slice(i, i + 2), 16));
+      expect(r, `${hex} is warm`).toBeGreaterThanOrEqual(g);
+      expect(g, `${hex} is warm`).toBeGreaterThanOrEqual(b);
+      // Faint: every channel near white, so the wash sits under the text rather than over it.
+      expect(b, `${hex} is faint`).toBeGreaterThanOrEqual(0xd0);
+    }
+  });
+
+  test('no cell style carries a status fill — the conditional formats own the colouring', () => {
+    // ragRed/ragAmber/ragGreen were cell styles nothing referenced: the presets had taken the job
+    // over, and three unreferenced fills is three chances to paint a cell by accident.
+    expect(Object.keys(STYLE_IDS)).not.toContain('ragRed');
+    expect(Object.keys(STYLE_IDS)).not.toContain('ragAmber');
+    expect(Object.keys(STYLE_IDS)).not.toContain('ragGreen');
   });
 });

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -1001,3 +1001,28 @@ describe('a rule and its row range have to agree', () => {
     expect(xml).not.toContain('%ROW%');
   });
 });
+
+describe('the two levels of an empty-cell wash', () => {
+  const dxfOf = (preset: CfPreset) => {
+    const xml = dec(
+      readZip(
+        buildWorkbook([
+          {
+            name: 'Data',
+            rows: [{ row: 2, cells: [{ ref: 'B2', value: 'x' }] }],
+            conditionalFormats: [{ sqref: 'B2:B5', preset, rowRange: '$B2:$Q2' }],
+          },
+        ]),
+      ).get('xl/worksheets/sheet1.xml')?.data as Uint8Array,
+    );
+    const id = Number(/dxfId="(\d+)"/.exec(xml)?.[1]);
+    return Object.entries(DXF_IDS).find(([, v]) => v === id)?.[0];
+  };
+
+  test('a cell something requires is urgent; one merely wanted is a level down', () => {
+    // A blank evidence cell blocks the element from ever being complete. An unanswered question does
+    // not — any one answer satisfies the rule — so the two cannot ask for the same attention.
+    expect(dxfOf('missingInRow')).toBe('urgent');
+    expect(dxfOf('wantedInRow')).toBe('watch');
+  });
+});

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -241,7 +241,9 @@ export type CfPreset =
   | 'completionText'
   | 'overdueDate'
   | 'missing'
-  | 'missingInRow';
+  | 'missingInRow'
+  | 'wanted'
+  | 'wantedInRow';
 
 /**
  * The section statuses `computeCompletion` emits.
@@ -318,6 +320,15 @@ const CF_PRESETS: Record<CfPreset, CfRule[]> = {
   // rows would wash. No shipped table is in that position — the tables with formulas are the keyed ones,
   // where every row is real anyway.
   missingInRow: [{ type: 'expression', formulas: ['AND(LEN(TRIM(%FIRST%))=0,COUNTA(%ROW%)>0)'], dxf: 'urgent' }],
+  // The same two rules a level down, for a cell nothing REQUIRES but a blank one is still worth seeing.
+  //
+  // An unanswered discovery question is the case this exists for. `qualStatus` calls an element complete
+  // when any one of its responses is filled in, so with two questions and one answer the element is
+  // genuinely done — and washing the blank sibling the same red as a missing evidence cell says
+  // something mandatory is absent when nothing requires it. A level down keeps the signal, which is among
+  // the most actionable things on the sheet, without the false alarm.
+  wanted: [{ type: 'expression', formulas: ['LEN(TRIM(%FIRST%))=0'], dxf: 'watch' }],
+  wantedInRow: [{ type: 'expression', formulas: ['AND(LEN(TRIM(%FIRST%))=0,COUNTA(%ROW%)>0)'], dxf: 'watch' }],
 };
 
 /** The placeholder a rule uses to mean "the row this cell is on, across its own table". */

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -136,9 +136,6 @@ const STYLE_ORDER = [
   'percent',
   'date',
   'score',
-  'ragRed',
-  'ragAmber',
-  'ragGreen',
   'muted',
 ] as const;
 
@@ -160,11 +157,8 @@ const FONT_WHITE_TITLE = 4;
 const FILL_NONE = 0;
 // index 1 is the format-reserved gray125 placeholder; Excel expects it present and unused
 const FILL_DARK = 2;
-const FILL_RED = 3;
-const FILL_AMBER = 4;
-const FILL_GREEN = 5;
-const FILL_TEAL = 6;
-const FILL_ACCENT = 7;
+const FILL_TEAL = 3;
+const FILL_ACCENT = 4;
 
 interface StyleDef {
   font: number;
@@ -198,19 +192,32 @@ const STYLE_DEFS: Record<StyleName, StyleDef> = {
   percent: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: NUMFMT_PERCENT, left: true, middle: true },
   date: { font: FONT_DEFAULT, fill: FILL_NONE, numFmt: NUMFMT_DATE, left: true, middle: true },
   score: { font: FONT_BOLD, fill: FILL_NONE, numFmt: 0, center: true, middle: true },
-  ragRed: { font: FONT_BOLD, fill: FILL_RED, numFmt: 0, center: true },
-  ragAmber: { font: FONT_BOLD, fill: FILL_AMBER, numFmt: 0, center: true },
-  ragGreen: { font: FONT_BOLD, fill: FILL_GREEN, numFmt: 0, center: true },
   muted: { font: FONT_ITALIC_GREY, fill: FILL_NONE, numFmt: 0 },
 };
 
 /**
  * Conditional-format fills, in `dxfs` order — the index of each name IS its `dxfId`.
  * Same discipline as the cell-style palette: one ordered list, indexes derived from it.
+ *
+ * **Colour marks what needs attention, and nothing else.** A finished element, a complete section, a
+ * "Green" rating and a score that went up all carry no fill at all: on a sheet read at a glance the
+ * eye should land on the gaps, and it lands instead on whatever has the most colour. Painting the good
+ * news green made a well-qualified deal the loudest thing on the page.
+ *
+ * So three faint washes, named for how much attention they ask for rather than for their hue, and
+ * ordered that way too:
+ *
+ * - `urgent` — nothing there at all: an unscored element, an untouched section, a required cell nobody
+ *   has filled, a "Red" rating, a date already past.
+ * - `warn` — barely begun, or a step backwards.
+ * - `watch` — nearly there. Partial, in progress, a score of 2.
+ *
+ * Faint on purpose. These sit under the text of a dense grid, so anything stronger reads as an error
+ * state; the render is what settles whether they are subtle enough, not the hex.
  */
-const DXF_ORDER = ['red', 'amber', 'green'] as const;
+const DXF_ORDER = ['urgent', 'warn', 'watch'] as const;
 type DxfName = (typeof DXF_ORDER)[number];
-const DXF_FILLS: Record<DxfName, string> = { red: 'FFF8CBAD', amber: 'FFFFE699', green: 'FFC6E0B4' };
+const DXF_FILLS: Record<DxfName, string> = { urgent: 'FFFAE4E1', warn: 'FFFCEBDB', watch: 'FFFDF6DD' };
 export const DXF_IDS: Record<DxfName, number> = Object.fromEntries(DXF_ORDER.map((name, i) => [name, i])) as Record<
   DxfName,
   number
@@ -226,7 +233,7 @@ export const DXF_IDS: Record<DxfName, number> = Object.fromEntries(DXF_ORDER.map
  * `%FIRST%` is replaced with the first cell of the range, which is how an expression rule
  * refers to "this cell" — Excel evaluates it relatively across the range.
  */
-export type CfPreset = 'score' | 'delta' | 'ragText' | 'statusText' | 'completionText' | 'overdueDate';
+export type CfPreset = 'score' | 'delta' | 'ragText' | 'statusText' | 'completionText' | 'overdueDate' | 'missing';
 
 /**
  * The section statuses `computeCompletion` emits.
@@ -246,41 +253,45 @@ interface CfRule {
 }
 
 const CF_PRESETS: Record<CfPreset, CfRule[]> = {
-  // A 0-4 element score. Matches how the engine reads them: 0-1 bad, 2 partial, 3-4 good.
+  // A 0-4 element score, as a ladder: 0 is nothing, 1 is barely, 2 is nearly — and 3 or 4 is done, so
+  // it carries no rule at all. Three rules rather than the old "under 2 / equal 2 / 3 and up", because
+  // the two ends of "under 2" are not the same news: an element nobody has scored and one scored 1 are
+  // a gap and a start.
   score: [
-    { type: 'cellIs', operator: 'lessThan', formulas: ['2'], dxf: 'red' },
-    { type: 'cellIs', operator: 'equal', formulas: ['2'], dxf: 'amber' },
-    { type: 'cellIs', operator: 'greaterThanOrEqual', formulas: ['3'], dxf: 'green' },
+    { type: 'cellIs', operator: 'equal', formulas: ['0'], dxf: 'urgent' },
+    { type: 'cellIs', operator: 'equal', formulas: ['1'], dxf: 'warn' },
+    { type: 'cellIs', operator: 'equal', formulas: ['2'], dxf: 'watch' },
   ],
   // The rating word itself, so the colours agree with `computeScore` exactly rather than
-  // re-deriving its brackets from a percentage and drifting by a rounding step.
+  // re-deriving its brackets from a percentage and drifting by a rounding step. "Green" gets no
+  // rule: a deal in good shape does not need to be pointed at.
   ragText: [
-    { type: 'cellIs', operator: 'equal', formulas: ['"Red"'], dxf: 'red' },
-    { type: 'cellIs', operator: 'equal', formulas: ['"Yellow"'], dxf: 'amber' },
-    { type: 'cellIs', operator: 'equal', formulas: ['"Green"'], dxf: 'green' },
+    { type: 'cellIs', operator: 'equal', formulas: ['"Red"'], dxf: 'urgent' },
+    { type: 'cellIs', operator: 'equal', formulas: ['"Yellow"'], dxf: 'watch' },
   ],
   // Matched against the LABEL the sheet displays, not the JSON value behind it. Both come from
   // `enumLabel`, so they cannot drift — a preset quoting `"not_started"` while the cell reads
   // "Not started" is a colour that never appears and nothing to notice it.
   completionText: [
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('complete')}"`], dxf: 'green' },
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('partial')}"`], dxf: 'amber' },
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('not_started')}"`], dxf: 'red' },
+    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('partial')}"`], dxf: 'watch' },
+    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('not_started')}"`], dxf: 'urgent' },
   ],
+  // A close-plan step, and a gentler ladder than the completion one on purpose: a milestone nobody has
+  // started is normal early in a deal, where a MEDDPICC section nobody has touched is the gap the
+  // review exists to find.
   statusText: [
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('complete')}"`], dxf: 'green' },
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('in_progress')}"`], dxf: 'amber' },
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('pending')}"`], dxf: 'red' },
+    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('in_progress')}"`], dxf: 'watch' },
+    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('pending')}"`], dxf: 'warn' },
   ],
-  // A change since the last review: up is good, down is not, and nought is neither. Deliberately no
-  // amber — a delta of zero is not a warning, and colouring it would make "nothing moved" look like a
-  // problem in a column read at a glance.
-  delta: [
-    { type: 'cellIs', operator: 'greaterThan', formulas: ['0'], dxf: 'green' },
-    { type: 'cellIs', operator: 'lessThan', formulas: ['0'], dxf: 'red' },
-  ],
+  // A change since the last review. Only a step backwards is painted: nought is not a warning, and an
+  // improvement is the good news this palette deliberately leaves alone.
+  delta: [{ type: 'cellIs', operator: 'lessThan', formulas: ['0'], dxf: 'warn' }],
   // Past its date and not blank. A blank cell is "no date set", not "overdue since 1900".
-  overdueDate: [{ type: 'expression', formulas: ['AND(%FIRST%<>"",%FIRST%<TODAY())'], dxf: 'red' }],
+  overdueDate: [{ type: 'expression', formulas: ['AND(%FIRST%<>"",%FIRST%<TODAY())'], dxf: 'urgent' }],
+  // Nothing typed in a cell something else depends on — see `SpecColumn.shadeWhenEmpty`. TRIM, so a
+  // cell holding a space reads as empty: it is empty to every rule that consults it, and a wash that
+  // disappears when somebody presses the space bar would be worse than none.
+  missing: [{ type: 'expression', formulas: ['LEN(TRIM(%FIRST%))=0'], dxf: 'urgent' }],
 };
 
 export interface ConditionalFormat {
@@ -327,9 +338,6 @@ function stylesXml(): string {
     '<fill><patternFill patternType="none"/></fill>',
     '<fill><patternFill patternType="gray125"/></fill>',
     '<fill><patternFill patternType="solid"><fgColor rgb="FF0E2841"/><bgColor indexed="64"/></patternFill></fill>',
-    '<fill><patternFill patternType="solid"><fgColor rgb="FFF8CBAD"/><bgColor indexed="64"/></patternFill></fill>',
-    '<fill><patternFill patternType="solid"><fgColor rgb="FFFFE699"/><bgColor indexed="64"/></patternFill></fill>',
-    '<fill><patternFill patternType="solid"><fgColor rgb="FFC6E0B4"/><bgColor indexed="64"/></patternFill></fill>',
     '<fill><patternFill patternType="solid"><fgColor rgb="FF156082"/><bgColor indexed="64"/></patternFill></fill>',
     '<fill><patternFill patternType="solid"><fgColor rgb="FF0F9ED5"/><bgColor indexed="64"/></patternFill></fill>',
   ];

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -233,7 +233,15 @@ export const DXF_IDS: Record<DxfName, number> = Object.fromEntries(DXF_ORDER.map
  * `%FIRST%` is replaced with the first cell of the range, which is how an expression rule
  * refers to "this cell" — Excel evaluates it relatively across the range.
  */
-export type CfPreset = 'score' | 'delta' | 'ragText' | 'statusText' | 'completionText' | 'overdueDate' | 'missing';
+export type CfPreset =
+  | 'score'
+  | 'delta'
+  | 'ragText'
+  | 'statusText'
+  | 'completionText'
+  | 'overdueDate'
+  | 'missing'
+  | 'missingInRow';
 
 /**
  * The section statuses `computeCompletion` emits.
@@ -292,11 +300,40 @@ const CF_PRESETS: Record<CfPreset, CfRule[]> = {
   // cell holding a space reads as empty: it is empty to every rule that consults it, and a wash that
   // disappears when somebody presses the space bar would be worse than none.
   missing: [{ type: 'expression', formulas: ['LEN(TRIM(%FIRST%))=0'], dxf: 'urgent' }],
+  // The same, for a row of a table — and it fires only once the row has been STARTED.
+  //
+  // A list keeps blank rows below its entries so there is somewhere to type, and a conditional-format
+  // range does not grow when somebody uses one. Ending the range at the last existing entry left the
+  // wash missing in the case it is most use — a half-entered stakeholder, whose blank title is then
+  // refused on read-back with a schema error rather than shown as a gap while it is being typed. And
+  // covering those rows unconditionally would open every new deal as a column of washes asking for work
+  // nobody owes yet. So the range covers the whole capacity and `%ROW%` decides: something else on this
+  // row means the row is real.
+  //
+  // On a keyed table every row carries its key, so the second half is always true and this behaves
+  // exactly like `missing`.
+  //
+  // One thing to know before putting this on a list that has a computed column: COUNTA counts a formula
+  // cell even when the formula returns "", so every row of such a table reads as started and its spare
+  // rows would wash. No shipped table is in that position — the tables with formulas are the keyed ones,
+  // where every row is real anyway.
+  missingInRow: [{ type: 'expression', formulas: ['AND(LEN(TRIM(%FIRST%))=0,COUNTA(%ROW%)>0)'], dxf: 'urgent' }],
 };
+
+/** The placeholder a rule uses to mean "the row this cell is on, across its own table". */
+const ROW_PLACEHOLDER = '%ROW%';
 
 export interface ConditionalFormat {
   sqref: string;
   preset: CfPreset;
+  /**
+   * What `%ROW%` stands for: the cell's own row, across the columns of the table it belongs to.
+   *
+   * Write the columns absolute and the row relative — `$B56:$Q56` — so Excel moves it down the range
+   * and never sideways. Scoped to one table on purpose: two tables share a band of rows, and a range
+   * spanning the sheet would let the milestones decide whether a critical action's row had been started.
+   */
+  rowRange?: string;
 }
 
 export interface Validation {
@@ -600,10 +637,29 @@ function conditionalFormattingXml(formats: ConditionalFormat[] | undefined): str
   return formats
     .map((format) => {
       const first = format.sqref.split(':')[0];
+      const wantsRow = CF_PRESETS[format.preset].some((rule) => rule.formulas.some((f) => f.includes(ROW_PLACEHOLDER)));
+      if (wantsRow && !format.rowRange) {
+        throw new Error(
+          `The "${format.preset}" format on ${format.sqref} needs a rowRange to resolve ${ROW_PLACEHOLDER}`,
+        );
+      }
+      if (!wantsRow && format.rowRange) {
+        // Data nothing reads is data that lies: a rowRange here would look like it scoped the rule.
+        throw new Error(`The "${format.preset}" format on ${format.sqref} was given a rowRange it does not use`);
+      }
       const rules = CF_PRESETS[format.preset]
         .map((rule) => {
           const formulas = rule.formulas
-            .map((f) => `<formula>${escapeXml(f.split('%FIRST%').join(first))}</formula>`)
+            .map(
+              (f) =>
+                `<formula>${escapeXml(
+                  f
+                    .split('%FIRST%')
+                    .join(first)
+                    .split(ROW_PLACEHOLDER)
+                    .join(format.rowRange ?? ''),
+                )}</formula>`,
+            )
             .join('');
           const operator = rule.operator ? ` operator="${rule.operator}"` : '';
           return `<cfRule type="${rule.type}"${operator} dxfId="${DXF_IDS[rule.dxf]}" priority="${priority++}">${formulas}</cfRule>`;

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -469,6 +469,35 @@ esac
 assert_warm_and_faint "the empty-cell wash" "$(cut -d'|' -f4 <<<"$evidence_rules" | head -1)"
 [ -z "${notes_rules//[[:space:]]/}" ] || fail "the notes column is washed, and a blank note is a choice: $notes_rules"
 
+# A list's spare rows are inside the wash's range, and the rule is what keeps them clear until somebody
+# starts one. Both halves matter and they pull in opposite directions: a range stopping at the last
+# entry leaves a half-typed stakeholder unwarned, and a rule without the row test washes every spare row
+# of every new deal. So ask Excel for the range it holds and for the formula it will evaluate.
+stake_name="$(table_cell stakeholders name 0)"
+stake_rows="$(jq -r '(.tables[] | select(.id == "stakeholders") | .rows)' <<<"$uat_plan")"
+stake_last="$(table_cell stakeholders name "$((stake_rows - 1))")"
+stake_rules="$(cf_rules "$stake_name")"
+stake_range="$(
+  osascript - "$SHEET" "$BOOK" "$stake_name" <<'OSA' 2>&1
+on run argv
+  tell application "Microsoft Excel"
+    set ws to worksheet (item 1 of argv) of workbook (item 2 of argv)
+    return get address of (applies to of format condition 1 of range (item 3 of argv) of ws) without external
+  end tell
+end run
+OSA
+)"
+echo "    stakeholder names: rule over $stake_range (capacity is $stake_rows rows, to $stake_last)"
+case "$stake_rules" in
+*COUNTA*) : ;;
+*) fail "the stakeholder wash does not test whether the row has been started: $stake_rules" ;;
+esac
+# Excel writes the address absolute; compare on the row numbers, which is what this is about.
+case "$stake_range" in
+*"${stake_last#[A-Z]}") : ;;
+*) fail "the stakeholder wash stops at $stake_range and the list has room to row ${stake_last#[A-Z]}" ;;
+esac
+
 # The rating word: "Red" and "Yellow" are painted, "Green" is not.
 rating_rules="$(cf_rules "$(named scoreRating)")"
 echo "    rating $(named scoreRating): ${rating_rules%$'\n'}"

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -385,6 +385,103 @@ echo "    boolean dropdown at $bool_cell: Excel=[$got_bool]"
 [ "$got_bool" = "Yes,No" ] || fail "the boolean dropdown is '$got_bool', expected Yes,No"
 echo "PASS: Excel recognises the conditional formats and the schema-derived dropdowns, and sees no Excel Table"
 
+# ── The palette ────────────────────────────────────────────────────────────────────────────────
+#
+# Colour marks what needs attention, and nothing else: a finished element, a complete section and a
+# rating of "Green" carry no fill at all. That is a rule about what is ABSENT, which is exactly what a
+# unit test over our own XML is worst at proving — it can only check the rules we wrote, not what Excel
+# resolved them to. So ask Excel for every rule on the cells that matter, including the colour it will
+# actually paint, and check the shape of the ladder rather than a hex nobody can review.
+#
+# `condition operator` is missing on an expression rule and raises rather than returning empty, so it is
+# read inside a try; a rule that has no operator is not a rule that failed.
+cf_rules() {
+  osascript - "$SHEET" "$BOOK" "$1" <<'OSA' 2>&1
+on run argv
+  tell application "Microsoft Excel"
+    set ws to worksheet (item 1 of argv) of workbook (item 2 of argv)
+    set r to range (item 3 of argv) of ws
+    set out to ""
+    repeat with i from 1 to (count of format conditions of r)
+      set fc to format condition i of r
+      set op to "none"
+      try
+        set op to (condition operator of fc) as string
+      end try
+      set c to color of interior object of fc
+      set out to out & (format condition type of fc as string) & "|" & op & "|" & (formula 1 of fc) & "|" & ¬
+        (item 1 of c) & "," & (item 2 of c) & "," & (item 3 of c) & linefeed
+    end repeat
+    return out
+  end tell
+end run
+OSA
+}
+
+# Every wash has to be warm and faint: red at least green at least blue, and no channel far from white.
+# This is the assertion that fails if green comes back anywhere — in a preset, in a dxf, or by somebody
+# editing the file and saving it.
+assert_warm_and_faint() {
+  local where="$1" rgb="$2" r g b
+  IFS=, read -r r g b <<<"$rgb"
+  [ -n "$r" ] && [ -n "$g" ] && [ -n "$b" ] || fail "$where: Excel reported no colour for the rule ($rgb)"
+  [ "$r" -ge "$g" ] && [ "$g" -ge "$b" ] || fail "$where: fill $rgb is not warm (needs red >= green >= blue)"
+  [ "$b" -ge 208 ] || fail "$where: fill $rgb is not faint — it would read as an error state, not a wash"
+}
+
+score_rules="$(cf_rules "$score_first:$score_last")"
+case "$score_rules" in
+*"execution error"* | *"syntax error"*) fail "could not read the score column's rules: $score_rules" ;;
+esac
+score_rule_count="$(grep -c . <<<"$score_rules")"
+echo "==> the score ladder, as Excel resolved it:"
+sed 's/^/    /' <<<"$score_rules"
+[ "$score_rule_count" = "3" ] || fail "expected 3 rules on the score column, Excel reports $score_rule_count"
+score_index=0
+while IFS='|' read -r _type _op formula rgb; do
+  [ -n "$_type" ] || continue
+  # 0 is nothing, 1 is barely, 2 is nearly — and the ladder stops there. A rule mentioning 3 or 4 would
+  # be colouring a score that is done, which is the whole thing this palette removed.
+  case "$formula" in
+  *3* | *4*) fail "a score rule fires on '$formula'; 3 and 4 are done and carry no fill" ;;
+  esac
+  [ "$formula" = "=$score_index" ] || fail "score rule $((score_index + 1)) is '$formula', expected '=$score_index'"
+  assert_warm_and_faint "score rule $formula" "$rgb"
+  score_index=$((score_index + 1))
+done <<<"$score_rules"
+
+# A blank cell that a completion rule consults is washed; a blank cell nobody depends on is not.
+evidence_cell="$(table_cell elements evidence 0)"
+notes_cell="$(table_cell elements notes 0)"
+evidence_rules="$(cf_rules "$evidence_cell")"
+notes_rules="$(cf_rules "$notes_cell")"
+echo "    evidence $evidence_cell: ${evidence_rules%$'\n'}"
+echo "    notes $notes_cell: ${notes_rules:-<none>}"
+[ "$(grep -c . <<<"$evidence_rules")" = "1" ] || fail "expected one wash on $evidence_cell, got: $evidence_rules"
+case "$evidence_rules" in
+*"expression|"*) : ;;
+*) fail "the wash on $evidence_cell is not an expression rule: $evidence_rules" ;;
+esac
+case "$evidence_rules" in
+*TRIM*) : ;;
+*) fail "the wash on $evidence_cell does not test emptiness: $evidence_rules" ;;
+esac
+assert_warm_and_faint "the empty-cell wash" "$(cut -d'|' -f4 <<<"$evidence_rules" | head -1)"
+[ -z "${notes_rules//[[:space:]]/}" ] || fail "the notes column is washed, and a blank note is a choice: $notes_rules"
+
+# The rating word: "Red" and "Yellow" are painted, "Green" is not.
+rating_rules="$(cf_rules "$(named scoreRating)")"
+echo "    rating $(named scoreRating): ${rating_rules%$'\n'}"
+[ "$(grep -c . <<<"$rating_rules")" = "2" ] || fail "expected 2 rules on the rating cell, got: $rating_rules"
+case "$rating_rules" in
+*Green*) fail "a rating rule fires on \"Green\" — good news carries no fill" ;;
+esac
+while IFS='|' read -r _t _o f rgb; do
+  [ -n "$f" ] || continue
+  assert_warm_and_faint "rating rule $f" "$rgb"
+done <<<"$rating_rules"
+echo "PASS: every wash Excel resolved is warm and faint, and nothing paints a value that is done"
+
 # The presentation primitives are the ones a unit test can least vouch for: a merge Excel
 # rejects, a print setup it ignores, a gridline flag in the wrong place — all of them produce a
 # file that still opens. So ask Excel what it made of them.


### PR DESCRIPTION
## What this does

Closes #913. Colour marks what needs attention, and nothing else.

The sheet used to paint something on every cell it evaluated, including every cell that was fine —
green at score 3-4, green on "Green", green on "Complete", green on any improvement. On a page read at a
glance the eye should land on the gaps; it was landing on whatever had the most fill, which on a
well-qualified deal is the good news.

## The palette

Three faint warm washes, named for the attention they ask for rather than for their hue:

| fill | means | where it lands |
| --- | --- | --- |
| `urgent` — faint red | nothing there | score 0, `not_started`, a "Red" rating, an overdue date, a required-but-empty cell |
| `warn` — faint orange | barely begun | score 1, `pending`, movement backwards |
| `watch` — faint yellow | nearly there | score 2, `partial`, `in_progress`, a "Yellow" rating |
| *no fill* | done | score 3-4, `complete`, a "Green" rating, movement level or up |

The score column is a **ladder** now — 0 red, 1 orange, 2 yellow, 3 and 4 clear — rather than three
bands with the top one shouting. An element nobody has scored and one scored 1 are a gap and a start,
and the old "under 2" rule painted them identically.

## New: a blank cell something depends on is washed, at one of two levels

`required` — a completion rule or the schema needs a value, so blank is a gap: an element's evidence, the
three whys, the two strategy cells, the identifying metadata, and a stakeholder's name, title and role.
Keeps the urgent tint.

`wanted` — nothing requires it and a blank one is still worth seeing: a discovery question nobody has
answered. Drops to the faintest tint, because `qualStatus` is satisfied by any **one** answer — so
calling the others missing raises a false alarm on an element that is genuinely complete. An unanswered
question is among the most actionable things on the sheet, so it drops a level rather than disappearing.

Deliberately nothing at all on `notes` or the partner-side whys, which are legitimately empty.
`check-spec` refuses a level nobody implemented, refuses the flag on a cell nobody types into, and
refuses it beside another conditional format on the same cell, since one wash would paint over the other
by a priority nobody chose.

**A row somebody has started is washed even if it was a spare one.** A list keeps blank rows below its
entries so there is somewhere to type, and a conditional-format range does not grow when one is used —
so a range stopping at the last existing entry was absent from the case the wash is most use: a
stakeholder halfway through being entered, whose blank title is schema-required and would otherwise be
first mentioned by a rejection on read-back. Covering those rows unconditionally would ask for work
nobody owes, so the rule carries the condition instead: empty **and** something else on this row, over
the table's **own** columns rather than the width of the page, because two tables share a band of rows.

## What the render shows

Rendered from a deliberately half-worked deal, old and new side by side at matched zoom:

- **Qualification** — score 4 goes from green to clear; score 1 is a faint peach; the six unscored
  elements are a faint pink, and their empty Evidence cells are washed for the first time. The wash
  covers the **full width of the merged cell**, which was the one thing I could not settle from the XML
  and checked in the application.
- **Responses** — the twelve unanswered questions are washed and the four answered ones are clean, so
  the gaps in the interview are visible without reading a word.
- **Stakeholders** — one person's missing Title is washed while their name and role are not.
- **Close Plan** — the overdue dates and `Pending` statuses drop from a solid salmon block to a wash.

## Verification

- **428 engine tests**, 27 shell tests, `check-spec` clean, `pre-commit-local.sh` clean, biome /
  codespell / textlint / shellcheck / shfmt clean from the repo root.
- **22 mutations, 22 killed.** Green reintroduced for a finished score; a wash made strong; a wash made
  cool; the empty-cell rule stripped of `TRIM`; "Green" painted again; the row test dropped; a rule
  emitted without its row range; an unused row range accepted; the row range widened to the page and
  narrowed to the sheet's start; the row reference made absolute; the wash stopped at the last entry
  again; the two levels collapsed; an unknown level accepted; the form-field wash removed; the column
  wash removed; both `check-spec` rules disabled; and the shipped spec's flags and levels removed. Three
  of those guards had no test at first — the page-wide row range survived because every shipped table
  with a wash happens to span the full width, so proving it needed a synthetic pair of side-by-side
  lists.
- **The Excel acceptance test: 16 stages, exit 0**, including a new stage that asks Excel for every rule
  on the score column, the evidence cell, the notes cell and the rating cell — their count, their
  formulas, and **the fill colour Excel resolved** — then checks each is warm (red ≥ green ≥ blue) and
  faint. That is what fails if green comes back anywhere, including by somebody editing the file.
- **The new stage was proved able to fail**: with the `watch` wash set back to the old green it reported
  `FAIL: score rule =2: fill 198,224,180 is not warm (needs red >= green >= blue)` — a colour read out
  of Excel, not out of our own XML.
- Presentation only: no address, width or height changes, so a v6.1.0 workbook still reads back.
  **v6.2.0.**

## The review layer earned its keep here

Three rounds, three findings, and each became something testable:

- **Refuted:** "the wash covers only the anchor column of a merged field." The reviewer reasoned from
  this file's own comment about base styles, which *do* need writing to every covered cell — conditional
  formats do not. Sampled across the merged Evidence cell in the render: `(246,229,226)` at every point
  from 0.80 to 0.92 of the width, not white. Corroborated by `overdueDate` and `statusText`, which have
  painted the merged Close Plan columns from their anchors since v5.
- **Confirmed:** a stakeholder typed into a spare row got no warning about its blank required fields.
  Fixed by the row-started condition above.
- **Confirmed:** an unanswered question was washed as urgently as a missing evidence cell, on an element
  the engine calls **complete**. Verified against the engine first — one answer of two, score 3, evidence
  present, `completionStatus.metrics === 'complete'` — then fixed by the two levels.

## Also removed

The `ragRed` / `ragAmber` / `ragGreen` **cell** styles. Nothing had referenced them since the
conditional formats took the colouring over — and the reachability test over `styles.xml` is what forced
their three fills out with them.
