### PR TITLE
fix(salesforce): discover schema at runtime instead of guessing field names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,4 @@ packages/typescript-edit-benchmark/runs/
 # Verified-review working artifacts (findings and verification evidence).
 # No trailing slash, so a symlink of this name is matched too.
 .codex-review
+.codex-review/

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -202,7 +202,7 @@
     {
       "name": "salesforce",
       "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -202,7 +202,7 @@
     {
       "name": "salesforce",
       "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`salesforce`** v1.3.4 — schema is discovered at runtime instead of guessed, and a rejected column
+  now says which one. Three defects compounded into a query the agent could not recover from.
+
+  The query prompt told the model to read `Opportunity.CompetitorName`, which exists on no org — it
+  belongs to the child `OpportunityCompetitor` object. Given a name that cannot work, the model
+  emitted the nearest plausible spelling, `Competitor__c`. `detectSfError` then looked for the error
+  code in the sf payload's `message`, but sf puts it in `name`, so every real `INVALID_FIELD` fell
+  through to a generic exec error whose one actionable line came last — exactly the line a host UI
+  truncates. And nothing offered a way to look a field up, so the agent shelled out to raw `sf`.
+
+  - **New `sf_describe` tool.** Returns an object's real fields filtered by a concept match on both
+    API name and label, with active picklist values and matching child relationships. Bounded on
+    purpose: a mature Opportunity carries several hundred fields, so an unfiltered call returns the
+    standard ones plus a count. Cells escape `|`, which a real picklist value contains.
+  - **Errors classify on `name`/`code`** and lead with `No such column 'X' on entity 'Y'` plus a
+    pointer to `sf_describe`. Covers `INVALID_FIELD`, `MALFORMED_QUERY`, `INVALID_TYPE` and
+    `INVALID_QUERY_FILTER_OPERATOR`; tests use payloads captured verbatim from a live org, because the
+    test that previously covered this fed a message shape sf never emits.
+  - **Nothing org-specific is hardcoded**, since the plugin ships beyond one org. The query prompt no
+    longer names particular territory fields or stage literals. The context probe reuses the describe
+    it already ran to cache the field catalog, replacing six booleans keyed off one org's field names.
+    Territory selection is empirical — candidates are ranked by schema, then probed against the user's
+    pipeline — replacing a hardcoded field that was not even `groupable`, so it could not back the
+    `GROUP BY` it was used for. Discovered stage names and forecast categories reach the session hint.
+  - Live UAT (`scripts/tests/live-uat.ts`) drives the real tools against an authenticated org and
+    skips cleanly without one.
+
 - **`meddpicc`** v7.1.0 — the engine can enumerate the text it renders, and prove the list complete.
   Additive: a new module and its tests, no generation path touched.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`salesforce`** bumped to v1.3.5
+
 - **`salesforce`** v1.3.4 — schema is discovered at runtime instead of guessed, and a rejected column
   now says which one. Three defects compounded into a query the agent could not recover from.
 

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/salesforce/README.md
+++ b/plugins/salesforce/README.md
@@ -37,8 +37,27 @@ detected in the environment.
 | -------------------- | ---------------------------------------------------------- |
 | `sf_setup`           | Verify Salesforce CLI installation and org connectivity     |
 | `sf_query`           | Execute SOQL queries against authenticated orgs             |
+| `sf_describe`        | Look up an object's real field and relationship names       |
 | `sf_org_display`     | Display org details (alias, username, instance URL, status) |
 | `sf_pipeline_report` | Generate F5 Distributed Cloud pipeline intelligence report  |
+
+### Schema discovery
+
+Salesforce orgs are heavily customized: a mature Opportunity carries several
+hundred custom fields, and two orgs rarely share them. Field names therefore
+have to be looked up rather than assumed, so `sf_describe` filters an object's
+schema down to what was asked for:
+
+```text
+sf_describe {sobject: "Opportunity", match: "competitor"}
+```
+
+It matches on both API name and label, returns active picklist values, and
+lists matching child relationships. An unfiltered call returns the standard
+fields plus a count rather than the whole catalog.
+
+When a query fails with `No such column`, the error names the rejected column
+and points here.
 
 ### Pipeline Report
 

--- a/plugins/salesforce/benchmarks/fixtures/data-query-invalid-field.json
+++ b/plugins/salesforce/benchmarks/fixtures/data-query-invalid-field.json
@@ -1,0 +1,14 @@
+{
+  "name": "INVALID_FIELD",
+  "message": "\nSELECT Id, Competitor__c FROM Opportunity LIMIT\n           ^\nERROR at Row:1:Column:12\nNo such column 'Competitor__c' on entity 'Opportunity'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names.",
+  "exitCode": 1,
+  "context": "DataSoqlQueryCommand",
+  "data": {
+    "message": "\nSELECT Id, Competitor__c FROM Opportunity LIMIT\n           ^\nERROR at Row:1:Column:12\nNo such column 'Competitor__c' on entity 'Opportunity'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names.",
+    "errorCode": "INVALID_FIELD"
+  },
+  "warnings": [],
+  "code": "1",
+  "status": 1,
+  "commandName": "DataSoqlQueryCommand"
+}

--- a/plugins/salesforce/benchmarks/fixtures/data-query-malformed-query.json
+++ b/plugins/salesforce/benchmarks/fixtures/data-query-malformed-query.json
@@ -1,0 +1,14 @@
+{
+  "name": "MALFORMED_QUERY",
+  "message": "\nSELECT Id FROM\n             ^\nERROR at Row:1:Column:14\nunexpected token: '<EOF>'",
+  "exitCode": 1,
+  "context": "DataSoqlQueryCommand",
+  "data": {
+    "message": "\nSELECT Id FROM\n             ^\nERROR at Row:1:Column:14\nunexpected token: '<EOF>'",
+    "errorCode": "MALFORMED_QUERY"
+  },
+  "warnings": [],
+  "code": "1",
+  "status": 1,
+  "commandName": "DataSoqlQueryCommand"
+}

--- a/plugins/salesforce/package.json
+++ b/plugins/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-salesforce",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Salesforce pipeline intelligence for xcsh — native tools, context discovery, pipeline reports",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Salesforce",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "description": "Salesforce pipeline intelligence",
     "extensions": [
       "src/index.ts"

--- a/plugins/salesforce/package.json
+++ b/plugins/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-salesforce",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Salesforce pipeline intelligence for xcsh — native tools, context discovery, pipeline reports",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Salesforce",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "description": "Salesforce pipeline intelligence",
     "extensions": [
       "src/index.ts"

--- a/plugins/salesforce/scripts/tests/live-uat.ts
+++ b/plugins/salesforce/scripts/tests/live-uat.ts
@@ -1,0 +1,137 @@
+// Live acceptance checks for schema discovery and query-error reporting.
+//
+// Runs the REAL tool code against a REAL org — the unit tests use captured payloads, so only
+// this catches a drift between what the sf CLI emits and what the plugin expects. Invoked by
+// test_live.sh, which skips it when no org is authenticated.
+//
+// Usage: bun run scripts/tests/live-uat.ts <org-alias>
+
+import { Type } from '@sinclair/typebox';
+import { createSfDescribeTool } from '../../src/tools/sf-describe';
+import { createSfQueryTool } from '../../src/tools/sf-query';
+
+const org = process.argv[2];
+if (!org) {
+  console.error('usage: bun run scripts/tests/live-uat.ts <org-alias>');
+  process.exit(2);
+}
+
+const pi = { typebox: { Type }, logger: { debug() {} } };
+const ctx = { cwd: process.cwd() };
+const failures: string[] = [];
+
+function check(name: string, condition: boolean, detail: string): void {
+  if (condition) {
+    console.log(`  ok    ${name}`);
+    return;
+  }
+  console.log(`  FAIL  ${name}`);
+  console.log(`        ${detail}`);
+  failures.push(name);
+}
+
+const describeTool = createSfDescribeTool(pi);
+const queryTool = createSfQueryTool(pi);
+
+// UAT.1 — a query naming a field that does not exist must say WHICH field, up front, and point
+// at the tool that resolves it. This is the exact failure that motivated the change.
+{
+  const result = await queryTool.execute(
+    'uat1',
+    {
+      query: 'SELECT Id, Name, Competitor__c FROM Opportunity LIMIT 1',
+      description: 'invalid field probe',
+      target_org: org,
+    },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const text = result.content[0].text;
+  check('UAT.1a invalid field is reported as an error', result.isError === true, `isError=${result.isError}`);
+  check(
+    'UAT.1b error is classified as invalid_query',
+    result.details?.errorType === 'invalid_query',
+    `errorType=${result.details?.errorType}`,
+  );
+  check('UAT.1c error names the offending column', text.includes("No such column 'Competitor__c'"), text.slice(0, 200));
+  check('UAT.1d error points at sf_describe', text.includes('sf_describe'), text.slice(0, 200));
+  const caret = text.indexOf('^');
+  check(
+    'UAT.1e actionable line precedes the caret block',
+    caret === -1 || text.indexOf('No such column') < caret,
+    `caret@${caret} column@${text.indexOf('No such column')}`,
+  );
+}
+
+// UAT.2 — the schema lookup finds the org's real competitor fields, which is what the model
+// could not do before and why it shelled out to raw sf + python.
+{
+  const result = await describeTool.execute(
+    'uat2',
+    { sobject: 'Opportunity', match: 'competitor', target_org: org },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const text = result.content[0].text;
+  check('UAT.2a describe succeeds', !result.isError, text.slice(0, 200));
+  check('UAT.2b returns at least one competitor field', /competitor/i.test(text), text.slice(0, 200));
+  check(
+    'UAT.2c surfaces the OpportunityCompetitors child relationship if the org has one',
+    !text.includes('OpportunityCompetitor') || text.includes('Child relationships'),
+    text.slice(0, 300),
+  );
+  check('UAT.2d output stays small enough to read', text.length < 12_000, `${text.length} chars`);
+  for (const line of text.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('|---'))) {
+    if (line.split(/(?<!\\)\|/).length !== 6 && line.split(/(?<!\\)\|/).length !== 5) {
+      check('UAT.2e every table row has a consistent column count', false, line);
+      break;
+    }
+  }
+}
+
+// UAT.3 — an unfiltered describe of a large object must not dump the whole catalog.
+{
+  const result = await describeTool.execute(
+    'uat3',
+    { sobject: 'Opportunity', target_org: org },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const text = result.content[0].text;
+  check('UAT.3a unfiltered describe succeeds', !result.isError, text.slice(0, 200));
+  check('UAT.3b unfiltered describe is bounded', text.length < 12_000, `${text.length} chars`);
+  check('UAT.3c unfiltered describe tells the caller to use match', text.includes('match'), text.slice(0, 300));
+}
+
+// UAT.4 — picklist discovery: stage names must come from the org, not from assumptions.
+{
+  const result = await describeTool.execute(
+    'uat4',
+    { sobject: 'Opportunity', match: 'stage', target_org: org },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const text = result.content[0].text;
+  check('UAT.4a stage lookup succeeds', !result.isError, text.slice(0, 200));
+  check('UAT.4b StageName is found', text.includes('StageName'), text.slice(0, 300));
+  check('UAT.4c active picklist values are listed', text.includes('values:'), text.slice(0, 400));
+}
+
+// UAT.5 — a bad object name is reported without the tool throwing.
+{
+  const result = await describeTool.execute(
+    'uat5',
+    { sobject: 'NoSuchObject__c', target_org: org },
+    undefined,
+    undefined,
+    ctx,
+  );
+  check('UAT.5a unknown sobject is a structured error', result.isError === true, JSON.stringify(result.details));
+}
+
+console.log(failures.length === 0 ? '\nlive UAT: all checks passed' : `\nlive UAT: ${failures.length} failed`);
+process.exit(failures.length === 0 ? 0 : 1);

--- a/plugins/salesforce/scripts/tests/test_live.sh
+++ b/plugins/salesforce/scripts/tests/test_live.sh
@@ -139,3 +139,28 @@ test_live_skip_connection_flag() {
       return 1
     }
 }
+
+# TL.7 — schema discovery and query-error reporting, exercised through the real tool code.
+# The unit tests run against captured payloads; this is the only check that fails if the sf CLI's
+# actual output drifts from what the plugin parses.
+test_live_schema_discovery_uat() {
+  local org
+  org=$(_detect_live_org 2>/dev/null) || {
+    echo "SKIP: no authenticated org"
+    return 0
+  }
+  command -v bun >/dev/null 2>&1 || {
+    echo "SKIP: bun not installed"
+    return 0
+  }
+  [ -d "$PLUGIN_ROOT/node_modules" ] || {
+    echo "SKIP: plugin dependencies not installed (run bun install)"
+    return 0
+  }
+
+  local out
+  out=$(cd "$PLUGIN_ROOT" && bun run scripts/tests/live-uat.ts "$org" 2>&1) || {
+    printf '%s\n' "$out"
+    return 1
+  }
+}

--- a/plugins/salesforce/src/context/salesforce-context.ts
+++ b/plugins/salesforce/src/context/salesforce-context.ts
@@ -293,11 +293,37 @@ async function describeOpportunity(): Promise<SfSObjectDescription | null> {
 /** Territory-ish, but never a usable grouping value. */
 const TERRITORY_NAME_EXCLUSIONS = [/code/i, /error/i, /exclude/i, /^old_/i, /_del__c$/i, /type__c$/i, /owner/i];
 
-/** Types that can hold a readable territory value. Excludes reference ids and booleans. */
+/** Types that can hold a readable territory value directly. */
 const TERRITORY_FIELD_TYPES: ReadonlySet<string> = new Set(['string', 'picklist']);
 
-/** Probing costs one SOQL query each, so the list is bounded. */
-const MAX_TERRITORY_CANDIDATES = 6;
+/**
+ * Standard objects that a territory lookup can point at. `Territory2` is Salesforce's own
+ * Enterprise Territory Management object — supporting it is not an org customization, and an
+ * ETM org with no custom territory field would otherwise get no territory context at all.
+ */
+const TERRITORY_REFERENCE_TARGETS: ReadonlySet<string> = new Set(['Territory2', 'Territory']);
+
+/**
+ * Probing costs one SOQL query each, so the list is bounded — but only bounded. It is
+ * deliberately NOT reordered by any name heuristic first: nothing in an API name predicts which
+ * field actually holds the data, and ranking by name length then truncating discarded a
+ * populated authoritative field in favour of shorter empty ones. Probing is what decides.
+ */
+const MAX_TERRITORY_CANDIDATES = 12;
+
+/**
+ * The SOQL path to read a candidate by. A plain field is its own path; a lookup has to be
+ * traversed to a readable name, because grouping by the raw id yields opaque 18-character keys.
+ */
+function territorySoqlPath(f: SfFieldDescription): string | undefined {
+  if (TERRITORY_FIELD_TYPES.has(f.type)) return f.name;
+  if (f.type !== 'reference') return undefined;
+  if (!f.referenceTo?.some((t) => TERRITORY_REFERENCE_TARGETS.has(t))) return undefined;
+  // Salesforce relationship naming: `Territory2Id` -> `Territory2`, `Foo__c` -> `Foo__r`.
+  if (f.name.endsWith('__c')) return `${f.name.slice(0, -3)}__r.Name`;
+  if (f.name.endsWith('Id')) return `${f.name.slice(0, -2)}.Name`;
+  return undefined;
+}
 
 export function rankTerritoryFieldCandidates(fields: SfFieldDescription[]): string[] {
   return fields
@@ -306,11 +332,11 @@ export function rankTerritoryFieldCandidates(fields: SfFieldDescription[]): stri
       // A field that cannot appear in GROUP BY cannot back a territory breakdown at all — which
       // is exactly the flaw in the field this code used to hardcode.
       if (!f.groupable || !f.filterable) return false;
-      if (!TERRITORY_FIELD_TYPES.has(f.type)) return false;
       return !TERRITORY_NAME_EXCLUSIONS.some((re) => re.test(f.name) || re.test(f.label));
     })
-    .map((f) => f.name)
-    .sort((a, b) => a.length - b.length || a.localeCompare(b))
+    .map(territorySoqlPath)
+    .filter((p): p is string => p !== undefined)
+    .sort()
     .slice(0, MAX_TERRITORY_CANDIDATES);
 }
 
@@ -343,6 +369,16 @@ export function pickBestTerritoryField(probes: TerritoryFieldProbe[]): Territory
 // Discovery probes
 // ---------------------------------------------------------------------------
 
+/** Walk a dotted SOQL path (`Territory2.Name`) through the nested record shape it returns. */
+function readPath(root: unknown, path: string): string | undefined {
+  let node: unknown = root;
+  for (const segment of path.split('.')) {
+    if (!node || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return typeof node === 'string' ? node : undefined;
+}
+
 /** Group this user's open pipeline by one candidate field. Empty when the field holds no data. */
 async function probeTerritoryField(userId: string, field: string): Promise<TerritoryFieldProbe> {
   const records = await runSfQuery(
@@ -350,8 +386,7 @@ async function probeTerritoryField(userId: string, field: string): Promise<Terri
   );
   const counts = new Map<string, number>();
   for (const r of records) {
-    const opp = r.Opportunity as Record<string, unknown> | undefined;
-    const value = opp?.[field] as string | undefined;
+    const value = readPath(r.Opportunity, field);
     if (value) counts.set(value, (counts.get(value) ?? 0) + 1);
   }
   return { field, counts };

--- a/plugins/salesforce/src/context/salesforce-context.ts
+++ b/plugins/salesforce/src/context/salesforce-context.ts
@@ -1,6 +1,8 @@
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { $ } from 'bun';
+import type { SfFieldDescription, SfSObjectDescription } from '../sf/describe';
+import { normalizeDescribe } from '../sf/describe';
 
 // ---------------------------------------------------------------------------
 // Dependency injection for loadProfile (from xcsh user-profile module)
@@ -141,15 +143,16 @@ export interface SalesforceContext {
     oppCount: number;
   }>;
 
-  // Org capabilities
-  customFields?: {
-    trueAcv: boolean;
-    upsellAcv: boolean;
-    productSegmentation: boolean;
-    useCaseCategory: boolean;
-    territory: boolean;
-    renewal: boolean;
-  };
+  // Org capabilities.
+  //
+  // Discovered, never assumed. This replaced a fixed struct of booleans named after one org's
+  // custom fields, which silently reported "no capabilities" everywhere else. Orgs share almost
+  // no custom schema, so the catalog is the source of truth and every consumer feature-detects
+  // against it.
+  /** Every Opportunity field API name in this org, from the describe the seed already performs. */
+  opportunityFields?: string[];
+  /** Territory field chosen empirically for grouping; absent when the org has no usable one. */
+  territoryField?: string;
 
   // Pipeline summary
   pipelineSummary?: {
@@ -157,7 +160,7 @@ export interface SalesforceContext {
     total: number;
     dealCount: number;
   };
-  // Team member roles on opps
+  // Team member roles on opportunities
   teamRoles?: string[];
 
   // Pipeline report configuration (discovered from saved report)
@@ -187,6 +190,15 @@ export interface SalesforceHint {
   partnerId?: string;
   /** Quarterly quota target for coverage ratio, from user profile */
   quota?: number;
+  /**
+   * Active StageName values in THIS org. Injected because stage names are org-configured, and a
+   * model that assumes Salesforce's defaults writes WHERE clauses that silently match nothing.
+   */
+  stages?: string;
+  /** ForecastCategoryName values in use in this org, for the same reason. */
+  forecastCategories?: string;
+  /** Territory grouping field resolved for this org, so queries need not guess its name. */
+  territoryField?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -255,62 +267,117 @@ async function getOrgInfo(): Promise<{ username: string; instanceUrl: string; al
   }
 }
 
-async function detectCustomFields(): Promise<SalesforceContext['customFields']> {
-  const defaults = {
-    trueAcv: false,
-    upsellAcv: false,
-    productSegmentation: false,
-    useCaseCategory: false,
-    territory: false,
-    renewal: false,
-  };
+async function describeOpportunity(): Promise<SfSObjectDescription | null> {
   try {
     const result = await $`sf sobject describe --sobject Opportunity --json`.quiet().nothrow();
-    if (result.exitCode !== 0) return defaults;
-    const parsed = JSON.parse(result.stdout.toString()) as {
-      result?: { fields?: Array<{ name: string }> };
-    };
-    const fieldNames = new Set((parsed.result?.fields ?? []).map((f) => f.name));
-    return {
-      trueAcv: fieldNames.has('True_ACV__c'),
-      upsellAcv: fieldNames.has('Upsell_ACV__c'),
-      productSegmentation: fieldNames.has('Product_Segmentation__c'),
-      useCaseCategory: fieldNames.has('Use_Case_Category__c'),
-      territory: fieldNames.has('Territory_Credited_District_del__c'),
-      renewal: fieldNames.has('Renewal__c'),
-    };
+    if (result.exitCode !== 0) return null;
+    const parsed = JSON.parse(result.stdout.toString()) as { result?: unknown };
+    if (!parsed.result) return null;
+    return normalizeDescribe(parsed.result);
   } catch {
-    return defaults;
+    return null;
   }
+}
+
+// Territory field selection.
+//
+// There is no standard Opportunity territory field, and a real org can carry twenty or more
+// territory-ish custom fields at different granularities. Naming a specific one only ever works
+// for the org it was copied from. Nor can a name heuristic alone decide: the same org holds
+// `ETM_Core_Territory__c`, `Territory_Grouping__c`, `Territory_Name__c` and a dozen more, several
+// of which are empty in practice.
+//
+// So: narrow by schema (below), then choose by DATA (pickBestTerritoryField) — whichever
+// candidate actually covers the most of this user's pipeline wins.
+
+/** Territory-ish, but never a usable grouping value. */
+const TERRITORY_NAME_EXCLUSIONS = [/code/i, /error/i, /exclude/i, /^old_/i, /_del__c$/i, /type__c$/i, /owner/i];
+
+/** Types that can hold a readable territory value. Excludes reference ids and booleans. */
+const TERRITORY_FIELD_TYPES: ReadonlySet<string> = new Set(['string', 'picklist']);
+
+/** Probing costs one SOQL query each, so the list is bounded. */
+const MAX_TERRITORY_CANDIDATES = 6;
+
+export function rankTerritoryFieldCandidates(fields: SfFieldDescription[]): string[] {
+  return fields
+    .filter((f) => {
+      if (!/territor/i.test(f.name) && !/territor/i.test(f.label)) return false;
+      // A field that cannot appear in GROUP BY cannot back a territory breakdown at all — which
+      // is exactly the flaw in the field this code used to hardcode.
+      if (!f.groupable || !f.filterable) return false;
+      if (!TERRITORY_FIELD_TYPES.has(f.type)) return false;
+      return !TERRITORY_NAME_EXCLUSIONS.some((re) => re.test(f.name) || re.test(f.label));
+    })
+    .map((f) => f.name)
+    .sort((a, b) => a.length - b.length || a.localeCompare(b))
+    .slice(0, MAX_TERRITORY_CANDIDATES);
+}
+
+export interface TerritoryFieldProbe {
+  field: string;
+  /** Territory value -> opportunity count, from a GROUP BY over the user's open pipeline. */
+  counts: Map<string, number>;
+}
+
+/**
+ * Choose among probed candidates.
+ *
+ * 1. Most opportunities covered — a field populated on 48 of the user's deals describes their
+ *    pipeline; one populated on 7 does not.
+ * 2. Then the FINER partition (more distinct values). Among fields annotating the same deals,
+ *    the one that separates them more carries more information; at the degenerate end, a field
+ *    with a single value covers everything and distinguishes nothing. Measured against a real
+ *    org this is what separates a genuine territory (`AMER: Major Accounts ... Red 9`) from a
+ *    region rollup (`USA` / `Canada`) that happens to be populated just as widely.
+ * 3. Then the lexically first name, purely so a re-run picks the same field.
+ */
+export function pickBestTerritoryField(probes: TerritoryFieldProbe[]): TerritoryFieldProbe | undefined {
+  const covered = (p: TerritoryFieldProbe) => [...p.counts.values()].reduce((a, b) => a + b, 0);
+  return probes
+    .filter((p) => p.counts.size > 0 && covered(p) > 0)
+    .sort((a, b) => covered(b) - covered(a) || b.counts.size - a.counts.size || a.field.localeCompare(b.field))[0];
 }
 
 // ---------------------------------------------------------------------------
 // Discovery probes
 // ---------------------------------------------------------------------------
 
+/** Group this user's open pipeline by one candidate field. Empty when the field holds no data. */
+async function probeTerritoryField(userId: string, field: string): Promise<TerritoryFieldProbe> {
+  const records = await runSfQuery(
+    `SELECT Opportunity.${field} FROM OpportunityTeamMember WHERE UserId = '${userId}' AND Opportunity.IsClosed = false AND Opportunity.${field} != null`,
+  );
+  const counts = new Map<string, number>();
+  for (const r of records) {
+    const opp = r.Opportunity as Record<string, unknown> | undefined;
+    const value = opp?.[field] as string | undefined;
+    if (value) counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return { field, counts };
+}
+
 async function discoverTerritories(
   userId: string,
-  customFields: SalesforceContext['customFields'],
+  described: SfSObjectDescription | null,
 ): Promise<Partial<SalesforceContext>> {
-  if (!customFields?.territory) return {};
+  const candidates = rankTerritoryFieldCandidates(described?.fields ?? []);
+  if (candidates.length === 0) return {};
 
-  const teamRecords = await runSfQuery(
-    `SELECT Opportunity.Territory_Credited_District_del__c FROM OpportunityTeamMember WHERE UserId = '${userId}' AND Opportunity.IsClosed = false AND Opportunity.Territory_Credited_District_del__c != null`,
+  const probes = await Promise.all(
+    candidates.map((field) => probeTerritoryField(userId, field).catch(() => ({ field, counts: new Map() }))),
   );
-  const teamCounts = new Map<string, number>();
-  for (const r of teamRecords) {
-    const opp = r.Opportunity as Record<string, unknown> | undefined;
-    const t = opp?.Territory_Credited_District_del__c as string | undefined;
-    if (t) teamCounts.set(t, (teamCounts.get(t) ?? 0) + 1);
-  }
+  const best = pickBestTerritoryField(probes);
+  if (!best) return { territories: [] };
+
+  const teamCounts = best.counts;
   const territories = [...teamCounts.keys()].sort();
-  if (territories.length === 0) return { territories: [] };
 
   const totalCounts = new Map<string, number>();
   const countPromises = territories.map(async (t) => {
     const escaped = t.replace(/'/g, "''");
     const recs = await runSfQuery(
-      `SELECT COUNT(Id) FROM Opportunity WHERE Territory_Credited_District_del__c = '${escaped}' AND IsClosed = false`,
+      `SELECT COUNT(Id) FROM Opportunity WHERE ${best.field} = '${escaped}' AND IsClosed = false`,
     );
     const cnt = (recs[0]?.expr0 ?? 0) as number;
     totalCounts.set(t, cnt);
@@ -326,7 +393,7 @@ async function discoverTerritories(
 
   territoryDetails.sort((a, b) => b.teamOpps - a.teamOpps);
 
-  return { territories, territoryDetails };
+  return { territories, territoryDetails, territoryField: best.field };
 }
 
 async function discoverAccounts(userId: string): Promise<Partial<SalesforceContext>> {
@@ -346,11 +413,18 @@ async function discoverAccounts(userId: string): Promise<Partial<SalesforceConte
   return { activeAccounts: accounts };
 }
 
+/**
+ * Optional named fields this plugin knows how to consume. Feature-detected against the discovered
+ * catalog, never assumed: an org without them simply gets no segmentation breakdown, rather than
+ * a failed query.
+ */
+const PRODUCT_SEGMENTATION_FIELD = 'Product_Segmentation__c';
+
 async function discoverSegmentations(
   userId: string,
-  customFields: SalesforceContext['customFields'],
+  described: SfSObjectDescription | null,
 ): Promise<Partial<SalesforceContext>> {
-  if (!customFields?.productSegmentation) return {};
+  if (!described?.fields.some((f) => f.name === PRODUCT_SEGMENTATION_FIELD)) return {};
   const records = await runSfQuery(
     `SELECT Product_Segmentation__c FROM Opportunity WHERE Id IN (SELECT OpportunityId FROM OpportunityTeamMember WHERE UserId = '${userId}') AND IsClosed = false AND Product_Segmentation__c != null`,
   );
@@ -492,7 +566,7 @@ async function discoverRoleAndTeam(userId: string): Promise<Partial<SalesforceCo
 export async function discoverSalesforceContext(): Promise<SalesforceContext | null> {
   if (!$which('sf')) return null;
 
-  const [orgInfo, customFields] = await Promise.all([getOrgInfo(), detectCustomFields()]);
+  const [orgInfo, described] = await Promise.all([getOrgInfo(), describeOpportunity()]);
   if (!orgInfo) return null;
 
   const profile = await loadProfileSafe();
@@ -500,9 +574,9 @@ export async function discoverSalesforceContext(): Promise<SalesforceContext | n
   if (!userId) return null;
 
   const results = await Promise.all([
-    discoverTerritories(userId, customFields).catch(() => ({})),
+    discoverTerritories(userId, described).catch(() => ({})),
     discoverAccounts(userId).catch(() => ({})),
-    discoverSegmentations(userId, customFields).catch(() => ({})),
+    discoverSegmentations(userId, described).catch(() => ({})),
     discoverForecasts(userId).catch(() => ({})),
     discoverStages(userId).catch(() => ({})),
     discoverPipelineSummary(userId).catch(() => ({})),
@@ -516,7 +590,7 @@ export async function discoverSalesforceContext(): Promise<SalesforceContext | n
     username: orgInfo.username,
     instanceUrl: orgInfo.instanceUrl,
     orgAlias: orgInfo.alias || undefined,
-    customFields,
+    opportunityFields: described?.fields.map((f) => f.name),
     collectedAt: new Date().toISOString(),
   };
   for (const partial of results) {
@@ -535,23 +609,26 @@ export async function seedSalesforceContext(): Promise<SalesforceContext | null>
 }
 
 // ---------------------------------------------------------------------------
-/** Format territory list with a character budget. If joined string exceeds budget, truncate with +N more. */
-function formatTerritoryDisplay(territories: string[] | undefined, budget: number): string | undefined {
-  if (!territories?.length) return undefined;
-  const joined = territories.join(', ');
+/** Join a value list under a character budget, truncating the tail as `+N more`. */
+function joinWithBudget(values: string[] | undefined, budget: number): string | undefined {
+  if (!values?.length) return undefined;
+  const joined = values.join(', ');
   if (joined.length <= budget) return joined;
-  let result = territories[0];
+  let result = values[0];
   let included = 1;
-  for (let i = 1; i < territories.length; i++) {
-    const candidate = `${result}, ${territories[i]}`;
+  for (let i = 1; i < values.length; i++) {
+    const candidate = `${result}, ${values[i]}`;
     if (candidate.length > budget - 10) break;
     result = candidate;
     included++;
   }
-  const remaining = territories.length - included;
+  const remaining = values.length - included;
   if (remaining > 0) result += `, +${remaining} more`;
   return result;
 }
+
+/** Budget for a discovered picklist list in the session hint — enough to be usable, not a dump. */
+const VALUE_LIST_CHAR_BUDGET = 160;
 
 // ---------------------------------------------------------------------------
 // Hint builder
@@ -577,7 +654,7 @@ export function buildSalesforceHint(
       ? ctx.confirmedTerritories
       : ctx.territories?.slice(0, 3);
   const TERRITORY_CHAR_BUDGET = 60;
-  const topTerritories = formatTerritoryDisplay(territorySource, TERRITORY_CHAR_BUDGET);
+  const topTerritories = joinWithBudget(territorySource, TERRITORY_CHAR_BUDGET);
 
   const byForecast = ctx.pipelineSummary.byForecast;
   const forecastParts: string[] = [];
@@ -607,6 +684,9 @@ export function buildSalesforceHint(
     orgAlias: ctx.orgAlias,
     partnerId: partner?.id,
     quota: profile?.quota,
+    stages: joinWithBudget(ctx.stages, VALUE_LIST_CHAR_BUDGET),
+    forecastCategories: joinWithBudget(ctx.forecastCategories, VALUE_LIST_CHAR_BUDGET),
+    territoryField: ctx.territoryField,
   };
 }
 
@@ -658,7 +738,7 @@ export function renderSalesforceContextMarkdown(
     sections.push('\n## Active Accounts');
     sections.push(`${ctx.activeAccounts.length} accounts with open pipeline:\n`);
     for (const acct of ctx.activeAccounts) {
-      sections.push(`- **${acct.name}** (${acct.oppCount} opps)`);
+      sections.push(`- **${acct.name}** (${acct.oppCount} opportunities)`);
     }
   }
 
@@ -671,7 +751,7 @@ export function renderSalesforceContextMarkdown(
       sections.push('\n> **Action needed:** Confirm which territories are your primary responsibility.');
       sections.push('> High team-opp coverage suggests primary ownership. Low coverage suggests overlay.\n');
     }
-    sections.push('| Territory | Your Opps | Total | Coverage | Status |');
+    sections.push('| Territory | Your Opportunities | Total | Coverage | Status |');
     sections.push('|---|---|---|---|---|');
     for (const td of ctx.territoryDetails) {
       const status = hasConfirmed
@@ -730,17 +810,17 @@ export function renderSalesforceContextMarkdown(
   }
 
   // Org Capabilities
-  if (ctx.customFields) {
+  if (ctx.opportunityFields?.length) {
     sections.push('\n## Org Capabilities');
-    const fields = ctx.customFields;
-    const enabled = Object.entries(fields)
-      .filter(([, v]) => v)
-      .map(([k]) => k);
-    if (enabled.length > 0) {
-      sections.push(`Custom fields detected: ${enabled.join(', ')}`);
-    } else {
-      sections.push('No custom opportunity fields detected.');
-    }
+    const custom = ctx.opportunityFields.filter((n) => n.endsWith('__c'));
+    sections.push(
+      `Opportunity schema: ${ctx.opportunityFields.length} fields (${custom.length} custom). Use \`sf_describe\` to look any of them up — they are not listed here.`,
+    );
+    sections.push(
+      ctx.territoryField
+        ? `Territory grouping field: \`${ctx.territoryField}\` (selected by pipeline coverage).`
+        : 'No usable territory grouping field found on Opportunity.',
+    );
   }
 
   // Action Needed

--- a/plugins/salesforce/src/index.ts
+++ b/plugins/salesforce/src/index.ts
@@ -123,9 +123,11 @@ const factory: ExtensionFactory = async (pi) => {
     const { createSfPipelineReportTool } = await import('./tools/sf-pipeline-report');
     const { createSfHelpTool } = await import('./tools/sf-help');
     const { createSfExecTool } = await import('./tools/sf-exec');
+    const { createSfDescribeTool } = await import('./tools/sf-describe');
 
     pi.registerTool(withErrorType(createSfSetupTool(pi)));
     pi.registerTool(withErrorType(createSfQueryTool(pi)));
+    pi.registerTool(withErrorType(createSfDescribeTool(pi)));
     pi.registerTool(withErrorType(createSfOrgDisplayTool(pi)));
     pi.registerTool(withErrorType(createSfPipelineReportTool(pi)));
     pi.registerTool(withErrorType(createSfHelpTool(pi)));
@@ -144,6 +146,11 @@ const factory: ExtensionFactory = async (pi) => {
         hint.forecastBreakdown ? `Forecast: ${hint.forecastBreakdown}` : '',
         hint.partnerName ? `Partner: ${hint.partnerName} (${hint.partnerRole ?? 'Partner'})` : '',
         hint.orgAlias ? `Org: ${hint.orgAlias}` : '',
+        // Org-configured picklist values and field names. Without these the model falls back to
+        // Salesforce's defaults, which silently match nothing in a customized org.
+        hint.stages ? `Opportunity stages (this org): ${hint.stages}` : '',
+        hint.forecastCategories ? `Forecast categories (this org): ${hint.forecastCategories}` : '',
+        hint.territoryField ? `Territory field (this org): ${hint.territoryField}` : '',
       ]
         .filter(Boolean)
         .join('\n');

--- a/plugins/salesforce/src/prompts/sf-describe.md
+++ b/plugins/salesforce/src/prompts/sf-describe.md
@@ -1,0 +1,42 @@
+Look up the real field and relationship names on a Salesforce object. Use this **before** writing SOQL that touches any field you have not already seen in this org.
+
+<instruction>
+Salesforce orgs are heavily customized. Beyond a small standard core, field names are org-specific and unguessable — a typical Opportunity carries several hundred custom fields, and two orgs rarely share them.
+
+A plausible-looking name is not evidence the field exists: `Competitor__c`, `CompetitorName`, and `LeadSource` are all absent from orgs where competitor and lead-source data is very much present under other names.
+
+**Never guess a field name. Look it up here first.** A guessed field costs a failed query and a round trip; a lookup costs one call.
+
+## Parameters
+
+- `sobject` (required) — API name of the object, e.g. `Opportunity`, `Account`, `OpportunityLineItem`, `My_Object__c`.
+- `match` (optional) — case-insensitive substring matched against both the API name and the human label. Also matches child relationships.
+- `target_org` (optional) — org alias or username; defaults to the default org.
+
+## Use `match`
+
+Objects are far too large to return whole, so an unfiltered call returns only the standard fields plus a count of the custom ones. Pass `match` to reach the custom fields:
+
+- Competitor data: `{sobject: "Opportunity", match: "competitor"}`
+- Territory or region fields: `{sobject: "Opportunity", match: "territory"}`
+- Renewal or subscription fields: `{sobject: "Opportunity", match: "renewal"}`
+- Anything with "ACV" in the name or label: `{sobject: "Opportunity", match: "acv"}`
+
+Match on the concept, not on a guessed spelling. `match: "competitor"` finds `Competitor_1__c`, `Other_Competitor__c`, and `LID__MainCompetitors__c` at once; `match: "Competitor__c"` finds nothing.
+
+## What comes back
+
+A table of `Field | Label | Type | Notes`. Notes carry the active picklist values, the target of a reference field, and a `not filterable` marker for fields that cannot appear in a `WHERE` clause.
+
+**Picklist values are authoritative** — take stage names, forecast categories, and type values from here rather than assuming the Salesforce defaults. Stage names in particular are configured per org.
+
+Matching child relationships are listed separately with the relationship name to use in a SOQL subquery. Competitors, for instance, often live on the child `OpportunityCompetitor` object rather than a field on Opportunity:
+
+```
+SELECT Name, (SELECT CompetitorName FROM OpportunityCompetitors) FROM Opportunity
+```
+
+## After a failed query
+
+When `sf_query` reports `No such column` or `sObject type ... is not supported`, call this tool with a `match` on the concept you were after, then re-run the query with the real name. Do not retry a guess, and do not shell out to `sf sobject describe` — this tool is that call, with the output filtered down to what fits.
+</instruction>

--- a/plugins/salesforce/src/prompts/sf-exec.md
+++ b/plugins/salesforce/src/prompts/sf-exec.md
@@ -12,7 +12,8 @@ Run any read-only `sf` (Salesforce CLI) command. Pass arguments as an array with
   - the single top-level commands `version`, `help`, `commands`, `which`, `info`
 - `sf api request rest|graphql` is allowed only when it resolves to a GET: no `-X`/`--method` naming a mutating method, and no `--body`/`--file` (a body payload can carry a mutating method the guard cannot inspect). Use it for GET reads only.
 - Everything else is blocked: `apex run`, `data create`/`update`/`delete`/`import`/`upsert`, `project deploy`/`delete`, `org create`/`delete`/`login`/`logout`, `config set`, `alias set`, and all package/agent writes. Run writes through an explicitly confirmed path, not `sf_exec`.
-- Prefer the typed tools (`sf_query`, `sf_org_display`, `sf_help`, ...) when they cover your need — they return structured data.
+- Prefer the typed tools (`sf_query`, `sf_describe`, `sf_org_display`, `sf_help`, ...) when they cover your need — they return structured data.
+- For schema lookups use **`sf_describe`**, not `sobject describe` here. A raw describe on a mature object returns several hundred fields; `sf_describe` filters them to what you asked for.
 
 ## Command grammar (colon or space)
 

--- a/plugins/salesforce/src/prompts/sf-query.md
+++ b/plugins/salesforce/src/prompts/sf-query.md
@@ -8,6 +8,20 @@ Use sf_query for ad-hoc SOQL queries: specific account lookups, MEDDPICC data, c
 
 Use for ad-hoc data queries, account intelligence, and one-off investigations.
 
+## Field discipline — never guess a field name
+
+Salesforce orgs are heavily customized, and the templates below cannot know which fields yours has. Only a small standard core is safe to assume:
+
+`Id`, `Name`, `Amount`, `StageName`, `CloseDate`, `ForecastCategoryName`, `Probability`, `Type`, `NextStep`, `Description`, `IsClosed`, `IsWon`, `CreatedDate`, `LastModifiedDate`, `LastActivityDate`, `OwnerId`, `AccountId`, and their `Account.`/`Owner.` relationships.
+
+Everything else — every `__c` field, and several fields that merely look standard — must be confirmed with **sf_describe** before it appears in a query. A plausible spelling is not evidence: `CompetitorName`, `Competitor__c`, and `LeadSource` are all absent from orgs that hold that data under other names.
+
+- Before using a field you have not already seen succeed in this org: `sf_describe {sobject: "Opportunity", match: "<concept>"}`.
+- Match on the concept, not a guessed spelling — `match: "competitor"` finds every competitor field at once.
+- When a query fails with `No such column`, call sf_describe and retry with the real name. Do not retry a guess.
+
+**Picklist values are org-specific too.** Stage names, forecast categories, `Type` values, and territory values all vary. Take them from the session's Salesforce hint when present, or from sf_describe's picklist output — do not assume Salesforce's defaults.
+
 Common query templates (substitute {userId} from user profile — read `xcsh://user` to get identifiers.salesforceId):
 
 In-quarter pipeline (current fiscal quarter, team-scoped):
@@ -53,7 +67,8 @@ Year-to-date bookings / top wins ("what are my top wins this year", "year-to-dat
   SELECT Account.Name, Name, Amount, CloseDate FROM Opportunity WHERE Id IN (SELECT OpportunityId FROM OpportunityTeamMember WHERE UserId = '{userId}') AND IsWon = true AND CloseDate = THIS_FISCAL_YEAR ORDER BY Amount DESC LIMIT 20
 
 Pipeline by territory ("break down pipeline by territory", "territory performance summary"):
-  SELECT ETM_Core_Territory__c, COUNT(Id) DealCount, SUM(Amount) TotalAmount FROM Opportunity WHERE Id IN (SELECT OpportunityId FROM OpportunityTeamMember WHERE UserId = '{userId}') AND IsClosed = false AND ForecastCategoryName <> 'Omitted' GROUP BY ETM_Core_Territory__c ORDER BY SUM(Amount) DESC NULLS LAST
+  (substitute {territoryField} — resolve it first with sf_describe, see "Territory-based filtering" below)
+  SELECT {territoryField}, COUNT(Id) DealCount, SUM(Amount) TotalAmount FROM Opportunity WHERE Id IN (SELECT OpportunityId FROM OpportunityTeamMember WHERE UserId = '{userId}') AND IsClosed = false AND ForecastCategoryName <> 'Omitted' GROUP BY {territoryField} ORDER BY SUM(Amount) DESC NULLS LAST
 
 Next-quarter pipeline (forward-looking):
   SELECT Account.Name, Name, Amount, StageName, ForecastCategoryName, CloseDate FROM Opportunity WHERE Id IN (SELECT OpportunityId FROM OpportunityTeamMember WHERE UserId = '{userId}') AND IsClosed = false AND CloseDate = NEXT_FISCAL_QUARTER AND ForecastCategoryName <> 'Omitted' ORDER BY Amount DESC NULLS LAST LIMIT 30
@@ -68,6 +83,7 @@ Deals by product/use case (solution mapping):
   SELECT Account.Name, Name, Amount, StageName, CloseDate, Type FROM Opportunity WHERE Id IN (SELECT OpportunityId FROM OpportunityTeamMember WHERE UserId = '{userId}') AND IsClosed = false AND CloseDate = THIS_FISCAL_YEAR ORDER BY Account.Name, Amount DESC NULLS LAST LIMIT 30
 
 Renewal pipeline (existing customer retention):
+  ('Renewal' is the common Type value but is org-configurable — confirm with sf_describe {sobject: "Opportunity", match: "type"}, and check `match: "renewal"` for a dedicated renewal flag)
   SELECT Account.Name, Name, Amount, StageName, CloseDate, Type FROM Opportunity WHERE Id IN (SELECT OpportunityId FROM OpportunityTeamMember WHERE UserId = '{userId}') AND IsClosed = false AND Type = 'Renewal' ORDER BY CloseDate ASC LIMIT 20
 
 Open cases:
@@ -98,17 +114,20 @@ AE-owned deals: SFDC does not allow OR with semi-join subselects. Run a SEPARATE
 
 Stage-based filtering: Add WHERE StageName clauses to any template when the user asks about
 deals needing technical engagement, demos, POCs, or specific stages.
-Early stages: 'Awareness', 'Research and Internal Education', 'Pending Initial Meeting'.
-Active stages: 'Budget and Timing Determination', 'Solution - Front Runner'.
-Late stages: 'Negotiation', 'Close - Booked'.
-Deals in early stages with close dates within 60 days are at-risk (insufficient time to progress).
+`StageName` is standard, but its **values are configured per org** — take them from the session's
+Salesforce hint, or from `sf_describe {sobject: "Opportunity", match: "stage"}`, which lists the
+active picklist values. Never hardcode a stage name you have not seen in this org.
+Order the discovered stages along the sales cycle and reason in terms of early / active / late:
+deals in an early stage with close dates within 60 days are at-risk (insufficient time to progress).
 
 Territory-based filtering: Add WHERE clauses on territory fields when the user asks about
-specific territories, regions, or countries. Available fields:
-`ETM_Core_Territory__c` (exact territory, e.g. 'AMER: Major Accounts FinSvcs Red 9'),
-`Territory_Credited_Category__c` (category, e.g. 'Financial', 'OEM'),
-`Territory_Grouping__c` (region, e.g. 'USA', 'Canada').
-Use LIKE '%keyword%' for partial matches (e.g. `ETM_Core_Territory__c LIKE '%Canada%'`).
+specific territories, regions, or countries. Territory fields are **custom and org-specific** —
+there is no standard one. Discover them with `sf_describe {sobject: "Opportunity", match: "territory"}`
+(also try `match: "region"`, `match: "district"`, `match: "geo"`), which returns the field names
+and, for picklists, their valid values.
+Orgs typically expose more than one granularity — an exact territory, a category, and a broader
+region — so pick the one matching what the user asked for.
+Use LIKE '%keyword%' for partial matches on a text territory field.
 Always combine territory filters with `ForecastCategoryName <> 'Omitted'`
 or quarter scoping to avoid zombie pipeline noise.
 
@@ -116,14 +135,14 @@ Coverage ratio: When the user asks about pipeline coverage or "do I have enough 
 
 MEDDPICC deal qualification — when user asks to "qualify", "score", or assess deal health:
 For each deal, assess these 8 MEDDPICC elements from available SFDC data:
-**M**etrics: Is there a quantified business outcome? Check Opportunity.Description, close plan notes.
-**E**conomic Buyer: Is the EB identified? Check Contact roles with 'Economic Buyer' or 'Decision Maker'.
-**D**ecision Criteria: Are evaluation criteria documented? Check Opportunity.NextStep, Description.
-**D**ecision Process: Is the buying process mapped? Check stage progression timeline, paper process.
-**P**aper Process: Are procurement steps known? Check Opportunity.Description for legal/procurement notes.
-**I**dentify Pain: Is the business pain articulated? Check Opportunity.Description, discovery notes.
-**C**hampion: Is there an internal advocate? Check Contact roles for 'Champion' or active engagement.
-**C**ompetition: Are competitors identified? Check Opportunity.CompetitorName or description.
+**M** — Metrics: Is there a quantified business outcome? Check Opportunity.Description, close plan notes.
+**E** — Economic Buyer: Is the EB identified? Check Contact roles with 'Economic Buyer' or 'Decision Maker'.
+**D** — Decision Criteria: Are evaluation criteria documented? Check Opportunity.NextStep, Description.
+**D** — Decision Process: Is the buying process mapped? Check stage progression timeline, paper process.
+**P** — Paper Process: Are procurement steps known? Check Opportunity.Description for legal/procurement notes.
+**I** — Identify Pain: Is the business pain articulated? Check Opportunity.Description, discovery notes.
+**C** — Champion: Is there an internal advocate? Check Contact roles for 'Champion' or active engagement.
+**C** — Competition: Are competitors identified? Competitor data has no standard home — run `sf_describe {sobject: "Opportunity", match: "competitor"}` to find this org's fields (they are often numbered, e.g. a primary plus alternates) and check the `OpportunityCompetitors` child relationship if it exists. Fall back to Opportunity.Description.
 Score each element: Green (validated), Yellow (partially known), Red (unknown/missing).
 Surface the gaps as action items, not just labels.
 

--- a/plugins/salesforce/src/sf/describe.ts
+++ b/plugins/salesforce/src/sf/describe.ts
@@ -114,6 +114,9 @@ function renderFieldRows(fields: SfFieldDescription[]): string[] {
     }
     if (f.referenceTo?.length) detail.push(`-> ${f.referenceTo.join(', ')}`);
     if (!f.filterable) detail.push('not filterable');
+    // Callers are told to pick grouping fields out of this table, so a field that GROUP BY
+    // rejects must not look identical to one it accepts.
+    if (!f.groupable) detail.push('not groupable');
     return `| ${cell(f.name)} | ${cell(f.label)} | ${cell(f.type)} | ${cell(detail.join('; '))} |`;
   });
 }

--- a/plugins/salesforce/src/sf/describe.ts
+++ b/plugins/salesforce/src/sf/describe.ts
@@ -1,0 +1,171 @@
+// Schema description: normalizing and rendering `sf sobject describe` payloads.
+//
+// Kept free of I/O so the filtering and volume rules are trivially testable, mirroring how
+// sf-exec-guard.ts keeps its allowlist logic pure.
+//
+// Why this exists at all: a mature Opportunity carries 642 fields (593 of them custom, ~14.5 KB
+// of names). Neither a model nor a prompt can hold that, and no two orgs agree on the custom
+// ones — so field names must be LOOKED UP, never guessed or hardcoded. Every consumer therefore
+// goes through a match filter, and an unfiltered call deliberately returns a summary rather than
+// the whole catalog.
+
+/** Maximum field rows rendered in one response, filtered or not. */
+export const DESCRIBE_MAX_ROWS = 60;
+
+/** Maximum active picklist values shown per field before eliding the tail. */
+const MAX_PICKLIST_VALUES = 15;
+
+export interface SfFieldDescription {
+  name: string;
+  label: string;
+  type: string;
+  custom: boolean;
+  filterable: boolean;
+  /** Usable in a GROUP BY. Not every filterable field is groupable — long text is not. */
+  groupable: boolean;
+  /** Active values only; an inactive value cannot appear in live data. */
+  picklistValues?: string[];
+  referenceTo?: string[];
+}
+
+export interface SfChildRelationship {
+  childSObject: string;
+  /** Absent on relationships that cannot be traversed in SOQL. */
+  relationshipName?: string;
+  field: string;
+}
+
+export interface SfSObjectDescription {
+  name: string;
+  label?: string;
+  fields: SfFieldDescription[];
+  childRelationships: SfChildRelationship[];
+}
+
+function asRecordArray(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? (value.filter((v) => v && typeof v === 'object') as Record<string, unknown>[]) : [];
+}
+
+function normalizeField(raw: Record<string, unknown>): SfFieldDescription {
+  const name = String(raw.name ?? '');
+  const picklist = asRecordArray(raw.picklistValues)
+    .filter((p) => p.active !== false)
+    .map((p) => String(p.value ?? ''))
+    .filter(Boolean);
+  const referenceTo = Array.isArray(raw.referenceTo) ? raw.referenceTo.map(String).filter(Boolean) : [];
+  return {
+    name,
+    label: String(raw.label ?? name),
+    type: String(raw.type ?? 'unknown'),
+    custom: Boolean(raw.custom),
+    filterable: raw.filterable !== false,
+    groupable: raw.groupable !== false,
+    ...(picklist.length > 0 ? { picklistValues: picklist } : {}),
+    ...(referenceTo.length > 0 ? { referenceTo } : {}),
+  };
+}
+
+export function normalizeDescribe(raw: unknown): SfSObjectDescription {
+  const obj = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const name = String(obj.name ?? '');
+  return {
+    name,
+    label: obj.label ? String(obj.label) : undefined,
+    fields: asRecordArray(obj.fields).map(normalizeField),
+    childRelationships: asRecordArray(obj.childRelationships)
+      .map((c) => ({
+        childSObject: String(c.childSObject ?? ''),
+        relationshipName: c.relationshipName ? String(c.relationshipName) : undefined,
+        field: String(c.field ?? ''),
+      }))
+      .filter((c) => c.childSObject),
+  };
+}
+
+function fieldMatches(field: SfFieldDescription, needle: string): boolean {
+  return field.name.toLowerCase().includes(needle) || field.label.toLowerCase().includes(needle);
+}
+
+function relationshipMatches(rel: SfChildRelationship, needle: string): boolean {
+  return rel.childSObject.toLowerCase().includes(needle) || (rel.relationshipName ?? '').toLowerCase().includes(needle);
+}
+
+/**
+ * Make a value safe to place in a markdown table cell.
+ *
+ * Not hypothetical: this org's `Competitor_1__c` picklist contains the literal value
+ * `Broadcom (Symantec | Blue Coat | VMware)`, whose pipes split one cell into four and shift
+ * every column after it. Newlines (common in textarea labels) end the row outright.
+ */
+function cell(value: string): string {
+  return value
+    .replace(/\|/g, '\\|')
+    .replace(/\s*[\r\n]+\s*/g, ' ')
+    .trim();
+}
+
+function renderFieldRows(fields: SfFieldDescription[]): string[] {
+  return fields.map((f) => {
+    const detail: string[] = [];
+    if (f.picklistValues?.length) {
+      const shown = f.picklistValues.slice(0, MAX_PICKLIST_VALUES);
+      const elided = f.picklistValues.length - shown.length;
+      detail.push(`values: ${shown.join(', ')}${elided > 0 ? ` (+${elided} more)` : ''}`);
+    }
+    if (f.referenceTo?.length) detail.push(`-> ${f.referenceTo.join(', ')}`);
+    if (!f.filterable) detail.push('not filterable');
+    return `| ${cell(f.name)} | ${cell(f.label)} | ${cell(f.type)} | ${cell(detail.join('; '))} |`;
+  });
+}
+
+function table(fields: SfFieldDescription[]): string[] {
+  return ['| Field | Label | Type | Notes |', '|---|---|---|---|', ...renderFieldRows(fields)];
+}
+
+export function formatDescribe(desc: SfSObjectDescription, match?: string): string {
+  const needle = (match ?? '').trim().toLowerCase();
+  const total = desc.fields.length;
+  const heading = `**${desc.name}** — ${total} fields`;
+
+  if (!needle) {
+    // No filter: standard fields only. The custom ones are where orgs diverge, they vastly
+    // outnumber the standard ones, and the caller has given nothing to select them by.
+    const standard = desc.fields.filter((f) => !f.custom);
+    const shown = standard.slice(0, DESCRIBE_MAX_ROWS);
+    const customCount = total - standard.length;
+    const lines = [
+      heading,
+      '',
+      `Showing ${shown.length} of ${standard.length} standard fields. ${customCount} custom field(s) are not listed — custom field names differ between orgs, so pass \`match\` to find them (e.g. \`match: "competitor"\`).`,
+      '',
+      ...table(shown),
+    ];
+    if (desc.childRelationships.length > 0) {
+      lines.push('', `${desc.childRelationships.length} child relationship(s); pass \`match\` to list them.`);
+    }
+    return lines.join('\n');
+  }
+
+  const matched = desc.fields.filter((f) => fieldMatches(f, needle));
+  const matchedRels = desc.childRelationships.filter((r) => relationshipMatches(r, needle));
+
+  if (matched.length === 0 && matchedRels.length === 0) {
+    return `${heading}\n\nNo field or child relationship on ${desc.name} matches "${match}". Try a shorter or different term, or call again without \`match\` to see the standard fields.`;
+  }
+
+  const shown = matched.slice(0, DESCRIBE_MAX_ROWS);
+  const withheld = matched.length - shown.length;
+  const lines = [heading, '', `${matched.length} field(s) match "${match}".`];
+  if (withheld > 0) lines.push(`Showing the first ${shown.length}; ${withheld} more — narrow \`match\` to see them.`);
+  if (shown.length > 0) lines.push('', ...table(shown));
+
+  if (matchedRels.length > 0) {
+    lines.push('', `**Child relationships matching "${match}"**`, '');
+    lines.push('| Child object | Relationship (use in SOQL) | Foreign key |', '|---|---|---|');
+    for (const r of matchedRels) {
+      lines.push(`| ${cell(r.childSObject)} | ${cell(r.relationshipName ?? '(not traversable)')} | ${cell(r.field)} |`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/plugins/salesforce/src/sf/exec.ts
+++ b/plugins/salesforce/src/sf/exec.ts
@@ -42,19 +42,62 @@ export class SfExecError extends Error {
   }
 }
 
+// The line sf emits between the caret block and its explanation of what went wrong.
+const QUERY_ERROR_LOCATOR = /^ERROR at Row:\d+:Column:\d+$/m;
+
+const DESCRIBE_HINT =
+  'Field and object names vary by org — confirm them with sf_describe before retrying, e.g. sf_describe {sobject: "Opportunity", match: "competitor"}.';
+
+/**
+ * Put the actionable sentence first.
+ *
+ * sf formats a query error as `<soql window>\n<caret>\nERROR at Row:R:Column:C\n<explanation>`,
+ * where the explanation ("No such column 'X' on entity 'Y'") is the only part that says what to
+ * fix — and it comes LAST, so a host UI that truncates tool output shows the caret block and
+ * hides the answer. That is exactly how this surfaced: the agent saw a bare caret block, could
+ * not tell which column was rejected, and shelled out to reverse-engineer the schema by hand.
+ *
+ * The original block is retained after the hint; nothing is discarded, only reordered.
+ */
+function formatQueryError(raw: string): string {
+  const detail = raw.trim();
+  const locator = QUERY_ERROR_LOCATOR.exec(detail);
+  const explanation = locator ? detail.slice(locator.index + locator[0].length).trim() : '';
+  if (!locator || !explanation) return `${detail}\n\n${DESCRIBE_HINT}`;
+  return `${explanation} [${locator[0]}]\n\n${DESCRIBE_HINT}\n\n${detail}`;
+}
+
 export class SfQueryError extends SfExecError {
   constructor(
     message: string,
     readonly query: string,
   ) {
-    super(message, 1);
+    super(formatQueryError(message), 1);
     this.name = 'SfQueryError';
   }
 }
 
-export function detectSfError(message: string, exitCode: number, query?: string): Error {
+/**
+ * sf error identifiers that mean "the SOQL itself is wrong", all of which are fixed by looking up
+ * the org's real schema. Captured from a live org: a bad column is INVALID_FIELD, a bad object is
+ * INVALID_TYPE, a bad operator is INVALID_QUERY_FILTER_OPERATOR, bad syntax is MALFORMED_QUERY.
+ */
+const QUERY_ERROR_CODES: ReadonlySet<string> = new Set([
+  'MALFORMED_QUERY',
+  'INVALID_FIELD',
+  'INVALID_TYPE',
+  'INVALID_QUERY_FILTER_OPERATOR',
+]);
+
+/**
+ * `errorCode` is the sf payload's `name` field. It is NOT optional decoration: sf puts the error
+ * identifier there and nowhere else, so the `message` scans below never fire on a real payload —
+ * they exist only for the raw-stderr path (execSfRaw), which has no structured code to read.
+ */
+export function detectSfError(message: string, exitCode: number, query?: string, errorCode?: string): Error {
   const lower = message.toLowerCase();
-  if (lower.includes('invalid_session_id')) {
+  const code = (errorCode ?? '').toUpperCase();
+  if (code === 'INVALID_SESSION_ID' || lower.includes('invalid_session_id')) {
     return new SfSessionExpiredError();
   }
   if (lower.includes('no default org')) {
@@ -63,7 +106,9 @@ export function detectSfError(message: string, exitCode: number, query?: string)
   if (lower.includes('no orgs found')) {
     return new SfAuthError();
   }
-  if ((lower.includes('malformed_query') || lower.includes('invalid_field')) && query !== undefined) {
+  const isQueryError =
+    QUERY_ERROR_CODES.has(code) || lower.includes('malformed_query') || lower.includes('invalid_field');
+  if (isQueryError && query !== undefined) {
     return new SfQueryError(message, query);
   }
   return new SfExecError(message, exitCode);
@@ -90,7 +135,7 @@ export async function execSfJson(
   const result = await api.exec('sf', [...args, '--json'], { signal });
   const parsed = parseSfJsonOutput(result.stdout);
   if (parsed.status !== 0 && parsed.message !== undefined) {
-    throw detectSfError(parsed.message, parsed.status, query);
+    throw detectSfError(parsed.message, parsed.status, query, parsed.name);
   }
   return parsed;
 }

--- a/plugins/salesforce/src/sf/types.ts
+++ b/plugins/salesforce/src/sf/types.ts
@@ -27,6 +27,14 @@ export interface SfJsonResult {
   result: unknown;
   message?: string;
   warnings?: string[];
+  /**
+   * The sf CLI's error identifier (`INVALID_FIELD`, `MALFORMED_QUERY`, ...). It lives HERE,
+   * never inside `message` — `message` carries only the human-facing caret block. Classifying
+   * on `message` alone silently misses every real query error, so `execSfJson` reads this.
+   */
+  name?: string;
+  /** Numeric-ish process code (`"1"`), NOT the error identifier. Falls back for older payloads. */
+  code?: string | number;
 }
 
 export interface SfRawResult {
@@ -38,3 +46,10 @@ export interface SfRawResult {
 export const SF_ORG_SAFE_FIELDS = ['username', 'orgId', 'instanceUrl', 'connectedStatus', 'alias'] as const;
 
 export const ORG_ALIAS_PATTERN = /^[a-zA-Z0-9._@-]+$/;
+
+/**
+ * Salesforce object API names: letters, digits and underscores only, and never leading with a
+ * digit or an underscore. Deliberately tighter than ORG_ALIAS_PATTERN — no '-' and no '.' — so a
+ * value can be neither a shell metacharacter nor an argv-injected `--flag`.
+ */
+export const SOBJECT_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_]*$/;

--- a/plugins/salesforce/src/tools/sf-describe.ts
+++ b/plugins/salesforce/src/tools/sf-describe.ts
@@ -1,0 +1,76 @@
+import sfDescribeDescription from '../prompts/sf-describe.md' with { type: 'text' };
+import { formatDescribe, normalizeDescribe } from '../sf/describe';
+import type { SfExecApi } from '../sf/exec';
+import { execSfJson } from '../sf/exec';
+import { ORG_ALIAS_PATTERN, SOBJECT_NAME_PATTERN } from '../sf/types';
+import type { PluginHost, ToolUpdateCallback } from './plugin-host';
+import { detectErrorType, errorResult, makeExecApi, textResult } from './shared';
+
+/**
+ * `makeApi` is injected by tests so a validation case can assert what the tool lets
+ * through without spawning the real CLI.
+ */
+export function createSfDescribeTool(pi: PluginHost, makeApi: (cwd: string) => SfExecApi = makeExecApi) {
+  const { Type } = pi.typebox;
+
+  const parameters = Type.Object({
+    sobject: Type.String({ description: 'API name of the object, e.g. Opportunity, Account, My_Object__c' }),
+    match: Type.Optional(
+      Type.String({
+        description:
+          "Case-insensitive substring matched against field API names, field labels, and child relationships (e.g. 'competitor', 'territory', 'acv')",
+      }),
+    ),
+    target_org: Type.Optional(Type.String({ description: 'Org alias or username to describe against' })),
+  });
+
+  return {
+    name: 'sf_describe',
+    label: 'Salesforce Describe',
+    description: sfDescribeDescription,
+    parameters,
+    async execute(
+      _toolCallId: string,
+      params: { sobject: string; match?: string; target_org?: string },
+      signal: AbortSignal | undefined,
+      _onUpdate: ToolUpdateCallback | undefined,
+      ctx: { cwd: string },
+    ) {
+      const base = { tool: 'sf_describe' as const, action: 'describe' };
+      const sobject = (params.sobject ?? '').trim();
+
+      if (!sobject) {
+        return errorResult('Error: sobject is required, e.g. { sobject: "Opportunity" }.', base);
+      }
+      // A bare identifier only. Blocks both shell metacharacters and an argv-injected flag
+      // (a leading '-' would otherwise be read by sf as an option, not as the object name).
+      if (!SOBJECT_NAME_PATTERN.test(sobject)) {
+        return errorResult(
+          `Error: invalid sobject "${sobject}". Object API names contain only letters, numbers, and underscores.`,
+          base,
+        );
+      }
+      if (params.target_org && !ORG_ALIAS_PATTERN.test(params.target_org)) {
+        return errorResult(
+          `Error: invalid org alias "${params.target_org}". Only alphanumeric characters, dots, underscores, hyphens, and @ are allowed.`,
+          base,
+        );
+      }
+
+      const args = ['sobject', 'describe', '--sobject', sobject];
+      if (params.target_org) args.push('--target-org', params.target_org);
+
+      try {
+        const api = makeApi(ctx.cwd);
+        const result = await execSfJson(api, args, signal);
+        const described = normalizeDescribe(result.result);
+        if (!described.name) described.name = sobject;
+        return textResult(formatDescribe(described, params.match), base);
+      } catch (err) {
+        const errorType = detectErrorType(err);
+        const message = err instanceof Error ? err.message : String(err);
+        return errorResult(message, { ...base, errorType });
+      }
+    },
+  };
+}

--- a/plugins/salesforce/src/tools/shared.ts
+++ b/plugins/salesforce/src/tools/shared.ts
@@ -9,7 +9,7 @@ import type { SfOrg, SfQueryResult, SfRawResult } from '../sf/types';
 export type SfErrorType = 'auth_required' | 'session_expired' | 'no_default_org' | 'invalid_query' | 'exec_error';
 
 export interface SfToolDetails {
-  tool: 'sf_setup' | 'sf_query' | 'sf_org_display' | 'sf_pipeline_report' | 'sf_help' | 'sf_exec';
+  tool: 'sf_setup' | 'sf_query' | 'sf_org_display' | 'sf_pipeline_report' | 'sf_help' | 'sf_exec' | 'sf_describe';
   action?: string;
   orgs?: SfOrg[];
   queryResult?: SfQueryResult;

--- a/plugins/salesforce/test/context/territory-field.test.ts
+++ b/plugins/salesforce/test/context/territory-field.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'bun:test';
+import { pickBestTerritoryField, rankTerritoryFieldCandidates } from '../../src/context/salesforce-context';
+import type { SfFieldDescription } from '../../src/sf/describe';
+
+function field(partial: Partial<SfFieldDescription> & { name: string }): SfFieldDescription {
+  return {
+    label: partial.name,
+    type: 'string',
+    custom: partial.name.endsWith('__c'),
+    filterable: true,
+    groupable: true,
+    ...partial,
+  } as SfFieldDescription;
+}
+
+// Every territory-ish field on a real, heavily customised Opportunity. Twenty-one candidates is
+// why the old hardcoded pick was wrong twice over: it named one org's field, and that field
+// (Territory_Credited_District_del__c) is not even groupable, so it could not back a GROUP BY.
+const REAL_TERRITORY_FIELDS: SfFieldDescription[] = [
+  field({ name: 'Territory2Id', label: 'Territory ID', type: 'reference', custom: false }),
+  field({
+    name: 'IsExcludedFromTerritory2Filter',
+    label: 'Exclude from the territory assignment filter logic',
+    type: 'boolean',
+    custom: false,
+  }),
+  field({ name: 'Territory__c', label: 'Territory', type: 'picklist' }),
+  field({ name: 'Territory_Credited__c', label: 'Territory Credited', type: 'reference' }),
+  field({ name: 'Territory_Grouping__c', label: 'Territory Grouping' }),
+  field({ name: 'Owner_PS_Sales__c', label: 'PS Sales Territory Owner', groupable: false }),
+  field({ name: 'Territory_Name__c', label: 'Territory Name' }),
+  field({ name: 'Territory_Grouping_SVC__c', label: 'Territory Grouping (SVC)', type: 'picklist' }),
+  field({ name: 'Territory_Credited_Category__c', label: 'Territory Credited Category', groupable: false }),
+  field({ name: 'ETM_Core_Territory_Code__c', label: 'ETM Core Territory Code' }),
+  field({ name: 'ETM_Core_Territory__c', label: 'ETM Core Territory' }),
+  field({ name: 'ETM_PS_Territory_Code__c', label: 'ETM PS Territory Code' }),
+  field({ name: 'ETM_PS_Territory__c', label: 'ETM PS Territory' }),
+  field({ name: 'Opportunity_Territory_Type__c', label: 'Opportunity Territory Type', type: 'picklist' }),
+  field({ name: 'Old_Territory_Credited__c', label: 'Old Territory Credited', type: 'reference' }),
+  field({ name: 'Territory_Assignment_Error__c', label: 'Territory Assignment Error' }),
+  field({
+    name: 'Exclude_From_Territory_Assignment__c',
+    label: 'Exclude Opp From Territory Assignment',
+    type: 'boolean',
+  }),
+  field({ name: 'Territory_Credited_Region__c', label: 'Territory Credited Region', groupable: false }),
+  field({ name: 'Territory_Credited_District_del__c', label: 'Territory Credited District', groupable: false }),
+  field({ name: 'Amount', label: 'Amount', type: 'currency', custom: false }),
+  field({ name: 'StageName', label: 'Stage', type: 'picklist', custom: false }),
+];
+
+describe('rankTerritoryFieldCandidates', () => {
+  const ranked = rankTerritoryFieldCandidates(REAL_TERRITORY_FIELDS);
+
+  it('returns only territory-related fields', () => {
+    for (const name of ranked) expect(name.toLowerCase()).toContain('territor');
+  });
+
+  it('excludes fields that cannot back a GROUP BY', () => {
+    expect(ranked).not.toContain('Territory_Credited_District_del__c');
+    expect(ranked).not.toContain('Territory_Credited_Region__c');
+    expect(ranked).not.toContain('Territory_Credited_Category__c');
+  });
+
+  it('excludes references, booleans, codes, error and legacy fields', () => {
+    expect(ranked).not.toContain('Territory2Id');
+    expect(ranked).not.toContain('Territory_Credited__c');
+    expect(ranked).not.toContain('Old_Territory_Credited__c');
+    expect(ranked).not.toContain('Exclude_From_Territory_Assignment__c');
+    expect(ranked).not.toContain('IsExcludedFromTerritory2Filter');
+    expect(ranked).not.toContain('ETM_Core_Territory_Code__c');
+    expect(ranked).not.toContain('Territory_Assignment_Error__c');
+    expect(ranked).not.toContain('Opportunity_Territory_Type__c');
+  });
+
+  it('keeps the plausible groupable name fields', () => {
+    expect(ranked).toContain('Territory__c');
+    expect(ranked).toContain('ETM_Core_Territory__c');
+    expect(ranked).toContain('Territory_Grouping__c');
+  });
+
+  it('bounds how many candidates will be probed', () => {
+    expect(ranked.length).toBeLessThanOrEqual(6);
+  });
+
+  it('is deterministic', () => {
+    expect(rankTerritoryFieldCandidates(REAL_TERRITORY_FIELDS)).toEqual(ranked);
+    expect(rankTerritoryFieldCandidates([...REAL_TERRITORY_FIELDS].reverse())).toEqual(ranked);
+  });
+
+  it('returns nothing for an org with no territory field', () => {
+    expect(rankTerritoryFieldCandidates([field({ name: 'Amount', type: 'currency', custom: false })])).toEqual([]);
+  });
+});
+
+describe('pickBestTerritoryField', () => {
+  it('picks the field that actually covers the most opportunities', () => {
+    const best = pickBestTerritoryField([
+      { field: 'Territory__c', counts: new Map([['A', 2]]) },
+      {
+        field: 'ETM_Core_Territory__c',
+        counts: new Map([
+          ['AMER Red 9', 40],
+          ['EMEA Blue 2', 35],
+        ]),
+      },
+      { field: 'Territory_Grouping__c', counts: new Map([['USA', 10]]) },
+    ]);
+    expect(best?.field).toBe('ETM_Core_Territory__c');
+  });
+
+  // Observed against a real org: ETM_PS_Territory__c and ETM_Core_Territory__c both cover 48
+  // opportunities, but the first is a professional-services rollup. The finer partition is the
+  // more informative territory; the degenerate case — one value covering everything — separates
+  // nothing at all.
+  it('prefers the finer partition when coverage ties', () => {
+    const best = pickBestTerritoryField([
+      {
+        field: 'Region__c',
+        counts: new Map([
+          ['USA', 12],
+          ['Canada', 8],
+        ]),
+      },
+      {
+        field: 'Territory__c',
+        counts: new Map([
+          ['a', 5],
+          ['b', 5],
+          ['c', 5],
+          ['d', 5],
+        ]),
+      },
+    ]);
+    expect(best?.field).toBe('Territory__c');
+  });
+
+  it('rejects a single-value field in favour of one that actually partitions', () => {
+    const best = pickBestTerritoryField([
+      { field: 'AlwaysSame__c', counts: new Map([['GLOBAL', 20]]) },
+      {
+        field: 'Real_Territory__c',
+        counts: new Map([
+          ['East', 10],
+          ['West', 10],
+        ]),
+      },
+    ]);
+    expect(best?.field).toBe('Real_Territory__c');
+  });
+
+  it('breaks a full tie by name so the choice is stable across runs', () => {
+    const best = pickBestTerritoryField([
+      { field: 'B__c', counts: new Map([['x', 5]]) },
+      { field: 'A__c', counts: new Map([['y', 5]]) },
+    ]);
+    expect(best?.field).toBe('A__c');
+  });
+
+  it('ignores candidates with no data at all', () => {
+    const best = pickBestTerritoryField([
+      { field: 'Empty__c', counts: new Map() },
+      { field: 'Used__c', counts: new Map([['x', 1]]) },
+    ]);
+    expect(best?.field).toBe('Used__c');
+  });
+
+  it('returns undefined when nothing has data', () => {
+    expect(pickBestTerritoryField([{ field: 'Empty__c', counts: new Map() }])).toBeUndefined();
+    expect(pickBestTerritoryField([])).toBeUndefined();
+  });
+});

--- a/plugins/salesforce/test/context/territory-field.test.ts
+++ b/plugins/salesforce/test/context/territory-field.test.ts
@@ -62,9 +62,7 @@ describe('rankTerritoryFieldCandidates', () => {
     expect(ranked).not.toContain('Territory_Credited_Category__c');
   });
 
-  it('excludes references, booleans, codes, error and legacy fields', () => {
-    expect(ranked).not.toContain('Territory2Id');
-    expect(ranked).not.toContain('Territory_Credited__c');
+  it('excludes booleans, codes, error and legacy fields', () => {
     expect(ranked).not.toContain('Old_Territory_Credited__c');
     expect(ranked).not.toContain('Exclude_From_Territory_Assignment__c');
     expect(ranked).not.toContain('IsExcludedFromTerritory2Filter');
@@ -73,14 +71,16 @@ describe('rankTerritoryFieldCandidates', () => {
     expect(ranked).not.toContain('Opportunity_Territory_Type__c');
   });
 
+  it('excludes a reference that does not point at a territory object', () => {
+    // Territory_Credited__c is a lookup to a User in this org; its raw id says nothing.
+    expect(ranked).not.toContain('Territory_Credited__c');
+    expect(ranked).not.toContain('Territory_Credited__r.Name');
+  });
+
   it('keeps the plausible groupable name fields', () => {
     expect(ranked).toContain('Territory__c');
     expect(ranked).toContain('ETM_Core_Territory__c');
     expect(ranked).toContain('Territory_Grouping__c');
-  });
-
-  it('bounds how many candidates will be probed', () => {
-    expect(ranked.length).toBeLessThanOrEqual(6);
   });
 
   it('is deterministic', () => {
@@ -90,6 +90,57 @@ describe('rankTerritoryFieldCandidates', () => {
 
   it('returns nothing for an org with no territory field', () => {
     expect(rankTerritoryFieldCandidates([field({ name: 'Amount', type: 'currency', custom: false })])).toEqual([]);
+  });
+
+  // Enterprise Territory Management is the STANDARD Salesforce territory model. An org using it
+  // with no custom territory field got no territory context at all, because the filter dropped
+  // every reference type. Territory2 is a standard object, so supporting it is not org-specific.
+  it('supports standard Enterprise Territory Management via the Territory2 relationship', () => {
+    const etmOnly = [
+      field({
+        name: 'Territory2Id',
+        label: 'Territory ID',
+        type: 'reference',
+        custom: false,
+        referenceTo: ['Territory2'],
+      }),
+      field({ name: 'Amount', label: 'Amount', type: 'currency', custom: false }),
+    ];
+    // Grouping by the raw id yields opaque 18-character keys, so the traversal is what is probed.
+    expect(rankTerritoryFieldCandidates(etmOnly)).toEqual(['Territory2.Name']);
+  });
+
+  it('offers ETM alongside custom fields rather than instead of them', () => {
+    const withEtm = [
+      ...REAL_TERRITORY_FIELDS,
+      field({
+        name: 'Territory2Id',
+        label: 'Territory ID',
+        type: 'reference',
+        custom: false,
+        referenceTo: ['Territory2'],
+      }),
+    ];
+    const out = rankTerritoryFieldCandidates(withEtm);
+    expect(out).toContain('Territory2.Name');
+    expect(out).toContain('ETM_Core_Territory__c');
+  });
+
+  // Ranking by API-name length then truncating discarded a populated authoritative field in
+  // favour of shorter empty ones. Nothing in a name predicts which field holds the data — that
+  // is what probing is for — so the list is only bounded, never reordered by a guess.
+  it('does not drop plausible candidates behind a name-length heuristic', () => {
+    const many = Array.from({ length: 9 }, (_, i) =>
+      field({ name: `Territory_${'x'.repeat(i)}_Field__c`, label: `Territory ${i}` }),
+    );
+    const out = rankTerritoryFieldCandidates(many);
+    expect(out).toHaveLength(9);
+    expect(out).toEqual([...out].sort());
+  });
+
+  it('still bounds the probe count for a pathological org', () => {
+    const many = Array.from({ length: 40 }, (_, i) => field({ name: `Territory_${i}__c`, label: `Territory ${i}` }));
+    expect(rankTerritoryFieldCandidates(many).length).toBeLessThanOrEqual(12);
   });
 });
 

--- a/plugins/salesforce/test/integration/extension-load.test.ts
+++ b/plugins/salesforce/test/integration/extension-load.test.ts
@@ -121,12 +121,21 @@ describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration — requires the sf
     await factory(pi);
 
     const names = tools.map((t) => t.name).sort();
-    expect(names).toEqual(['sf_exec', 'sf_help', 'sf_org_display', 'sf_pipeline_report', 'sf_query', 'sf_setup']);
+    expect(names).toEqual([
+      'sf_describe',
+      'sf_exec',
+      'sf_help',
+      'sf_org_display',
+      'sf_pipeline_report',
+      'sf_query',
+      'sf_setup',
+    ]);
 
     const labels = tools.map((t) => t.label).sort();
     expect(labels).toEqual([
       'Salesforce CLI Execute',
       'Salesforce CLI Help',
+      'Salesforce Describe',
       'Salesforce Org Display',
       'Salesforce Pipeline Report',
       'Salesforce Query',
@@ -143,7 +152,7 @@ describe.skipIf(!SF_INSTALLED)('ExtensionFactory integration — requires the sf
 
     // Without this the loop below has nothing to iterate when no tools were registered,
     // and the test passes having asserted nothing.
-    expect(tools).toHaveLength(6);
+    expect(tools).toHaveLength(7);
 
     for (const tool of tools) {
       expect(typeof tool.name).toBe('string');

--- a/plugins/salesforce/test/sf/describe.test.ts
+++ b/plugins/salesforce/test/sf/describe.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'bun:test';
+import { DESCRIBE_MAX_ROWS, formatDescribe, normalizeDescribe } from '../../src/sf/describe';
+
+// Shaped after a real `sf sobject describe --sobject Opportunity --json` payload. The field
+// names are the ones this org actually has — the bug that motivated this tool was an agent
+// querying `Competitor__c`, which does not exist, because nothing let it look them up.
+const OPPORTUNITY_RAW = {
+  name: 'Opportunity',
+  label: 'Opportunity',
+  fields: [
+    { name: 'Id', label: 'Opportunity ID', type: 'id', custom: false, filterable: true },
+    { name: 'Name', label: 'Opportunity Name', type: 'string', custom: false, filterable: true },
+    { name: 'Amount', label: 'Amount', type: 'currency', custom: false, filterable: true },
+    {
+      name: 'StageName',
+      label: 'Stage',
+      type: 'picklist',
+      custom: false,
+      filterable: true,
+      picklistValues: [
+        { value: 'Awareness', active: true },
+        { value: 'Negotiation', active: true },
+        { value: 'Retired Stage', active: false },
+      ],
+    },
+    { name: 'Competitor_1__c', label: 'Primary Competitor', type: 'picklist', custom: true, filterable: true },
+    { name: 'Competition_Notes__c', label: 'Competition Notes', type: 'textarea', custom: true, filterable: false },
+    { name: 'Other_Competitor__c', label: 'Other Competitor', type: 'string', custom: true, filterable: true },
+    { name: 'LID__MainCompetitors__c', label: 'Main Competitor(s)', type: 'string', custom: true, filterable: true },
+    { name: 'ETM_Core_Territory__c', label: 'Core Territory', type: 'string', custom: true, filterable: true },
+    {
+      name: 'AccountId',
+      label: 'Account ID',
+      type: 'reference',
+      custom: false,
+      filterable: true,
+      referenceTo: ['Account'],
+    },
+  ],
+  childRelationships: [
+    { childSObject: 'OpportunityCompetitor', relationshipName: 'OpportunityCompetitors', field: 'OpportunityId' },
+    { childSObject: 'OpportunityLineItem', relationshipName: 'OpportunityLineItems', field: 'OpportunityId' },
+    { childSObject: 'Note', relationshipName: null, field: 'ParentId' },
+  ],
+};
+
+describe('normalizeDescribe', () => {
+  it('extracts fields and child relationships', () => {
+    const d = normalizeDescribe(OPPORTUNITY_RAW);
+    expect(d.name).toBe('Opportunity');
+    expect(d.fields).toHaveLength(10);
+    expect(d.childRelationships).toHaveLength(3);
+  });
+
+  it('keeps only ACTIVE picklist values', () => {
+    const d = normalizeDescribe(OPPORTUNITY_RAW);
+    const stage = d.fields.find((f) => f.name === 'StageName');
+    expect(stage?.picklistValues).toEqual(['Awareness', 'Negotiation']);
+  });
+
+  it('tolerates a payload with no fields or relationships', () => {
+    const d = normalizeDescribe({ name: 'Empty' });
+    expect(d.fields).toEqual([]);
+    expect(d.childRelationships).toEqual([]);
+  });
+});
+
+describe('formatDescribe — match filtering', () => {
+  it('finds the org\'s real competitor fields, which are not named "Competitor__c"', () => {
+    const out = formatDescribe(normalizeDescribe(OPPORTUNITY_RAW), 'competitor');
+    expect(out).toContain('Competitor_1__c');
+    expect(out).toContain('Other_Competitor__c');
+    expect(out).toContain('LID__MainCompetitors__c');
+    expect(out).not.toContain('ETM_Core_Territory__c');
+  });
+
+  it('matches on the LABEL as well as the API name', () => {
+    // "Competition Notes" is only reachable via its label when searching for "notes".
+    const out = formatDescribe(normalizeDescribe(OPPORTUNITY_RAW), 'notes');
+    expect(out).toContain('Competition_Notes__c');
+  });
+
+  it('is case-insensitive', () => {
+    const out = formatDescribe(normalizeDescribe(OPPORTUNITY_RAW), 'COMPETITOR');
+    expect(out).toContain('Competitor_1__c');
+  });
+
+  it('surfaces matching child relationships', () => {
+    const out = formatDescribe(normalizeDescribe(OPPORTUNITY_RAW), 'competitor');
+    expect(out).toContain('OpportunityCompetitors');
+    expect(out).not.toContain('OpportunityLineItems');
+  });
+
+  it('reports no match plainly rather than silently returning an empty table', () => {
+    const out = formatDescribe(normalizeDescribe(OPPORTUNITY_RAW), 'zzzznope');
+    expect(out).toContain('No field or child relationship');
+    expect(out).toContain('zzzznope');
+  });
+
+  it('lists active picklist values so stage and category names need not be guessed', () => {
+    const out = formatDescribe(normalizeDescribe(OPPORTUNITY_RAW), 'stage');
+    expect(out).toContain('Awareness');
+    expect(out).toContain('Negotiation');
+    expect(out).not.toContain('Retired Stage');
+  });
+});
+
+describe('formatDescribe — table safety', () => {
+  // Real value observed on this org's Competitor_1__c picklist. Unescaped, its pipes split one
+  // cell into four and shift every column to the right of it.
+  const piped = normalizeDescribe({
+    name: 'Opportunity',
+    fields: [
+      {
+        name: 'Competitor_1__c',
+        label: 'Primary Competitor',
+        type: 'picklist',
+        custom: true,
+        filterable: true,
+        picklistValues: [{ value: 'Broadcom (Symantec | Blue Coat | VMware)', active: true }],
+      },
+      { name: 'Notes__c', label: 'Line\none\nlabel', type: 'textarea', custom: true, filterable: true },
+    ],
+    childRelationships: [],
+  });
+
+  it('escapes pipes inside a cell so the table keeps its column count', () => {
+    const out = formatDescribe(piped, 'competitor');
+    const row = out.split('\n').find((l) => l.includes('Competitor_1__c')) ?? '';
+    expect(row).toContain('Symantec \\| Blue Coat');
+    // 4 columns -> 5 delimiters once the interior pipes are escaped.
+    expect(row.split(/(?<!\\)\|/)).toHaveLength(6);
+  });
+
+  it('flattens newlines in a label so the row cannot end early', () => {
+    const out = formatDescribe(piped, 'notes');
+    const row = out.split('\n').find((l) => l.includes('Notes__c')) ?? '';
+    expect(row).toContain('Line one label');
+  });
+});
+
+describe('formatDescribe — unfiltered volume', () => {
+  // Opportunity in a mature org has 642 fields / ~14.5 KB of names alone. Returning that
+  // wholesale would blow the context window the tool exists to protect.
+  const big = normalizeDescribe({
+    name: 'Opportunity',
+    fields: [
+      ...Array.from({ length: 40 }, (_, i) => ({
+        name: `Standard${i}`,
+        label: `Standard ${i}`,
+        type: 'string',
+        custom: false,
+        filterable: true,
+      })),
+      ...Array.from({ length: 600 }, (_, i) => ({
+        name: `Custom${i}__c`,
+        label: `Custom ${i}`,
+        type: 'string',
+        custom: true,
+        filterable: true,
+      })),
+    ],
+    childRelationships: [],
+  });
+
+  it('does not dump every field when no match is given', () => {
+    const out = formatDescribe(big, undefined);
+    const rows = out.split('\n').filter((l) => l.startsWith('| ') && l.includes('__c'));
+    expect(rows.length).toBeLessThanOrEqual(DESCRIBE_MAX_ROWS);
+    expect(out).not.toContain('Custom599__c');
+  });
+
+  it('states the real total and tells the caller how to narrow', () => {
+    const out = formatDescribe(big, undefined);
+    expect(out).toContain('640');
+    expect(out).toContain('match');
+  });
+
+  it('caps a broad match and says how many were withheld', () => {
+    const out = formatDescribe(big, 'custom');
+    const rows = out.split('\n').filter((l) => l.startsWith('| ') && l.includes('__c'));
+    expect(rows.length).toBeLessThanOrEqual(DESCRIBE_MAX_ROWS);
+    expect(out).toContain('more');
+  });
+});

--- a/plugins/salesforce/test/sf/describe.test.ts
+++ b/plugins/salesforce/test/sf/describe.test.ts
@@ -97,6 +97,32 @@ describe('formatDescribe — match filtering', () => {
     expect(out).toContain('zzzznope');
   });
 
+  // sf-query.md directs the agent to pick a territory field out of this output and GROUP BY it.
+  // A field that cannot be grouped looked identical to one that can, so the agent would write a
+  // query Salesforce rejects — the same failure class this tool exists to prevent.
+  it('marks a field that cannot be used in GROUP BY', () => {
+    const d = normalizeDescribe({
+      name: 'Opportunity',
+      fields: [
+        {
+          name: 'Long_Notes__c',
+          label: 'Long Notes',
+          type: 'textarea',
+          custom: true,
+          filterable: true,
+          groupable: false,
+        },
+        { name: 'Region__c', label: 'Region', type: 'string', custom: true, filterable: true, groupable: true },
+      ],
+      childRelationships: [],
+    });
+    const out = formatDescribe(d, 'o');
+    const notGroupable = out.split('\n').find((l) => l.includes('Long_Notes__c')) ?? '';
+    const groupable = out.split('\n').find((l) => l.includes('Region__c')) ?? '';
+    expect(notGroupable).toContain('not groupable');
+    expect(groupable).not.toContain('not groupable');
+  });
+
   it('lists active picklist values so stage and category names need not be guessed', () => {
     const out = formatDescribe(normalizeDescribe(OPPORTUNITY_RAW), 'stage');
     expect(out).toContain('Awareness');

--- a/plugins/salesforce/test/sf/exec.test.ts
+++ b/plugins/salesforce/test/sf/exec.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'bun:test';
+import INVALID_FIELD_FIXTURE from '../../benchmarks/fixtures/data-query-invalid-field.json';
+import MALFORMED_QUERY_FIXTURE from '../../benchmarks/fixtures/data-query-malformed-query.json';
 import {
   detectSfError,
   execSfJson,
@@ -77,18 +79,62 @@ describe('detectSfError', () => {
     expect(err).toBeInstanceOf(SfAuthError);
   });
 
-  it('returns SfQueryError for MALFORMED_QUERY with query param', () => {
-    const err = detectSfError('MALFORMED_QUERY: unexpected token', 1, 'SELECT Bad');
+  // The sf CLI never puts its error code in `message` — it goes in `name`/`code`, and
+  // `message` holds only the caret block. These cases use payloads captured verbatim from
+  // `sf data query --json` against a live org (benchmarks/fixtures/data-query-*.json), so a
+  // regression here means the classifier drifted from what sf actually emits.
+  it('returns SfQueryError for a real INVALID_FIELD payload (code in name, not message)', () => {
+    const err = detectSfError(
+      INVALID_FIELD_FIXTURE.message,
+      1,
+      'SELECT Id, Competitor__c FROM Opportunity',
+      'INVALID_FIELD',
+    );
     expect(err).toBeInstanceOf(SfQueryError);
   });
 
-  it('returns SfQueryError for INVALID_FIELD with query param', () => {
-    const err = detectSfError('INVALID_FIELD: no such column', 1, 'SELECT Bad FROM X');
+  it('returns SfQueryError for a real MALFORMED_QUERY payload (code in name, not message)', () => {
+    const err = detectSfError(MALFORMED_QUERY_FIXTURE.message, 1, 'SELECT Id FROM', 'MALFORMED_QUERY');
+    expect(err).toBeInstanceOf(SfQueryError);
+  });
+
+  it('leads an INVALID_FIELD message with the offending column, ahead of the caret block', () => {
+    const err = detectSfError(
+      INVALID_FIELD_FIXTURE.message,
+      1,
+      'SELECT Id, Competitor__c FROM Opportunity',
+      'INVALID_FIELD',
+    );
+    // The caret block is what host UIs truncate, so the actionable line must come first.
+    const caretIndex = err.message.indexOf('^');
+    const columnIndex = err.message.indexOf("No such column 'Competitor__c' on entity 'Opportunity'");
+    expect(columnIndex).toBeGreaterThan(-1);
+    expect(columnIndex).toBeLessThan(caretIndex);
+  });
+
+  it('points an invalid-field failure at sf_describe', () => {
+    const err = detectSfError(
+      INVALID_FIELD_FIXTURE.message,
+      1,
+      'SELECT Id, Competitor__c FROM Opportunity',
+      'INVALID_FIELD',
+    );
+    expect(err.message).toContain('sf_describe');
+  });
+
+  it('still classifies from the message when no code is supplied', () => {
+    const err = detectSfError('MALFORMED_QUERY: unexpected token', 1, 'SELECT Bad');
     expect(err).toBeInstanceOf(SfQueryError);
   });
 
   it('returns SfExecError for MALFORMED_QUERY without query param', () => {
     const err = detectSfError('MALFORMED_QUERY: unexpected token', 1);
+    expect(err).toBeInstanceOf(SfExecError);
+    expect(err).not.toBeInstanceOf(SfQueryError);
+  });
+
+  it('returns SfExecError when a query error code arrives without a query param', () => {
+    const err = detectSfError(INVALID_FIELD_FIXTURE.message, 1, undefined, 'INVALID_FIELD');
     expect(err).toBeInstanceOf(SfExecError);
     expect(err).not.toBeInstanceOf(SfQueryError);
   });
@@ -161,6 +207,17 @@ describe('execSfJson', () => {
       exitCode: 1,
     });
     await expect(execSfJson(api, ['data', 'query'], undefined, 'SELECT Bad')).rejects.toBeInstanceOf(SfQueryError);
+  });
+
+  it('threads the sf error code from `name` through to the classifier', async () => {
+    const api = mockApi({
+      stdout: JSON.stringify(INVALID_FIELD_FIXTURE),
+      stderr: '',
+      exitCode: 1,
+    });
+    await expect(
+      execSfJson(api, ['data', 'query'], undefined, 'SELECT Id, Competitor__c FROM Opportunity'),
+    ).rejects.toBeInstanceOf(SfQueryError);
   });
 
   it('does not throw when status is 0 even with message', async () => {

--- a/plugins/salesforce/test/tools/sf-describe.test.ts
+++ b/plugins/salesforce/test/tools/sf-describe.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'bun:test';
+import { Type } from '@sinclair/typebox';
+import { createSfDescribeTool } from '../../src/tools/sf-describe';
+
+const mockPi = { typebox: { Type }, logger: { debug() {} } };
+
+// Validation tests must never reach a real CLI: whether one is installed, and how long it
+// takes to answer, is not part of what they are asserting.
+const stubExec = () => ({
+  exec: async () => ({ stdout: '{"status":0,"result":{}}', stderr: '', exitCode: 0 }),
+});
+
+function describeExec(payload: unknown, capture?: { args?: string[] }) {
+  return () => ({
+    exec: async (_cmd: string, args: string[]) => {
+      if (capture) capture.args = args;
+      return { stdout: JSON.stringify({ status: 0, result: payload }), stderr: '', exitCode: 0 };
+    },
+  });
+}
+
+const OPPORTUNITY = {
+  name: 'Opportunity',
+  fields: [
+    { name: 'Competitor_1__c', label: 'Primary Competitor', type: 'picklist', custom: true, filterable: true },
+    { name: 'Amount', label: 'Amount', type: 'currency', custom: false, filterable: true },
+  ],
+  childRelationships: [
+    { childSObject: 'OpportunityCompetitor', relationshipName: 'OpportunityCompetitors', field: 'OpportunityId' },
+  ],
+};
+
+describe('createSfDescribeTool', () => {
+  it('returns a tool definition with correct name and label', () => {
+    const tool = createSfDescribeTool(mockPi, stubExec);
+    expect(tool.name).toBe('sf_describe');
+    expect(tool.label).toBe('Salesforce Describe');
+  });
+
+  it('has description loaded from prompt template', () => {
+    const tool = createSfDescribeTool(mockPi, stubExec);
+    expect(typeof tool.description).toBe('string');
+    expect(tool.description.length).toBeGreaterThan(10);
+  });
+});
+
+describe('sf_describe execute — validation', () => {
+  it('requires an sobject', async () => {
+    const tool = createSfDescribeTool(mockPi, stubExec);
+    const result = await tool.execute('t1', { sobject: '' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('sobject');
+  });
+
+  it('rejects an sobject name that is not a bare identifier', async () => {
+    const tool = createSfDescribeTool(mockPi, stubExec);
+    for (const bad of ['Opportunity; rm -rf /', 'Opp$(id)', 'Opp|cat /etc/passwd', '--target-org']) {
+      const result = await tool.execute('t1', { sobject: bad }, undefined, undefined, { cwd: '/tmp' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('invalid sobject');
+    }
+  });
+
+  it('rejects shell injection in org alias', async () => {
+    const tool = createSfDescribeTool(mockPi, stubExec);
+    const result = await tool.execute('t1', { sobject: 'Opportunity', target_org: 'bad$(id)' }, undefined, undefined, {
+      cwd: '/tmp',
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('invalid org alias');
+  });
+
+  it('accepts a namespaced custom object', async () => {
+    const tool = createSfDescribeTool(mockPi, describeExec(OPPORTUNITY));
+    const result = await tool.execute('t1', { sobject: 'LID__Opportunity__c' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBeUndefined();
+  });
+});
+
+describe('sf_describe execute — behaviour', () => {
+  it('invokes `sobject describe` with the requested object and org', async () => {
+    const capture: { args?: string[] } = {};
+    const tool = createSfDescribeTool(mockPi, describeExec(OPPORTUNITY, capture));
+    await tool.execute('t1', { sobject: 'Opportunity', target_org: 'f5' }, undefined, undefined, { cwd: '/tmp' });
+    expect(capture.args).toEqual(['sobject', 'describe', '--sobject', 'Opportunity', '--target-org', 'f5', '--json']);
+  });
+
+  it('returns the real competitor field for a "competitor" match', async () => {
+    const tool = createSfDescribeTool(mockPi, describeExec(OPPORTUNITY));
+    const result = await tool.execute('t1', { sobject: 'Opportunity', match: 'competitor' }, undefined, undefined, {
+      cwd: '/tmp',
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('Competitor_1__c');
+    expect(result.content[0].text).toContain('OpportunityCompetitors');
+  });
+
+  it('surfaces an sf failure as a structured error rather than throwing', async () => {
+    const failing = () => ({
+      exec: async () => ({
+        stdout: JSON.stringify({ status: 1, name: 'NotFoundError', message: "The requested resource doesn't exist." }),
+        stderr: '',
+        exitCode: 1,
+      }),
+    });
+    const tool = createSfDescribeTool(mockPi, failing);
+    const result = await tool.execute('t1', { sobject: 'Nope__c' }, undefined, undefined, { cwd: '/tmp' });
+    expect(result.isError).toBe(true);
+    expect(result.details?.errorType).toBe('exec_error');
+  });
+});


### PR DESCRIPTION
Fixes #932

## What happened

`sf_query` returned a bare caret block for a query naming a field that does not exist, and the agent could not recover from it — it shelled out to raw `sf` + ad-hoc Python, which then died on `KeyError: 'result'`. Three defects combined, all reproduced against a live org.

**The prompt named a field that exists in no org.** `sf-query.md` told the model to read `Opportunity.CompetitorName` — that field belongs to the child `OpportunityCompetitor` object. Given a name that cannot work, the model produced the nearest plausible spelling, `Competitor__c`. The org's real fields are `Competitor_1__c`, `Competition__c`, `Other_Competitor__c` and six more.

**`INVALID_FIELD` was misclassified.** `detectSfError` scanned `message` for the error code, but sf puts it in `name`; `message` holds only the caret block. Captured live:

```
name    = "INVALID_FIELD"
message = "\nSELECT Id, Competitor__c FROM Opportunity LIMIT\n  ^\nERROR at Row:1:Column:12\n
           No such column 'Competitor__c' on entity 'Opportunity'. ..."
```

So `SfQueryError` and `errorType: 'invalid_query'` were unreachable, and the one actionable line came *last* — exactly what host UIs truncate. The existing test passed only because it fed a message shape sf never emits.

**Nothing let the model look a field up**, so it reached for Bash.

## What changed

Errors now classify on `name`/`code` and lead with the rejected column plus a pointer to schema discovery. Before and after, same query:

```
- sf CLI error (exit 1):
- Probability, ExpectedRevenue, LeadSource, CampaignId, Competitor__c
-                               ^
- ERROR at Row:1:Column:59
- … 1 more lines            ← the useful part, truncated away

+ No such column 'Competitor__c' on entity 'Opportunity'. If you are attempting to use a
+ custom field, be sure to append the '__c' … [ERROR at Row:1:Column:12]
+
+ Field and object names vary by org — confirm them with sf_describe before retrying,
+ e.g. sf_describe {sobject: "Opportunity", match: "competitor"}.
+
+ (original caret block retained below)
```

New **`sf_describe`** tool returns an object's real fields filtered by a concept match on both API name and label, with active picklist values and matching child relationships. Bounded deliberately: Opportunity here has **642 fields (593 custom, ~14.5 KB of names)**, so an unfiltered call returns the standard fields plus a count, and a filtered one caps at 60 rows. Cells escape `|` — this org has a picklist value `Broadcom (Symantec | Blue Coat | VMware)` that silently shifted every column right of it.

## Org-agnostic, per review of the plan

The plugin ships beyond one org, so nothing is hardcoded:

- `sf-query.md` no longer names org-specific territory fields or stage-name literals; it states the standard core, and directs everything else through `sf_describe`.
- `detectCustomFields()` keyed six booleans off one org's field names and discarded the rest of a describe it was already running. It now caches the whole field catalog, and consumers feature-detect against it.
- `discoverTerritories()` hardcoded `Territory_Credited_District_del__c` — which is not `groupable`, so it could not back the `GROUP BY` it was used for. Territory selection is now **empirical**: rank candidates by schema, probe each against the user's pipeline, keep whichever actually covers the most deals.
- Discovered stage names and forecast categories now reach the session hint, so they need not be guessed.

A name heuristic alone would not have worked — this org has 21 territory-ish fields. Live probe:

```
Territory__c                covered=   7  distinct=3
Territory_Name__c           covered=  45  distinct=13
ETM_PS_Territory__c         covered=  48  distinct=7
ETM_Core_Territory__c       covered=  48  distinct=10   ← selected
Territory_Grouping__c       covered=  21  distinct=2
Territory_Grouping_SVC__c   covered=   0  distinct=0
```

The tie-break was changed after seeing this data: preferring the *coarser* grouping picked `ETM_PS_Territory__c`, a professional-services rollup. Among fields covering the same deals the finer partition carries more information — at the limit, one value covering everything distinguishes nothing.

## Verification

```
bun test                      258 pass, 0 fail  (19 files)
./scripts/tests/run-tests.sh  53 passed, 3 skipped, 0 failed
pre-commit (changed files)    all hooks pass
```

New automated live UAT (`scripts/tests/live-uat.ts`, wired into `test_live.sh`, skips without an org) drives the real tools against a real org — 16 checks, all passing. The unit tests use payloads captured verbatim from `sf data query --json`, so a future drift between sf's output and what the plugin parses fails a test rather than a user.

While here, fixed four pre-existing codespell failures in the touched files (`opps`, and the MEDDPICC `**I**dentify` splitting into the non-word "dentify"), so the hooks pass without a bypass.

## Not in this PR

`src/pipeline-report/generator.ts` is hardcoded to the same org's schema (`FYB_Total_Price__c`, `True_ACV__c`, `Subscription_Renewal__c`, …). That is a larger question than a rename — what the report *is* on an org without those fields — so it is tracked in #933 rather than left unrecorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
