### PR TITLE
MEDDPICC: three formulas stop spelling enum words by hand (v7.0.1)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v7.0.1 — three formulas stop spelling enum words by hand. No behaviour change: the
+  generated workbook is **byte-identical**, same sha256, and the resolved formulas still read `"Green"`
+  and `"Unknown"` exactly as before.
+
+  `generate.ts` has a `FORMULA_WORDS` table for one purpose, and says so: *"One source of truth for a
+  spelling that appears in two places — the cell and the formula that counts it."* Three formulas did
+  the thing that comment forbids — `scoreRating` emitted `"Green"`/`"Yellow"`/`"Red"`, and the two
+  sentiment tallies matched `"Unknown"` and `"Negative"` — while `xlsx.ts` held a third copy of the
+  rating words in its conditional-format rules, beside two presets that already routed through
+  `enumLabel`.
+
+  - Nothing was broken. Every spelling agreed, so this was latent — and latent in the way that matters:
+    rename a sentiment value in the schema and the `COUNTIF` silently returns nought, reporting no
+    negative-sentiment stakeholders when there are four. No error, no failed test, nothing to notice.
+  - **Three guards, because the table alone cannot promise much.** `FORMULA_WORDS` is a module constant
+    and the schema arrives as an argument, so it cannot read the schema; and `enumLabel` falls through
+    for a value it has no entry for, which means `enumLabel('Red')` is `'Red'` whatever the schema says.
+    So the tests do the real work: no spec formula may spell an enum word by hand, every word the table
+    offers must still be one a dropdown shows, and every word a conditional format compares must be too.
+    A rename now fails the build instead of going half-done.
+  - This is also what lets localisation (#925) translate the sentiment and rating dropdowns at all.
+
 - **`meddpicc`** v7.0.0 — a deal has to say which deal it is. **Breaking**: a deal file whose
   `dealId`, `accountName`, `dealName`, or whose first stakeholder's `name` or `title`, is an empty
   string was valid and is now refused, with the path named.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to
 
 ## [Unreleased]
 
-- **`meddpicc`** v7.0.1 — three formulas stop spelling enum words by hand. No behaviour change: the
-  generated workbook is **byte-identical**, same sha256, and the resolved formulas still read `"Green"`
-  and `"Unknown"` exactly as before.
+- **`meddpicc`** v7.0.1 — three formulas stop spelling enum words by hand. No behaviour change: every
+  OOXML part of the generated workbook is byte-identical to v7.0.0 except `docProps/custom.xml`, which
+  differs only in the recorded engine version, and the resolved formulas still read `"Green"` and
+  `"Unknown"` exactly as before.
 
   `generate.ts` has a `FORMULA_WORDS` table for one purpose, and says so: *"One source of truth for a
   spelling that appears in two places — the cell and the formula that counts it."* Three formulas did

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/formula-words.test.ts
+++ b/plugins/meddpicc/engine/formula-words.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { BOOLEAN_NO, BOOLEAN_YES, FORMULA_WORDS } from './generate';
+import { enumLabel } from './labels';
+import { CF_PRESETS } from './xlsx';
+
+const dir = path.join(import.meta.dir, '..');
+const spec = JSON.parse(await Bun.file(path.join(dir, 'engine', 'workbook-spec.json')).text());
+const schema = JSON.parse(await Bun.file(path.join(dir, 'schema', 'meddpicc-schema.json')).text());
+
+/**
+ * Every word a dropdown can show, as the sheet spells it.
+ *
+ * `metadata.locale` is excluded: its members are locale identifiers, not prose, and a formula naming
+ * one would be naming an identifier rather than repeating a displayed word.
+ */
+const displayedEnumWords = (): Set<string> => {
+  const out = new Set<string>();
+  const walk = (node: unknown, dotted: string): void => {
+    if (!node || typeof node !== 'object') return;
+    const n = node as Record<string, unknown>;
+    if (Array.isArray(n.enum) && dotted !== 'metadata.locale') {
+      for (const value of n.enum) if (typeof value === 'string') out.add(enumLabel(value));
+    }
+    for (const [key, value] of Object.entries(n)) {
+      if (key === 'enum' || key === 'const' || key === 'default') continue;
+      if (key === 'properties' || key === '$defs') {
+        if (value && typeof value === 'object')
+          for (const [name, sub] of Object.entries(value)) walk(sub, dotted ? `${dotted}.${name}` : name);
+        continue;
+      }
+      if (key === 'items') walk(value, dotted);
+      else if (value && typeof value === 'object' && !Array.isArray(value)) walk(value, dotted);
+    }
+  };
+  walk(schema, '');
+  return out;
+};
+
+/** Every quoted literal in every formula the spec carries, with the id of the cell that carries it. */
+const specFormulaLiterals = (): Array<{ id: string; literal: string }> => {
+  const out: Array<{ id: string; literal: string }> = [];
+  const walk = (node: unknown, fallbackId: string): void => {
+    if (Array.isArray(node)) {
+      for (const [i, item] of node.entries()) walk(item, `${fallbackId}[${i}]`);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const n = node as Record<string, unknown>;
+    const id = typeof n.id === 'string' ? n.id : fallbackId;
+    if (typeof n.formula === 'string') {
+      for (const match of n.formula.matchAll(/"([^"]*)"/g)) out.push({ id, literal: match[1] ?? '' });
+    }
+    for (const [key, value] of Object.entries(n)) if (typeof value === 'object') walk(value, `${id}.${key}`);
+  };
+  walk(spec, '$');
+  return out;
+};
+
+test('no formula in the spec spells an enum word by hand', () => {
+  // FORMULA_WORDS exists so that a word appearing in both a cell and the formula that counts it has one
+  // source. A literal in the JSON is one file away from the constant that decides what the cell says:
+  // rename the enum value and the COUNTIF silently returns nought, with no error and nothing to notice
+  // it. Use `{{word:…}}` instead, and add the word to FORMULA_WORDS if it is not there yet.
+  const words = displayedEnumWords();
+  const offenders = specFormulaLiterals().filter((l) => words.has(l.literal));
+  expect(offenders.map((o) => `${o.id}: "${o.literal}"`)).toEqual([]);
+});
+
+test('every word a conditional format compares is one a dropdown still offers', () => {
+  // Named for what it checks. It cannot tell a hand-spelled `"Red"` from `enumLabel('Red')`, because both
+  // produce the same string — and `enumLabel` falls through for a value it has no entry for, so routing
+  // through it is presentation, not coupling. What it does catch is the failure that matters: a preset
+  // comparing against a word no dropdown offers any more is a colour that never appears, and nothing
+  // else in the suite would notice.
+  const words = displayedEnumWords();
+  const offenders: string[] = [];
+  for (const [preset, rules] of Object.entries(CF_PRESETS)) {
+    for (const rule of rules) {
+      for (const formula of rule.formulas) {
+        const literal = /^"(.*)"$/.exec(formula)?.[1];
+        if (literal !== undefined && !words.has(literal)) offenders.push(`${preset}: ${formula}`);
+      }
+    }
+  }
+  // Every quoted word a preset compares against must still be a word some dropdown offers. Renaming an
+  // enum value in the schema without following it here fails this.
+  expect(offenders).toEqual([]);
+});
+
+test('every word the formulas can name is one the sheet still shows', () => {
+  // The rename guard for the other direction. FORMULA_WORDS entries that no enum offers any more are
+  // formulas comparing against a word that cannot appear.
+  const words = displayedEnumWords();
+  const booleans = new Set([BOOLEAN_YES, BOOLEAN_NO]);
+  const orphans = Object.entries(FORMULA_WORDS)
+    .filter(([, value]) => !words.has(value) && !booleans.has(value))
+    .map(([key, value]) => `${key} -> "${value}"`);
+  expect(orphans).toEqual([]);
+});

--- a/plugins/meddpicc/engine/formula-words.test.ts
+++ b/plugins/meddpicc/engine/formula-words.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test';
 import * as path from 'node:path';
 import { BOOLEAN_NO, BOOLEAN_YES, FORMULA_WORDS } from './generate';
 import { enumLabel } from './labels';
+import { schemaConstraint } from './schema-path';
 import { CF_PRESETS } from './xlsx';
 
 const dir = path.join(import.meta.dir, '..');
@@ -57,6 +58,84 @@ const specFormulaLiterals = (): Array<{ id: string; literal: string }> => {
   return out;
 };
 
+/** Every formula the spec carries, with the id of the cell carrying it. */
+const specFormulas = (): Array<{ id: string; formula: string }> => {
+  const out: Array<{ id: string; formula: string }> = [];
+  const walk = (node: unknown, fallbackId: string): void => {
+    if (Array.isArray(node)) {
+      for (const [i, item] of node.entries()) walk(item, `${fallbackId}[${i}]`);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const n = node as Record<string, unknown>;
+    const id = typeof n.id === 'string' ? n.id : fallbackId;
+    if (typeof n.formula === 'string') out.push({ id, formula: n.formula });
+    for (const [key, value] of Object.entries(n)) if (typeof value === 'object') walk(value, `${id}.${key}`);
+  };
+  walk(spec, '$');
+  return out;
+};
+
+/** Every table in the spec, by id. */
+const specTables = (): Map<string, Record<string, unknown>> => {
+  const out = new Map<string, Record<string, unknown>>();
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const n = node as Record<string, unknown>;
+    const table = n.table as Record<string, unknown> | undefined;
+    if (table && typeof table.id === 'string') out.set(table.id, table);
+    for (const value of Object.values(n)) if (typeof value === 'object') walk(value);
+  };
+  walk(spec);
+  return out;
+};
+
+/** The labels a schema enum at this dotted path offers, or undefined when it has none. */
+const enumLabelsAt = (dotted: string): Set<string> | undefined => {
+  const values = schemaConstraint(schema, dotted)?.enum;
+  return values ? new Set(values.map(enumLabel)) : undefined;
+};
+
+/**
+ * Columns whose values are not a deal field, so their enum cannot be read from a `jsonPath`.
+ *
+ * `sections.status` is computed by `computeCompletion`, which emits the members of
+ * `$defs.sectionStatus` — the one place the sheet shows a value no deal field holds.
+ */
+const DERIVED_COLUMN_ENUMS: Record<string, readonly string[]> = {
+  'sections.status': (schema.$defs?.sectionStatus?.enum ?? []) as readonly string[],
+};
+
+/**
+ * Words a formula writes INTO a cell rather than comparing against a column, with the enum that cell
+ * holds. `scoreRating` emits a rating; nothing in its formula names the rating column, so the binding
+ * cannot be derived from the formula and is stated here instead.
+ */
+const EMITTED_WORD_ENUMS: Record<string, string> = {
+  ratingRed: 'scoring.overallRating',
+  ratingYellow: 'scoring.overallRating',
+  ratingGreen: 'scoring.overallRating',
+};
+
+/** The enum behind `{{col:table.column}}`, or undefined when that column has none. */
+const columnEnumOf = (reference: string): { path: string; labels: Set<string> } | undefined => {
+  const derived = DERIVED_COLUMN_ENUMS[reference];
+  if (derived) return { path: reference, labels: new Set(derived.map(enumLabel)) };
+  const [tableId, columnId] = reference.split('.');
+  const table = tableId === undefined ? undefined : specTables().get(tableId);
+  if (!table) return undefined;
+  const source = table.source as { kind?: string; jsonPath?: string } | undefined;
+  const column = (table.columns as Array<Record<string, unknown>> | undefined)?.find((c) => c.id === columnId);
+  if (source?.kind !== 'list' || !source.jsonPath || typeof column?.jsonPath !== 'string') return undefined;
+  const path = `${source.jsonPath}.${column.jsonPath}`;
+  const labels = enumLabelsAt(path);
+  return labels ? { path, labels } : undefined;
+};
+
 test('no formula in the spec spells an enum word by hand', () => {
   // FORMULA_WORDS exists so that a word appearing in both a cell and the formula that counts it has one
   // source. A literal in the JSON is one file away from the constant that decides what the cell says:
@@ -88,13 +167,59 @@ test('every word a conditional format compares is one a dropdown still offers', 
   expect(offenders).toEqual([]);
 });
 
-test('every word the formulas can name is one the sheet still shows', () => {
-  // The rename guard for the other direction. FORMULA_WORDS entries that no enum offers any more are
-  // formulas comparing against a word that cannot appear.
-  const words = displayedEnumWords();
+test('every word is checked against the enum of the column it is actually compared with', () => {
+  // The global set above is too weak on its own, and `statusComplete` is why. One word is compared
+  // against THREE independently-renameable enums — `sections.status` from `$defs.sectionStatus`,
+  // `milestones.status` from `closePlan.milestones[]`, and `actions.status` from
+  // `closePlan.criticalActions[]`. Rename `complete` to `done` under milestones alone and
+  // `milestonesComplete` counts a word that column no longer shows, silently returning nought — while a
+  // check that only asks "does this word exist somewhere in the schema" still passes, because
+  // `sectionStatus` kept it.
+  //
+  // So each word is checked against the enum of each column its own formula names. The pairing is read
+  // out of the spec rather than declared here, so it cannot drift from the formulas it describes.
+  const failures: string[] = [];
+  for (const { id, formula } of specFormulas()) {
+    const wordKeys = [...formula.matchAll(/\{\{word:([^}]+)\}\}/g)].map((m) => m[1] ?? '');
+    if (wordKeys.length === 0) continue;
+    const columnEnums = [...formula.matchAll(/\{\{col:([^}]+)\}\}/g)]
+      .map((m) => columnEnumOf(m[1] ?? ''))
+      .filter((e): e is { path: string; labels: Set<string> } => e !== undefined);
+    for (const key of wordKeys) {
+      const value = FORMULA_WORDS[key];
+      if (value === undefined) {
+        failures.push(`${id}: {{word:${key}}} names no word`);
+        continue;
+      }
+      for (const { path, labels } of columnEnums) {
+        if (!labels.has(value)) failures.push(`${id}: "${value}" is not a value ${path} offers`);
+      }
+      // A word a formula EMITS is compared with nothing, so the receiving cell's own enum is the binding.
+      const emitted = EMITTED_WORD_ENUMS[key];
+      if (emitted) {
+        const labels = enumLabelsAt(emitted);
+        if (!labels?.has(value)) failures.push(`${id}: "${value}" is not a value ${emitted} offers`);
+      }
+    }
+  }
+  expect(failures).toEqual([]);
+});
+
+test('every word in the table is bound to an enum by something', () => {
+  // Otherwise the check above is satisfied by a word no formula uses, or by one whose formula names no
+  // enumerated column — and an unbound word is back to being spelled by hand, just in TypeScript.
   const booleans = new Set([BOOLEAN_YES, BOOLEAN_NO]);
-  const orphans = Object.entries(FORMULA_WORDS)
-    .filter(([, value]) => !words.has(value) && !booleans.has(value))
+  const bound = new Set<string>(Object.keys(EMITTED_WORD_ENUMS));
+  for (const { formula } of specFormulas()) {
+    const hasEnumeratedColumn = [...formula.matchAll(/\{\{col:([^}]+)\}\}/g)].some(
+      (m) => columnEnumOf(m[1] ?? '') !== undefined,
+    );
+    if (!hasEnumeratedColumn) continue;
+    for (const m of formula.matchAll(/\{\{word:([^}]+)\}\}/g)) bound.add(m[1] ?? '');
+  }
+  const unbound = Object.entries(FORMULA_WORDS)
+    // The two boolean words are bound by the Yes/No pair itself: a boolean column has no enum to read.
+    .filter(([key, value]) => !bound.has(key) && !booleans.has(value))
     .map(([key, value]) => `${key} -> "${value}"`);
-  expect(orphans).toEqual([]);
+  expect(unbound).toEqual([]);
 });

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -490,11 +490,26 @@ function layout(
  * One source of truth for a spelling that appears in two places — the cell and the formula that
  * counts it. Writing `"Yes"` into the spec by hand would be the display-versus-match trap again,
  * one JSON file away from the constant that decides what the cell says.
+ *
+ * The rating and sentiment words joined the table in #929, where three formulas were still spelling
+ * them by hand. Note what this table can and cannot promise. It cannot read the schema — it is a
+ * module constant and the schema arrives as an argument — and `enumLabel` falls through for a value it
+ * has no entry for, so `enumLabel('Red')` is 'Red' whatever the schema says. So these spellings are
+ * written as the schema spells them, and their agreement is enforced by `formula-words.test.ts`, which
+ * fails when a word here is one no dropdown offers any more. The table buys one place to change; the
+ * test is what makes a rename impossible to get half-done.
  */
-const FORMULA_WORDS: Record<string, string> = {
+export const FORMULA_WORDS: Record<string, string> = {
   booleanYes: BOOLEAN_YES,
   booleanNo: BOOLEAN_NO,
   statusComplete: enumLabel('complete'),
+  // `scoring.overallRating`, which `scoreRating` computes and the rating conditional format colours.
+  ratingRed: enumLabel('Red'),
+  ratingYellow: enumLabel('Yellow'),
+  ratingGreen: enumLabel('Green'),
+  // `stakeholders[].sentiment`, counted by the two scorecard tallies.
+  sentimentUnknownLabel: enumLabel('Unknown'),
+  sentimentNegativeLabel: enumLabel('Negative'),
 };
 
 function resolveFormula(

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/workbook-spec.json
+++ b/plugins/meddpicc/engine/workbook-spec.json
@@ -1030,7 +1030,7 @@
               "kind": "computed",
               "span": 2,
               "id": "scoreRating",
-              "formula": "IF({{ref:scoreTotal}}>=26,\"Green\",IF({{ref:scoreTotal}}>=14,\"Yellow\",\"Red\"))",
+              "formula": "IF({{ref:scoreTotal}}>=26,{{word:ratingGreen}},IF({{ref:scoreTotal}}>=14,{{word:ratingYellow}},{{word:ratingRed}}))",
               "valueType": "rating",
               "conditionalFormat": "ragText"
             }
@@ -1252,7 +1252,7 @@
               "kind": "computed",
               "span": 2,
               "id": "sentimentUnknown",
-              "formula": "COUNTIF({{col:stakeholders.sentiment}},\"Unknown\")",
+              "formula": "COUNTIF({{col:stakeholders.sentiment}},{{word:sentimentUnknownLabel}})",
               "valueType": "number"
             },
             {
@@ -1264,7 +1264,7 @@
               "kind": "computed",
               "span": 2,
               "id": "sentimentNegative",
-              "formula": "COUNTIF({{col:stakeholders.sentiment}},\"Negative\")",
+              "formula": "COUNTIF({{col:stakeholders.sentiment}},{{word:sentimentNegativeLabel}})",
               "valueType": "number"
             },
             {

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -265,7 +265,7 @@ interface CfRule {
   dxf: DxfName;
 }
 
-const CF_PRESETS: Record<CfPreset, CfRule[]> = {
+export const CF_PRESETS: Record<CfPreset, CfRule[]> = {
   // A 0-4 element score, as a ladder: 0 is nothing, 1 is barely, 2 is nearly — and 3 or 4 is done, so
   // it carries no rule at all. Three rules rather than the old "under 2 / equal 2 / 3 and up", because
   // the two ends of "under 2" are not the same news: an element nobody has scored and one scored 1 are
@@ -279,8 +279,8 @@ const CF_PRESETS: Record<CfPreset, CfRule[]> = {
   // re-deriving its brackets from a percentage and drifting by a rounding step. "Green" gets no
   // rule: a deal in good shape does not need to be pointed at.
   ragText: [
-    { type: 'cellIs', operator: 'equal', formulas: ['"Red"'], dxf: 'urgent' },
-    { type: 'cellIs', operator: 'equal', formulas: ['"Yellow"'], dxf: 'watch' },
+    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('Red')}"`], dxf: 'urgent' },
+    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('Yellow')}"`], dxf: 'watch' },
   ],
   // Matched against the LABEL the sheet displays, not the JSON value behind it. Both come from
   // `enumLabel`, so they cannot drift — a preset quoting `"not_started"` while the cell reads

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
## What this does

Closes #929. Three formulas stop spelling enum words by hand.

`generate.ts` has a table for exactly one purpose, and says so:

> *"One source of truth for a spelling that appears in two places — the cell and the formula that counts
> it. Writing `"Yes"` into the spec by hand would be the display-versus-match trap again, one JSON file
> away from the constant that decides what the cell says."*

Three formulas did the thing that comment forbids — `scoreRating` emitted `"Green"`/`"Yellow"`/`"Red"`,
and the two sentiment tallies matched `"Unknown"` and `"Negative"` — while `xlsx.ts` held a third copy of
the rating words in its conditional-format rules, sitting directly beside two presets that already routed
through `enumLabel` and a comment explaining why they had to.

## Nothing was broken, which is the point

Every one of those words is spelled identically in the schema, the dropdown, the formula and the
conditional format, so behaviour today is correct. It was latent.

Latent in a way worth removing before it is load-bearing: rename a sentiment value in the schema and
`COUNTIF(…,"Unknown")` silently returns nought. The scorecard reports no unknown-sentiment stakeholders
when there are four. No error, no failed test, nothing to notice. Change the rating vocabulary and the
conditional format stops colouring — the same silence.

## Three guards, because the table alone cannot promise much

Worth being precise about what this does and does not buy, because I nearly overstated it.

`FORMULA_WORDS` cannot read the schema — it is a module constant and the schema arrives as an argument.
And `enumLabel` falls through for a value it has no entry for, so **`enumLabel('Red')` is `'Red'` whatever
the schema says**. Routing through it is presentation, not coupling.

So the tests do the real work:

1. **No spec formula may spell an enum word by hand.** Red before this change, naming all five literals
   and the cells carrying them. This is the one that stops a fourth copy being added.
2. **Every word the table offers must still be one a dropdown shows.** A schema rename that does not
   follow through to the table fails here.
3. **Every word a conditional format compares must be too.** Same rename protection, one layer down.

Test 3 is deliberately named for what it checks rather than what I first wanted it to check. My first
version was called *"no conditional-format rule spells an enum word by hand"* and could not actually tell
a hand-spelled `"Red"` from `enumLabel('Red')` — they produce the same string. It passed for the wrong
reason, which is a vacuous test. Renamed, with the limitation written down beside it.

## Verification

- **The generated workbook is unchanged except for the version stamp.** Every OOXML part compares
  byte-equal to `origin/main` for the example deal except `docProps/custom.xml`, and that part differs in
  exactly one property: `MeddpiccEngineVersion` 7.0.0 → 7.0.1. The fingerprint and schema hash are
  unchanged, and the resolved formulas still read `IF(D96>=26,"Green",…)` and `COUNTIF(O56:O65,"Unknown")`
  exactly as before.

  Worth stating precisely rather than loosely: at the point I first measured, before bumping the version,
  the whole file matched on sha256. It no longer does, because `cli.ts` reads the plugin version and
  writes it into the workbook, so any version bump changes the bytes. A claim of "byte-identical" would
  have been true when I made it and false by the time it shipped. I checked the comparison was not
  vacuous either — main carries all five literals in its spec, this branch none.
- **489 engine tests**, 39 shell tests, **19 Excel UAT stages** green. `biome ci`, `markdownlint`,
  `codespell`, `textlint` and `locale-lint` clean.
- **4 mutations, 4 killed**: a spec formula hardcoding a word again (1 fail), a word going stale
  (`ratingRed: 'Crimson'`, 1 fail), a conditional format comparing a word no dropdown offers
  (`"Scarlet"`, 1 fail), and removing a word the spec names, which takes down 94 tests because
  `resolveFormula` throws.

Two failures on the way that were mine, not the code's, recorded because the cause is worth knowing: I
ran the Excel UAT, `biome`, `npx` and a bun suite concurrently, and the UAT died with
`Excel is not frontmost (-2700)` while `github-ops`'s `test_poll_until_uses_actual_retry_after_on_second_failure`
missed its `MAX_POLL_WALLCLOCK=4` budget. Both pass 3/3 alone, on this branch and on main. The screenshot
stage needs Excel focused and that test sleeps a real second against a four-second budget, so neither
survives a starved machine — worth knowing before blaming a diff for either.

## Why this comes before #925

Localisation cannot translate the sentiment or rating dropdowns while three formulas and two
conditional-format rules compare English. With this merged, it can — and #925's decision to keep that
vocabulary in English becomes a preference rather than a constraint.

**v7.0.1**, no behaviour change.
