### PR TITLE
MEDDPICC: let the engine enumerate the text it renders (v7.1.0)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v7.1.0 — the engine can enumerate the text it renders, and prove the list complete.
+  Additive: a new module and its tests, no generation path touched.
+
+  Localisation (#925) needs that list, and three attempts at writing it down by reading the code gave
+  three different answers — 129, then 198, then 199 — each wrong in a way nothing could catch, because
+  there was nothing to check against.
+
+  - `engine/translatable.ts` declares six sources and returns every string the engine chooses to render,
+    with which source each came from. **199 strings**, and the number comes from running it.
+  - **The test is the point.** It generates a workbook, extracts every string the workbook shows, and
+    asserts the catalogue covers exactly that — nothing missing, nothing surplus. It cannot miss a source
+    because it does not depend on knowing what the sources are.
+  - Two things that only came out by asking the artifact. **All 40 rubric lines live inside a formula**:
+    the "What This Score Means" column is `IF(D20=4,"Committed — …",IF(D20=3,"Quantified — …",…))`, so it
+    follows the score live in Excel. They are the most prose-heavy text on the sheet and not one of them
+    is a cell value anywhere, so an oracle that skipped formula cells — as mine first did — declared the
+    catalogue complete while missing them. And a deal-supplied value must never be catalogued, which is
+    what `plan.inputCells` is asked rather than guessed at: an account name is rendered, and translating
+    it would be corrupting the deal.
+  - `note: "elementDefinition"` is excluded by name: `NoteSource` is a discriminator, not prose, and a
+    key-name heuristic cannot tell a type tag from text.
+
 - **`meddpicc`** v7.0.1 — three formulas stop spelling enum words by hand. No behaviour change: every
   OOXML part of the generated workbook is byte-identical to v7.0.0 except `docProps/custom.xml`, which
   differs only in the recorded engine version, and the resolved formulas still read `"Green"` and

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -684,7 +684,7 @@ function derivedValue(
 }
 
 /** What the header says when the deal names nothing — see {@link presentation}. */
-const FALLBACK_HEADER = 'MEDDPICC Deal Review';
+export const FALLBACK_HEADER = 'MEDDPICC Deal Review';
 
 /**
  * Presentation settings every sheet shares: no grid, and a print setup that puts the deal on
@@ -699,10 +699,14 @@ function presentation(deal: unknown): Pick<SheetSpec, 'hideGridlines' | 'print'>
   // them, so a very long account name cannot crowd a later part out and leave every deal for that
   // account printing identically.
   //
-  // `dealId` is in there because it is the only part guaranteed to identify the deal. The schema
-  // requires all three of these but bounds none of them, so a deal whose account and deal names
-  // are both empty strings still validates — and a printout of it would carry nothing to file it
-  // by. The id is short, so per-part budgeting always lets it through.
+  // `dealId` is in there because it is the only part guaranteed to identify the deal, and it is short,
+  // so per-part budgeting always lets it through.
+  //
+  // The fallback below is no longer reachable from a VALID deal: #901 bounded all three of these with
+  // `minLength` and `pattern: "\S"`, so a validated deal always names itself and `header` is never
+  // empty. It stays because `planWorkbook` takes `deal: unknown` and does not validate — a caller that
+  // plans an unvalidated deal, which the tests and the acceptance harness both do, can still reach it,
+  // and an unlabelled printout is worse than a generic one.
   const header = ['metadata.accountName', 'metadata.dealName', 'metadata.dealId']
     .map((path) => readPath(deal, path))
     .filter((part): part is string => typeof part === 'string' && part !== '');

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/translatable.test.ts
+++ b/plugins/meddpicc/engine/translatable.test.ts
@@ -150,6 +150,21 @@ describe('the catalogue is proven against a workbook, not against my reading of 
     expect(translatableSet(titleless, schema).has('MEDDPICC Deal Review')).toBe(true);
   });
 
+  test('prose inside a spec formula is catalogued', () => {
+    // The shipped spec has none — #929 moved the last three onto `{{word:…}}` — so this cannot be tested
+    // against it, and a guard nothing exercises is a guard nobody knows is broken. Feed it one.
+    const withProse = structuredClone(spec) as WorkbookSpec;
+    const scorecard = withProse.sheets[0].blocks.find((b) => b.cells?.some((c) => c.formula));
+    const cell = scorecard?.cells?.find((c) => c.formula);
+    if (!cell) throw new Error('no formula cell in the spec to extend — the fixture needs revisiting');
+    cell.formula = 'IF(1=1,"On track","At risk")';
+    const catalogue = translatableSet(withProse, schema);
+    expect(catalogue.has('On track')).toBe(true);
+    expect(catalogue.has('At risk')).toBe(true);
+    // And the operators around them are not mistaken for prose.
+    expect(catalogue.has('1=1')).toBe(false);
+  });
+
   test('a NoteSource discriminator is not prose', () => {
     // `note: "elementDefinition"` names which note to hang. My first extraction counted it, which would
     // have produced a locale entry for a type tag — invisible, and indistinguishable from coverage.

--- a/plugins/meddpicc/engine/translatable.test.ts
+++ b/plugins/meddpicc/engine/translatable.test.ts
@@ -81,6 +81,20 @@ describe('the catalogue is proven against a workbook, not against my reading of 
     }
   });
 
+  test("a sheet's tab name is catalogued even when it does not match its title", () => {
+    // The shipped spec names its sheet exactly what its title block says, so the two checks above passed
+    // whether or not tab names were collected — the oracle found the string, having been handed it by the
+    // title. That is a coincidence, not coverage, and review caught it. Breaking the coincidence is the
+    // only way to test the thing.
+    const renamed = structuredClone(spec) as WorkbookSpec;
+    renamed.sheets[0].name = 'Revue de transaction';
+    expect(translatableSet(renamed, schema).has('Revue de transaction')).toBe(true);
+    // And the shipped one still holds its own name, by that route rather than by the title's.
+    const titleless = structuredClone(spec) as WorkbookSpec;
+    titleless.sheets[0].blocks = titleless.sheets[0].blocks.filter((b) => b.kind !== 'title');
+    expect(translatableSet(titleless, schema).has('MEDDPICC Deal Review')).toBe(true);
+  });
+
   test('a NoteSource discriminator is not prose', () => {
     // `note: "elementDefinition"` names which note to hang. My first extraction counted it, which would
     // have produced a locale entry for a type tag — invisible, and indistinguishable from coverage.

--- a/plugins/meddpicc/engine/translatable.test.ts
+++ b/plugins/meddpicc/engine/translatable.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test';
+import * as path from 'node:path';
+import { planWorkbook } from './generate';
+import { isNonProse, translatableSet, translatableStrings } from './translatable';
+import type { WorkbookSpec } from './workbook-spec';
+
+const dir = path.join(import.meta.dir, '..');
+const spec = JSON.parse(await Bun.file(path.join(dir, 'engine', 'workbook-spec.json')).text()) as WorkbookSpec;
+const schema = JSON.parse(await Bun.file(path.join(dir, 'schema', 'meddpicc-schema.json')).text());
+const example = JSON.parse(await Bun.file(path.join(dir, 'schema', 'example-deal.json')).text());
+
+/**
+ * Every string a generated workbook shows that the ENGINE chose, not the deal.
+ *
+ * The exclusion is the whole difficulty. A workbook renders the rep's account name, deal name, prose,
+ * evidence and notes, and translating any of them would be corruption rather than localisation. So the
+ * subtraction is `plan.inputCells`, the map whose entire purpose is to say which cells hold a person's
+ * value — asked rather than guessed at.
+ */
+const renderedByEngine = (deal: unknown): Set<string> => {
+  const plan = planWorkbook(schema, spec, deal);
+  const dealCells = new Set(plan.inputCells.map((c) => `${c.sheet}!${c.address}`));
+  const out = new Set<string>();
+  const keep = (text: unknown): void => {
+    if (typeof text !== 'string' || text.trim() === '' || isNonProse(text)) return;
+    out.add(text);
+  };
+  for (const sheet of plan.sheets) {
+    keep(sheet.name);
+    for (const row of sheet.rows) {
+      for (const cell of row.cells) {
+        if (dealCells.has(`${sheet.name}!${cell.ref}`)) continue;
+        // A formula's own string literals are rendered text, and skipping them was wrong. The rubric
+        // column is `IF(D20=4,"Committed — …",IF(D20=3,"Quantified — …",…))`: all five lines of every
+        // element's rubric live inside a formula so the cell follows the score live in Excel. They are
+        // the most prose-heavy text on the sheet and none of them is a cell value anywhere.
+        if (cell.formula !== undefined) {
+          for (const match of cell.formula.matchAll(/"((?:[^"]|"")*)"/g)) keep(match[1]?.replace(/""/g, '"'));
+          continue;
+        }
+        keep(cell.value);
+      }
+    }
+    for (const validation of sheet.validations ?? []) for (const value of validation.values) keep(value);
+  }
+  for (const note of plan.notes) keep(note.text);
+  return out;
+};
+
+describe('the catalogue is proven against a workbook, not against my reading of the code', () => {
+  test('every string the engine renders is in the catalogue', () => {
+    // The check that cannot miss a source, because it does not depend on knowing what the sources are.
+    // Three hand-written enumerations of this list were wrong before it existed.
+    const catalogue = translatableSet(spec, schema);
+    const missing = [...renderedByEngine(example)].filter((text) => !catalogue.has(text));
+    expect(missing).toEqual([]);
+  });
+
+  test('the catalogue holds nothing the workbook does not show', () => {
+    // The other direction, so the catalogue cannot pass the first test by containing everything. A
+    // surplus entry is a translation nobody reads, and it looks exactly like coverage.
+    const rendered = renderedByEngine(example);
+    const surplus = [...translatableSet(spec, schema)].filter((text) => !rendered.has(text));
+    expect(surplus).toEqual([]);
+  });
+
+  test('a deal-supplied value is never in the catalogue', () => {
+    // Localising an account name would be corrupting the deal, not translating the sheet.
+    const deal = structuredClone(example);
+    deal.metadata.accountName = 'Zzyzx Holdings Kommanditgesellschaft';
+    deal.metadata.dealName = 'Qwertyuiop Platform Refresh';
+    deal.qualification.metrics.evidence = 'Xyzzy plugh, per the CTO';
+    const catalogue = translatableSet(spec, schema);
+    for (const value of [deal.metadata.accountName, deal.metadata.dealName, deal.qualification.metrics.evidence]) {
+      expect(catalogue.has(value), value).toBe(false);
+    }
+    // And the oracle agrees: those strings are rendered, but not by the engine.
+    const rendered = renderedByEngine(deal);
+    for (const value of [deal.metadata.accountName, deal.qualification.metrics.evidence]) {
+      expect(rendered.has(value), value).toBe(false);
+    }
+  });
+
+  test('a NoteSource discriminator is not prose', () => {
+    // `note: "elementDefinition"` names which note to hang. My first extraction counted it, which would
+    // have produced a locale entry for a type tag — invisible, and indistinguishable from coverage.
+    expect(translatableSet(spec, schema).has('elementDefinition')).toBe(false);
+  });
+
+  test('the count comes from the function, and every source contributes', () => {
+    // Published numbers get stale; this one is computed. The per-source tally is here because each of the
+    // six was a miss at some point, and a source silently contributing nothing is how it would recur.
+    const catalogue = translatableStrings(spec, schema);
+    const bySource = new Map<string, number>();
+    for (const sources of catalogue.values()) {
+      for (const source of sources) bySource.set(source, (bySource.get(source) ?? 0) + 1);
+    }
+    for (const source of ['spec', 'schema', 'enum', 'label', 'boolean', 'section']) {
+      expect(bySource.get(source) ?? 0, source).toBeGreaterThan(0);
+    }
+    // The schema-derived strings were the largest miss: 8 definitions, 16 questions, 40 rubric lines.
+    expect(bySource.get('schema')).toBe(64);
+    expect(catalogue.size).toBe(199);
+  });
+});

--- a/plugins/meddpicc/engine/translatable.test.ts
+++ b/plugins/meddpicc/engine/translatable.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import * as path from 'node:path';
-import { planWorkbook } from './generate';
+import { FALLBACK_HEADER, planWorkbook } from './generate';
 import { isNonProse, translatableSet, translatableStrings } from './translatable';
 import type { WorkbookSpec } from './workbook-spec';
 
@@ -43,7 +43,43 @@ const renderedByEngine = (deal: unknown): Set<string> => {
     }
     for (const validation of sheet.validations ?? []) for (const value of validation.values) keep(value);
   }
+  // The print header, whose parts are mostly the deal's own — account name, deal name, id. Position
+  // cannot separate those from the engine's fallback the way `inputCells` separates cells, so they are
+  // excluded by value: a header part equal to something a deal-derived cell holds is the deal's.
+  const dealValues = new Set<string>();
+  for (const sheet of plan.sheets) {
+    for (const row of sheet.rows) {
+      for (const cell of row.cells) {
+        if (dealCells.has(`${sheet.name}!${cell.ref}`) && typeof cell.value === 'string') dealValues.add(cell.value);
+      }
+    }
+  }
+  for (const sheet of plan.sheets) {
+    for (const part of sheet.print?.header ?? []) if (!dealValues.has(part)) keep(part);
+  }
   for (const note of plan.notes) keep(note.text);
+  return out;
+};
+
+/** A deal that names nothing, so the engine's fallback header is the one that prints. */
+const anonymousDeal = (): unknown => {
+  const deal = structuredClone(example);
+  deal.metadata.accountName = '';
+  deal.metadata.dealName = '';
+  deal.metadata.dealId = '';
+  return deal;
+};
+
+/**
+ * Everything reachable across the deals that between them exercise each branch.
+ *
+ * One deal is not enough, and pretending otherwise would make the surplus check lie. The header is the
+ * clearest case: it prints the deal's own identifiers, and the engine's fallback only when the deal names
+ * nothing. Two deals cover both.
+ */
+const reachable = (): Set<string> => {
+  const out = new Set<string>();
+  for (const deal of [example, anonymousDeal()]) for (const text of renderedByEngine(deal)) out.add(text);
   return out;
 };
 
@@ -52,16 +88,35 @@ describe('the catalogue is proven against a workbook, not against my reading of 
     // The check that cannot miss a source, because it does not depend on knowing what the sources are.
     // Three hand-written enumerations of this list were wrong before it existed.
     const catalogue = translatableSet(spec, schema);
-    const missing = [...renderedByEngine(example)].filter((text) => !catalogue.has(text));
+    const missing = [...reachable()].filter((text) => !catalogue.has(text));
     expect(missing).toEqual([]);
   });
 
   test('the catalogue holds nothing the workbook does not show', () => {
     // The other direction, so the catalogue cannot pass the first test by containing everything. A
     // surplus entry is a translation nobody reads, and it looks exactly like coverage.
-    const rendered = renderedByEngine(example);
+    const rendered = reachable();
     const surplus = [...translatableSet(spec, schema)].filter((text) => !rendered.has(text));
     expect(surplus).toEqual([]);
+  });
+
+  test("the printed header the engine falls back to is catalogued, and the deal's own parts are not", () => {
+    // Another string masked by a coincidence: FALLBACK_HEADER is spelled exactly like the title and the
+    // sheet name, so the checks above passed without ever scanning a print header. Review caught it after
+    // the same bug in the tab name — one instance fixed is not the class swept.
+    const anonymous = renderedByEngine(anonymousDeal());
+    expect(anonymous.has(FALLBACK_HEADER)).toBe(true);
+    // Asserted on the SOURCE, not on presence. `FALLBACK_HEADER` is spelled exactly like the title and
+    // the sheet name, so the string is in the catalogue whether or not the header is a source — a
+    // presence check here passes with the header source deleted, which is how the same coincidence
+    // defeated this test's first version. The source set is what distinguishes them.
+    expect([...(translatableStrings(spec, schema).get(FALLBACK_HEADER) ?? [])]).toContain('header');
+    // With identifiers present the header is the deal's, and none of it is the engine's to translate.
+    const named = structuredClone(example);
+    named.metadata.accountName = 'Zzyzx Holdings';
+    named.metadata.dealName = 'Qwertyuiop Refresh';
+    expect(renderedByEngine(named).has('Zzyzx Holdings')).toBe(false);
+    expect(renderedByEngine(named).has('Qwertyuiop Refresh')).toBe(false);
   });
 
   test('a deal-supplied value is never in the catalogue', () => {

--- a/plugins/meddpicc/engine/translatable.ts
+++ b/plugins/meddpicc/engine/translatable.ts
@@ -1,0 +1,163 @@
+/**
+ * Every string the engine chooses to put on the sheet.
+ *
+ * Localisation needs this list, and three attempts at writing it down by reading the code produced three
+ * different answers — 129, then 198, then 199 — each wrong in a way nothing could catch, because there
+ * was nothing to check against. The misses were not exotic: 64 schema-derived strings that carry the
+ * questions and the rubric, six element names living only in `SECTION_LABELS`, and the two words every
+ * boolean dropdown offers. One false positive too: `note: "elementDefinition"` is a `NoteSource`
+ * discriminator, not prose, and a key-name heuristic cannot tell a type tag from text.
+ *
+ * So this module declares the sources, and `translatable.test.ts` proves the declaration exhaustive
+ * against a generated workbook rather than against my reading of the code. The count that gets published
+ * is whatever this returns.
+ *
+ * What is NOT here: anything the deal supplies. An account name is rendered and must never be
+ * translated, which is the distinction the oracle draws using `plan.inputCells` — the map that exists to
+ * say which cells hold a person's value.
+ */
+import { BOOLEAN_NO, BOOLEAN_YES } from './generate';
+import { ENUM_LABELS, enumLabel } from './labels';
+import { schemaConstraint } from './schema-path';
+import { QUALIFICATION_ELEMENTS, SECTION_LABELS } from './sections';
+import type { WorkbookSpec } from './workbook-spec';
+
+/** Where a translatable string comes from, which is also what has to be re-read when it changes. */
+export type TranslatableSource =
+  /** `text`, `label`, `title` or `header` in the workbook spec. */
+  | 'spec'
+  /** An element's definition, questions, or one line of its rubric — all from the schema. */
+  | 'schema'
+  /** A value some dropdown offers, as the sheet spells it. */
+  | 'enum'
+  /** A snake_case token's display form, from `ENUM_LABELS`. */
+  | 'label'
+  /** `Yes` or `No`. */
+  | 'boolean'
+  /** An element or section name, from `SECTION_LABELS`. */
+  | 'section';
+
+/**
+ * Keys that carry a string which is NOT prose.
+ *
+ * `note` names which note to hang (`NoteSource`), so translating it would produce an entry nothing
+ * displays — and, worse, would look like coverage.
+ */
+const NON_PROSE_KEYS = new Set(['note', 'kind', 'id', 'role', 'valueType', 'conditionalFormat', 'shadeWhenEmpty']);
+
+/** Keys in the workbook spec whose string value the sheet shows. */
+const PROSE_KEYS = ['text', 'label', 'title', 'header'] as const;
+
+/**
+ * The locale enum is identifiers, not prose.
+ *
+ * A locale slug is chosen by a rep from a list of languages, but the value that lands in the deal is
+ * `pt-br` — translating it would mean writing a workbook that asks for a locale that does not exist.
+ */
+const IDENTIFIER_ENUM_PATHS = new Set(['metadata.locale']);
+
+/** Every dotted path in the schema whose node carries an enum, with the path so a caller can exclude one. */
+function enumPaths(schema: unknown): Map<string, readonly string[]> {
+  const out = new Map<string, readonly string[]>();
+  const walk = (node: unknown, dotted: string): void => {
+    if (!node || typeof node !== 'object') return;
+    const n = node as Record<string, unknown>;
+    if (Array.isArray(n.enum)) {
+      const values = n.enum.filter((v): v is string => typeof v === 'string');
+      if (values.length > 0) out.set(dotted, values);
+    }
+    for (const [key, value] of Object.entries(n)) {
+      // `enum`, `const` and `default` hold data, not subschemas: a score table under `default` has keys
+      // "0" to "4", and descending into it reports those as schema paths.
+      if (key === 'enum' || key === 'const' || key === 'default') continue;
+      if (key === 'properties' || key === '$defs' || key === 'definitions') {
+        if (value && typeof value === 'object') {
+          for (const [name, sub] of Object.entries(value)) walk(sub, dotted ? `${dotted}.${name}` : name);
+        }
+        continue;
+      }
+      // An array's members live at the array's own path, which is how `schemaConstraint` reads it too.
+      if (key === 'items') walk(value, dotted);
+      else if (value && typeof value === 'object' && !Array.isArray(value)) walk(value, dotted);
+    }
+  };
+  walk(schema, '');
+  return out;
+}
+
+/**
+ * The catalogue: every string the engine renders, with every source that renders it.
+ *
+ * A string can have more than one source — `Close Plan` is both a spec heading and a `SECTION_LABELS`
+ * entry — and that matters, because changing either place has to invalidate the same translation.
+ */
+export function translatableStrings(spec: WorkbookSpec, schema: unknown): Map<string, Set<TranslatableSource>> {
+  const out = new Map<string, Set<TranslatableSource>>();
+  const add = (text: unknown, source: TranslatableSource): void => {
+    if (typeof text !== 'string' || text.trim() === '') return;
+    const sources = out.get(text) ?? new Set<TranslatableSource>();
+    sources.add(source);
+    out.set(text, sources);
+  };
+
+  const walkSpec = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) walkSpec(item);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const n = node as Record<string, unknown>;
+    for (const key of PROSE_KEYS) add(n[key], 'spec');
+    for (const [key, value] of Object.entries(n)) {
+      if (NON_PROSE_KEYS.has(key)) continue;
+      if (typeof value === 'object') walkSpec(value);
+    }
+  };
+  walkSpec(spec);
+
+  // The element text lives in the schema as `const` and `default`, so it is documentation and rendered
+  // content at once — the sheet shows every word of it.
+  const qualification = (schema as { properties?: { qualification?: { properties?: Record<string, unknown> } } })
+    ?.properties?.qualification?.properties;
+  for (const element of QUALIFICATION_ELEMENTS) {
+    const node = qualification?.[element] as { properties?: Record<string, Record<string, unknown>> } | undefined;
+    const properties = node?.properties;
+    add(properties?.definition?.const, 'schema');
+    for (const question of (properties?.questions?.default as unknown[]) ?? []) add(question, 'schema');
+    for (const line of Object.values((properties?.scoreDefinition?.default as Record<string, unknown>) ?? {})) {
+      add(line, 'schema');
+    }
+  }
+
+  for (const [path, values] of enumPaths(schema)) {
+    if (IDENTIFIER_ENUM_PATHS.has(path)) continue;
+    for (const value of values) add(enumLabel(value), 'enum');
+  }
+
+  // A token's display form. Every one of these is also an enum member, so this source exists to say that
+  // editing the label table changes the sheet — not to add strings the enums missed.
+  for (const label of Object.values(ENUM_LABELS)) add(label, 'label');
+
+  add(BOOLEAN_YES, 'boolean');
+  add(BOOLEAN_NO, 'boolean');
+
+  for (const label of Object.values(SECTION_LABELS)) add(label, 'section');
+
+  return out;
+}
+
+/** Whether a rendered string is a number, an operator, or punctuation rather than something to translate. */
+export function isNonProse(text: string): boolean {
+  return /^[\s<>=0-9.%,()/:+-]*$/.test(text);
+}
+
+/** Convenience for callers that only need the strings. `schemaConstraint` is re-exported nowhere; this is. */
+export function translatableSet(spec: WorkbookSpec, schema: unknown): Set<string> {
+  return new Set(translatableStrings(spec, schema).keys());
+}
+
+/** The enum values a dotted schema path offers as the sheet spells them, or undefined when it has none. */
+export function displayedEnumAt(schema: unknown, dotted: string): Set<string> | undefined {
+  const values = schemaConstraint(schema, dotted)?.enum;
+  return values ? new Set(values.map(enumLabel)) : undefined;
+}

--- a/plugins/meddpicc/engine/translatable.ts
+++ b/plugins/meddpicc/engine/translatable.ts
@@ -110,6 +110,16 @@ export function translatableStrings(spec: WorkbookSpec, schema: unknown): Map<st
     if (!node || typeof node !== 'object') return;
     const n = node as Record<string, unknown>;
     for (const key of PROSE_KEYS) add(n[key], 'spec');
+    // A formula's string literals are rendered text — the cell shows whichever branch wins. There are
+    // none in the shipped spec, because #929 moved the last three onto `{{word:…}}` references, so this
+    // collects nothing today. It is here because a future `IF(…,"On track","At risk")` would otherwise
+    // render English that the catalogue never heard of, and the completeness checks would still pass.
+    if (typeof n.formula === 'string') {
+      for (const match of n.formula.matchAll(/"((?:[^"]|"")*)"/g)) {
+        const literal = match[1]?.replace(/""/g, '"');
+        if (literal !== undefined && !isNonProse(literal)) add(literal, 'spec');
+      }
+    }
     for (const [key, value] of Object.entries(n)) {
       if (NON_PROSE_KEYS.has(key)) continue;
       if (typeof value === 'object') walkSpec(value);

--- a/plugins/meddpicc/engine/translatable.ts
+++ b/plugins/meddpicc/engine/translatable.ts
@@ -16,7 +16,7 @@
  * translated, which is the distinction the oracle draws using `plan.inputCells` — the map that exists to
  * say which cells hold a person's value.
  */
-import { BOOLEAN_NO, BOOLEAN_YES } from './generate';
+import { BOOLEAN_NO, BOOLEAN_YES, FALLBACK_HEADER } from './generate';
 import { ENUM_LABELS, enumLabel } from './labels';
 import { schemaConstraint } from './schema-path';
 import { QUALIFICATION_ELEMENTS, SECTION_LABELS } from './sections';
@@ -35,7 +35,9 @@ export type TranslatableSource =
   /** `Yes` or `No`. */
   | 'boolean'
   /** An element or section name, from `SECTION_LABELS`. */
-  | 'section';
+  | 'section'
+  /** The printed header the engine supplies when the deal names nothing. */
+  | 'header';
 
 /**
  * Keys that carry a string which is NOT prose.
@@ -147,6 +149,12 @@ export function translatableStrings(spec: WorkbookSpec, schema: unknown): Map<st
 
   add(BOOLEAN_YES, 'boolean');
   add(BOOLEAN_NO, 'boolean');
+
+  // The printed header. Its parts are the deal's own account name, deal name and id — never translated —
+  // except when the deal names none of them, where the engine supplies this instead. Unreachable from a
+  // valid deal since #901 bounded all three identity fields, but `planWorkbook` does not validate, so a
+  // caller that plans an unvalidated deal still prints it.
+  add(FALLBACK_HEADER, 'header');
 
   for (const label of Object.values(SECTION_LABELS)) add(label, 'section');
 

--- a/plugins/meddpicc/engine/translatable.ts
+++ b/plugins/meddpicc/engine/translatable.ts
@@ -115,6 +115,13 @@ export function translatableStrings(spec: WorkbookSpec, schema: unknown): Map<st
   };
   walkSpec(spec);
 
+  // A sheet's name is its Excel tab, which is rendered text — and it is deliberately NOT collected by the
+  // walk above, because `name` is a common key on things that are not prose. The shipped spec happens to
+  // name its one sheet exactly what its title block says, so a catalogue that missed tab names looked
+  // complete: the oracle found the string, having been given it by the title. Review caught that; a
+  // custom spec with a distinct sheet name would have shipped an untranslated tab.
+  for (const sheet of spec.sheets) add(sheet.name, 'spec');
+
   // The element text lives in the schema as `const` and `default`, so it is documentation and rendered
   // content at once — the sheet shows every word of it.
   const qualification = (schema as { properties?: { qualification?: { properties?: Record<string, unknown> } } })

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
## What this does

Closes #931. The engine can now enumerate the text it renders, and prove the list complete.

Localisation (#925) needs that list. I tried three times to write it by reading the code and produced
three different answers — 129, then 198, then 199 — each wrong in a way nothing could catch, because
there was nothing to check it against.

## The test is the deliverable, not the module

`engine/translatable.ts` declares seven sources and returns every string the engine chooses to render,
with which source each came from. **199 strings**, and the number comes from running it.

The test generates a workbook, extracts every string it shows, and asserts the catalogue covers exactly
that — nothing missing, nothing surplus. It cannot miss a source, because it does not depend on knowing
what the sources are.

That needs an exclusion contract, and getting it right was most of the work:

- **Deal-supplied values are not ours.** An account name is rendered; translating it would corrupt the
  deal. `plan.inputCells` is asked rather than guessed at, since saying which cells hold a person's value
  is the only reason it exists.
- **A formula's string literals are rendered text.** The "What This Score Means" column is
  `IF(D20=4,"Committed — …",IF(D20=3,"Quantified — …",…))` — **all 40 rubric lines live inside formulas**
  so the cell follows the score live in Excel. They are the most prose-heavy content on the sheet and not
  one is a cell value anywhere. My first oracle skipped formula cells and declared the catalogue complete.
- **One deal is not enough.** The print header shows the deal's own identifiers, and the engine's fallback
  only when the deal names nothing, so coverage unions over a named deal and an anonymous one.
- `note: "elementDefinition"` is excluded by name: `NoteSource` is a discriminator, and a key-name
  heuristic cannot tell a type tag from prose.

## What review found, three rounds of one class

Every round found text the walker did not look at, and all three were hidden by the same coincidence:
**`FALLBACK_HEADER`, the sheet's tab name and the title block all spell `MEDDPICC Deal Review`.** None of
them being catalogued was visible while any one of them was.

1. **Tab names.** `PROSE_KEYS` has no `name` — deliberately, since `name` is a common key on things that
   are not prose — so tab names were never collected. Proven by breaking the coincidence: renaming the
   sheet and asking the catalogue returned false.
2. **The print header.** Never scanned at all. Fixing the tab name was fixing an instance, not sweeping
   the class; the sweep is now every text-bearing field a `SheetSpec` has — name, cell values, formula
   literals, validations, `print.header`, notes.
3. **Prose in a spec formula.** Zero today, because #929 moved the last three onto `{{word:…}}`. So the
   guard was absent rather than wrong, and the finding is about what ships next.

**My own mutation test for finding 2 survived at first.** Deleting the header source left the string in
the catalogue anyway — the title had already contributed it — so a presence check proved nothing. The
assertion moved to the source set, which is what the source map is for, and both that mutation and the
tab-name one now fail as they should.

## Also

A comment in `presentation()` claimed the schema "requires all three of these but bounds none of them".
**#901 made that false** — all three identity fields now carry `minLength` and a non-blank `pattern` — so
`FALLBACK_HEADER` is no longer reachable from a valid deal, only through `planWorkbook`, which takes
`deal: unknown` and does not validate. Corrected rather than left to mislead the next reader.

## Verification

- **498 engine tests**, 39 shell tests. `biome ci`, `markdownlint`, `codespell`, `textlint` clean.
- **6 mutations, 6 killed**: dropping a source, dropping the element definitions, an entry nothing
  renders, the sheet-name source, the header source, and the spec-formula collection. Two of them
  survived a first, weaker assertion — recorded above rather than quietly strengthened.
- **English output is unchanged.** Every OOXML part byte-equal to `origin/main` except
  `docProps/custom.xml`, which carries the version bump. This adds a module and its tests; no generation
  path changed behaviour.

**v7.1.0** — additive.
