### PR TITLE
docs(salesforce): label the changelog entry v1.3.5, the version that shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-- **`salesforce`** bumped to v1.3.5
-
-- **`salesforce`** v1.3.4 — schema is discovered at runtime instead of guessed, and a rejected column
+- **`salesforce`** v1.3.5 — schema is discovered at runtime instead of guessed, and a rejected column
   now says which one. Three defects compounded into a query the agent could not recover from.
 
   The query prompt told the model to read `Opportunity.CompetitorName`, which exists on no org — it


### PR DESCRIPTION
Fixes #939

## What was wrong

The published `salesforce/v1.3.5` release notes contradict themselves:

```
$ gh release view salesforce/v1.3.5 --json body
- **`salesforce`** bumped to v1.3.5
- **`salesforce`** v1.3.4 — schema is discovered at runtime instead of guessed, and a rejected column
```

Two entries for one release, and the only descriptive one is labelled **v1.3.4** — a version with no tag, no release, and no way to install it. Every manifest (`marketplace.json`, `plugin.json`, `package.json`) says `1.3.5`.

## Cause

The version-bump hook fires once per commit. #934 landed two commits — the feature, then a round of review fixes — so it bumped 1.3.3 → 1.3.4 → 1.3.5 and appended a fresh `bumped to v1.3.5` placeholder on the second pass. The prose entry written against the first commit was never relabelled, and the placeholder was never folded into it.

My own error, and a specific one: I confirmed the pre-commit hooks *passed* without checking what they *wrote*. The version bump is a mutating hook; I treated it as a validator.

## Fix

Collapse the placeholder into the prose entry, labelled v1.3.5. Release metadata only — no behaviour change.

Emulating the workflow's own extraction (`sed -n '/^## \[/,/^## \[/{//!p}' | head -20 | grep -i salesforce`) against the fixed file:

```
- **`salesforce`** v1.3.5 — schema is discovered at runtime instead of guessed, and a rejected column

(1 line matched — 1 expected, and it says v1.3.5)
```

## Verification of the shipped behaviour

Prompted by a challenge to my earlier claim: my #934 UAT ran against the **source tree**, not the published artifact. I have now done the latter. The installed plugin was five versions stale (1.3.0), so it had never exercised the fix at all.

```
$ xcsh plugin upgrade salesforce@f5-sales-demo-marketplace
Upgraded salesforce@f5-sales-demo-marketplace (user) to 1.3.5

$ cd ~/.xcsh/plugins/cache/plugins/f5-sales-demo-marketplace___salesforce___1.3.5
$ bun test                                → 263 pass, 0 fail
$ bun run scripts/tests/live-uat.ts f5    → all 16 checks passed
```

The original failing query, verbatim, through the installed artifact:

```
sf CLI error (exit 1): No such column 'LeadSource' on entity 'Opportunity'. ... [ERROR at Row:1:Column:78]

Field and object names vary by org — confirm them with sf_describe before retrying,
e.g. sf_describe {sobject: "Opportunity", match: "competitor"}.

(original caret block retained below)

errorType = invalid_query
```

Post-merge CI on `main` for #934 also verified green after the fact: `Release Plugins` and `Validate Plugins` both succeeded on `9b91366`.

## Follow-up worth considering

`release-plugins.yml` builds its body with `head -20 | grep -i "$NAME"`, which silently concatenated a placeholder and a prose entry into one release note and never noticed the version mismatch against the tag it was cutting. Failing — or at least warning — on more than one match, or on an entry whose version does not match the tag, would have caught this before publication. Noted in #939 rather than changed here, since it touches release machinery beyond this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
