### PR TITLE
MEDDPICC: completion statuses that follow the sheet (v6.3.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,4 +212,3 @@ packages/typescript-edit-benchmark/runs/
 # Verified-review working artifacts (findings and verification evidence).
 # No trailing slash, so a symlink of this name is matched too.
 .codex-review
-.codex-review/

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,18 @@ and this project adheres to
     refuses to compile rather than emitting a formula that reads `#NAME?` mid-review.
   - **The scorecard follows for free.** `sectionsComplete` already counted the status column, so the
     count and the completion percentage are live too.
-  - **One bridge, stated where the two readers differ.** The engine counts entries in the deal's array;
-    the sheet counts rows whose identity column is filled in. They agree for a blank row and a filled
-    one, and differ for an entry that exists in the JSON with no name — which the sheet does not count,
-    and which the `required` wash already asks for.
+  - **A row is an entry when ANY of its fields is filled in.** The schema permits an entry that fills
+    in anything but its first field — `team.internal: [{"role":"SE"}]` validates, and the engine calls
+    the team complete — so counting the name column alone made the sheet answer not_started on exactly
+    that data. Found by the second-opinion review, and now a fixture of its own in the Excel run. One
+    case is left and cannot be closed from a sheet: an entry whose every field is empty is
+    indistinguishable from one of the pre-allocated blank rows.
+  - **The whitespace the two readers disagree about is removed first.** Excel's `TRIM` takes ordinary
+    spaces only, while the engine's `trim()` also takes tabs, newlines and non-breaking spaces — so a
+    value pasted from a web page read as filled to the sheet and empty to the engine. `CLEAN` handles
+    the control characters and the non-breaking space is substituted, which also cut the longest
+    compiled formula from 5483 characters to 2602 against Excel's cap of 8192. The writer refuses a
+    formula past that cap now, because Excel's answer to one is to prompt for repair and empty the cell.
   - **The refactor is proved rather than reviewed.** The previous implementation is frozen in the suite
     as an oracle and asked the same question as the new one over every combination each rule can see —
     all 96 an element rule has, and every shape the five collection sections can take. Exhaustive rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ and this project adheres to
     refuses to compile rather than emitting a formula that reads `#NAME?` mid-review.
   - **The scorecard follows for free.** `sectionsComplete` already counted the status column, so the
     count and the completion percentage are live too.
+  - **What makes a row an entry belongs to the list.** `ENTRY_FIELDS` names each list's declared fields
+    once, and both halves of a rule read it — as does the compiler, which looks each one up as a column.
+    So the two readers count the same rows by construction, and a rule naming a field the workbook does
+    not show fails at generation rather than counting a row the sheet cannot see. Three rounds of review
+    got here: first the leftmost column, then every column, then the fields themselves, when the reviewer
+    pointed out that the schema does not forbid extra properties — `[{"unmappedField":"x"}]` validates,
+    and the sheet has nowhere to show it.
+  - **A score cell is read the way the reader reads it.** `N("3")` is nought, while the round-trip reader
+    accepts a textual "3" and applies it as 3 — so a pasted score showed 3 on the sheet, left the status
+    partial, and changed meaning on read-back. `IFERROR(VALUE(…),0)` reads it as the reader does and keeps
+    a blank or a word at nought, as the engine does.
+  - **A completion block can sit anywhere in the spec.** The statuses were compiled at the end of each
+    sheet, against the input cells known so far — so a two-sheet spec that passes `check-spec` failed to
+    generate when the Completion block came first. They are compiled once, after every sheet is laid out.
   - **An entry counts when it has something in it — in the engine too.** The old rule counted the array's
     length, so `team.internal: [{}]` completed the whole Team section: one object with no fields, which
     the schema permits and which is not a team member in any sense. No sheet could ever agree, because an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to
     refuses to compile rather than emitting a formula that reads `#NAME?` mid-review.
   - **The scorecard follows for free.** `sectionsComplete` already counted the status column, so the
     count and the completion percentage are live too.
+  - **An entry counts when it has something in it — in the engine too.** The old rule counted the array's
+    length, so `team.internal: [{}]` completed the whole Team section: one object with no fields, which
+    the schema permits and which is not a team member in any sense. No sheet could ever agree, because an
+    entry with every cell empty is indistinguishable from one of the pre-allocated blank rows. So both
+    readers ask the same question now, and it is the defensible one. This is the **one** class of answer
+    that moved, and the suite records it against the frozen oracle rather than quietly absorbing it.
+  - **A cell on another sheet is named with its sheet.** Latent today, since the workbook is one laid-out
+    sheet — but a two-sheet spec passes `check-spec`, and a bare `$D$20` would then mean whatever sits at
+    D20 on the sheet the formula is on. Excel evaluates that without complaint, which is the worst way
+    for it to be wrong. The quoting rule comes from the same `sheetPrefix` that `{{ref:…}}` already uses.
   - **A row is an entry when ANY of its fields is filled in.** The schema permits an entry that fills
     in anything but its first field — `team.internal: [{"role":"SE"}]` validates, and the engine calls
     the team complete — so counting the name column alone made the sheet answer not_started on exactly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v6.3.0 — the completion statuses follow the sheet. Not breaking: no address moved, so
+  a v6.2.0 workbook still reads back.
+
+  The thirteen section statuses were literals, computed when the workbook was written. Fill in the
+  missing evidence during a live review and the sheet went on calling the section not started — in the
+  one column whose job is to say where the deal stands.
+
+  - **One rule, two readers.** Each section's rule is data now: two predicates, `complete` and
+    `started`, over deal paths, in a vocabulary of six leaves and two combinators. The engine evaluates
+    them against the deal and the generator compiles the same ones into formulas, so there is no second
+    set of rules free to drift. Six kinds covered all thirteen rules; a seventh would have been a rule
+    the sheet could not express, which is worth discovering in TypeScript rather than in Excel.
+  - **Nothing in the compiler knows a coordinate.** `plan.inputCells` already maps every deal path to
+    the cell it landed in, so a rule naming `qualification.metrics.evidence` resolves to a cell and that
+    element's responses to the range of its rows — and a rule naming a field the sheet does not show
+    refuses to compile rather than emitting a formula that reads `#NAME?` mid-review.
+  - **The scorecard follows for free.** `sectionsComplete` already counted the status column, so the
+    count and the completion percentage are live too.
+  - **One bridge, stated where the two readers differ.** The engine counts entries in the deal's array;
+    the sheet counts rows whose identity column is filled in. They agree for a blank row and a filled
+    one, and differ for an entry that exists in the JSON with no name — which the sheet does not count,
+    and which the `required` wash already asks for.
+  - **The refactor is proved rather than reviewed.** The previous implementation is frozen in the suite
+    as an oracle and asked the same question as the new one over every combination each rule can see —
+    all 96 an element rule has, and every shape the five collection sections can take. Exhaustive rather
+    than random, so no seed can miss a case.
+  - **Excel is asked directly**: all thirteen statuses agree with the engine on the example deal *and*
+    on the partly-qualified fixture, and setting an element's score to 0 in Excel moves its status from
+    Complete to Partial — what the engine says about the same deal with that score changed, computed by
+    the engine rather than written down here.
+
 - **`meddpicc`** v6.2.0 — colour marks what needs attention, and nothing else. Not breaking: no
   address, width or height changes, so a v6.1.0 workbook still reads back.
 
@@ -563,7 +594,6 @@ and this project adheres to
   No Reference sheet: inline validation lists made it redundant, and the 0-4 rubric text
   already sits on the Qualification row it describes.
 
-
 - **`meddpicc`** v2.5.0 — the workbook generator. `engine/generate.ts` turns the spec plus a
   deal into a real `.xlsx`: `generate <deal.json> --out <file>`, or `--plan` to print where
   every input cell landed without writing anything.
@@ -596,7 +626,6 @@ and this project adheres to
   And `dateToSerial` **rejects impossible dates** rather than rolling them forward: it was
   turning `2026-02-31` into `2026-03-03`, a close date three days late that nothing downstream
   would question.
-
 
 - **Plugin tests no longer depend on a real cloud CLI** (`aws` v1.2.2, `azure` v1.2.2,
   `gcloud` v1.2.2, `github` v1.2.2, `gitlab` v1.2.3, `salesforce` v1.3.3) — 32 tests across

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/README.md
+++ b/plugins/meddpicc/README.md
@@ -246,7 +246,9 @@ schema-derived dropdowns. Colour marks only what needs attention — a faint war
 unscored element, an untouched section, an overdue date, or a cell a completion rule needs and
 nobody has filled in — and anything finished carries no fill at all. Each element name carries
 what that element means as a hover note, so the sheet explains itself without spending a column
-on it. `read` pulls edits back out.
+on it. The scorecard, the rubric beside each score and the completion status of every section are
+formulas rather than snapshots, so typing an answer in during a review updates them in front of
+you. `read` pulls edits back out.
 
 ### Get coaching (auto-activates)
 

--- a/plugins/meddpicc/engine/completion-formula.test.ts
+++ b/plugins/meddpicc/engine/completion-formula.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'bun:test';
+import { cellResolver, compilePredicate, compileStatus } from './completion-formula';
+import type { Predicate } from './completion-rules';
+import { SECTION_RULES } from './completion-rules';
+import type { InputCell } from './generate';
+import { statusLabel } from './sections';
+
+/** Input cells the way the plan reports them, for a sheet laid out the way the shipped one is. */
+const inputs = (entries: Array<[string, string]>): InputCell[] =>
+  entries.map(([jsonPath, address]) => ({ jsonPath, sheet: 'Deal Review', address, valueType: 'string' }));
+
+const stakeholderCells = inputs([
+  ['stakeholders[0].name', 'B56'],
+  ['stakeholders[0].title', 'D56'],
+  ['stakeholders[0].roleInDeal', 'G56'],
+  ['stakeholders[1].name', 'B57'],
+  ['stakeholders[1].title', 'D57'],
+  ['stakeholders[1].roleInDeal', 'G57'],
+]);
+
+describe('cellResolver — what a deal path is on the sheet', () => {
+  test('a scalar path is the one cell that holds it', () => {
+    const resolve = cellResolver(inputs([['threeWhys.us.whyNow', 'B51']]));
+    expect(resolve.cell('threeWhys.us.whyNow')).toBe('$B$51');
+  });
+
+  test('an array of text is the range of its cells', () => {
+    const resolve = cellResolver(
+      inputs([
+        ['qualification.metrics.responses[0]', 'I30'],
+        ['qualification.metrics.responses[1]', 'I31'],
+      ]),
+    );
+    expect(resolve.range('qualification.metrics.responses')).toBe('$I$30:$I$31');
+  });
+
+  test("a list's identity column is its leftmost, and each field has its own range", () => {
+    // Whichever column the layout puts first is the one that says a row exists — a stakeholder is a
+    // stakeholder once they have a name. Read from the addresses rather than from the spec, so moving
+    // a column moves this with it.
+    const resolve = cellResolver(stakeholderCells);
+    expect(resolve.entryRange('stakeholders')).toBe('$B$56:$B$57');
+    expect(resolve.fieldRange('stakeholders', 'title')).toBe('$D$56:$D$57');
+  });
+
+  test('a path the sheet does not show refuses to resolve', () => {
+    // A rule naming a field with no cell would otherwise compile to a formula referring to nothing,
+    // which Excel shows as a status of #NAME? in the middle of a review.
+    const resolve = cellResolver(inputs([['threeWhys.us.whyNow', 'B51']]));
+    expect(() => resolve.cell('threeWhys.us.whyUs')).toThrow(/whyUs/);
+    expect(() => resolve.range('qualification.metrics.responses')).toThrow(/responses/);
+    expect(() => resolve.entryRange('stakeholders')).toThrow(/stakeholders/);
+    expect(() => resolve.fieldRange('stakeholders', 'title')).toThrow(/title/);
+  });
+
+  test('every address is absolute, so a filled row cannot drag the rule sideways', () => {
+    const resolve = cellResolver(stakeholderCells);
+    for (const ref of [resolve.cell('stakeholders[0].name'), resolve.entryRange('stakeholders')]) {
+      expect(ref.startsWith('$'), ref).toBe(true);
+    }
+  });
+});
+
+describe('compileStatus — the same rule, as a formula', () => {
+  const elementCells = inputs([
+    ['qualification.metrics.score', 'D20'],
+    ['qualification.metrics.evidence', 'H20'],
+    ['qualification.metrics.responses[0]', 'I30'],
+    ['qualification.metrics.responses[1]', 'I31'],
+  ]);
+
+  test('an element asks about its score, its answers and its evidence', () => {
+    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    // The three things the engine's rule reads, and the bar it reads them against.
+    expect(formula).toContain('$D$20');
+    expect(formula).toContain('$H$20');
+    expect(formula).toContain('$I$30:$I$31');
+    expect(formula).toContain('>=3');
+    // Trimmed, because the engine trims: a cell holding a space is empty to it.
+    expect(formula).toContain('TRIM');
+  });
+
+  test('it returns the words the sheet shows, not the words the JSON holds', () => {
+    // The completion column is coloured by matching those words, and the scorecard COUNTIFs them. A
+    // formula answering "complete" where the cell used to read "Complete" is a colour that never
+    // appears and a count that stays at zero.
+    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    expect(formula).toContain(`"${statusLabel('complete')}"`);
+    expect(formula).toContain(`"${statusLabel('partial')}"`);
+    expect(formula).toContain(`"${statusLabel('not_started')}"`);
+    expect(formula).not.toContain('"complete"');
+    expect(formula).not.toContain('"not_started"');
+  });
+
+  test('complete is asked first, so a complete section never reads as partial', () => {
+    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    expect(formula.indexOf(`"${statusLabel('complete')}"`)).toBeLessThan(
+      formula.indexOf(`"${statusLabel('partial')}"`),
+    );
+  });
+
+  test('a score is read through N(), so text cannot outrank a number', () => {
+    // Excel sorts text above every number: `$D$20>=3` is TRUE for a cell holding "four", where the
+    // engine reads a non-number as 0 and says false. N() makes both read it the same way.
+    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    expect(formula).toContain('N($D$20)>=3');
+    expect(formula).not.toMatch(/[^(]\$D\$20\)?>=/);
+  });
+
+  test('a field is only required of a row somebody has started', () => {
+    // Without the identity factor the pre-allocated blank rows count as entries missing a title, and
+    // the section can never be complete — a list with room to grow would read as permanently unfinished.
+    const formula = compileStatus(SECTION_RULES.stakeholders, cellResolver(stakeholderCells));
+    expect(formula).toContain('SUMPRODUCT((TRIM($B$56:$B$57)<>"")*(TRIM($D$56:$D$57)=""))=0');
+    // And the identity column is not compared against itself, which would be a term that can never
+    // be anything but nought.
+    expect(formula).not.toContain('(TRIM($B$56:$B$57)<>"")*(TRIM($B$56:$B$57)="")');
+  });
+
+  test('a list section counts entries and checks their fields', () => {
+    const formula = compileStatus(SECTION_RULES.stakeholders, cellResolver(stakeholderCells));
+    // At least one entry...
+    expect(formula).toContain('$B$56:$B$57');
+    // ...and no started row missing a title or a role.
+    expect(formula).toContain('$D$56:$D$57');
+    expect(formula).toContain('$G$56:$G$57');
+    expect(formula).toContain('SUMPRODUCT');
+  });
+
+  test('every shipped rule compiles against the shipped layout', () => {
+    // The point of the small vocabulary: if a rule cannot be expressed over cells, that is a fact
+    // worth learning here rather than from a #VALUE! in front of a customer.
+    const resolve = cellResolver([
+      ...elementCells,
+      ...stakeholderCells,
+      ...inputs([
+        ['threeWhys.us.whyAnything', 'B49'],
+        ['threeWhys.us.whyUs', 'B50'],
+        ['threeWhys.us.whyNow', 'B51'],
+        ['salesStrategy.differentiatedValueProposition', 'B68'],
+        ['salesStrategy.winStrategy', 'J68'],
+        ['closePlan.milestones[0].title', 'B74'],
+        ['closePlan.criticalActions[0].action', 'J74'],
+        ['team.internal[0].name', 'B86'],
+        ['team.partner[0].name', 'J86'],
+      ]),
+    ]);
+    for (const section of ['metrics', 'threeWhys', 'stakeholders', 'salesStrategy', 'closePlan', 'team']) {
+      const formula = compileStatus(SECTION_RULES[section], resolve);
+      expect(formula.length, section).toBeGreaterThan(0);
+      expect(formula, section).not.toContain('undefined');
+    }
+  });
+
+  test('all is AND and any is OR, which is the difference between complete and started', () => {
+    // Swapped, a section would read complete as soon as any one of its conditions held — and the
+    // formula would still look perfectly reasonable. Everything else in this suite matches on the
+    // cells a formula names, so nothing else here would notice.
+    const resolve = cellResolver(elementCells);
+    const two: Predicate[] = [
+      { kind: 'nonEmpty', path: 'qualification.metrics.evidence' },
+      { kind: 'atLeast', path: 'qualification.metrics.score', value: 3 },
+    ];
+    expect(compilePredicate({ kind: 'all', of: two }, resolve).startsWith('AND(')).toBe(true);
+    expect(compilePredicate({ kind: 'any', of: two }, resolve).startsWith('OR(')).toBe(true);
+    // Excel has no AND() of nothing, and the identities are the right way round.
+    expect(compilePredicate({ kind: 'all', of: [] }, resolve)).toBe('TRUE');
+    expect(compilePredicate({ kind: 'any', of: [] }, resolve)).toBe('FALSE');
+  });
+
+  test('a predicate the compiler does not know fails loudly', () => {
+    expect(() =>
+      compileStatus(
+        { complete: { kind: 'whenever' } as never, started: { kind: 'any', of: [] } },
+        cellResolver(elementCells),
+      ),
+    ).toThrow(/whenever/);
+  });
+});

--- a/plugins/meddpicc/engine/completion-formula.test.ts
+++ b/plugins/meddpicc/engine/completion-formula.test.ts
@@ -34,12 +34,12 @@ describe('cellResolver — what a deal path is on the sheet', () => {
     expect(resolve.range('qualification.metrics.responses')).toBe('$I$30:$I$31');
   });
 
-  test("a list's identity column is its leftmost, and each field has its own range", () => {
-    // Whichever column the layout puts first is the one that says a row exists — a stakeholder is a
-    // stakeholder once they have a name. Read from the addresses rather than from the spec, so moving
-    // a column moves this with it.
+  test("a list's columns come back in layout order, and each field has its own range", () => {
+    // Every column, because a row is an entry when ANY of them is filled in — the engine counts an
+    // entry with no name, and the schema permits one. Read from the addresses rather than from the
+    // spec, so moving a column moves this with it.
     const resolve = cellResolver(stakeholderCells);
-    expect(resolve.entryRange('stakeholders')).toBe('$B$56:$B$57');
+    expect(resolve.allRanges('stakeholders')).toEqual(['$B$56:$B$57', '$D$56:$D$57', '$G$56:$G$57']);
     expect(resolve.fieldRange('stakeholders', 'title')).toBe('$D$56:$D$57');
   });
 
@@ -49,13 +49,13 @@ describe('cellResolver — what a deal path is on the sheet', () => {
     const resolve = cellResolver(inputs([['threeWhys.us.whyNow', 'B51']]));
     expect(() => resolve.cell('threeWhys.us.whyUs')).toThrow(/whyUs/);
     expect(() => resolve.range('qualification.metrics.responses')).toThrow(/responses/);
-    expect(() => resolve.entryRange('stakeholders')).toThrow(/stakeholders/);
+    expect(() => resolve.allRanges('stakeholders')).toThrow(/stakeholders/);
     expect(() => resolve.fieldRange('stakeholders', 'title')).toThrow(/title/);
   });
 
   test('every address is absolute, so a filled row cannot drag the rule sideways', () => {
     const resolve = cellResolver(stakeholderCells);
-    for (const ref of [resolve.cell('stakeholders[0].name'), resolve.entryRange('stakeholders')]) {
+    for (const ref of [resolve.cell('stakeholders[0].name'), ...resolve.allRanges('stakeholders')]) {
       expect(ref.startsWith('$'), ref).toBe(true);
     }
   });
@@ -99,6 +99,29 @@ describe('compileStatus — the same rule, as a formula', () => {
     );
   });
 
+  test('a row counts as an entry when ANY of its fields is filled in, not just the first', () => {
+    // The engine counts entries in the array. A stakeholder with a role and no name is an entry to it,
+    // and the schema permits one — so counting only the leftmost column made the sheet say not_started
+    // where the engine said complete. Every column of the list has to be consulted.
+    const formula = compileStatus(SECTION_RULES.stakeholders, cellResolver(stakeholderCells));
+    for (const range of ['$B$56:$B$57', '$D$56:$D$57', '$G$56:$G$57']) {
+      expect(formula, range).toContain(range);
+    }
+    // Summed across the columns and then tested, so a row with two fields filled counts once.
+    expect(formula).toContain('>0))>=1');
+  });
+
+  test('the whitespace Excel keeps is removed before the comparison', () => {
+    // Excel's TRIM takes ordinary spaces only. JavaScript's trim() also takes tabs, newlines and
+    // non-breaking spaces — so a value pasted from a web page reads as filled to Excel and empty to the
+    // engine, and the sheet would call an element complete on evidence the engine cannot see.
+    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    // CLEAN takes every control character — tab, newline, carriage return — and the non-breaking space
+    // is the one it leaves behind, so that one is substituted first.
+    expect(formula).toContain('CLEAN(');
+    expect(formula).toContain('CHAR(160)');
+  });
+
   test('a score is read through N(), so text cannot outrank a number', () => {
     // Excel sorts text above every number: `$D$20>=3` is TRUE for a cell holding "four", where the
     // engine reads a non-number as 0 and says false. N() makes both read it the same way.
@@ -108,13 +131,11 @@ describe('compileStatus — the same rule, as a formula', () => {
   });
 
   test('a field is only required of a row somebody has started', () => {
-    // Without the identity factor the pre-allocated blank rows count as entries missing a title, and
-    // the section can never be complete — a list with room to grow would read as permanently unfinished.
+    // Without the started factor the pre-allocated blank rows count as entries missing a title, and the
+    // section can never be complete — a list with room to grow would read as permanently unfinished.
     const formula = compileStatus(SECTION_RULES.stakeholders, cellResolver(stakeholderCells));
-    expect(formula).toContain('SUMPRODUCT((TRIM($B$56:$B$57)<>"")*(TRIM($D$56:$D$57)=""))=0');
-    // And the identity column is not compared against itself, which would be a term that can never
-    // be anything but nought.
-    expect(formula).not.toContain('(TRIM($B$56:$B$57)<>"")*(TRIM($B$56:$B$57)="")');
+    // Each field's term is "rows that are started AND lack this field" = 0.
+    expect(formula).toContain(')>0)*(TRIM(CLEAN(SUBSTITUTE($D$56:$D$57,CHAR(160)," ")))=""))=0');
   });
 
   test('a list section counts entries and checks their fields', () => {

--- a/plugins/meddpicc/engine/completion-formula.test.ts
+++ b/plugins/meddpicc/engine/completion-formula.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { cellResolver, compilePredicate, compileStatus } from './completion-formula';
 import type { Predicate } from './completion-rules';
-import { SECTION_RULES } from './completion-rules';
+import { SECTION_RULES, statusOf } from './completion-rules';
 import type { InputCell } from './generate';
 import { statusLabel } from './sections';
 
@@ -118,6 +118,14 @@ describe('compileStatus — the same rule, as a formula', () => {
     ['qualification.metrics.responses[1]', 'I31'],
   ]);
 
+  /** The deal those cells describe: an element complete but for whatever score it is handed. */
+  const elementDeal = (score: unknown) => ({
+    dealId: 'D',
+    accountName: 'A',
+    dealName: 'N',
+    qualification: { metrics: { score, responses: ['an answer'], evidence: 'written down' } },
+  });
+
   test('an element asks about its score, its answers and its evidence', () => {
     const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
     // The three things the engine's rule reads, and the bar it reads them against.
@@ -196,6 +204,18 @@ describe('compileStatus — the same rule, as a formula', () => {
     const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
     expect(formula).toContain('IFERROR(VALUE($D$20),0)>=3');
     expect(formula).not.toContain('N($D$20)');
+  });
+
+  test('neither reader puts a ceiling on a score', () => {
+    // A score outside 0-4 is the schema's business, and read-workbook already refuses one — so neither
+    // reader bounds it above, and both must go on not bounding it. Teaching the formula the schema's
+    // ceiling would make the sheet call a pasted 5 partial while the engine calls it complete, which is
+    // the one disagreement this whole rule set exists to remove. Guarding both sides, because the defect
+    // would be a bound added to either one alone.
+    expect(statusOf('metrics', elementDeal(5))).toBe('complete');
+    expect(statusOf('metrics', elementDeal(99))).toBe('complete');
+    const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
+    expect(formula).not.toContain('<=');
   });
 
   test('a field is only required of a row somebody has started', () => {

--- a/plugins/meddpicc/engine/completion-formula.test.ts
+++ b/plugins/meddpicc/engine/completion-formula.test.ts
@@ -6,8 +6,12 @@ import type { InputCell } from './generate';
 import { statusLabel } from './sections';
 
 /** Input cells the way the plan reports them, for a sheet laid out the way the shipped one is. */
+const SHEET = 'Deal Review';
 const inputs = (entries: Array<[string, string]>): InputCell[] =>
-  entries.map(([jsonPath, address]) => ({ jsonPath, sheet: 'Deal Review', address, valueType: 'string' }));
+  entries.map(([jsonPath, address]) => ({ jsonPath, sheet: SHEET, address, valueType: 'string' }));
+
+/** A resolver for formulas living on the same sheet as their cells, which is the shipped workbook. */
+const resolverFor = (cells: InputCell[]) => cellResolver(cells, SHEET);
 
 const stakeholderCells = inputs([
   ['stakeholders[0].name', 'B56'],
@@ -20,12 +24,12 @@ const stakeholderCells = inputs([
 
 describe('cellResolver — what a deal path is on the sheet', () => {
   test('a scalar path is the one cell that holds it', () => {
-    const resolve = cellResolver(inputs([['threeWhys.us.whyNow', 'B51']]));
+    const resolve = resolverFor(inputs([['threeWhys.us.whyNow', 'B51']]));
     expect(resolve.cell('threeWhys.us.whyNow')).toBe('$B$51');
   });
 
   test('an array of text is the range of its cells', () => {
-    const resolve = cellResolver(
+    const resolve = resolverFor(
       inputs([
         ['qualification.metrics.responses[0]', 'I30'],
         ['qualification.metrics.responses[1]', 'I31'],
@@ -38,15 +42,40 @@ describe('cellResolver — what a deal path is on the sheet', () => {
     // Every column, because a row is an entry when ANY of them is filled in — the engine counts an
     // entry with no name, and the schema permits one. Read from the addresses rather than from the
     // spec, so moving a column moves this with it.
-    const resolve = cellResolver(stakeholderCells);
+    const resolve = resolverFor(stakeholderCells);
     expect(resolve.allRanges('stakeholders')).toEqual(['$B$56:$B$57', '$D$56:$D$57', '$G$56:$G$57']);
     expect(resolve.fieldRange('stakeholders', 'title')).toBe('$D$56:$D$57');
+  });
+
+  test('a cell on another sheet is named with its sheet', () => {
+    // The workbook is one laid-out sheet today, so a bare address is right — and a spec with two sheets
+    // passes `check-spec`, at which point a bare `$D$20` on the Completion sheet means whatever happens
+    // to be at D20 THERE. Excel evaluates that without complaint. So the sheet is part of the reference
+    // whenever it differs, exactly as a `{{ref:…}}` formula already qualifies one.
+    const cells = [
+      { jsonPath: 'qualification.metrics.score', sheet: 'Qualification', address: 'D20', valueType: 'score' as const },
+      { jsonPath: 'threeWhys.us.whyNow', sheet: 'Completion', address: 'B51', valueType: 'text' as const },
+    ];
+    const onCompletion = cellResolver(cells, 'Completion');
+    expect(onCompletion.cell('qualification.metrics.score')).toBe('Qualification!$D$20');
+    // ...and a cell on the formula's own sheet stays bare, which keeps every existing formula unchanged.
+    expect(onCompletion.cell('threeWhys.us.whyNow')).toBe('$B$51');
+  });
+
+  test('a sheet name needing quotes gets them, and an apostrophe in one is doubled', () => {
+    const cells = [
+      { jsonPath: 'a', sheet: "Bob's Deal Review", address: 'D20', valueType: 'string' as const },
+      { jsonPath: 'b', sheet: 'Plain', address: 'D21', valueType: 'string' as const },
+    ];
+    const resolve = cellResolver(cells, 'Elsewhere');
+    expect(resolve.cell('a')).toBe("'Bob''s Deal Review'!$D$20");
+    expect(resolve.cell('b')).toBe('Plain!$D$21');
   });
 
   test('a path the sheet does not show refuses to resolve', () => {
     // A rule naming a field with no cell would otherwise compile to a formula referring to nothing,
     // which Excel shows as a status of #NAME? in the middle of a review.
-    const resolve = cellResolver(inputs([['threeWhys.us.whyNow', 'B51']]));
+    const resolve = resolverFor(inputs([['threeWhys.us.whyNow', 'B51']]));
     expect(() => resolve.cell('threeWhys.us.whyUs')).toThrow(/whyUs/);
     expect(() => resolve.range('qualification.metrics.responses')).toThrow(/responses/);
     expect(() => resolve.allRanges('stakeholders')).toThrow(/stakeholders/);
@@ -54,7 +83,7 @@ describe('cellResolver — what a deal path is on the sheet', () => {
   });
 
   test('every address is absolute, so a filled row cannot drag the rule sideways', () => {
-    const resolve = cellResolver(stakeholderCells);
+    const resolve = resolverFor(stakeholderCells);
     for (const ref of [resolve.cell('stakeholders[0].name'), ...resolve.allRanges('stakeholders')]) {
       expect(ref.startsWith('$'), ref).toBe(true);
     }
@@ -70,7 +99,7 @@ describe('compileStatus — the same rule, as a formula', () => {
   ]);
 
   test('an element asks about its score, its answers and its evidence', () => {
-    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
     // The three things the engine's rule reads, and the bar it reads them against.
     expect(formula).toContain('$D$20');
     expect(formula).toContain('$H$20');
@@ -84,7 +113,7 @@ describe('compileStatus — the same rule, as a formula', () => {
     // The completion column is coloured by matching those words, and the scorecard COUNTIFs them. A
     // formula answering "complete" where the cell used to read "Complete" is a colour that never
     // appears and a count that stays at zero.
-    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
     expect(formula).toContain(`"${statusLabel('complete')}"`);
     expect(formula).toContain(`"${statusLabel('partial')}"`);
     expect(formula).toContain(`"${statusLabel('not_started')}"`);
@@ -93,7 +122,7 @@ describe('compileStatus — the same rule, as a formula', () => {
   });
 
   test('complete is asked first, so a complete section never reads as partial', () => {
-    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
     expect(formula.indexOf(`"${statusLabel('complete')}"`)).toBeLessThan(
       formula.indexOf(`"${statusLabel('partial')}"`),
     );
@@ -103,7 +132,7 @@ describe('compileStatus — the same rule, as a formula', () => {
     // The engine counts entries in the array. A stakeholder with a role and no name is an entry to it,
     // and the schema permits one — so counting only the leftmost column made the sheet say not_started
     // where the engine said complete. Every column of the list has to be consulted.
-    const formula = compileStatus(SECTION_RULES.stakeholders, cellResolver(stakeholderCells));
+    const formula = compileStatus(SECTION_RULES.stakeholders, resolverFor(stakeholderCells));
     for (const range of ['$B$56:$B$57', '$D$56:$D$57', '$G$56:$G$57']) {
       expect(formula, range).toContain(range);
     }
@@ -115,7 +144,7 @@ describe('compileStatus — the same rule, as a formula', () => {
     // Excel's TRIM takes ordinary spaces only. JavaScript's trim() also takes tabs, newlines and
     // non-breaking spaces — so a value pasted from a web page reads as filled to Excel and empty to the
     // engine, and the sheet would call an element complete on evidence the engine cannot see.
-    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
     // CLEAN takes every control character — tab, newline, carriage return — and the non-breaking space
     // is the one it leaves behind, so that one is substituted first.
     expect(formula).toContain('CLEAN(');
@@ -125,7 +154,7 @@ describe('compileStatus — the same rule, as a formula', () => {
   test('a score is read through N(), so text cannot outrank a number', () => {
     // Excel sorts text above every number: `$D$20>=3` is TRUE for a cell holding "four", where the
     // engine reads a non-number as 0 and says false. N() makes both read it the same way.
-    const formula = compileStatus(SECTION_RULES.metrics, cellResolver(elementCells));
+    const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
     expect(formula).toContain('N($D$20)>=3');
     expect(formula).not.toMatch(/[^(]\$D\$20\)?>=/);
   });
@@ -133,13 +162,13 @@ describe('compileStatus — the same rule, as a formula', () => {
   test('a field is only required of a row somebody has started', () => {
     // Without the started factor the pre-allocated blank rows count as entries missing a title, and the
     // section can never be complete — a list with room to grow would read as permanently unfinished.
-    const formula = compileStatus(SECTION_RULES.stakeholders, cellResolver(stakeholderCells));
+    const formula = compileStatus(SECTION_RULES.stakeholders, resolverFor(stakeholderCells));
     // Each field's term is "rows that are started AND lack this field" = 0.
     expect(formula).toContain(')>0)*(TRIM(CLEAN(SUBSTITUTE($D$56:$D$57,CHAR(160)," ")))=""))=0');
   });
 
   test('a list section counts entries and checks their fields', () => {
-    const formula = compileStatus(SECTION_RULES.stakeholders, cellResolver(stakeholderCells));
+    const formula = compileStatus(SECTION_RULES.stakeholders, resolverFor(stakeholderCells));
     // At least one entry...
     expect(formula).toContain('$B$56:$B$57');
     // ...and no started row missing a title or a role.
@@ -151,7 +180,7 @@ describe('compileStatus — the same rule, as a formula', () => {
   test('every shipped rule compiles against the shipped layout', () => {
     // The point of the small vocabulary: if a rule cannot be expressed over cells, that is a fact
     // worth learning here rather than from a #VALUE! in front of a customer.
-    const resolve = cellResolver([
+    const resolve = resolverFor([
       ...elementCells,
       ...stakeholderCells,
       ...inputs([
@@ -177,7 +206,7 @@ describe('compileStatus — the same rule, as a formula', () => {
     // Swapped, a section would read complete as soon as any one of its conditions held — and the
     // formula would still look perfectly reasonable. Everything else in this suite matches on the
     // cells a formula names, so nothing else here would notice.
-    const resolve = cellResolver(elementCells);
+    const resolve = resolverFor(elementCells);
     const two: Predicate[] = [
       { kind: 'nonEmpty', path: 'qualification.metrics.evidence' },
       { kind: 'atLeast', path: 'qualification.metrics.score', value: 3 },
@@ -193,7 +222,7 @@ describe('compileStatus — the same rule, as a formula', () => {
     expect(() =>
       compileStatus(
         { complete: { kind: 'whenever' } as never, started: { kind: 'any', of: [] } },
-        cellResolver(elementCells),
+        resolverFor(elementCells),
       ),
     ).toThrow(/whenever/);
   });

--- a/plugins/meddpicc/engine/completion-formula.test.ts
+++ b/plugins/meddpicc/engine/completion-formula.test.ts
@@ -13,14 +13,25 @@ const inputs = (entries: Array<[string, string]>): InputCell[] =>
 /** A resolver for formulas living on the same sheet as their cells, which is the shipped workbook. */
 const resolverFor = (cells: InputCell[]) => cellResolver(cells, SHEET);
 
-const stakeholderCells = inputs([
-  ['stakeholders[0].name', 'B56'],
-  ['stakeholders[0].title', 'D56'],
-  ['stakeholders[0].roleInDeal', 'G56'],
-  ['stakeholders[1].name', 'B57'],
-  ['stakeholders[1].title', 'D57'],
-  ['stakeholders[1].roleInDeal', 'G57'],
-]);
+/**
+ * Two stakeholder rows with every column the rule names.
+ *
+ * All eight, not a convenient three: the rule counts a row as an entry when any of its declared fields
+ * is filled in, and asking the sheet for a column it does not have is a generation error by design. A
+ * short fixture would have been testing a workbook that cannot exist.
+ */
+const stakeholderCells = inputs(
+  [0, 1].flatMap((row) => [
+    [`stakeholders[${row}].name`, `B${56 + row}`] as [string, string],
+    [`stakeholders[${row}].title`, `D${56 + row}`] as [string, string],
+    [`stakeholders[${row}].roleInDeal`, `G${56 + row}`] as [string, string],
+    [`stakeholders[${row}].mustSayYes`, `I${56 + row}`] as [string, string],
+    [`stakeholders[${row}].canSayNo`, `J${56 + row}`] as [string, string],
+    [`stakeholders[${row}].whatTheyNeedToBelieve`, `K${56 + row}`] as [string, string],
+    [`stakeholders[${row}].sentiment`, `O${56 + row}`] as [string, string],
+    [`stakeholders[${row}].relationshipOwner`, `P${56 + row}`] as [string, string],
+  ]),
+);
 
 describe('cellResolver — what a deal path is on the sheet', () => {
   test('a scalar path is the one cell that holds it', () => {
@@ -43,7 +54,16 @@ describe('cellResolver — what a deal path is on the sheet', () => {
     // entry with no name, and the schema permits one. Read from the addresses rather than from the
     // spec, so moving a column moves this with it.
     const resolve = resolverFor(stakeholderCells);
-    expect(resolve.allRanges('stakeholders')).toEqual(['$B$56:$B$57', '$D$56:$D$57', '$G$56:$G$57']);
+    expect(resolve.allRanges('stakeholders')).toEqual([
+      '$B$56:$B$57',
+      '$D$56:$D$57',
+      '$G$56:$G$57',
+      '$I$56:$I$57',
+      '$J$56:$J$57',
+      '$K$56:$K$57',
+      '$O$56:$O$57',
+      '$P$56:$P$57',
+    ]);
     expect(resolve.fieldRange('stakeholders', 'title')).toBe('$D$56:$D$57');
   });
 
@@ -151,12 +171,31 @@ describe('compileStatus — the same rule, as a formula', () => {
     expect(formula).toContain('CHAR(160)');
   });
 
-  test('a score is read through N(), so text cannot outrank a number', () => {
-    // Excel sorts text above every number: `$D$20>=3` is TRUE for a cell holding "four", where the
-    // engine reads a non-number as 0 and says false. N() makes both read it the same way.
+  test('the count consults the fields the rule names, not every column the sheet has', () => {
+    // Today the two coincide, so nothing else here can tell them apart. They are the same by
+    // construction, not by luck: a column the rule does not name is a column the engine does not read,
+    // and counting it would put the two readers back into disagreement.
+    const withExtra = [
+      ...stakeholderCells,
+      ...inputs([
+        ['stakeholders[0].somethingTheRuleIgnores', 'Z56'],
+        ['stakeholders[1].somethingTheRuleIgnores', 'Z57'],
+      ]),
+    ];
+    const formula = compileStatus(SECTION_RULES.stakeholders, resolverFor(withExtra));
+    expect(formula).toContain('$B$56:$B$57');
+    expect(formula).not.toContain('$Z$56');
+  });
+
+  test('a score cell is read the way the reader reads it', () => {
+    // Two ways to get this wrong. A bare `$D$20>=3` is TRUE for a cell holding "four", because Excel
+    // sorts text above every number. And `N("3")` is 0, while the round-trip reader accepts a textual
+    // "3" and applies it as 3 — so a pasted score would show 3 on the sheet, leave the status partial,
+    // and then change meaning on read-back. VALUE reads it as the reader does, and IFERROR keeps a blank
+    // or a word at nought, as the engine does.
     const formula = compileStatus(SECTION_RULES.metrics, resolverFor(elementCells));
-    expect(formula).toContain('N($D$20)>=3');
-    expect(formula).not.toMatch(/[^(]\$D\$20\)?>=/);
+    expect(formula).toContain('IFERROR(VALUE($D$20),0)>=3');
+    expect(formula).not.toContain('N($D$20)');
   });
 
   test('a field is only required of a row somebody has started', () => {
@@ -189,10 +228,22 @@ describe('compileStatus — the same rule, as a formula', () => {
         ['threeWhys.us.whyNow', 'B51'],
         ['salesStrategy.differentiatedValueProposition', 'B68'],
         ['salesStrategy.winStrategy', 'J68'],
-        ['closePlan.milestones[0].title', 'B74'],
+        // Every field each rule names, since a rule asking for a column the sheet lacks fails by design.
+        ['closePlan.milestones[0].description', 'B74'],
+        ['closePlan.milestones[0].targetDate', 'F74'],
+        ['closePlan.milestones[0].status', 'H74'],
         ['closePlan.criticalActions[0].action', 'J74'],
+        ['closePlan.criticalActions[0].owner', 'M74'],
+        ['closePlan.criticalActions[0].dueDate', 'O74'],
+        ['closePlan.criticalActions[0].status', 'Q74'],
         ['team.internal[0].name', 'B86'],
+        ['team.internal[0].role', 'D86'],
+        ['team.internal[0].dateRequiredFrom', 'F86'],
+        ['team.internal[0].assignedToDeal', 'H86'],
         ['team.partner[0].name', 'J86'],
+        ['team.partner[0].role', 'L86'],
+        ['team.partner[0].dateRequiredFrom', 'N86'],
+        ['team.partner[0].assignedToDeal', 'P86'],
       ]),
     ]);
     for (const section of ['metrics', 'threeWhys', 'stakeholders', 'salesStrategy', 'closePlan', 'team']) {

--- a/plugins/meddpicc/engine/completion-formula.ts
+++ b/plugins/meddpicc/engine/completion-formula.ts
@@ -1,0 +1,185 @@
+/**
+ * The completion rules, compiled into Excel.
+ *
+ * `completion-rules.ts` states each rule once as data; {@link evaluate} reads it against the deal and
+ * this reads the same rule against the sheet. That is the whole design: the status beside a section
+ * has to follow what somebody types during a review, and a second set of rules written directly as
+ * formulas would be free to disagree with the engine — a sheet whose completion column contradicts
+ * `engine score` is worse than one that is merely stale.
+ *
+ * **Where a path lives is not written here either.** `plan.inputCells` already maps every deal path to
+ * the cell it landed in, so `qualification.metrics.evidence` resolves to a cell and that element's
+ * `responses[]` to the range of its rows. Nothing in this file knows a coordinate.
+ *
+ * ## The one place the two readers see different inputs
+ *
+ * The engine counts **entries in the deal's array**. The sheet counts **rows whose identity column is
+ * filled in** — the leftmost column of the list, which is a stakeholder's name, a milestone's title, a
+ * team member's name. They agree for a blank row and for a filled one. They differ for an entry that
+ * exists in the JSON with an empty name, which the engine counts and the sheet does not.
+ *
+ * That is the right way round for a live review: the rows a person can type into include the
+ * pre-allocated blank ones, and a row is not somebody until it has a name. The `required` wash already
+ * asks for that name, so the sheet says what to do before the count moves.
+ */
+import type { Predicate, SectionRule } from './completion-rules';
+import type { InputCell } from './generate';
+import { statusLabel } from './sections';
+import { columnIndex } from './xlsx';
+
+/** Where the deal's paths ended up on the sheet. Built from the plan, never from a coordinate. */
+export interface CellResolver {
+  /** The one cell holding a scalar path. */
+  cell(path: string): string;
+  /** The cells of an array of text — a question's answers. */
+  range(list: string): string;
+  /** The column that says a row of this list exists: its leftmost. */
+  entryRange(list: string): string;
+  /** One field's column, over the same rows as {@link entryRange}. */
+  fieldRange(list: string, field: string): string;
+}
+
+/** `B56` -> `$B$56`, so nothing drags a rule sideways or down when Excel copies it. */
+function absolute(address: string): string {
+  const m = /^([A-Z]+)(\d+)$/.exec(address);
+  if (!m) throw new Error(`"${address}" is not a cell reference`);
+  return `$${m[1]}$${m[2]}`;
+}
+
+function spanOf(addresses: string[], what: string): string {
+  if (addresses.length === 0) throw new Error(`the sheet has no cell for ${what}`);
+  const rows = addresses.map((a) => Number(/\d+/.exec(a)?.[0]));
+  const column = /^[A-Z]+/.exec(addresses[0])?.[0] ?? '';
+  for (const address of addresses) {
+    if (/^[A-Z]+/.exec(address)?.[0] !== column) {
+      throw new Error(`${what} is spread across more than one column, so it has no single range`);
+    }
+  }
+  return `$${column}$${Math.min(...rows)}:$${column}$${Math.max(...rows)}`;
+}
+
+/** `stakeholders[3].title` -> `{list: 'stakeholders', index: 3, field: 'title'}`, or null. */
+function parseEntryPath(jsonPath: string): { list: string; index: number; field: string } | null {
+  const m = /^(.*)\[(\d+)\]\.(.+)$/.exec(jsonPath);
+  return m ? { list: m[1], index: Number(m[2]), field: m[3] } : null;
+}
+
+/** `qualification.metrics.responses[2]` -> `{list: 'qualification.metrics.responses', index: 2}`. */
+function parseArrayPath(jsonPath: string): { list: string; index: number } | null {
+  const m = /^(.*)\[(\d+)\]$/.exec(jsonPath);
+  return m ? { list: m[1], index: Number(m[2]) } : null;
+}
+
+export function cellResolver(inputCells: readonly InputCell[]): CellResolver {
+  const byPath = new Map<string, string>();
+  /** list -> field -> addresses, in row order. */
+  const lists = new Map<string, Map<string, string[]>>();
+  /** list -> addresses of a bare array's cells. */
+  const arrays = new Map<string, string[]>();
+
+  for (const input of inputCells) {
+    byPath.set(input.jsonPath, input.address);
+    const entry = parseEntryPath(input.jsonPath);
+    if (entry) {
+      const fields = lists.get(entry.list) ?? new Map<string, string[]>();
+      fields.set(entry.field, [...(fields.get(entry.field) ?? []), input.address]);
+      lists.set(entry.list, fields);
+      continue;
+    }
+    const array = parseArrayPath(input.jsonPath);
+    if (array) arrays.set(array.list, [...(arrays.get(array.list) ?? []), input.address]);
+  }
+
+  /** The leftmost field of a list — the one that says a row is an entry. */
+  const identityField = (list: string): string => {
+    const fields = lists.get(list);
+    if (!fields) throw new Error(`the sheet has no rows for the list "${list}"`);
+    let leftmost: { field: string; column: number } | undefined;
+    for (const [field, addresses] of fields) {
+      const column = columnIndex(/^[A-Z]+/.exec(addresses[0])?.[0] ?? '');
+      if (!leftmost || column < leftmost.column) leftmost = { field, column };
+    }
+    if (!leftmost) throw new Error(`the list "${list}" has no columns on the sheet`);
+    return leftmost.field;
+  };
+
+  return {
+    cell(path) {
+      const address = byPath.get(path);
+      if (!address) throw new Error(`the sheet has no cell for "${path}"`);
+      return absolute(address);
+    },
+    range(list) {
+      return spanOf(arrays.get(list) ?? [], `the array "${list}"`);
+    },
+    entryRange(list) {
+      const field = identityField(list);
+      return spanOf(lists.get(list)?.get(field) ?? [], `the list "${list}"`);
+    },
+    fieldRange(list, field) {
+      const addresses = lists.get(list)?.get(field);
+      if (!addresses) throw new Error(`the list "${list}" has no "${field}" column on the sheet`);
+      return spanOf(addresses, `"${list}.${field}"`);
+    },
+  };
+}
+
+/** Non-empty after trimming, as the engine reads it. Excel's ISBLANK would call a space filled in. */
+const filled = (ref: string) => `TRIM(${ref})<>""`;
+
+/** How many rows of this list somebody has started. */
+const startedRows = (resolve: CellResolver, list: string) => `SUMPRODUCT(--(${filled(resolve.entryRange(list))}))`;
+
+export function compilePredicate(predicate: Predicate, resolve: CellResolver): string {
+  switch (predicate.kind) {
+    case 'all':
+      // AND() of nothing is not valid Excel, and the identity of AND is TRUE.
+      return predicate.of.length === 0
+        ? 'TRUE'
+        : `AND(${predicate.of.map((p) => compilePredicate(p, resolve)).join(',')})`;
+    case 'any':
+      return predicate.of.length === 0
+        ? 'FALSE'
+        : `OR(${predicate.of.map((p) => compilePredicate(p, resolve)).join(',')})`;
+    case 'nonEmpty':
+      return filled(resolve.cell(predicate.path));
+    case 'atLeast':
+      // N() so text and a blank both read as 0, which is how the engine reads a missing score.
+      return `N(${resolve.cell(predicate.path)})>=${predicate.value}`;
+    case 'anyNonEmpty':
+      return `SUMPRODUCT(--(${filled(resolve.range(predicate.list))}))>0`;
+    case 'countAtLeast':
+      return `${startedRows(resolve, predicate.list)}>=${predicate.value}`;
+    case 'everyEntryHas': {
+      // No started row may be missing one of these. Counted rather than tested row by row, because a
+      // formula cannot loop: for each field, the number of rows that have an identity and lack that
+      // field must be nought.
+      //
+      // The identity column itself is skipped. A row without it is not an entry at all — that is what
+      // `countAtLeast` means on a sheet — so the term would compare that column against itself and be
+      // nought whatever anybody types.
+      const entries = resolve.entryRange(predicate.list);
+      const terms = predicate.fields
+        .filter((field) => resolve.fieldRange(predicate.list, field) !== entries)
+        .map((field) => `SUMPRODUCT((${filled(entries)})*(TRIM(${resolve.fieldRange(predicate.list, field)})=""))=0`);
+      if (terms.length === 0) return 'TRUE';
+      return terms.length === 1 ? terms[0] : `AND(${terms.join(',')})`;
+    }
+    default:
+      throw new Error(`no formula for predicate: ${JSON.stringify((predicate as { kind: unknown }).kind)}`);
+  }
+}
+
+/**
+ * One section's rule as a formula returning the word the sheet shows.
+ *
+ * `complete` is asked first, exactly as {@link statusOf} asks it, so a section that satisfies both
+ * halves reads as complete rather than as partial. The words come from `statusLabel` because the
+ * column is coloured by matching them and the scorecard counts them — a formula answering "complete"
+ * where the cell used to read "Complete" is a colour that never appears and a count stuck at nought.
+ */
+export function compileStatus(rule: SectionRule, resolve: CellResolver): string {
+  const complete = compilePredicate(rule.complete, resolve);
+  const started = compilePredicate(rule.started, resolve);
+  return `IF(${complete},"${statusLabel('complete')}",IF(${started},"${statusLabel('partial')}","${statusLabel('not_started')}"))`;
+}

--- a/plugins/meddpicc/engine/completion-formula.ts
+++ b/plugins/meddpicc/engine/completion-formula.ts
@@ -23,7 +23,7 @@
  * asks for that name, so the sheet says what to do before the count moves.
  */
 import type { Predicate, SectionRule } from './completion-rules';
-import type { InputCell } from './generate';
+import { type InputCell, sheetPrefix } from './generate';
 import { statusLabel } from './sections';
 import { columnIndex } from './xlsx';
 
@@ -70,8 +70,18 @@ function parseArrayPath(jsonPath: string): { list: string; index: number } | nul
   return m ? { list: m[1], index: Number(m[2]) } : null;
 }
 
-export function cellResolver(inputCells: readonly InputCell[]): CellResolver {
+/**
+ * Where the deal's paths ended up, ready to be named from a formula on `formulaSheet`.
+ *
+ * A cell on another sheet is named with its sheet. The workbook is one laid-out sheet today, so this
+ * changes nothing about what it emits — but a two-sheet spec passes `check-spec`, and a bare `$D$20`
+ * would then mean whatever happens to sit at D20 on the sheet the formula is on. Excel evaluates that
+ * without complaint, which is the worst way for it to be wrong.
+ */
+export function cellResolver(inputCells: readonly InputCell[], formulaSheet?: string): CellResolver {
   const byPath = new Map<string, string>();
+  /** path -> the sheet it is on, so a reference can be qualified when it needs to be. */
+  const sheetByPath = new Map<string, string>();
   /** list -> field -> addresses, in row order. */
   const lists = new Map<string, Map<string, string[]>>();
   /** list -> addresses of a bare array's cells. */
@@ -79,6 +89,7 @@ export function cellResolver(inputCells: readonly InputCell[]): CellResolver {
 
   for (const input of inputCells) {
     byPath.set(input.jsonPath, input.address);
+    sheetByPath.set(input.jsonPath, input.sheet);
     const entry = parseEntryPath(input.jsonPath);
     if (entry) {
       const fields = lists.get(entry.list) ?? new Map<string, string[]>();
@@ -90,14 +101,28 @@ export function cellResolver(inputCells: readonly InputCell[]): CellResolver {
     if (array) arrays.set(array.list, [...(arrays.get(array.list) ?? []), input.address]);
   }
 
+  /** Prefix a reference with its sheet when that is not the sheet the formula lives on. */
+  const qualify = (sheet: string | undefined, reference: string) =>
+    sheet === undefined || sheet === formulaSheet ? reference : `${sheetPrefix(sheet)}${reference}`;
+
+  /** Every cell of one column is on one sheet, so the first entry answers for the range. */
+  const sheetOfList = (list: string, field?: string) => {
+    for (const [path, sheet] of sheetByPath) {
+      const entry = parseEntryPath(path);
+      if (entry?.list === list && (field === undefined || entry.field === field)) return sheet;
+      if (parseArrayPath(path)?.list === list) return sheet;
+    }
+    return undefined;
+  };
+
   return {
     cell(path) {
       const address = byPath.get(path);
       if (!address) throw new Error(`the sheet has no cell for "${path}"`);
-      return absolute(address);
+      return qualify(sheetByPath.get(path), absolute(address));
     },
     range(list) {
-      return spanOf(arrays.get(list) ?? [], `the array "${list}"`);
+      return qualify(sheetOfList(list), spanOf(arrays.get(list) ?? [], `the array "${list}"`));
     },
     allRanges(list) {
       const fields = lists.get(list);
@@ -108,12 +133,12 @@ export function cellResolver(inputCells: readonly InputCell[]): CellResolver {
           range: spanOf(addresses, `"${list}.${field}"`),
         }))
         .sort((a, b) => a.column - b.column)
-        .map((entry) => entry.range);
+        .map((entry) => qualify(sheetOfList(list), entry.range));
     },
     fieldRange(list, field) {
       const addresses = lists.get(list)?.get(field);
       if (!addresses) throw new Error(`the list "${list}" has no "${field}" column on the sheet`);
-      return spanOf(addresses, `"${list}.${field}"`);
+      return qualify(sheetOfList(list, field), spanOf(addresses, `"${list}.${field}"`));
     },
   };
 }

--- a/plugins/meddpicc/engine/completion-formula.ts
+++ b/plugins/meddpicc/engine/completion-formula.ts
@@ -22,7 +22,7 @@
  * pre-allocated blank ones, and a row is not somebody until it has a name. The `required` wash already
  * asks for that name, so the sheet says what to do before the count moves.
  */
-import type { Predicate, SectionRule } from './completion-rules';
+import { entryFieldsOf, type Predicate, type SectionRule } from './completion-rules';
 import { type InputCell, sheetPrefix } from './generate';
 import { statusLabel } from './sections';
 import { columnIndex } from './xlsx';
@@ -166,6 +166,10 @@ const filled = (ref: string) => `TRIM(${cleaned(ref)})<>""`;
 /**
  * How many rows of this list are entries.
  *
+ * The fields come from the RULE and are looked up as columns here, so the two readers count the same
+ * rows by construction rather than by coincidence — and a rule naming a field the workbook does not show
+ * fails at generation instead of counting a row the sheet cannot see.
+ *
  * A row is an entry when ANY of its fields is filled in — not just the leftmost. The engine counts
  * entries in the deal's array, and the schema permits an entry with no name: `team.internal:
  * [{"role":"SE"}]` validates, and the engine calls the team complete. Counting the name column alone
@@ -179,9 +183,8 @@ const filled = (ref: string) => `TRIM(${cleaned(ref)})<>""`;
  * not. Nothing on the sheet could tell them apart.
  */
 const startedRows = (resolve: CellResolver, list: string) =>
-  `SUMPRODUCT(--((${resolve
-    .allRanges(list)
-    .map((range) => `${filled(range)}`)
+  `SUMPRODUCT(--((${entryFieldsOf(list)
+    .map((field) => filled(resolve.fieldRange(list, field)))
     .join(')+(')})>0))`;
 
 export function compilePredicate(predicate: Predicate, resolve: CellResolver): string {
@@ -198,8 +201,11 @@ export function compilePredicate(predicate: Predicate, resolve: CellResolver): s
     case 'nonEmpty':
       return filled(resolve.cell(predicate.path));
     case 'atLeast':
-      // N() so text and a blank both read as 0, which is how the engine reads a missing score.
-      return `N(${resolve.cell(predicate.path)})>=${predicate.value}`;
+      // VALUE, not N(): `N("3")` is nought, while the round-trip reader accepts a textual "3" and applies
+      // it as 3 — so a pasted score would show 3 on the sheet, leave the status partial, and change
+      // meaning on read-back. IFERROR keeps a blank or a word at nought, which is how the engine reads a
+      // score it cannot make a number of.
+      return `IFERROR(VALUE(${resolve.cell(predicate.path)}),0)>=${predicate.value}`;
     case 'anyNonEmpty':
       return `SUMPRODUCT(--(${filled(resolve.range(predicate.list))}))>0`;
     case 'countAtLeast':
@@ -210,9 +216,8 @@ export function compilePredicate(predicate: Predicate, resolve: CellResolver): s
       //
       // "Started" is the same test the count uses, so the two halves of a rule cannot disagree about
       // which rows they are talking about.
-      const started = resolve
-        .allRanges(predicate.list)
-        .map((range) => `${filled(range)}`)
+      const started = entryFieldsOf(predicate.list)
+        .map((field) => filled(resolve.fieldRange(predicate.list, field)))
         .join(')+(');
       const terms = predicate.fields.map(
         (field) => `SUMPRODUCT(--((${started})>0)*(TRIM(${cleaned(resolve.fieldRange(predicate.list, field))})=""))=0`,

--- a/plugins/meddpicc/engine/completion-formula.ts
+++ b/plugins/meddpicc/engine/completion-formula.ts
@@ -33,8 +33,8 @@ export interface CellResolver {
   cell(path: string): string;
   /** The cells of an array of text — a question's answers. */
   range(list: string): string;
-  /** The column that says a row of this list exists: its leftmost. */
-  entryRange(list: string): string;
+  /** Every column of this list, in layout order — what decides whether a row is an entry at all. */
+  allRanges(list: string): string[];
   /** One field's column, over the same rows as {@link entryRange}. */
   fieldRange(list: string, field: string): string;
 }
@@ -90,19 +90,6 @@ export function cellResolver(inputCells: readonly InputCell[]): CellResolver {
     if (array) arrays.set(array.list, [...(arrays.get(array.list) ?? []), input.address]);
   }
 
-  /** The leftmost field of a list — the one that says a row is an entry. */
-  const identityField = (list: string): string => {
-    const fields = lists.get(list);
-    if (!fields) throw new Error(`the sheet has no rows for the list "${list}"`);
-    let leftmost: { field: string; column: number } | undefined;
-    for (const [field, addresses] of fields) {
-      const column = columnIndex(/^[A-Z]+/.exec(addresses[0])?.[0] ?? '');
-      if (!leftmost || column < leftmost.column) leftmost = { field, column };
-    }
-    if (!leftmost) throw new Error(`the list "${list}" has no columns on the sheet`);
-    return leftmost.field;
-  };
-
   return {
     cell(path) {
       const address = byPath.get(path);
@@ -112,9 +99,16 @@ export function cellResolver(inputCells: readonly InputCell[]): CellResolver {
     range(list) {
       return spanOf(arrays.get(list) ?? [], `the array "${list}"`);
     },
-    entryRange(list) {
-      const field = identityField(list);
-      return spanOf(lists.get(list)?.get(field) ?? [], `the list "${list}"`);
+    allRanges(list) {
+      const fields = lists.get(list);
+      if (!fields) throw new Error(`the sheet has no rows for the list "${list}"`);
+      return [...fields.entries()]
+        .map(([field, addresses]) => ({
+          column: columnIndex(/^[A-Z]+/.exec(addresses[0])?.[0] ?? ''),
+          range: spanOf(addresses, `"${list}.${field}"`),
+        }))
+        .sort((a, b) => a.column - b.column)
+        .map((entry) => entry.range);
     },
     fieldRange(list, field) {
       const addresses = lists.get(list)?.get(field);
@@ -124,11 +118,46 @@ export function cellResolver(inputCells: readonly InputCell[]): CellResolver {
   };
 }
 
-/** Non-empty after trimming, as the engine reads it. Excel's ISBLANK would call a space filled in. */
-const filled = (ref: string) => `TRIM(${ref})<>""`;
+/** A non-breaking space: whitespace to JavaScript, an ordinary character to Excel's TRIM and CLEAN. */
+const NBSP = 160;
 
-/** How many rows of this list somebody has started. */
-const startedRows = (resolve: CellResolver, list: string) => `SUMPRODUCT(--(${filled(resolve.entryRange(list))}))`;
+/**
+ * The text of a cell or range with the whitespace both readers ignore taken out.
+ *
+ * `TRIM` alone takes ordinary spaces only, while the engine's `trim()` also takes tabs, newlines and
+ * non-breaking spaces — so a value pasted in from a web page reads as filled to the sheet and empty to
+ * the engine, and the two then disagree about whether an element is complete on evidence one of them
+ * cannot see. `CLEAN` removes every control character, which covers the tab, the newline, the carriage
+ * return and the vertical tab; the non-breaking space is the one it leaves, so it becomes a space first.
+ *
+ * What is left uncovered is the exotic end of Unicode's spaces — U+2000..U+200A, U+3000 and their like.
+ * Each would need its own SUBSTITUTE, and a formula has 8192 characters to live in.
+ */
+const cleaned = (ref: string) => `CLEAN(SUBSTITUTE(${ref},CHAR(${NBSP})," "))`;
+
+/** Non-empty after trimming, as the engine reads it. Excel's ISBLANK would call a space filled in. */
+const filled = (ref: string) => `TRIM(${cleaned(ref)})<>""`;
+
+/**
+ * How many rows of this list are entries.
+ *
+ * A row is an entry when ANY of its fields is filled in — not just the leftmost. The engine counts
+ * entries in the deal's array, and the schema permits an entry with no name: `team.internal:
+ * [{"role":"SE"}]` validates, and the engine calls the team complete. Counting the name column alone
+ * made the sheet answer not_started on exactly that data, which is the contradiction this whole design
+ * exists to prevent.
+ *
+ * The per-column tests are SUMMED and then compared, so a row with three fields filled counts once.
+ *
+ * One case is left, and it cannot be closed from the sheet: an entry whose every field is empty is
+ * indistinguishable from one of the pre-allocated blank rows. The engine counts it and the sheet does
+ * not. Nothing on the sheet could tell them apart.
+ */
+const startedRows = (resolve: CellResolver, list: string) =>
+  `SUMPRODUCT(--((${resolve
+    .allRanges(list)
+    .map((range) => `${filled(range)}`)
+    .join(')+(')})>0))`;
 
 export function compilePredicate(predicate: Predicate, resolve: CellResolver): string {
   switch (predicate.kind) {
@@ -152,16 +181,17 @@ export function compilePredicate(predicate: Predicate, resolve: CellResolver): s
       return `${startedRows(resolve, predicate.list)}>=${predicate.value}`;
     case 'everyEntryHas': {
       // No started row may be missing one of these. Counted rather than tested row by row, because a
-      // formula cannot loop: for each field, the number of rows that have an identity and lack that
-      // field must be nought.
+      // formula cannot loop: for each field, the number of started rows lacking it must be nought.
       //
-      // The identity column itself is skipped. A row without it is not an entry at all — that is what
-      // `countAtLeast` means on a sheet — so the term would compare that column against itself and be
-      // nought whatever anybody types.
-      const entries = resolve.entryRange(predicate.list);
-      const terms = predicate.fields
-        .filter((field) => resolve.fieldRange(predicate.list, field) !== entries)
-        .map((field) => `SUMPRODUCT((${filled(entries)})*(TRIM(${resolve.fieldRange(predicate.list, field)})=""))=0`);
+      // "Started" is the same test the count uses, so the two halves of a rule cannot disagree about
+      // which rows they are talking about.
+      const started = resolve
+        .allRanges(predicate.list)
+        .map((range) => `${filled(range)}`)
+        .join(')+(');
+      const terms = predicate.fields.map(
+        (field) => `SUMPRODUCT(--((${started})>0)*(TRIM(${cleaned(resolve.fieldRange(predicate.list, field))})=""))=0`,
+      );
       if (terms.length === 0) return 'TRUE';
       return terms.length === 1 ? terms[0] : `AND(${terms.join(',')})`;
     }

--- a/plugins/meddpicc/engine/completion-rules.test.ts
+++ b/plugins/meddpicc/engine/completion-rules.test.ts
@@ -179,7 +179,7 @@ describe('the completion rules answer exactly what the old implementation answer
     agree({ closePlan: undefined }, 'no closePlan');
     // An entry with something in it: `[{}]` is the one shape whose answer changed on purpose, and the
     // test below owns it.
-    for (const milestones of [undefined, [], [{ title: 'Sign' }]]) {
+    for (const milestones of [undefined, [], [{ description: 'Sign' }]]) {
       for (const criticalActions of [undefined, [], [{ action: 'Chase' }]]) {
         agree({ closePlan: { milestones, criticalActions } }, `closePlan ${!!milestones}${!!criticalActions}`);
       }
@@ -227,10 +227,25 @@ describe('one class of answer changed on purpose: an entry with nothing in it', 
     expect(computeCompletion(plan).completionStatus.closePlan).toBe('not_started');
   });
 
+  test('a field the workbook never shows does not make a row an entry', () => {
+    // The schema does not forbid extra properties, so `[{"unmappedField":"x"}]` validates — and the old
+    // rule called the Team section complete on it, while every team cell on the sheet is blank. A rule
+    // has to mean the same thing to both readers, so it counts only the fields it names.
+    const deal = { team: { internal: [{ unmappedField: 'x' }] } };
+    expect(computeCompletion(deal).completionStatus.team).toBe('not_started');
+    // A declared field in the same position does count.
+    expect(computeCompletion({ team: { internal: [{ role: 'SE' }] } }).completionStatus.team).toBe('complete');
+  });
+
   test('an entry with anything at all in it still counts', () => {
     // Including the values that are easy to mistake for emptiness: a zero, and a boolean false, both of
     // which the sheet displays as something.
-    for (const entry of [{ role: 'SE' }, { assignedToDeal: false }, { headcount: 0 }, { name: 'A' }]) {
+    for (const entry of [
+      { role: 'SE' },
+      { assignedToDeal: false },
+      { name: 'A' },
+      { dateRequiredFrom: '2026-01-01' },
+    ]) {
       expect(computeCompletion({ team: { internal: [entry] } }).completionStatus.team, JSON.stringify(entry)).toBe(
         'complete',
       );
@@ -276,16 +291,26 @@ describe('the predicates themselves', () => {
   });
 
   test('countAtLeast counts entries, and everyEntryHas checks their fields', () => {
-    const two = { a: [{ n: 'x' }, { n: '' }] };
+    // A real list, because what makes a row an entry is a property of the list itself now — a rule about
+    // a list nobody has described cannot be read by either side, and says so.
+    const two = { stakeholders: [{ name: 'x' }, { name: '' }] };
+    const count = (value: number, deal: unknown) =>
+      evaluate({ kind: 'countAtLeast', list: 'stakeholders', value }, deal);
     // One of those two has something in it; the other is as empty as a blank row on the sheet.
-    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 1 }, two)).toBe(true);
-    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 2 }, two)).toBe(false);
-    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 2 }, { a: [{ n: 'x' }, { n: 'y' }] })).toBe(true);
-    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 1 }, { a: 'not a list' })).toBe(false);
-    expect(evaluate({ kind: 'everyEntryHas', list: 'a', fields: ['n'] }, two)).toBe(false);
-    expect(evaluate({ kind: 'everyEntryHas', list: 'a', fields: ['n'] }, { a: [{ n: 'x' }] })).toBe(true);
+    expect(count(1, two)).toBe(true);
+    expect(count(2, two)).toBe(false);
+    expect(count(2, { stakeholders: [{ name: 'x' }, { name: 'y' }] })).toBe(true);
+    expect(count(1, { stakeholders: 'not a list' })).toBe(false);
+    // A field nobody declared cannot make a row count, because the sheet has no cell for it.
+    expect(count(1, { stakeholders: [{ somethingElse: 'x' }] })).toBe(false);
+    // And a list with no declared fields is a mistake, not an empty list.
+    expect(() => evaluate({ kind: 'countAtLeast', list: 'nosuch', value: 1 }, {})).toThrow(/nosuch/);
+    const everyHasName = (deal: unknown) =>
+      evaluate({ kind: 'everyEntryHas', list: 'stakeholders', fields: ['name'] }, deal);
+    expect(everyHasName(two)).toBe(false);
+    expect(everyHasName({ stakeholders: [{ name: 'x' }] })).toBe(true);
     // Vacuously true on an empty list, which is why every rule that uses it also asks for a count.
-    expect(evaluate({ kind: 'everyEntryHas', list: 'a', fields: ['n'] }, { a: [] })).toBe(true);
+    expect(everyHasName({ stakeholders: [] })).toBe(true);
   });
 
   test('all and any over nothing are true and false', () => {

--- a/plugins/meddpicc/engine/completion-rules.test.ts
+++ b/plugins/meddpicc/engine/completion-rules.test.ts
@@ -158,7 +158,6 @@ describe('the completion rules answer exactly what the old implementation answer
       [full, full],
       [{ ...full, title: '' }],
       [full, { ...full, roleInDeal: '  ' }],
-      [{}],
     ]) {
       agree({ stakeholders: list }, `stakeholders ${JSON.stringify(list)}`);
     }
@@ -178,8 +177,10 @@ describe('the completion rules answer exactly what the old implementation answer
 
   test('every combination the close plan can see', () => {
     agree({ closePlan: undefined }, 'no closePlan');
-    for (const milestones of [undefined, [], [{}]]) {
-      for (const criticalActions of [undefined, [], [{}]]) {
+    // An entry with something in it: `[{}]` is the one shape whose answer changed on purpose, and the
+    // test below owns it.
+    for (const milestones of [undefined, [], [{ title: 'Sign' }]]) {
+      for (const criticalActions of [undefined, [], [{ action: 'Chase' }]]) {
         agree({ closePlan: { milestones, criticalActions } }, `closePlan ${!!milestones}${!!criticalActions}`);
       }
     }
@@ -187,8 +188,8 @@ describe('the completion rules answer exactly what the old implementation answer
 
   test('every combination the team can see', () => {
     agree({ team: undefined }, 'no team');
-    for (const internal of [undefined, [], [{}]]) {
-      for (const partner of [undefined, [], [{}]]) {
+    for (const internal of [undefined, [], [{ name: 'A' }]]) {
+      for (const partner of [undefined, [], [{ name: 'B' }]]) {
         agree({ team: { internal, partner } }, `team ${!!internal}${!!partner}`);
       }
     }
@@ -202,6 +203,40 @@ describe('the completion rules answer exactly what the old implementation answer
       stripped.qualification[element].evidence = '';
     }
     agree(stripped, 'the example with every score and evidence removed');
+  });
+});
+
+describe('one class of answer changed on purpose: an entry with nothing in it', () => {
+  // Everywhere else this refactor answers exactly what the old implementation answered. Here it does
+  // not, and it should not have: the old rule counted the LENGTH of the array, so `team.internal: [{}]`
+  // — one object with no fields — made the whole Team section complete. The schema permits it, nothing
+  // about it is a team member, and the sheet could never agree, because on a sheet an entry with every
+  // cell empty is indistinguishable from one of the pre-allocated blank rows.
+  //
+  // So an entry counts when it has something in it. Both readers now say the same thing, and the thing
+  // they say is the defensible one. Found by the second-opinion review.
+  test('an array of empty objects is not a list of entries', () => {
+    expect(legacyCompletion({ team: { internal: [{}] } }).team).toBe('complete');
+    expect(computeCompletion({ team: { internal: [{}] } }).completionStatus.team).toBe('not_started');
+
+    expect(legacyCompletion({ stakeholders: [{}] }).stakeholders).toBe('partial');
+    expect(computeCompletion({ stakeholders: [{}] }).completionStatus.stakeholders).toBe('not_started');
+
+    const plan = { closePlan: { milestones: [{}], criticalActions: [{}] } };
+    expect(legacyCompletion(plan).closePlan).toBe('complete');
+    expect(computeCompletion(plan).completionStatus.closePlan).toBe('not_started');
+  });
+
+  test('an entry with anything at all in it still counts', () => {
+    // Including the values that are easy to mistake for emptiness: a zero, and a boolean false, both of
+    // which the sheet displays as something.
+    for (const entry of [{ role: 'SE' }, { assignedToDeal: false }, { headcount: 0 }, { name: 'A' }]) {
+      expect(computeCompletion({ team: { internal: [entry] } }).completionStatus.team, JSON.stringify(entry)).toBe(
+        'complete',
+      );
+    }
+    // And whitespace is not anything.
+    expect(computeCompletion({ team: { internal: [{ role: '   ' }] } }).completionStatus.team).toBe('not_started');
   });
 });
 
@@ -242,8 +277,10 @@ describe('the predicates themselves', () => {
 
   test('countAtLeast counts entries, and everyEntryHas checks their fields', () => {
     const two = { a: [{ n: 'x' }, { n: '' }] };
-    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 2 }, two)).toBe(true);
-    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 3 }, two)).toBe(false);
+    // One of those two has something in it; the other is as empty as a blank row on the sheet.
+    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 1 }, two)).toBe(true);
+    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 2 }, two)).toBe(false);
+    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 2 }, { a: [{ n: 'x' }, { n: 'y' }] })).toBe(true);
     expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 1 }, { a: 'not a list' })).toBe(false);
     expect(evaluate({ kind: 'everyEntryHas', list: 'a', fields: ['n'] }, two)).toBe(false);
     expect(evaluate({ kind: 'everyEntryHas', list: 'a', fields: ['n'] }, { a: [{ n: 'x' }] })).toBe(true);

--- a/plugins/meddpicc/engine/completion-rules.test.ts
+++ b/plugins/meddpicc/engine/completion-rules.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { computeCompletion } from './completion';
+import { evaluate, SECTION_RULES, statusOf } from './completion-rules';
+import { QUALIFICATION_ELEMENTS, SECTION_ORDER } from './sections';
+
+const example = JSON.parse(fs.readFileSync(path.join(import.meta.dir, '..', 'schema', 'example-deal.json'), 'utf8'));
+
+/**
+ * Today's rules, frozen, as the oracle this refactor is measured against.
+ *
+ * The point of the predicate language is that the SAME rule can be read by the engine and compiled
+ * into a formula — which is only worth anything if the engine's answers do not move on the way. So
+ * this is a verbatim copy of `completion.ts` as it stood before, and every case below asks both
+ * implementations the same question.
+ *
+ * It is deliberately duplicated rather than imported: an oracle that shares code with the thing it
+ * checks agrees with it by construction.
+ */
+type Deal = Record<string, unknown>;
+const nonEmptyString = (v: unknown): boolean => typeof v === 'string' && v.trim().length > 0;
+const hasNonEmptyResponse = (responses: unknown): boolean => Array.isArray(responses) && responses.some(nonEmptyString);
+
+function legacyQualStatus(el: Record<string, unknown> | undefined): string {
+  if (!el) return 'not_started';
+  const score = typeof el.score === 'number' ? el.score : 0;
+  const responses = hasNonEmptyResponse(el.responses);
+  const evidence = nonEmptyString(el.evidence);
+  if (score >= 3 && responses && evidence) return 'complete';
+  if (score === 0 && !responses && !evidence) return 'not_started';
+  return 'partial';
+}
+
+function legacyCompletion(deal: unknown): Record<string, string> {
+  const d = (deal ?? {}) as Deal;
+  const qualification = (d.qualification ?? {}) as Record<string, Record<string, unknown>>;
+  const status: Record<string, string> = {};
+  for (const el of QUALIFICATION_ELEMENTS) status[el] = legacyQualStatus(qualification[el]);
+
+  const tw = d.threeWhys as { us?: Record<string, unknown> } | undefined;
+  if (!tw?.us) {
+    status.threeWhys = 'not_started';
+  } else {
+    const us = tw.us;
+    const all = nonEmptyString(us.whyAnything) && nonEmptyString(us.whyUs) && nonEmptyString(us.whyNow);
+    const any = nonEmptyString(us.whyAnything) || nonEmptyString(us.whyUs) || nonEmptyString(us.whyNow);
+    status.threeWhys = all ? 'complete' : any ? 'partial' : 'not_started';
+  }
+
+  const list = d.stakeholders;
+  if (!Array.isArray(list) || list.length === 0) {
+    status.stakeholders = 'not_started';
+  } else {
+    const complete = list.every(
+      (s) =>
+        nonEmptyString((s as Record<string, unknown>).name) &&
+        nonEmptyString((s as Record<string, unknown>).title) &&
+        nonEmptyString((s as Record<string, unknown>).roleInDeal),
+    );
+    status.stakeholders = complete ? 'complete' : 'partial';
+  }
+
+  const ss = d.salesStrategy as Record<string, unknown> | undefined;
+  if (!ss) {
+    status.salesStrategy = 'not_started';
+  } else {
+    const dvp = nonEmptyString(ss.differentiatedValueProposition);
+    const win = nonEmptyString(ss.winStrategy);
+    status.salesStrategy = dvp && win ? 'complete' : dvp || win ? 'partial' : 'not_started';
+  }
+
+  const cp = d.closePlan as { milestones?: unknown; criticalActions?: unknown } | undefined;
+  if (!cp) {
+    status.closePlan = 'not_started';
+  } else {
+    const m = Array.isArray(cp.milestones) && cp.milestones.length > 0;
+    const a = Array.isArray(cp.criticalActions) && cp.criticalActions.length > 0;
+    status.closePlan = m && a ? 'complete' : m || a ? 'partial' : 'not_started';
+  }
+
+  const team = d.team as { internal?: unknown; partner?: unknown } | undefined;
+  if (!team) {
+    status.team = 'not_started';
+  } else {
+    const internal = Array.isArray(team.internal) && team.internal.length > 0;
+    const partner = Array.isArray(team.partner) && team.partner.length > 0;
+    status.team = internal ? 'complete' : partner ? 'partial' : 'not_started';
+  }
+
+  return status;
+}
+
+/** Both implementations, asked the same question about one deal. */
+const agree = (deal: unknown, what: string) => {
+  const legacy = legacyCompletion(deal);
+  const now = computeCompletion(deal).completionStatus as Record<string, string>;
+  for (const section of SECTION_ORDER) {
+    expect(now[section], `${what}: ${section}`).toBe(legacy[section]);
+  }
+};
+
+/** A deal carrying one element, so the element rule can be swept on its own. */
+const withElement = (element: string, value: unknown) => ({ qualification: { [element]: value } });
+
+describe('the completion rules answer exactly what the old implementation answered', () => {
+  test('every combination an element rule can see', () => {
+    // Exhaustive rather than random: the element rule reads three fields with small input spaces, so
+    // all 96 combinations fit in a test and there is nothing left for a seed to miss. The absent and
+    // whitespace cases are the ones that matter — `score` missing reads as 0, and a cell holding a
+    // space is empty to every rule that consults it.
+    const scores = [undefined, 0, 1, 2, 3, 4];
+    const responses = [undefined, [], [''], ['   '], ['x'], ['', 'x']];
+    const evidences = [undefined, '', '   ', 'x'];
+    let checked = 0;
+    for (const score of scores) {
+      for (const response of responses) {
+        for (const evidence of evidences) {
+          agree(
+            withElement('metrics', { score, responses: response, evidence }),
+            `metrics ${JSON.stringify({ score, response, evidence })}`,
+          );
+          checked++;
+        }
+      }
+    }
+    expect(checked).toBe(scores.length * responses.length * evidences.length);
+  });
+
+  test('an element that is absent, null, or not an object at all', () => {
+    for (const value of [undefined, null, 'nonsense', 42, []]) {
+      agree(withElement('champion', value), `champion ${JSON.stringify(value)}`);
+    }
+    agree({}, 'an empty deal');
+    agree({ qualification: null }, 'a null qualification');
+    agree(null, 'no deal at all');
+  });
+
+  test('every combination the three whys can see', () => {
+    agree({ threeWhys: undefined }, 'no threeWhys');
+    agree({ threeWhys: {} }, 'threeWhys with no us');
+    for (const whyAnything of ['', 'x']) {
+      for (const whyUs of ['', 'x']) {
+        for (const whyNow of ['', 'x']) {
+          agree({ threeWhys: { us: { whyAnything, whyUs, whyNow } } }, `whys ${whyAnything}${whyUs}${whyNow}`);
+        }
+      }
+    }
+  });
+
+  test('every shape the stakeholder list can take', () => {
+    const full = { name: 'A', title: 'B', roleInDeal: 'C' };
+    for (const list of [
+      undefined,
+      [],
+      'not a list',
+      [full],
+      [full, full],
+      [{ ...full, title: '' }],
+      [full, { ...full, roleInDeal: '  ' }],
+      [{}],
+    ]) {
+      agree({ stakeholders: list }, `stakeholders ${JSON.stringify(list)}`);
+    }
+  });
+
+  test('every combination the sales strategy can see', () => {
+    agree({ salesStrategy: undefined }, 'no salesStrategy');
+    for (const differentiatedValueProposition of ['', 'x']) {
+      for (const winStrategy of ['', 'x']) {
+        agree(
+          { salesStrategy: { differentiatedValueProposition, winStrategy } },
+          `strategy ${differentiatedValueProposition}${winStrategy}`,
+        );
+      }
+    }
+  });
+
+  test('every combination the close plan can see', () => {
+    agree({ closePlan: undefined }, 'no closePlan');
+    for (const milestones of [undefined, [], [{}]]) {
+      for (const criticalActions of [undefined, [], [{}]]) {
+        agree({ closePlan: { milestones, criticalActions } }, `closePlan ${!!milestones}${!!criticalActions}`);
+      }
+    }
+  });
+
+  test('every combination the team can see', () => {
+    agree({ team: undefined }, 'no team');
+    for (const internal of [undefined, [], [{}]]) {
+      for (const partner of [undefined, [], [{}]]) {
+        agree({ team: { internal, partner } }, `team ${!!internal}${!!partner}`);
+      }
+    }
+  });
+
+  test('the shipped example and a stripped copy of it', () => {
+    agree(example, 'the example deal');
+    const stripped = JSON.parse(JSON.stringify(example));
+    for (const element of QUALIFICATION_ELEMENTS) {
+      delete stripped.qualification[element].score;
+      stripped.qualification[element].evidence = '';
+    }
+    agree(stripped, 'the example with every score and evidence removed');
+  });
+});
+
+describe('the predicates themselves', () => {
+  test('a rule exists for every section, and each has both halves', () => {
+    // A section with no rule would silently read as not_started — the same answer a genuinely
+    // untouched section gives, so nothing would look wrong.
+    expect(Object.keys(SECTION_RULES).sort()).toEqual([...SECTION_ORDER].sort());
+    for (const section of SECTION_ORDER) {
+      expect(SECTION_RULES[section].complete, section).toBeDefined();
+      expect(SECTION_RULES[section].started, section).toBeDefined();
+    }
+  });
+
+  test('nonEmpty treats whitespace as empty', () => {
+    expect(evaluate({ kind: 'nonEmpty', path: 'a' }, { a: 'x' })).toBe(true);
+    expect(evaluate({ kind: 'nonEmpty', path: 'a' }, { a: '   ' })).toBe(false);
+    expect(evaluate({ kind: 'nonEmpty', path: 'a' }, {})).toBe(false);
+    // A number is not text, and the fields this asks about are text. Reading 0 as "filled in" would
+    // make a score of 0 satisfy a rule about evidence.
+    expect(evaluate({ kind: 'nonEmpty', path: 'a' }, { a: 0 })).toBe(false);
+  });
+
+  test('atLeast reads a missing number as zero', () => {
+    expect(evaluate({ kind: 'atLeast', path: 'a', value: 3 }, { a: 3 })).toBe(true);
+    expect(evaluate({ kind: 'atLeast', path: 'a', value: 3 }, { a: 2 })).toBe(false);
+    expect(evaluate({ kind: 'atLeast', path: 'a', value: 1 }, {})).toBe(false);
+    expect(evaluate({ kind: 'atLeast', path: 'a', value: 0 }, {})).toBe(true);
+    expect(evaluate({ kind: 'atLeast', path: 'a', value: 1 }, { a: 'three' })).toBe(false);
+  });
+
+  test('anyNonEmpty asks about the entries, not the array', () => {
+    expect(evaluate({ kind: 'anyNonEmpty', list: 'a' }, { a: ['', 'x'] })).toBe(true);
+    expect(evaluate({ kind: 'anyNonEmpty', list: 'a' }, { a: ['', '  '] })).toBe(false);
+    expect(evaluate({ kind: 'anyNonEmpty', list: 'a' }, { a: [] })).toBe(false);
+    expect(evaluate({ kind: 'anyNonEmpty', list: 'a' }, {})).toBe(false);
+  });
+
+  test('countAtLeast counts entries, and everyEntryHas checks their fields', () => {
+    const two = { a: [{ n: 'x' }, { n: '' }] };
+    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 2 }, two)).toBe(true);
+    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 3 }, two)).toBe(false);
+    expect(evaluate({ kind: 'countAtLeast', list: 'a', value: 1 }, { a: 'not a list' })).toBe(false);
+    expect(evaluate({ kind: 'everyEntryHas', list: 'a', fields: ['n'] }, two)).toBe(false);
+    expect(evaluate({ kind: 'everyEntryHas', list: 'a', fields: ['n'] }, { a: [{ n: 'x' }] })).toBe(true);
+    // Vacuously true on an empty list, which is why every rule that uses it also asks for a count.
+    expect(evaluate({ kind: 'everyEntryHas', list: 'a', fields: ['n'] }, { a: [] })).toBe(true);
+  });
+
+  test('all and any over nothing are true and false', () => {
+    expect(evaluate({ kind: 'all', of: [] }, {})).toBe(true);
+    expect(evaluate({ kind: 'any', of: [] }, {})).toBe(false);
+  });
+
+  test('a section with no rule fails loudly rather than reading as untouched', () => {
+    // not_started is a real answer for a real section, so a missing rule returning it would look
+    // exactly like a deal nobody had started — the one wrong answer that raises no question.
+    expect(() => statusOf('nonesuch', {})).toThrow(/nonesuch/);
+  });
+
+  test('a predicate kind that does not exist fails loudly', () => {
+    // The rules are TypeScript, so this is unreachable by mistake — but an evaluator that returned
+    // false for an unknown kind would turn a typo into a section that is never complete.
+    expect(() => evaluate({ kind: 'sometimes' } as never, {})).toThrow(/sometimes/);
+  });
+});

--- a/plugins/meddpicc/engine/completion-rules.ts
+++ b/plugins/meddpicc/engine/completion-rules.ts
@@ -34,12 +34,12 @@ export type Predicate =
   /** An array of text with at least one non-empty entry — a question somebody has answered. */
   | { kind: 'anyNonEmpty'; list: string }
   /**
-   * An array with at least `value` entries that have something in them.
+   * An array with at least `value` entries that have something in them — see {@link ENTRY_FIELDS}.
    *
    * "Something" rather than "exists" on purpose. Counting the array's length made
    * `team.internal: [{}]` — one object with no fields — complete the whole Team section, and the sheet
    * could never agree with that: an entry whose every cell is empty is indistinguishable from one of the
-   * pre-allocated blank rows. So both readers ask the same question, and it is the defensible one.
+   * pre-allocated blank rows.
    */
   | { kind: 'countAtLeast'; list: string; value: number }
   /** Every entry of an array has all of these fields filled in. Vacuously true on an empty array. */
@@ -75,6 +75,42 @@ function isList(deal: unknown, list: string): boolean {
 }
 
 /**
+ * What each list's entries are made of: the item's declared fields, which are exactly the columns the
+ * workbook gives them.
+ *
+ * A property of the LIST rather than of a predicate, because that is what it is — and because the two
+ * halves of a rule must not disagree about which rows they are talking about. `countAtLeast` and
+ * `everyEntryHas` both read this, and so does the formula compiler.
+ *
+ * Named rather than taken as "whatever the object has": the schema does not forbid extra properties, so
+ * `[{"unmappedField":"x"}]` validates and the workbook has no cell for it. Counting that entry would be
+ * a rule the sheet could never agree with.
+ */
+export const ENTRY_FIELDS: Record<string, readonly string[]> = {
+  stakeholders: [
+    'name',
+    'title',
+    'roleInDeal',
+    'mustSayYes',
+    'canSayNo',
+    'whatTheyNeedToBelieve',
+    'sentiment',
+    'relationshipOwner',
+  ],
+  'closePlan.milestones': ['description', 'targetDate', 'status'],
+  'closePlan.criticalActions': ['action', 'owner', 'dueDate', 'status'],
+  'team.internal': ['name', 'role', 'dateRequiredFrom', 'assignedToDeal'],
+  'team.partner': ['name', 'role', 'dateRequiredFrom', 'assignedToDeal'],
+};
+
+/** The fields that make a row of this list an entry. A list nobody described is a rule nobody can read. */
+export function entryFieldsOf(list: string): readonly string[] {
+  const fields = ENTRY_FIELDS[list];
+  if (!fields) throw new Error(`no entry fields are declared for the list "${list}"`);
+  return fields;
+}
+
+/**
  * An entry with something in it — the same question the sheet asks of a row.
  *
  * A field counts when it would show something in a cell: text with characters in it, any number
@@ -82,9 +118,11 @@ function isList(deal: unknown, list: string): boolean {
  * because no cell displays one — so the two readers stay aligned by construction rather than by
  * agreement.
  */
-function hasContent(entry: unknown): boolean {
+function hasContent(entry: unknown, fields: readonly string[]): boolean {
   if (entry === null || typeof entry !== 'object') return false;
-  return Object.values(entry as Record<string, unknown>).some((value) => {
+  const record = entry as Record<string, unknown>;
+  return fields.some((field) => {
+    const value = record[field];
     if (typeof value === 'string') return value.trim().length > 0;
     if (typeof value === 'number') return Number.isFinite(value);
     return typeof value === 'boolean';
@@ -106,10 +144,15 @@ export function evaluate(predicate: Predicate, deal: unknown): boolean {
     }
     case 'anyNonEmpty':
       return entriesOf(deal, predicate.list).some(isFilled);
-    case 'countAtLeast':
+    case 'countAtLeast': {
+      // The fields first, so a rule naming a list nobody has described fails on every deal rather than
+      // only on one that happens to carry that array.
+      const fields = entryFieldsOf(predicate.list);
       return (
-        isList(deal, predicate.list) && entriesOf(deal, predicate.list).filter(hasContent).length >= predicate.value
+        isList(deal, predicate.list) &&
+        entriesOf(deal, predicate.list).filter((entry) => hasContent(entry, fields)).length >= predicate.value
       );
+    }
     case 'everyEntryHas':
       return entriesOf(deal, predicate.list).every((entry) =>
         predicate.fields.every((field) => isFilled((entry as Record<string, unknown>)?.[field])),

--- a/plugins/meddpicc/engine/completion-rules.ts
+++ b/plugins/meddpicc/engine/completion-rules.ts
@@ -1,0 +1,156 @@
+/**
+ * What "complete" means, written once.
+ *
+ * A section's status is read in two places that must never disagree: the engine computes it from the
+ * deal, and the workbook wants to show it live so that filling a cell in during a review updates the
+ * status beside it. Writing the rules twice — once in TypeScript and once in Excel formulas — is a
+ * second implementation that can drift, which is what this codebase refuses everywhere else (see
+ * `labels.ts`, which owns every displayed enum word in both directions).
+ *
+ * So a rule is DATA. Each section declares two predicates over deal paths:
+ *
+ * - `complete` — everything the section needs is there.
+ * - `started`  — something is there. A section that is neither is `not_started`.
+ *
+ * {@link evaluate} reads a predicate against a deal; the workbook generator compiles the same
+ * predicate into a formula over the cells those paths landed in. One rule, two readers.
+ *
+ * The vocabulary is deliberately tiny — six leaf kinds and two combinators cover all thirteen rules.
+ * Anything that needed a seventh would be a rule the sheet could not express, and that is worth
+ * discovering here rather than in Excel.
+ */
+import { readPath } from './json-path';
+import { QUALIFICATION_ELEMENTS } from './sections';
+
+export type Predicate =
+  /** Every one of these holds. Vacuously true. */
+  | { kind: 'all'; of: Predicate[] }
+  /** At least one of these holds. Vacuously false. */
+  | { kind: 'any'; of: Predicate[] }
+  /** A text field with something in it. Whitespace is not something. */
+  | { kind: 'nonEmpty'; path: string }
+  /** A number at or above `value`. A missing number reads as 0, as the engine has always read it. */
+  | { kind: 'atLeast'; path: string; value: number }
+  /** An array of text with at least one non-empty entry — a question somebody has answered. */
+  | { kind: 'anyNonEmpty'; list: string }
+  /** An array with at least `value` entries. */
+  | { kind: 'countAtLeast'; list: string; value: number }
+  /** Every entry of an array has all of these fields filled in. Vacuously true on an empty array. */
+  | { kind: 'everyEntryHas'; list: string; fields: string[] };
+
+export interface SectionRule {
+  complete: Predicate;
+  started: Predicate;
+}
+
+const all = (...of: Predicate[]): Predicate => ({ kind: 'all', of });
+const any = (...of: Predicate[]): Predicate => ({ kind: 'any', of });
+const nonEmpty = (path: string): Predicate => ({ kind: 'nonEmpty', path });
+const atLeast = (path: string, value: number): Predicate => ({ kind: 'atLeast', path, value });
+const anyNonEmpty = (list: string): Predicate => ({ kind: 'anyNonEmpty', list });
+const countAtLeast = (list: string, value: number): Predicate => ({ kind: 'countAtLeast', list, value });
+const everyEntryHas = (list: string, fields: string[]): Predicate => ({ kind: 'everyEntryHas', list, fields });
+
+/** Text with something in it. The one place trimming is decided, for both readers. */
+function isFilled(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/** The entries of a list, or none when the path holds anything else. */
+function entriesOf(deal: unknown, list: string): unknown[] {
+  const value = readPath(deal, list);
+  return Array.isArray(value) ? value : [];
+}
+
+/** A list path is an array; `readPath` on `a.b` of a non-array is `undefined`, which reads as absent. */
+function isList(deal: unknown, list: string): boolean {
+  return Array.isArray(readPath(deal, list));
+}
+
+export function evaluate(predicate: Predicate, deal: unknown): boolean {
+  switch (predicate.kind) {
+    case 'all':
+      return predicate.of.every((p) => evaluate(p, deal));
+    case 'any':
+      return predicate.of.some((p) => evaluate(p, deal));
+    case 'nonEmpty':
+      return isFilled(readPath(deal, predicate.path));
+    case 'atLeast': {
+      const value = readPath(deal, predicate.path);
+      const score = typeof value === 'number' && Number.isFinite(value) ? value : 0;
+      return score >= predicate.value;
+    }
+    case 'anyNonEmpty':
+      return entriesOf(deal, predicate.list).some(isFilled);
+    case 'countAtLeast':
+      return isList(deal, predicate.list) && entriesOf(deal, predicate.list).length >= predicate.value;
+    case 'everyEntryHas':
+      return entriesOf(deal, predicate.list).every((entry) =>
+        predicate.fields.every((field) => isFilled((entry as Record<string, unknown>)?.[field])),
+      );
+    default:
+      // Unreachable from TypeScript, and worth a throw all the same: returning false here would turn a
+      // typo into a section that can never be complete, which looks exactly like an unfinished deal.
+      throw new Error(`no such predicate: ${JSON.stringify((predicate as { kind: unknown }).kind)}`);
+  }
+}
+
+/**
+ * A MEDDPICC element: scored at least 3, with a question answered and evidence written down.
+ *
+ * `started` is the negation of the engine's original "nothing at all" test — score 0 with no response
+ * and no evidence — spelled as the positive so both halves of the rule read the same way.
+ */
+const elementRule = (element: string): SectionRule => {
+  const at = `qualification.${element}`;
+  return {
+    complete: all(atLeast(`${at}.score`, 3), anyNonEmpty(`${at}.responses`), nonEmpty(`${at}.evidence`)),
+    started: any(atLeast(`${at}.score`, 1), anyNonEmpty(`${at}.responses`), nonEmpty(`${at}.evidence`)),
+  };
+};
+
+/**
+ * Every section's rule, by the name `SECTION_ORDER` uses.
+ *
+ * The eight elements come from one template: eight hand-written copies of the same rule is eight
+ * chances for one of them to be subtly different, and the near-miss that shipped here before was
+ * exactly that shape — a spec that captured seven elements and scored the deal out of 28.
+ */
+export const SECTION_RULES: Record<string, SectionRule> = {
+  ...Object.fromEntries(QUALIFICATION_ELEMENTS.map((element) => [element, elementRule(element)])),
+  threeWhys: {
+    complete: all(
+      nonEmpty('threeWhys.us.whyAnything'),
+      nonEmpty('threeWhys.us.whyUs'),
+      nonEmpty('threeWhys.us.whyNow'),
+    ),
+    started: any(nonEmpty('threeWhys.us.whyAnything'), nonEmpty('threeWhys.us.whyUs'), nonEmpty('threeWhys.us.whyNow')),
+  },
+  stakeholders: {
+    complete: all(countAtLeast('stakeholders', 1), everyEntryHas('stakeholders', ['name', 'title', 'roleInDeal'])),
+    started: countAtLeast('stakeholders', 1),
+  },
+  salesStrategy: {
+    complete: all(nonEmpty('salesStrategy.differentiatedValueProposition'), nonEmpty('salesStrategy.winStrategy')),
+    started: any(nonEmpty('salesStrategy.differentiatedValueProposition'), nonEmpty('salesStrategy.winStrategy')),
+  },
+  closePlan: {
+    complete: all(countAtLeast('closePlan.milestones', 1), countAtLeast('closePlan.criticalActions', 1)),
+    started: any(countAtLeast('closePlan.milestones', 1), countAtLeast('closePlan.criticalActions', 1)),
+  },
+  // The internal team is what completes this; a partner team on its own is a start. Asking about both
+  // in `started` changes nothing — `complete` has already fired when the internal team is there — and
+  // it says what the rule means rather than what the original code happened to check.
+  team: {
+    complete: countAtLeast('team.internal', 1),
+    started: any(countAtLeast('team.internal', 1), countAtLeast('team.partner', 1)),
+  },
+};
+
+/** The status one section's rule gives for this deal. */
+export function statusOf(section: string, deal: unknown): 'complete' | 'partial' | 'not_started' {
+  const rule = SECTION_RULES[section];
+  if (!rule) throw new Error(`no completion rule for section "${section}"`);
+  if (evaluate(rule.complete, deal)) return 'complete';
+  return evaluate(rule.started, deal) ? 'partial' : 'not_started';
+}

--- a/plugins/meddpicc/engine/completion-rules.ts
+++ b/plugins/meddpicc/engine/completion-rules.ts
@@ -33,7 +33,14 @@ export type Predicate =
   | { kind: 'atLeast'; path: string; value: number }
   /** An array of text with at least one non-empty entry — a question somebody has answered. */
   | { kind: 'anyNonEmpty'; list: string }
-  /** An array with at least `value` entries. */
+  /**
+   * An array with at least `value` entries that have something in them.
+   *
+   * "Something" rather than "exists" on purpose. Counting the array's length made
+   * `team.internal: [{}]` — one object with no fields — complete the whole Team section, and the sheet
+   * could never agree with that: an entry whose every cell is empty is indistinguishable from one of the
+   * pre-allocated blank rows. So both readers ask the same question, and it is the defensible one.
+   */
   | { kind: 'countAtLeast'; list: string; value: number }
   /** Every entry of an array has all of these fields filled in. Vacuously true on an empty array. */
   | { kind: 'everyEntryHas'; list: string; fields: string[] };
@@ -67,6 +74,23 @@ function isList(deal: unknown, list: string): boolean {
   return Array.isArray(readPath(deal, list));
 }
 
+/**
+ * An entry with something in it — the same question the sheet asks of a row.
+ *
+ * A field counts when it would show something in a cell: text with characters in it, any number
+ * including nought, either boolean. Whitespace does not, and neither does a nested object or array,
+ * because no cell displays one — so the two readers stay aligned by construction rather than by
+ * agreement.
+ */
+function hasContent(entry: unknown): boolean {
+  if (entry === null || typeof entry !== 'object') return false;
+  return Object.values(entry as Record<string, unknown>).some((value) => {
+    if (typeof value === 'string') return value.trim().length > 0;
+    if (typeof value === 'number') return Number.isFinite(value);
+    return typeof value === 'boolean';
+  });
+}
+
 export function evaluate(predicate: Predicate, deal: unknown): boolean {
   switch (predicate.kind) {
     case 'all':
@@ -83,7 +107,9 @@ export function evaluate(predicate: Predicate, deal: unknown): boolean {
     case 'anyNonEmpty':
       return entriesOf(deal, predicate.list).some(isFilled);
     case 'countAtLeast':
-      return isList(deal, predicate.list) && entriesOf(deal, predicate.list).length >= predicate.value;
+      return (
+        isList(deal, predicate.list) && entriesOf(deal, predicate.list).filter(hasContent).length >= predicate.value
+      );
     case 'everyEntryHas':
       return entriesOf(deal, predicate.list).every((entry) =>
         predicate.fields.every((field) => isFilled((entry as Record<string, unknown>)?.[field])),

--- a/plugins/meddpicc/engine/completion.ts
+++ b/plugins/meddpicc/engine/completion.ts
@@ -1,4 +1,5 @@
-import { QUALIFICATION_ELEMENTS, SECTION_ORDER, type SectionStatus } from './sections';
+import { statusOf } from './completion-rules';
+import { SECTION_ORDER, type SectionStatus } from './sections';
 
 export interface CompletionResult {
   order: readonly string[];
@@ -6,89 +7,17 @@ export interface CompletionResult {
   nextIncompleteSection: string | null;
 }
 
-function nonEmptyString(v: unknown): boolean {
-  return typeof v === 'string' && v.trim().length > 0;
-}
-
-function hasNonEmptyResponse(responses: unknown): boolean {
-  return Array.isArray(responses) && responses.some(nonEmptyString);
-}
-
-function qualStatus(el: Record<string, unknown> | undefined): SectionStatus {
-  if (!el) return 'not_started';
-  const score = typeof el.score === 'number' ? el.score : 0;
-  const responses = hasNonEmptyResponse(el.responses);
-  const evidence = nonEmptyString(el.evidence);
-  if (score >= 3 && responses && evidence) return 'complete';
-  if (score === 0 && !responses && !evidence) return 'not_started';
-  return 'partial';
-}
-
-type Deal = Record<string, unknown>;
-
-function threeWhysStatus(deal: Deal): SectionStatus {
-  const tw = deal.threeWhys as { us?: Record<string, unknown> } | undefined;
-  if (!tw?.us) return 'not_started';
-  const us = tw.us;
-  const all = nonEmptyString(us.whyAnything) && nonEmptyString(us.whyUs) && nonEmptyString(us.whyNow);
-  const any = nonEmptyString(us.whyAnything) || nonEmptyString(us.whyUs) || nonEmptyString(us.whyNow);
-  return all ? 'complete' : any ? 'partial' : 'not_started';
-}
-
-function stakeholdersStatus(deal: Deal): SectionStatus {
-  const list = deal.stakeholders;
-  if (!Array.isArray(list) || list.length === 0) return 'not_started';
-  const complete = list.every(
-    (s) =>
-      nonEmptyString((s as Record<string, unknown>).name) &&
-      nonEmptyString((s as Record<string, unknown>).title) &&
-      nonEmptyString((s as Record<string, unknown>).roleInDeal),
-  );
-  return complete ? 'complete' : 'partial';
-}
-
-function salesStrategyStatus(deal: Deal): SectionStatus {
-  const ss = deal.salesStrategy as Record<string, unknown> | undefined;
-  if (!ss) return 'not_started';
-  const dvp = nonEmptyString(ss.differentiatedValueProposition);
-  const win = nonEmptyString(ss.winStrategy);
-  if (dvp && win) return 'complete';
-  return dvp || win ? 'partial' : 'not_started';
-}
-
-function closePlanStatus(deal: Deal): SectionStatus {
-  const cp = deal.closePlan as { milestones?: unknown; criticalActions?: unknown } | undefined;
-  if (!cp) return 'not_started';
-  const m = Array.isArray(cp.milestones) && cp.milestones.length > 0;
-  const a = Array.isArray(cp.criticalActions) && cp.criticalActions.length > 0;
-  if (m && a) return 'complete';
-  return m || a ? 'partial' : 'not_started';
-}
-
-function teamStatus(deal: Deal): SectionStatus {
-  const team = deal.team as { internal?: unknown; partner?: unknown } | undefined;
-  if (!team) return 'not_started';
-  const internal = Array.isArray(team.internal) && team.internal.length > 0;
-  const partner = Array.isArray(team.partner) && team.partner.length > 0;
-  if (internal) return 'complete';
-  return partner ? 'partial' : 'not_started';
-}
-
+/**
+ * Where the deal stands, section by section.
+ *
+ * The rules themselves live in `completion-rules.ts` as data, because the workbook has to show these
+ * statuses live — filling a cell in during a review should update the status beside it — and a second
+ * set of rules written in Excel formulas would be free to disagree with this one. So this walks the
+ * same predicates the generator compiles.
+ */
 export function computeCompletion(deal: unknown): CompletionResult {
-  const d = (deal ?? {}) as Deal;
-  const qualification = (d.qualification ?? {}) as Record<string, Record<string, unknown>>;
   const completionStatus: Record<string, SectionStatus> = {};
-
-  for (const el of QUALIFICATION_ELEMENTS) {
-    completionStatus[el] = qualStatus(qualification[el]);
-  }
-  completionStatus.threeWhys = threeWhysStatus(d);
-  completionStatus.stakeholders = stakeholdersStatus(d);
-  completionStatus.salesStrategy = salesStrategyStatus(d);
-  completionStatus.closePlan = closePlanStatus(d);
-  completionStatus.team = teamStatus(d);
-
+  for (const section of SECTION_ORDER) completionStatus[section] = statusOf(section, deal) as SectionStatus;
   const nextIncompleteSection = SECTION_ORDER.find((s) => completionStatus[s] !== 'complete') ?? null;
-
   return { order: SECTION_ORDER, completionStatus, nextIncompleteSection };
 }

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -218,12 +218,34 @@ describe('planWorkbook — derived cells come from the schema, not from prose', 
     expect(names).toEqual(QUALIFICATION_ELEMENTS.map(sectionLabel));
   });
 
-  test('the completion block lists every tracked section with its computed status', () => {
+  test('the completion block lists every tracked section, and each status is a live formula', () => {
+    // The statuses used to be written as literals, computed from the deal at generation time: fill in
+    // the missing evidence during a review and the sheet went on calling the section not started. They
+    // are the engine's own rules compiled now, so Excel answers as the engine would.
     const completion = table('sections');
     const names = SECTION_ORDER.map((_, i) => cellAt(completion.ref('section', i))?.value);
     expect(names).toEqual(SECTION_ORDER.map(sectionLabel));
-    const metricsStatus = cellAt(completion.ref('status', SECTION_ORDER.indexOf('metrics')))?.value;
-    expect(COMPLETION_STATUSES.map(statusLabel)).toContain(metricsStatus);
+
+    for (const [row, section] of SECTION_ORDER.entries()) {
+      const cell = cellAt(completion.ref('status', row));
+      expect(cell?.value, section).toBeUndefined();
+      const formula = cell?.formula ?? '';
+      // It can only ever answer one of the three words the column is coloured by.
+      for (const status of COMPLETION_STATUSES) expect(formula, section).toContain(`"${statusLabel(status)}"`);
+    }
+  });
+
+  test("an element's status formula reads that element's own cells", () => {
+    // Compiled against the wrong row it would be well-formed and wrong — the failure mode a formula
+    // cannot show you. So the cells it names have to be the ones the plan gave that element.
+    const completion = table('sections');
+    const formula = cellAt(completion.ref('status', SECTION_ORDER.indexOf('champion')))?.formula ?? '';
+    const address = (jsonPath: string) => plan.inputCells.find((c) => c.jsonPath === jsonPath)?.address ?? 'MISSING';
+    const absolute = (ref: string) => ref.replace(/^([A-Z]+)(\d+)$/, '$$$1$$$2');
+    expect(formula).toContain(absolute(address('qualification.champion.score')));
+    expect(formula).toContain(absolute(address('qualification.champion.evidence')));
+    // ...and not another element's.
+    expect(formula).not.toContain(absolute(address('qualification.metrics.evidence')));
   });
 
   test('questions come from the schema and pair with the responses in the deal', () => {

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -1069,6 +1069,36 @@ describe('planWorkbook — a blank cell something depends on is shaded', () => {
   });
 });
 
+describe('planWorkbook — a completion block can sit anywhere in the spec', () => {
+  test('a Completion sheet placed BEFORE the inputs still compiles', () => {
+    // The statuses used to be compiled at the end of each sheet, against the input cells known so far —
+    // so a two-sheet spec that passes check-spec failed to generate when the Completion block came
+    // first, with "the sheet has no cell for qualification.metrics.score". Loud rather than silent, but
+    // a valid spec should not depend on the order its sheets happen to be written in.
+    //
+    // Built by MOVING the shipped Completion block onto its own sheet and putting that sheet first, so
+    // every cell the thirteen rules name exists exactly as it does today and the only thing that
+    // changes is the order.
+    const reordered = clone(spec);
+    const blocks = reordered.sheets[0].blocks;
+    const at = blocks.findIndex((b) => b.kind === 'table' && b.table.id === 'sections');
+    expect(at, 'the shipped spec has a sections table').toBeGreaterThan(-1);
+    const [completionBlock] = blocks.splice(at, 1);
+    reordered.sheets.unshift({
+      name: 'Completion',
+      kind: 'grid',
+      columns: reordered.sheets[0].columns,
+      blocks: [completionBlock],
+    });
+
+    const p = planWorkbook(schema, reordered, deal);
+    const statuses = p.sheets[0].rows.flatMap((r) => r.cells).filter((c) => c.formula?.includes('Not started'));
+    expect(statuses).toHaveLength(SECTION_ORDER.length);
+    // And each one names the sheet the cells are on, since that is no longer its own.
+    for (const cell of statuses) expect(cell.formula).toContain(`${spec.sheets[0].name}'!`);
+  });
+});
+
 describe('planWorkbook — the row a wash asks about is its own table’s row', () => {
   /** A sheet with two narrow lists side by side, the way the Close Plan and the Team are laid out. */
   const sideBySide = (): WorkbookSpec =>

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -116,7 +116,13 @@ function displayValue(
   return constraint?.enum?.includes(value) ? enumLabel(value) : value;
 }
 
-const sheetPrefix = (name: string) => (/^[A-Za-z0-9_]+$/.test(name) ? `${name}!` : `'${name.replace(/'/g, "''")}'!`);
+/**
+ * How a formula names a cell on another sheet: bare when the name is simple, quoted otherwise, with an
+ * apostrophe in the name doubled. Exported because the completion compiler needs the same rule — two
+ * ways of writing a cross-sheet reference is two ways to get one wrong.
+ */
+export const sheetPrefix = (name: string) =>
+  /^[A-Za-z0-9_]+$/.test(name) ? `${name}!` : `'${name.replace(/'/g, "''")}'!`;
 
 /** Row keys for a keyed source, or null when the rows depend on the deal. */
 function keysOf(source: SpecTableSource): readonly string[] | null {
@@ -1019,7 +1025,7 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
     }
 
     if (pendingStatuses.length > 0) {
-      const resolve = cellResolver(inputCells);
+      const resolve = cellResolver(inputCells, s.name);
       for (const { cell, section } of pendingStatuses) {
         const rule = SECTION_RULES[section];
         if (!rule) throw new Error(`the Completion block names section "${section}", which has no rule`);

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -711,6 +711,15 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
   const clippedCells: ClippedCell[] = [];
   const notes: PlannedNote[] = [];
   const sheets: SheetSpec[] = [];
+  /**
+   * Status cells whose formula cannot be written yet.
+   *
+   * A completion rule names cells anywhere in the workbook, so the formulas are compiled after every
+   * sheet has been laid out. Compiled per sheet they could only see the input cells of that sheet and
+   * the ones before it — and a two-sheet spec with its Completion block first then failed to generate,
+   * which made a valid spec depend on the order its sheets happened to be written in.
+   */
+  const pendingStatuses: Array<{ cell: CellSpec; section: string; sheet: string }> = [];
   /** `sheet!ref` for every cell the generator writes — see {@link WorkbookPlan.writtenCells}. */
   const writtenCells: string[] = [];
 
@@ -718,8 +727,6 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
     const byRow = new Map<number, CellSpec[]>();
     const heights = new Map<number, number>();
     const merges: string[] = [];
-    /** Status cells whose formula needs every input cell to have been placed first. */
-    const pendingStatuses: Array<{ cell: CellSpec; section: string }> = [];
     const formats: ConditionalFormat[] = [];
     const validations: Validation[] = [];
     const push = (row: number, cell: CellSpec) => {
@@ -970,7 +977,7 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
           if (table.source.kind === 'sections' && spec.id === 'status') {
             const cell: CellSpec = { ref, style };
             push(dataRow, cell);
-            pendingStatuses.push({ cell, section: entry.key as string });
+            pendingStatuses.push({ cell, section: entry.key as string, sheet: s.name });
             continue;
           }
 
@@ -1024,15 +1031,6 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
       }
     }
 
-    if (pendingStatuses.length > 0) {
-      const resolve = cellResolver(inputCells, s.name);
-      for (const { cell, section } of pendingStatuses) {
-        const rule = SECTION_RULES[section];
-        if (!rule) throw new Error(`the Completion block names section "${section}", which has no rule`);
-        cell.formula = compileStatus(rule, resolve);
-      }
-    }
-
     // Taken from the one collection rather than accumulated twice: the plan reports notes per
     // workbook and the writer takes them per sheet, and two lists would be two chances to disagree.
     const sheetNotes = notes.filter((n) => n.sheet === s.name).map(({ address, text }) => ({ ref: address, text }));
@@ -1051,6 +1049,12 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
       validations: validations.length ? validations : undefined,
       notes: sheetNotes.length ? sheetNotes : undefined,
     });
+  }
+
+  for (const { cell, section, sheet } of pendingStatuses) {
+    const rule = SECTION_RULES[section];
+    if (!rule) throw new Error(`the Completion block names section "${section}", which has no rule`);
+    cell.formula = compileStatus(rule, cellResolver(inputCells, sheet));
   }
 
   return {

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -13,6 +13,8 @@
  */
 import { createHash } from 'node:crypto';
 import { computeCompletion } from './completion';
+import { cellResolver, compileStatus } from './completion-formula';
+import { SECTION_RULES } from './completion-rules';
 import { computeElementHint } from './hint';
 import { readPath } from './json-path';
 import { enumLabel, enumLabels } from './labels';
@@ -710,6 +712,8 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
     const byRow = new Map<number, CellSpec[]>();
     const heights = new Map<number, number>();
     const merges: string[] = [];
+    /** Status cells whose formula needs every input cell to have been placed first. */
+    const pendingStatuses: Array<{ cell: CellSpec; section: string }> = [];
     const formats: ConditionalFormat[] = [];
     const validations: Validation[] = [];
     const push = (row: number, cell: CellSpec) => {
@@ -952,6 +956,18 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
             continue;
           }
 
+          // A section's completion status: the engine's own rule, compiled into a formula so it follows
+          // what somebody types during a review instead of describing the deal as it was generated.
+          // Filled in after the walk, because a rule names cells that later blocks may not have placed
+          // yet — the Completion block happens to sit near the end today, and nothing should depend on
+          // that.
+          if (table.source.kind === 'sections' && spec.id === 'status') {
+            const cell: CellSpec = { ref, style };
+            push(dataRow, cell);
+            pendingStatuses.push({ cell, section: entry.key as string });
+            continue;
+          }
+
           const derived = derivedValue(spec, entry, table, schema, deal, completion);
           push(dataRow, { ref, value: derived, style });
           // A derived cell says which element or question its row is about, and nothing a person may
@@ -999,6 +1015,15 @@ export function planWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown)
           if (values) validations.push({ sqref, values });
         }
         column += span;
+      }
+    }
+
+    if (pendingStatuses.length > 0) {
+      const resolve = cellResolver(inputCells);
+      for (const { cell, section } of pendingStatuses) {
+        const rule = SECTION_RULES[section];
+        if (!rule) throw new Error(`the Completion block names section "${section}", which has no rule`);
+        cell.formula = compileStatus(rule, resolve);
       }
     }
 

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -143,6 +143,22 @@ describe('buildWorkbook — cells', () => {
     expect(sheet).toContain(`s="${STYLE_IDS.label}"`);
   });
 
+  test("refuses a formula past Excel's own limit", () => {
+    // Past 8192 characters Excel does not warn: it prompts to repair the file and the cell comes back
+    // empty. A compiled rule is the realistic way to reach it — the completion statuses are already a
+    // third of the way there — so the writer refuses rather than shipping a file that opens broken.
+    const long = `IF(${'A1+'.repeat(3000)}0,1,2)`;
+    expect(long.length).toBeGreaterThan(8192);
+    expect(() => buildWorkbook([{ name: 'S', rows: [{ row: 1, cells: [{ ref: 'B1', formula: long }] }] }])).toThrow(
+      /8192/,
+    );
+    // And one inside the limit is written without complaint.
+    const short = `IF(${'A1+'.repeat(100)}0,1,2)`;
+    expect(() =>
+      buildWorkbook([{ name: 'S', rows: [{ row: 1, cells: [{ ref: 'B1', formula: short }] }] }]),
+    ).not.toThrow();
+  });
+
   test('rejects an unknown style name rather than emitting a wrong index', () => {
     // A bad index silently mis-styles a cell, or makes Excel reject the file — the one
     // failure mode of a hand-written styles.xml, so it fails loudly at build time.

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -71,6 +71,9 @@ interface Range {
   r2: number;
 }
 
+/** Excel's limit on the text of one formula. Past it, opening the file offers to repair it. */
+const MAX_FORMULA_LENGTH = 8192;
+
 /** The last cell Excel has: column XFD, row 1048576. Anything past it is not a cell at all. */
 const MAX_COLUMN = 16384;
 const MAX_ROW = 1048576;
@@ -629,6 +632,14 @@ function cellXml(cell: CellSpec): string {
   const s = style === undefined ? '' : ` s="${STYLE_IDS[style]}"`;
 
   if (cell.formula !== undefined) {
+    // Excel's cap on one formula. Past it the file does not warn — it prompts to repair, and the cell
+    // comes back empty. A compiled rule is the realistic way to reach this, so it is checked here where
+    // every formula passes rather than at the one place that happens to build a long one.
+    if (cell.formula.length > MAX_FORMULA_LENGTH) {
+      throw new Error(
+        `The formula for ${cell.ref} is ${cell.formula.length} characters; Excel allows ${MAX_FORMULA_LENGTH}`,
+      );
+    }
     // No cached <v>: Excel computes on open. Writing a value we guessed would be worse —
     // it would show a stale number until something forced a recalculation.
     return `<c r="${cell.ref}"${s}><f>${escapeXml(cell.formula)}</f></c>`;

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -210,6 +210,95 @@ check_count elementsBelowThree "$(jq -r '[.elementScores[] | select(. < 3)] | le
 check_count scorePreviousTotal "$(deal_count '[.scoring.previousElementScores[]] | add')"
 echo "PASS: every scorecard count Excel computes agrees with the deal JSON"
 
+# ── Completion statuses ────────────────────────────────────────────────────────────────────────
+#
+# The thirteen section statuses used to be literals, computed when the workbook was written: fill in
+# the missing evidence during a review and the sheet went on calling the section not started. They are
+# the engine's own rules compiled into formulas now, and the whole risk of that is disagreement — a
+# completion column that contradicts `engine next` is worse than one that is merely stale.
+#
+# So ask Excel for all thirteen and compare each against the engine's answer for the same deal. The
+# comparison normalises Excel's word rather than repeating the label table here: "Not started" becomes
+# not_started by lowercasing and swapping the space. That is derived from the labelling rule, so a
+# change to the WORDS keeps passing while a change to what they MEAN fails — which is the way round it
+# should be.
+#
+# `statuses_from_excel <book> <plan> <engine-json>` prints `section<TAB>normalised-status` per section.
+#
+# The cells are read in the engine's own section order and paired back up here: AppleScript does the
+# one thing it is needed for. Splitting a "section:ref" string inside the tell block was the first
+# attempt and it fails with -1723 — `offset of` belongs to StandardAdditions, so inside
+# `tell application "Microsoft Excel"` it is sent to Excel, which has no such command.
+statuses_from_excel() {
+  local book="$1" plan="$2" engine="$3" section row first column refs=() sections=()
+  # The block's geometry once, from the plan: nothing here counts rows for itself.
+  column="$(letters "$(jq -r '(.tables[] | select(.id == "sections") | .columns.status)' <<<"$plan")")"
+  first="$(jq -r '(.tables[] | select(.id == "sections") | .firstDataRow)' <<<"$plan")"
+  [ -n "$column" ] && [ "$first" != "null" ] || fail "the plan has no sections table to read statuses from"
+  row=0
+  for section in $(jq -r '.order[]' <<<"$engine"); do
+    sections+=("$section")
+    refs+=("$column$((first + row))")
+    row=$((row + 1))
+  done
+
+  local values
+  values="$(
+    osascript - "$SHEET" "$book" "${refs[@]}" <<'OSA' 2>&1
+on run argv
+  set sheetName to item 1 of argv
+  set bookName to item 2 of argv
+  set out to ""
+  tell application "Microsoft Excel"
+    set ws to worksheet sheetName of workbook bookName
+    repeat with i from 3 to (count of argv)
+      set out to out & ((get value of range (item i of argv) of ws) as string) & linefeed
+    end repeat
+  end tell
+  return out
+end run
+OSA
+  )"
+  case "$values" in
+  *"execution error"* | *"syntax error"*) fail "could not read the completion statuses: $values" ;;
+  esac
+
+  # Excel's word -> the engine's value: lowercase, and a space is an underscore. Derived from the
+  # labelling rule rather than a second copy of the label table, so renaming a status still fails here
+  # while restyling one does not.
+  local i=0 value
+  while IFS= read -r value; do
+    [ -n "$value" ] || continue
+    printf '%s\t%s\n' "${sections[$i]}" "$(tr '[:upper:]' '[:lower:]' <<<"$value" | tr ' ' '_')"
+    i=$((i + 1))
+  done <<<"$values"
+}
+
+compare_statuses() {
+  local book="$1" deal="$2" plan="$3" label="$4" engine seen want got mismatches=0 compared=0
+  engine="$(bun "$PLUGIN_ROOT/engine/cli.ts" next "$deal")" || fail "next failed for $deal"
+  seen="$(statuses_from_excel "$book" "$plan" "$engine")"
+  while IFS=$'\t' read -r section got; do
+    [ -n "$section" ] || continue
+    want="$(jq -r --arg s "$section" '.completionStatus[$s]' <<<"$engine")"
+    compared=$((compared + 1))
+    if [ "$got" != "$want" ]; then
+      echo "    MISMATCH $section: Excel says '$got', the engine says '$want'"
+      mismatches=$((mismatches + 1))
+    fi
+  done <<<"$seen"
+  local tracked
+  tracked="$(jq -r '.order | length' <<<"$engine")"
+  [ "$compared" = "$tracked" ] || fail "compared $compared of $tracked sections in $label — the stage is not covering the block"
+  [ "$mismatches" = "0" ] || fail "$mismatches completion status(es) in $label disagree with the engine"
+  echo "    $compared section statuses in $label agree with the engine"
+}
+
+echo "==> comparing all thirteen completion statuses against the engine"
+compare_statuses "$BOOK" "$DEAL" "$uat_plan" "the example deal"
+
+echo "PASS: every completion status Excel computes agrees with the engine"
+
 # A formula pointing at the wrong range is well-formed and wrong; an error value is at least
 # loud. Check for the loud ones across every sheet.
 # This check was vacuous for two independent reasons, either of which was enough (#904).
@@ -510,6 +599,70 @@ while IFS='|' read -r _t _o f rgb; do
   assert_warm_and_faint "rating rule $f" "$rgb"
 done <<<"$rating_rules"
 echo "PASS: every wash Excel resolved is warm and faint, and nothing paints a value that is done"
+
+# And the part that matters: they have to FOLLOW an edit. Drop an element's score in Excel and the
+# status beside it must change to whatever the engine says about the same deal with that score changed
+# — computed by the engine here rather than written down, so this cannot drift from its rules.
+status_col="$(jq -r '(.tables[] | select(.id == "sections") | .columns.status)' <<<"$uat_plan")"
+status_row="$(jq -r '(.tables[] | select(.id == "sections") | .firstDataRow)' <<<"$uat_plan")"
+status_cell="$(letters "$status_col")$status_row"
+metrics_score="$(table_cell elements score 0)"
+edited_deal="$WORK/status-edited.json"
+jq '.qualification.metrics.score = 0' "$DEAL" >"$edited_deal" || fail "could not build the edited deal"
+want_edited="$(bun "$PLUGIN_ROOT/engine/cli.ts" next "$edited_deal" | jq -r '.completionStatus.metrics')"
+[ -n "$metrics_score" ] && [ -n "$status_cell" ] || fail "no cells to edit: score='$metrics_score' status='$status_cell'"
+echo "==> setting $metrics_score to 0 and reading $status_cell back (engine says metrics becomes $want_edited)"
+status_seen="$(
+  osascript - "$SHEET" "$BOOK" "$metrics_score" "$status_cell" <<'OSA' 2>&1
+on run argv
+  set sheetName to item 1 of argv
+  set bookName to item 2 of argv
+  -- Pulled out of the tell block deliberately: inside one, `item n of argv` and the string it yields
+  -- are resolved against Excel, and `range (item 3 of argv)` fails with -1728 rather than reading the
+  -- cell. The rubric stage below has always assigned its refs first, for the same reason.
+  set scoreRef to item 3 of argv
+  set statusRef to item 4 of argv
+  tell application "Microsoft Excel"
+    set ws to worksheet sheetName of workbook bookName
+    set scoreCell to range scoreRef of ws
+    set statusCell to range statusRef of ws
+    set original to (get value of scoreCell)
+    set was to (get value of statusCell) as string
+    -- Excel accepts a workbook before it has finished with it, so the write is confirmed before the
+    -- dependent cell is polled, and each half reports its own timeout.
+    repeat 40 times
+      set value of scoreCell to 0
+      calculate ws
+      if (get value of scoreCell) = 0 then
+        repeat 40 times
+          calculate ws
+          set nowText to (get value of statusCell) as string
+          if nowText is not was then
+            set value of scoreCell to original
+            calculate ws
+            return was & "|" & nowText
+          end if
+          delay 0.1
+        end repeat
+        set value of scoreCell to original
+        return "TIMEOUT-status-did-not-follow-the-score"
+      end if
+      delay 0.25
+    end repeat
+    return "TIMEOUT-score-write-never-took"
+  end tell
+end run
+OSA
+)"
+case "$status_seen" in
+*"execution error"* | *"syntax error"*) fail "the completion-status check could not run: $status_seen" ;;
+*"TIMEOUT-score-write-never-took"*) fail "Excel discarded the score write — it was still busy: $status_seen" ;;
+*"TIMEOUT-status-did-not-follow-the-score"*) fail "the score changed and the completion status did not follow it" ;;
+esac
+status_now="$(cut -d'|' -f2 <<<"$status_seen" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')"
+echo "    metrics was '$(cut -d'|' -f1 <<<"$status_seen")', became '$(cut -d'|' -f2 <<<"$status_seen")'"
+[ "$status_now" = "$want_edited" ] || fail "Excel says metrics is '$status_now' at score 0; the engine says '$want_edited'"
+echo "PASS: a completion status follows a score changed in Excel"
 
 # The presentation primitives are the ones a unit test can least vouch for: a merge Excel
 # rejects, a print setup it ignores, a gridline flag in the wrong place — all of them produce a
@@ -1387,6 +1540,9 @@ OSA
 )"
 got_partial="$(awk -v v="$got_partial_raw" 'BEGIN { printf "%.1f", v * 100 }')"
 echo "    partly-qualified overall score: Excel=$got_partial% engine=$want_partial_pct%"
+# The statuses too, on a deal where most sections are NOT complete — the example deal is nearly
+# finished, so on its own it exercises mostly the complete branch of every rule.
+compare_statuses "$PARTIAL_BOOK" "$PARTIAL" "$partial_plan" "the partly-qualified deal"
 osascript -e "tell application \"Microsoft Excel\" to close workbook \"$PARTIAL_BOOK\" saving no" >/dev/null 2>&1
 [ "$got_partial" = "$want_partial_pct" ] || fail "Excel showed $got_partial% for a partly-qualified deal, engine says $want_partial_pct%"
 

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -1406,6 +1406,38 @@ again="$(bun "$PLUGIN_ROOT/engine/cli.ts" read "$RT_OUT" --deal "$RT_DEAL")" || 
 [ "$(jq -r '.proposals | length' <<<"$again")" = "0" ] || fail "a second read still proposes $(jq -c '.proposals' <<<"$again")"
 echo "PASS: edits made in Excel round-trip into the deal JSON, and applying them twice changes nothing"
 
+# ── A list entry with no name ──────────────────────────────────────────────────────────────────
+#
+# The schema permits an entry that fills in anything but its first field: `team.internal:
+# [{"role":"SE"}]` validates, and the engine counts it, so the team is complete. A sheet that counted
+# only the leftmost column would answer not_started on that data — a completion status contradicting
+# `engine next`, which is the one thing the compiled rules exist to prevent. The second-opinion review
+# found it; this is the case it named.
+nameless="$WORK/nameless.json"
+jq '.team.internal = [{"role": "Solutions Engineer"}]
+  | .closePlan.milestones = [{"owner": "Jane Smith", "targetDate": "2026-06-01"}]' "$DEAL" >"$nameless" ||
+  fail "could not build the nameless-entry deal"
+bun "$PLUGIN_ROOT/engine/cli.ts" validate "$nameless" >/dev/null || fail "the nameless-entry deal does not validate"
+nameless_out="$WORK/nameless.xlsx"
+nameless_book="$(basename "$nameless_out")"
+OUR_WORKBOOKS+=("$nameless_book")
+bun "$PLUGIN_ROOT/engine/cli.ts" generate "$nameless" --out "$nameless_out" >/dev/null ||
+  fail "generate failed on the nameless-entry deal"
+nameless_plan="$(bun "$PLUGIN_ROOT/engine/cli.ts" generate "$nameless" --plan)" || fail "generate --plan failed"
+echo "==> opening a deal whose team member has a role and no name"
+open -a "Microsoft Excel" "$nameless_out" || fail "could not open $nameless_book"
+for _ in $(seq 1 30); do
+  if osascript -e 'tell application "Microsoft Excel" to get name of every workbook' 2>/dev/null | grep -qF "$nameless_book"; then
+    nameless_opened=1
+    break
+  fi
+  sleep 2
+done
+[ "${nameless_opened:-0}" = "1" ] || fail "Excel never listed $nameless_book"
+compare_statuses "$nameless_book" "$nameless" "$nameless_plan" "a deal with unnamed list entries"
+osascript -e "tell application \"Microsoft Excel\" to close workbook \"$nameless_book\" saving no" >/dev/null 2>&1
+echo "PASS: an entry that fills in anything but its first field counts on the sheet as it does in the engine"
+
 # A row typed UNDER the last padded one, which is what running out of room looks like.
 #
 # A list's capacity is the rows the generator laid out and nothing beyond them: the row under the

--- a/plugins/meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/meddpicc/skills/deal-qualification/SKILL.md
@@ -360,6 +360,10 @@ Rules that matter:
 - **Relay a rejection by its cell address**, as the tool gives it —
   `G20`, not a JSON path. The user is looking at Excel. A non-zero exit
   means something was refused; do not apply anyway.
+- **The sheet recomputes as it is filled in.** The scorecard, each score's rubric
+  and every section's completion status are formulas, not a snapshot of the deal as
+  it was generated — so an answer typed into a review updates them there and then,
+  and what Excel shows agrees with `next` and `score` without regenerating.
 - **What each element means is a hover note, not a cell.** Asked on the
   sheet what "Paper Process" or "Decision Criteria" covers, say to hover
   the element name — the definition is there, which is why the column of


### PR DESCRIPTION
## What this does

Closes #908. The thirteen section statuses follow the sheet now, instead of describing the deal as it
was when the workbook was written.

They were literals. Fill in the missing evidence during a live review and the sheet went on calling the
section not started — in the one column whose job is to say where the deal stands.

## Not one of the three options in the issue

The issue offered: leave it stale and label it; move the rules into the workbook; or write them twice
and test that the two agree. Reading `completion.ts` against what the sheet can express turned up a
fourth, which is the one built here — **one rule, two readers**, the same shape as `labels.ts` owning
every displayed enum word in both directions.

Each section's rule is data: two predicates, `complete` and `started`, over deal paths, in a vocabulary
of six leaves and two combinators. `evaluate` reads them against the deal; the generator compiles the
same ones into formulas. There is no second set of rules to drift.

Six kinds covered all thirteen rules. A seventh would have meant a rule the sheet could not express,
and learning that in TypeScript is much cheaper than learning it from a `#VALUE!` in front of a
customer.

## Nothing in the compiler knows a coordinate

`plan.inputCells` already maps every deal path to the cell it landed in, so `nonEmpty` resolves to a
cell and an element's `responses` to the range of its own rows — the per-element sub-range, not the
whole column. I had expected to need a new `{{span:…}}` reference kind; the plan already had the answer.

A rule naming a field the sheet does not show **refuses to compile** rather than emitting a formula that
reads `#NAME?` during a review.

**The scorecard follows for free.** `sectionsComplete` already counted the status column, so the count
and the completion percentage are live too.

## Where the two readers see the same inputs

An entry counts when it has **something in it** — and both readers ask exactly that, so there is no
residual disagreement to document. Getting there took two rounds of review and one correction to the
engine; see below.

A row on the sheet is an entry when any of its cells shows something, which is also what the `required`
wash from #913 means by a started row. The two agree about which rows they are talking about.

## Verification

A refactor with no visible output needs a different kind of proof, so there are three layers.

- **The previous implementation is frozen in the suite as an oracle** — duplicated rather than imported,
  since an oracle sharing code with the thing it checks agrees by construction — and asked the same
  question as the new one over **every combination each rule can see**: all 96 an element rule has, and
  every shape the five collection sections can take. Exhaustive rather than random, so no seed can miss
  a case. Absent scores, whitespace-only cells, `stakeholders: 'not a list'` and a null deal are all in
  there.
- **Excel is asked directly.** All thirteen statuses agree with the engine on three fixtures — the
  example deal, the partly-qualified one, and a deal whose list entries have no names — and setting the
  metrics score to 0 in Excel moved its status from `Complete` to `Partial`, which is what the engine
  says about the same deal with that score changed, computed by the engine during the run rather than
  written down in the script.
- **41 mutations, 41 killed** across both halves. The ones worth naming:
  - **`all` compiling to `OR`** survived the first pass. Swap them and a section reads complete as soon
    as *any* one condition holds, while the formula still looks reasonable — and every other test in the
    suite matches on *which cells* a formula names, so none of them would have noticed.
  - **`N()` around a score cell.** Excel sorts text above every number, so `$D$20>=3` is TRUE for a cell
    holding "four" where the engine reads a non-number as 0.
  - **The entry factor in `everyEntryHas`.** Without it the pre-allocated blank rows count as entries
    missing a title, and the section can never be complete.
  - The bar dropping from 3 to 2, whitespace counting as filled in, a missing score not reading as zero,
    `everyEntryHas` passing when only one entry does, and a section with no rule reading as
    `not_started` — which looks exactly like a deal nobody started, the one wrong answer that raises no
    question.

470 engine tests, 27 shell tests, **19 Excel stages** green, biome / codespell / textlint /
markdownlint / shellcheck / shfmt clean from the repo root. **v6.3.0**, not breaking: no address moved,
so a v6.2.0 workbook still reads back.

## What the review found

Five findings over four rounds, every one checked against the engine before anything changed. Four were
confirmed and fixed; the fifth was refuted, and its refutation is below with the rest. Two of the
confirmed ones were about the same thing and the second was the interesting one.

- **A row with no name.** The schema permits an entry that fills in anything but its first field, and
  the engine counts it: `team.internal: [{"role":"SE"}]` reads as complete, `closePlan.milestones:
  [{"owner":"x"}]` likewise. Counting the leftmost column alone made the sheet answer not started on
  exactly that data. I had written a comment calling this an accepted bridge; the issue's own acceptance
  criterion says the sheet must never contradict the engine, so the comment was too generous to itself.
  Fixed, and there is now a fixture built from the reviewer's case: *13 section statuses in a deal with
  unnamed list entries agree with the engine.*
- **Whitespace.** Excel's `TRIM` takes ordinary spaces only; the engine's `trim()` also takes tabs,
  newlines and non-breaking spaces. So a value pasted from a web page read as filled to the sheet and
  empty to the engine, and the sheet would have called an element complete on evidence the engine could
  not see. `CLEAN` covers every control character and the non-breaking space is substituted first.

That second fix had a consequence worth measuring: my first version wrapped four nested `SUBSTITUTE`s
around every range, and the longest compiled formula came to **5483 characters against Excel's cap of
8192** — a third of headroom, and only visible because I measured it. `CLEAN` brought it to **2602**.
The writer now refuses a formula past the cap, since Excel's response to one is to prompt for repair and
leave the cell empty.

Round two, and the first of these sent me back to the engine rather than to the sheet:

- **An entry with nothing in it.** After the fix above, `team.internal: [{}]` still disagreed: the
  engine counted the array's **length**, so one object with no fields completed the whole Team section.
  I had written that off as irreducible — a sheet cannot tell an all-empty entry from a pre-allocated
  blank row. But the engine was the one answering wrongly: an empty object is not a team member, and the
  sheet's answer was the better one. Both readers ask the same question now, so **there is no residual
  disagreement left to document**. This is the one class of answer the refactor moves, and the suite
  states it against the frozen oracle — legacy says complete, we say not started, with the reason beside
  it.
- **A cell on another sheet.** The resolver discarded `InputCell.sheet` and emitted bare addresses.
  Latent, since the workbook is one laid-out sheet — but a two-sheet spec passes `check-spec`, and then
  `$D$20` means whatever sits at D20 on the sheet the *formula* is on, which Excel evaluates without
  complaint. References carry their sheet when it differs, through the same `sheetPrefix` that
  `{{ref:…}}` already uses. The pre-existing test asserting *one sheet means no formula needs a prefix*
  caught my first attempt over-qualifying everything.

Round four found one thing, and it was wrong — but wrong in a way worth keeping the answer to.

- **REFUTED: "out-of-domain scores satisfy the completion formulas."** The ask was to compile the
  schema's `0-4` bound into the formula. Doing that would *create* the disagreement this PR exists to
  remove: the engine's `atLeast` has no upper bound, so it reads a score of 5 as **complete** (probed
  across `0, 2, 3, 4, 5, 99, -1`), and a ceiling on the sheet alone would have it say *partial* where
  the engine says *complete*. The premise that the deal gets contradicted is also wrong — an
  out-of-domain score cannot reach the deal, because read-back rejects it against the schema
  (`read-workbook.ts:315-317`) and the score dropdown is derived from those same bounds
  (`generate.ts:326-329`). Duplicating the bound here is the "second opinion that could disagree" that
  `read-workbook.ts` already declines to give.

  The **coverage** half of it was fair, though: the exhaustive element sweep runs `undefined, 0-4` — the
  schema domain, and nothing outside it. So the invariant is now pinned from *both* sides, since the
  defect would be a bound added to either one alone. Mutation-checked both ways: a ceiling in the
  formula fails it, and a ceiling in the engine fails it.

## Two things the acceptance test told me about itself

Both are recorded in the script, since the next person will hit them:

- `offset of` is a StandardAdditions command. Inside `tell application "Microsoft Excel"` it is sent to
  Excel, which has no such command — so string parsing belongs outside the tell block, or better,
  nowhere near AppleScript.
- I first placed the stage above the helper it calls, and its own "compared 0 of 13 sections — the stage
  is not covering the block" guard is what said so. A stage that silently compares nothing is the
  failure mode this codebase keeps finding.

## Also tidied

Two pre-existing double blank lines in `CHANGELOG.md`. A lint finding sitting behind mine is worse than
a two-line diff.

And a duplicate `.gitignore` entry for the review artifacts, which I added in #912 directly beneath the
entry whose comment explains why it deliberately has no trailing slash. The surviving rule still matches
the directory and a symlink of that name — verified with `git check-ignore -v`.
