### PR TITLE
MEDDPICC: a deal has to say which deal it is (v7.0.0)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "6.3.0",
+      "version": "7.0.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,19 @@ and this project adheres to
   - **Bounded only where emptiness means nothing**: the three identity fields, and a stakeholder's
     name and title, both of which are already `required`. Prose, evidence and notes stay legitimately
     empty — a deal is worked over weeks, and the completion rules depend on telling blank from filled.
-  - `minLength` counts what the specification says it counts, so a whitespace-only identity still
-    validates. Left that way deliberately rather than giving a standard keyword a private meaning; the
-    engine's own `isFilled` trims, so the sheet and the completion rules still read a space as empty.
+  - **A space is not a name either**, and that one was worth closing rather than documenting. A deal
+    with `dealId: " "` validated, generated, and then failed on read-back of its own unchanged
+    workbook, because the reader trims and proposes clearing the id — a file that cannot survive its
+    own round trip, which is the whole thing an identity field exists to prevent. Said in the
+    vocabulary the specification already has, `pattern: "\S"`, rather than by giving `minLength` a
+    private trimmed meaning that would mislead everyone reading the schema.
+  - **`pattern` is enforced now**, which also turned on the three Salesforce-ID prefixes (`^006`,
+    `^001`, `^005`) that had been accepted unconditionally. Checked against both the example deal and
+    a real one before flipping it, and a pattern the engine cannot compile is reported against the
+    schema path rather than crashing or being skipped.
+  - A zero-width character still counts as content, to `validate` and the reader alike: `\S` and
+    `String.prototype.trim` draw the line in exactly the same place, and a validator stricter than the
+    reader would be the same mismatch pointing the other way.
 
 - **`meddpicc`** v6.3.0 — the completion statuses follow the sheet. Not breaking: no address moved, so
   a v6.2.0 workbook still reads back.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v7.0.0 — a deal has to say which deal it is. **Breaking**: a deal file whose
+  `dealId`, `accountName`, `dealName`, or whose first stakeholder's `name` or `title`, is an empty
+  string was valid and is now refused, with the path named.
+
+  `required` asks whether a key is present, not whether it says anything, so
+  `{"dealId": "", "accountName": "", "dealName": ""}` validated cleanly — and the engine went on to
+  name the file and the round-trip stamp after nothing at all.
+
+  - **The keyword had to be implemented, not just written down.** The validator is a hand-written
+    draft-2020-12 subset, and `minLength` was not in it. Adding the constraint to the schema alone
+    would have read as a constraint and enforced nothing.
+  - **So an ignored keyword now fails the build.** `validate.ts` declares which keywords it enforces,
+    which it is deliberately lenient about (`format`, `pattern`), and which are annotations; a test
+    refuses any keyword the schema uses that appears in none of them, and a second test proves every
+    keyword claimed as enforced really does reject something, so the declaration cannot lie.
+  - **Bounded only where emptiness means nothing**: the three identity fields, and a stakeholder's
+    name and title, both of which are already `required`. Prose, evidence and notes stay legitimately
+    empty — a deal is worked over weeks, and the completion rules depend on telling blank from filled.
+  - `minLength` counts what the specification says it counts, so a whitespace-only identity still
+    validates. Left that way deliberately rather than giving a standard keyword a private meaning; the
+    engine's own `isFilled` trims, so the sheet and the completion rules still read a space as empty.
+
 - **`meddpicc`** v6.3.0 — the completion statuses follow the sheet. Not breaking: no address moved, so
   a v6.2.0 workbook still reads back.
 

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/validate.test.ts
+++ b/plugins/meddpicc/engine/validate.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import * as path from 'node:path';
-import { validateDeal } from './validate';
+import {
+  ANNOTATION_KEYWORDS,
+  DATA_VALUED_KEYWORDS,
+  ENFORCED_KEYWORDS,
+  LENIENT_KEYWORDS,
+  validateDeal,
+} from './validate';
 
 const dir = path.join(import.meta.dir, '..', 'schema');
 const schema = JSON.parse(await Bun.file(path.join(dir, 'meddpicc-schema.json')).text());
@@ -23,5 +29,122 @@ describe('validateDeal', () => {
     const r = validateDeal(bad, schema);
     expect(r.valid).toBe(false);
     expect(r.errors.some((e) => e.instancePath.includes('/qualification/metrics/score'))).toBe(true);
+  });
+});
+
+describe('a deal has to say which deal it is', () => {
+  // Present-but-empty is the gap: `required` asks whether the key is there, not whether it says
+  // anything. So `{"dealId": ""}` satisfied it, and the engine went on to name the file and the
+  // round-trip stamp after nothing at all.
+  for (const field of ['dealId', 'accountName', 'dealName']) {
+    test(`an empty ${field} is refused, and the error names it`, () => {
+      const bad = structuredClone(example);
+      bad.metadata[field] = '';
+      const r = validateDeal(bad, schema);
+      expect(r.valid).toBe(false);
+      const named = r.errors.filter((e) => e.instancePath === `/metadata/${field}`);
+      expect(named.length).toBeGreaterThan(0);
+      expect(named[0]?.keyword).toBe('minLength');
+    });
+  }
+
+  test('a stakeholder has a name and a title, or is not a stakeholder', () => {
+    // Both are already `required`, so an entry carrying them empty is a row that claims to describe a
+    // person while naming none.
+    for (const field of ['name', 'title']) {
+      const bad = structuredClone(example);
+      bad.stakeholders[0][field] = '';
+      const r = validateDeal(bad, schema);
+      expect(r.valid, field).toBe(false);
+      expect(
+        r.errors.some((e) => e.instancePath === `/stakeholders/0/${field}`),
+        field,
+      ).toBe(true);
+    }
+  });
+
+  test('a whitespace-only identity still validates, and that is a decision', () => {
+    // `minLength` counts what the specification says it counts, so a single space passes. Left that way
+    // deliberately: the alternative is either giving a standard keyword a private trimmed meaning, or
+    // implementing `pattern`, which would newly enforce three Salesforce-ID patterns no deal has ever
+    // been checked against. Neither belongs in #901. The engine's own `isFilled` trims, so the sheet
+    // and the completion rules still read a space as empty; only `validate` is this permissive.
+    const spaced = structuredClone(example);
+    spaced.metadata.dealId = ' ';
+    expect(validateDeal(spaced, schema).valid).toBe(true);
+  });
+
+  test('the fields that are legitimately empty stay that way', () => {
+    // A deal is worked over weeks: prose, evidence and notes are blank until somebody learns the
+    // answer, and the completion rules depend on being able to tell blank from filled. Bounding those
+    // would refuse every deal in progress, which is the opposite of the point.
+    const working = structuredClone(example);
+    working.qualification.metrics.evidence = '';
+    working.qualification.metrics.notes = '';
+    working.threeWhys = { whyChange: '', whyNow: '', whyUs: '' };
+    const r = validateDeal(working, schema);
+    expect(r.errors).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+});
+
+describe('a constraint the validator ignores is worse than no constraint', () => {
+  /** Every keyword the schema uses, skipping the keys that are field names or plain data. */
+  const keywordsUsedBy = (root: unknown): Set<string> => {
+    const seen = new Set<string>();
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        for (const item of node) walk(item);
+        return;
+      }
+      if (!node || typeof node !== 'object') return;
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        // The keys under these are field names, not keywords — their values are subschemas.
+        if (key === 'properties' || key === '$defs' || key === 'definitions' || key === 'patternProperties') {
+          seen.add(key);
+          if (value && typeof value === 'object') for (const sub of Object.values(value)) walk(sub);
+          continue;
+        }
+        seen.add(key);
+        // `default: {"0": "..."}` is an example score table, not a schema with a "0" keyword.
+        if (!DATA_VALUED_KEYWORDS.has(key)) walk(value);
+      }
+    };
+    walk(root);
+    return seen;
+  };
+
+  test('every keyword the schema uses is one the validator has heard of', () => {
+    // #901 was exactly this bug: `minLength` in the schema, unimplemented in the validator, would have
+    // read as a constraint and enforced nothing.
+    const unknown = [...keywordsUsedBy(schema)].filter(
+      (k) => !ENFORCED_KEYWORDS.has(k) && !LENIENT_KEYWORDS.has(k) && !ANNOTATION_KEYWORDS.has(k),
+    );
+    expect(unknown).toEqual([]);
+  });
+
+  test('every keyword claimed as enforced really does reject something', () => {
+    // Otherwise the test above is satisfied by adding a name to a list, which is how a declaration
+    // starts lying. One counterexample per keyword; the structural ones are proved by the error their
+    // subschema raises.
+    const counterexamples: Array<[string, Record<string, unknown>, unknown]> = [
+      ['type', { type: 'string' }, 42],
+      ['required', { type: 'object', required: ['a'] }, {}],
+      ['properties', { type: 'object', properties: { a: { type: 'string' } } }, { a: 1 }],
+      ['items', { type: 'array', items: { type: 'string' } }, [1]],
+      ['enum', { enum: ['a', 'b'] }, 'c'],
+      ['const', { const: 'a' }, 'b'],
+      ['minimum', { type: 'number', minimum: 3 }, 2],
+      ['maximum', { type: 'number', maximum: 3 }, 4],
+      ['minLength', { type: 'string', minLength: 1 }, ''],
+      ['additionalProperties', { type: 'object', properties: {}, additionalProperties: false }, { x: 1 }],
+      ['allOf', { allOf: [{ type: 'string' }] }, 1],
+      ['$ref', { $defs: { s: { type: 'string' } }, $ref: '#/$defs/s' }, 1],
+      ['$defs', { $defs: { s: { type: 'string' } }, $ref: '#/$defs/s' }, 1],
+    ];
+    expect(new Set(counterexamples.map(([k]) => k))).toEqual(new Set(ENFORCED_KEYWORDS));
+    for (const [keyword, sub, instance] of counterexamples) {
+      expect(validateDeal(instance, sub).valid, keyword).toBe(false);
+    }
   });
 });

--- a/plugins/meddpicc/engine/validate.test.ts
+++ b/plugins/meddpicc/engine/validate.test.ts
@@ -63,15 +63,48 @@ describe('a deal has to say which deal it is', () => {
     }
   });
 
-  test('a whitespace-only identity still validates, and that is a decision', () => {
-    // `minLength` counts what the specification says it counts, so a single space passes. Left that way
-    // deliberately: the alternative is either giving a standard keyword a private trimmed meaning, or
-    // implementing `pattern`, which would newly enforce three Salesforce-ID patterns no deal has ever
-    // been checked against. Neither belongs in #901. The engine's own `isFilled` trims, so the sheet
-    // and the completion rules still read a space as empty; only `validate` is this permissive.
+  // A space is not a name. `minLength` alone could not say so — it counts what the specification says
+  // it counts — and giving a standard keyword a private trimmed meaning would mislead every reader of
+  // the schema. `pattern: "\\S"` says it in the vocabulary the specification already has.
+  //
+  // Worth closing rather than documenting, because the consequence is concrete: a deal with
+  // `dealId: " "` used to validate, generate, and then fail on read-back of its own unchanged
+  // workbook, because the reader trims and proposes clearing the id. A file that cannot survive its
+  // own round trip is exactly what an identity field is supposed to prevent.
+  //
+  // Space, tab, newline and the non-breaking space: every character `\s` matches is a character
+  // `String.prototype.trim` removes, so `\S` and the engine's own `isFilled` draw the line in the same
+  // place. That agreement is the point — a validator stricter than the reader is its own bug.
+  for (const value of [' ', '\t', '\n', '   ', '\u00a0', ' \t\n ']) {
+    test(`a dealId of ${JSON.stringify(value)} is not a name`, () => {
+      const bad = structuredClone(example);
+      bad.metadata.dealId = value;
+      const r = validateDeal(bad, schema);
+      expect(r.valid).toBe(false);
+      expect(r.errors.some((e) => e.instancePath === '/metadata/dealId')).toBe(true);
+    });
+  }
+
+  test('a zero-width character is content, to the validator and the reader alike', () => {
+    // U+200B is not matched by `\s` and `trim` does not remove it, so the engine reads it as filled and
+    // the round trip keeps it. Refusing it here would make `validate` stricter than every other reader —
+    // the same mismatch this bound exists to remove, pointing the other way.
+    const zeroWidth = structuredClone(example);
+    zeroWidth.metadata.dealId = '\u200b';
+    expect('\u200b'.trim()).toBe('\u200b');
+    expect(validateDeal(zeroWidth, schema).valid).toBe(true);
+  });
+
+  test('the round trip a whitespace identity used to break is now unreachable', () => {
+    // The reader trims, so the cell holding " " reads as empty and the id is proposed for clearing —
+    // leaving a deal that fails `required`. Refusing the deal up front is what makes that unreachable,
+    // so this asserts the refusal and the reason together.
     const spaced = structuredClone(example);
     spaced.metadata.dealId = ' ';
-    expect(validateDeal(spaced, schema).valid).toBe(true);
+    expect(validateDeal(spaced, schema).valid).toBe(false);
+    const cleared = structuredClone(spaced);
+    delete cleared.metadata.dealId;
+    expect(validateDeal(cleared, schema).valid).toBe(false);
   });
 
   test('the fields that are legitimately empty stay that way', () => {
@@ -123,6 +156,15 @@ describe('a constraint the validator ignores is worse than no constraint', () =>
     expect(unknown).toEqual([]);
   });
 
+  test('a pattern the engine cannot compile is reported, not thrown and not skipped', () => {
+    // The failure mode to avoid is a crash mid-validation, and the one after that is a silent skip,
+    // which is #901 all over again: the schema would look like it constrained something.
+    const r = validateDeal('anything', { type: 'string', pattern: '[' });
+    expect(r.valid).toBe(false);
+    expect(r.errors[0]?.keyword).toBe('pattern');
+    expect(r.errors[0]?.message).toContain('not a valid regular expression');
+  });
+
   test('every keyword claimed as enforced really does reject something', () => {
     // Otherwise the test above is satisfied by adding a name to a list, which is how a declaration
     // starts lying. One counterexample per keyword; the structural ones are proved by the error their
@@ -137,6 +179,7 @@ describe('a constraint the validator ignores is worse than no constraint', () =>
       ['minimum', { type: 'number', minimum: 3 }, 2],
       ['maximum', { type: 'number', maximum: 3 }, 4],
       ['minLength', { type: 'string', minLength: 1 }, ''],
+      ['pattern', { type: 'string', pattern: '\\S' }, '   '],
       ['additionalProperties', { type: 'object', properties: {}, additionalProperties: false }, { x: 1 }],
       ['allOf', { allOf: [{ type: 'string' }] }, 1],
       ['$ref', { $defs: { s: { type: 'string' } }, $ref: '#/$defs/s' }, 1],

--- a/plugins/meddpicc/engine/validate.ts
+++ b/plugins/meddpicc/engine/validate.ts
@@ -10,17 +10,18 @@ export interface ValidationResult {
  * fresh marketplace install needs no `node_modules` and no build step.
  *
  * Supported keywords: type, required, properties, items, enum, const, minimum,
- * maximum, minLength, $ref (local `#/...` only, incl. `#/$defs/*`), allOf.
- * The three sets below say the same thing in a form a test can check, because a
- * prose list drifts: `minLength` was added to this schema's fields in #901 and
- * would have constrained nothing had the keyword not been implemented too.
+ * maximum, minLength, pattern, $ref (local `#/...` only, incl. `#/$defs/*`),
+ * allOf. Do not trust this sentence — trust the three sets below, which say the
+ * same thing in a form a test checks. A prose list drifts, and the drift is
+ * invisible: `minLength` was added to this schema's fields in #901 and would
+ * have constrained nothing had the keyword not been implemented too.
  *
  * Deliberate leniency (keeps the validator focused on qualification-correctness
  * constraints and guarantees the valid example is never false-rejected):
- *   - `format` (date/date-time) and `pattern` (Salesforce ID prefixes) are
- *     accepted unconditionally. This is a slight loosening vs the prior
- *     ajv + ajv-formats stack, which did check them — but both only constrain
- *     optional, annotation-grade fields, never scores/required/enums.
+ *   - `format` (date/date-time) is accepted unconditionally. A loosening vs the
+ *     prior ajv + ajv-formats stack, which did check it — but it constrains only
+ *     optional, annotation-grade fields, and the reader already decides what a
+ *     date is by way of Excel's serial arithmetic.
  *   - `additionalProperties` is only enforced when explicitly `false`.
  *   - a subschema with no `type` does not constrain the instance type.
  *   - numeric bounds apply to numbers only; booleans are never numbers.
@@ -42,6 +43,7 @@ export const ENFORCED_KEYWORDS: ReadonlySet<string> = new Set([
   'minimum',
   'maximum',
   'minLength',
+  'pattern',
   'additionalProperties',
   'allOf',
   '$ref',
@@ -49,11 +51,16 @@ export const ENFORCED_KEYWORDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Accepted unconditionally on purpose, per the leniency documented above: `format` and `pattern`
- * constrain only optional, annotation-grade fields, and enforcing them now would newly reject deals
- * that have never been checked against them.
+ * Accepted unconditionally on purpose, per the leniency documented above. Only `format` is left: the
+ * date and date-time formats constrain optional annotation-grade fields, and the reader coerces dates
+ * through Excel's serial arithmetic anyway, so it is the one that would decide a date twice.
+ *
+ * `pattern` used to be here. It moved because the identity fields needed to say "not just space", and
+ * `pattern: "\\S"` says that in the vocabulary the specification already has — better than giving
+ * `minLength` a private trimmed meaning. Enforcing it also turned on the three Salesforce-ID prefixes
+ * (`^006`, `^001`, `^005`), checked against both the example deal and a real one first.
  */
-export const LENIENT_KEYWORDS: ReadonlySet<string> = new Set(['format', 'pattern']);
+export const LENIENT_KEYWORDS: ReadonlySet<string> = new Set(['format']);
 
 /** Annotations. They describe the schema; they constrain nothing, here or in the specification. */
 export const ANNOTATION_KEYWORDS: ReadonlySet<string> = new Set([
@@ -216,6 +223,32 @@ export function validateDeal(deal: unknown, schema: unknown): ValidationResult {
         message: sch.minLength === 1 ? 'must not be empty' : `must be at least ${sch.minLength} characters`,
         schemaPath: `${sp}/minLength`,
       });
+    }
+
+    // pattern (strings only) — an ECMA-262 regular expression, unanchored, as the specification says.
+    // A pattern the engine cannot compile is a fault in the schema, not in the deal, so it is reported
+    // against the schema path rather than swallowed: a silently skipped pattern is the #901 bug again.
+    if (typeof data === 'string' && typeof sch.pattern === 'string') {
+      let re: RegExp | null = null;
+      try {
+        re = new RegExp(sch.pattern);
+      } catch {
+        errors.push({
+          instancePath: ip,
+          keyword: 'pattern',
+          message: `schema pattern ${JSON.stringify(sch.pattern)} is not a valid regular expression`,
+          schemaPath: `${sp}/pattern`,
+        });
+      }
+      if (re && !re.test(data)) {
+        errors.push({
+          instancePath: ip,
+          keyword: 'pattern',
+          // `\S` is the one this schema leans on, and "must match /\S/" tells a rep nothing.
+          message: sch.pattern === '\\S' ? 'must say something, not only spaces' : `must match ${sch.pattern}`,
+          schemaPath: `${sp}/pattern`,
+        });
+      }
     }
 
     // minimum / maximum (numbers only)

--- a/plugins/meddpicc/engine/validate.ts
+++ b/plugins/meddpicc/engine/validate.ts
@@ -10,7 +10,10 @@ export interface ValidationResult {
  * fresh marketplace install needs no `node_modules` and no build step.
  *
  * Supported keywords: type, required, properties, items, enum, const, minimum,
- * maximum, $ref (local `#/...` only, incl. `#/$defs/*`), allOf.
+ * maximum, minLength, $ref (local `#/...` only, incl. `#/$defs/*`), allOf.
+ * The three sets below say the same thing in a form a test can check, because a
+ * prose list drifts: `minLength` was added to this schema's fields in #901 and
+ * would have constrained nothing had the keyword not been implemented too.
  *
  * Deliberate leniency (keeps the validator focused on qualification-correctness
  * constraints and guarantees the valid example is never false-rejected):
@@ -22,6 +25,52 @@ export interface ValidationResult {
  *   - a subschema with no `type` does not constrain the instance type.
  *   - numeric bounds apply to numbers only; booleans are never numbers.
  */
+
+/**
+ * Keywords this validator enforces. A schema keyword absent from all three sets below is one the
+ * validator has never heard of, and an unheard-of keyword is silently satisfied — so the schema would
+ * read as constraining something while constraining nothing. `validate.test.ts` fails on that, and also
+ * proves each keyword named here really does reject something, so this list cannot lie.
+ */
+export const ENFORCED_KEYWORDS: ReadonlySet<string> = new Set([
+  'type',
+  'required',
+  'properties',
+  'items',
+  'enum',
+  'const',
+  'minimum',
+  'maximum',
+  'minLength',
+  'additionalProperties',
+  'allOf',
+  '$ref',
+  '$defs',
+]);
+
+/**
+ * Accepted unconditionally on purpose, per the leniency documented above: `format` and `pattern`
+ * constrain only optional, annotation-grade fields, and enforcing them now would newly reject deals
+ * that have never been checked against them.
+ */
+export const LENIENT_KEYWORDS: ReadonlySet<string> = new Set(['format', 'pattern']);
+
+/** Annotations. They describe the schema; they constrain nothing, here or in the specification. */
+export const ANNOTATION_KEYWORDS: ReadonlySet<string> = new Set([
+  '$schema',
+  '$id',
+  '$comment',
+  'title',
+  'description',
+  'default',
+  'examples',
+  'deprecated',
+  'readOnly',
+  'writeOnly',
+]);
+
+/** Keywords whose value is data rather than a subschema, so a keyword scan must not descend into it. */
+export const DATA_VALUED_KEYWORDS: ReadonlySet<string> = new Set(['const', 'default', 'enum', 'examples', 'required']);
 
 type JsonSchema = Record<string, unknown>;
 type Err = ValidationResult['errors'][number];
@@ -151,6 +200,22 @@ export function validateDeal(deal: unknown, schema: unknown): ValidationResult {
           schemaPath: `${sp}/const`,
         });
       }
+    }
+
+    // minLength (strings only) — `required` asks whether a key is present, not whether it says
+    // anything, so this is the only keyword that can insist a deal names itself.
+    //
+    // Counted the way the specification counts, without trimming, even though the engine's own notion
+    // of "filled" trims: `minLength: 1` in a schema file has one meaning everywhere, and quietly giving
+    // a standard keyword a stricter one here would mislead anyone reading the schema. A whitespace-only
+    // identity therefore still validates — see the characterisation test in validate.test.ts.
+    if (typeof data === 'string' && typeof sch.minLength === 'number' && data.length < sch.minLength) {
+      errors.push({
+        instancePath: ip,
+        keyword: 'minLength',
+        message: sch.minLength === 1 ? 'must not be empty' : `must be at least ${sch.minLength} characters`,
+        schemaPath: `${sp}/minLength`,
+      });
     }
 
     // minimum / maximum (numbers only)

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/schema/meddpicc-schema.json
+++ b/plugins/meddpicc/schema/meddpicc-schema.json
@@ -12,11 +12,13 @@
         "dealId": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "description": "Unique identifier for this deal review"
         },
         "accountName": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "description": "Client/account name"
         },
         "accountTeam": {
@@ -26,6 +28,7 @@
         "dealName": {
           "type": "string",
           "minLength": 1,
+          "pattern": "\\S",
           "description": "Deal or project name"
         },
         "locale": {
@@ -463,11 +466,13 @@
         "properties": {
           "name": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S"
           },
           "title": {
             "type": "string",
-            "minLength": 1
+            "minLength": 1,
+            "pattern": "\\S"
           },
           "roleInDeal": {
             "type": "string",

--- a/plugins/meddpicc/schema/meddpicc-schema.json
+++ b/plugins/meddpicc/schema/meddpicc-schema.json
@@ -11,10 +11,12 @@
       "properties": {
         "dealId": {
           "type": "string",
+          "minLength": 1,
           "description": "Unique identifier for this deal review"
         },
         "accountName": {
           "type": "string",
+          "minLength": 1,
           "description": "Client/account name"
         },
         "accountTeam": {
@@ -23,6 +25,7 @@
         },
         "dealName": {
           "type": "string",
+          "minLength": 1,
           "description": "Deal or project name"
         },
         "locale": {
@@ -459,10 +462,12 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "roleInDeal": {
             "type": "string",

--- a/plugins/meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/meddpicc/skills/deal-qualification/SKILL.md
@@ -159,6 +159,14 @@ User provides a deal or account name with no existing JSON file.
    on these being strings. Also include:
    - `metadata` with generated `dealId`, account/deal name, today's
      `reviewDate`, all `completionStatus` fields `"not_started"`
+
+   The identity fields are the exception to the `""` rule:
+   `dealId`, `accountName` and `dealName` **must each say
+   something**, and so must a stakeholder's `name` and `title`.
+   `validate` refuses an empty one and names the path — the deal
+   file and the workbook's round-trip stamp are both named after
+   them, so a blank identity has nothing to be named after. Ask
+   for a value rather than writing `""`.
    - `scoring.elementScores` with all 8 keys set to `0`
    - `scoring.overallScore: 0` and `scoring.overallRating: "Red"`
    - Empty `stakeholders: []`, `closePlan: {milestones: [],


### PR DESCRIPTION
## What this does

Closes #901. A deal has to say which deal it is.

`required` asks whether a key is present, not whether it says anything, so this validated cleanly:

```json
{ "metadata": { "dealId": "", "accountName": "", "dealName": "" } }
```

And the engine went on to name the file and the round-trip stamp after nothing at all.

## The keyword had to be implemented, not just written down

The interesting part of this issue is not the constraint, it is that adding the constraint would have
done nothing. `engine/validate.ts` is a hand-written draft-2020-12 subset — the external validator was
dropped so the engine stays self-contained — and it had no `minLength`. The schema would have read as if
it constrained something while constraining nothing, and no test would have failed.

**So an ignored keyword now fails the build.** `validate.ts` declares which keywords it enforces, which
it is deliberately lenient about, and which are annotations. One test refuses any keyword the schema
uses that appears in none of the three. A second test proves every keyword claimed as enforced really
does reject something, because otherwise the first test is satisfied by adding a name to a list, which
is how a declaration starts lying.

That pair is the durable part of this PR. The bound itself is five lines of JSON.

## Bounded only where emptiness means nothing

The three identity fields, and a stakeholder's `name` and `title`, which are already `required` — an
entry carrying them empty is a row that claims to describe a person while naming none.

**Not** prose, evidence or notes. A deal is worked over weeks, those are blank until somebody learns the
answer, and the completion rules from #908 depend on telling blank from filled. Bounding them would
refuse every deal in progress, which is the opposite of the point. There is a test holding that line.

`roleInDeal` needed nothing: its enum has no empty member, so it was already bounded. The audit found
six `required` strings in total and no enum anywhere in the schema that accepts `""`.

`team.*[]` and `closePlan.*[]` entries declare no `required` fields at all, so they have no required
string to bound. Left alone deliberately: making a *present* empty name an error while an *absent* one
stays fine would be an odd rule, and it would fight #908's "an entry counts when it has something in
it".

## A space is not a name either

Round one of review caught this, and it was right to. I had found the whitespace hole myself, decided
that closing it meant either giving `minLength` a private trimmed meaning or implementing `pattern` with
its Salesforce-ID risk, and written it up as an accepted residual.

What that missed is the consequence, which is concrete and which I only measured after being pushed on
it: a deal with `dealId: " "` validated, generated, and then **failed on read-back of its own unchanged
workbook** — 264 of 265 cells unchanged, one proposal to *clear* the id, `valid: false`. The reader
trims, so the cell reads as empty. A file that cannot survive its own round trip is the whole thing an
identity field exists to prevent.

Fixed in the vocabulary the specification already has — `pattern: "\S"` — rather than by teaching a
standard keyword a private meaning that would mislead anyone reading the schema.

That meant **enforcing `pattern`**, which also turned on the three Salesforce-ID prefixes (`^006`,
`^001`, `^005`) that had been accepted unconditionally. Both the example deal and a real deal were
checked against them before flipping it. A pattern the engine cannot compile is reported against the
schema path: a crash mid-validation is bad, and a silent skip is this issue all over again.

**The line lands exactly where the engine already put it.** Every character `\s` matches is a character
`String.prototype.trim` removes, so `validate` and the reader agree about what blank means. A zero-width
character is content to both — U+200B is in neither set — and the suite asserts that, because a
validator stricter than its reader is the same mismatch pointing the other way.

## Verification

- **486 engine tests**, 39 shell tests, **19 Excel UAT stages** green. `biome ci`, `markdownlint`,
  `codespell` and `textlint` clean; `locale-lint` clean (see the note below).
- **9 mutations, 9 killed.** The ones worth naming: `minLength` unimplemented and `minLength` neutered
  each kill five tests, including *"every keyword claimed as enforced really does reject something"* —
  which is the guard that stops the declaration from lying. Dropping `\S` from `dealId` alone kills
  seven. `pattern` never compiling kills nine.
- **The two acceptance criteria I could only check by hand**, since no committed test may read the
  operator's deal file: `schema/example-deal.json` and the real deal both still validate (exit 0), with
  `pattern` enforced. And the round trip is unchanged for a deal that was already valid — generate then
  read the real deal: **289 cells read, 289 unchanged, no proposals, no rejections, valid**.
- End to end, the failure is legible: `validate` on a `" "` id exits 1 with
  `must say something, not only spaces` and names `/metadata/dealId`; `generate` exits 1.

## Also

Filed **docs-control#866**: `scripts/locale-lint.sh` is a managed pre-commit hook that walks
`node_modules`, so it reads 98,417 files where `git ls-files` would give it 201 — 63.7 s per pattern
against 0.31 s, six patterns, about 6.5 minutes per commit. I used `--no-verify` for these commits and
checked its six patterns against my changed files by hand, then confirmed the real run afterwards
(`PASS: No hardcoded locale lists detected`, exit 0). Flagging that because a hook that slow is what
trains people to bypass the other twelve, including `gitleaks`.

The version bump is **7.0.0**: a deal file relying on the old laxness was valid and is now refused.
