### PR TITLE
MEDDPICC: decide the locale once, early, from every input (v7.2.0)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ and this project adheres to
   unsupported one arrived after all the layout work, and a rep whose machine is in Japanese had no way to
   ask for anything else.
 
-  - **Precedence**: `--locale` > `metadata.locale` > `MEDDPICC_LOCALE` > `LC_ALL` > `LANG` > macOS
-    `AppleLocale` > `en`. `LC_ALL` before `LANG`, because that is what POSIX means by it.
+  - **Precedence**: `--locale` > `metadata.locale` > `MEDDPICC_LOCALE` > `LC_ALL` > `LC_MESSAGES` > `LANG`
+    > macOS `AppleLocale` > `en`. That is POSIX order for the language of user-facing messages, which is
+    what a workbook's text is: `LC_ALL` overrides everything, `LC_MESSAGES` governs the message category,
+    `LANG` is the default for every category.
   - **Normalization**: `fr_CA.UTF-8@euro` → `fr-ca` → French, once French ships. Canonical form is the
     lowercase slug — `pt-br`, `zh-cn` — matching the schema enum and i18n-core's `slug`, not BCP-47's
     `pt-BR`, because two spellings of one locale is how a workbook records one nothing recognises.
@@ -33,6 +35,10 @@ and this project adheres to
     test caught: `generateWorkbook` without a locale would have stamped English over a deal explicitly
     asking for Korean, which is worse than the refusal it replaced. It now refuses when the two disagree —
     not resolving twice, but checking that whoever resolved honoured the deal.
+  - **Also fixed, and wider than the locale**: `flag()` matched `--out deal.xlsx` and not
+    `--out=deal.xlsx`, for every flag the CLI has, so `--out=path` wrote to the default path with exit 0
+    and nothing said. One parser now reads both spellings, refuses a flag given twice or given nothing, and
+    treats a following flag as no value rather than as the value.
   - **Not in this change**: the locale is not yet threaded into `planWorkbook`. It has nothing to do there
     until translated strings exist, and a parameter nothing reads would be speculative. It lands with the
     loader.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v7.2.0 — the locale is decided once, early, from every input. `generate` takes
+  `--locale`. English output is unchanged, because English is still what everything resolves to.
+
+  It used to be decided inside `workbookProperties`, which runs *after* the sheet is laid out, and from
+  one input: `metadata.locale`. So nothing in planning could know the locale, the refusal for an
+  unsupported one arrived after all the layout work, and a rep whose machine is in Japanese had no way to
+  ask for anything else.
+
+  - **Precedence**: `--locale` > `metadata.locale` > `MEDDPICC_LOCALE` > `LC_ALL` > `LANG` > macOS
+    `AppleLocale` > `en`. `LC_ALL` before `LANG`, because that is what POSIX means by it.
+  - **Normalization**: `fr_CA.UTF-8@euro` → `fr-ca` → French, once French ships. Canonical form is the
+    lowercase slug — `pt-br`, `zh-cn` — matching the schema enum and i18n-core's `slug`, not BCP-47's
+    `pt-BR`, because two spellings of one locale is how a workbook records one nothing recognises.
+    Chinese resolves by script where given and by region otherwise: `zh_Hant_TW` and `zh_TW` → `zh-tw`,
+    bare `zh` → `zh-cn`.
+  - **Explicit and ambient failures are opposites.** `--locale ko` is refused and names what is shipped —
+    somebody asked for something specific. `LANG=is_IS` falls back to English silently, because a rep
+    wants a workbook, not a lecture about Icelandic. Same unsupported locale, opposite right answers,
+    which is why one function decides.
+  - **The stamp must agree with the deal.** Moving resolution to the caller opened a hole a pre-existing
+    test caught: `generateWorkbook` without a locale would have stamped English over a deal explicitly
+    asking for Korean, which is worse than the refusal it replaced. It now refuses when the two disagree —
+    not resolving twice, but checking that whoever resolved honoured the deal.
+  - **Not in this change**: the locale is not yet threaded into `planWorkbook`. It has nothing to do there
+    until translated strings exist, and a parameter nothing reads would be speculative. It lands with the
+    loader.
+
 - **`meddpicc`** v7.1.0 — the engine can enumerate the text it renders, and prove the list complete.
   Additive: a new module and its tests, no generation path touched.
 

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -392,6 +392,23 @@ describe('--locale', () => {
     expect(mixed.err).toMatch(/once/);
   });
 
+  test('no flag may be given without a value, not only the locale', async () => {
+    // The strict checks lived in a second function that only the newest flag called, so `--spec` with
+    // nothing after it built from the DEFAULT spec and exited 0 — a plausible workbook from the wrong
+    // layout. Every value-flag goes through one parser now.
+    for (const args of [
+      ['generate', example, '--spec', '--locale', 'en', '--plan'],
+      ['generate', example, '--out'],
+      ['check-spec', '--schema'],
+    ]) {
+      const { code, err } = await run(args);
+      expect(code, args.join(' ')).toBe(1);
+      expect(err, args.join(' ')).toMatch(/no value/);
+    }
+    // And a well-formed request still works, so the parser has not simply become hostile.
+    expect((await run(['generate', example, '--plan'])).code).toBe(0);
+  });
+
   test('the locale a workbook is written in is the one it records', async () => {
     const out = path.join(scratch, 'stamped.xlsx');
     const { code } = await run(['generate', example, '--locale', 'en', '--out', out]);

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -45,11 +45,13 @@ function legacyDeal(name: string): string {
   return at;
 }
 
-async function run(args: string[]): Promise<{ code: number; out: string }> {
+async function run(args: string[]): Promise<{ code: number; out: string; err: string }> {
   const proc = Bun.spawn(['bun', path.join(engineDir, 'cli.ts'), ...args], { stdout: 'pipe', stderr: 'pipe' });
-  const out = await new Response(proc.stdout).text();
+  // Both streams, because a refusal that does not say what was wrong with the request is barely a refusal,
+  // and the message is what a rep reads. `stderr` was being piped and then dropped.
+  const [out, err] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
   const code = await proc.exited;
-  return { code, out };
+  return { code, out, err };
 }
 
 describe('cli', () => {
@@ -328,5 +330,48 @@ describe('cli migrate', () => {
 
   test('migrate without a deal exits 1', async () => {
     expect((await run(['migrate'])).code).toBe(1);
+  });
+});
+
+describe('--locale', () => {
+  test('an explicit locale is validated on every path, not only the one that writes', () => {
+    // `--plan --locale ko` used to exit 0 while the same request on the writing path was refused, because
+    // resolution sat after the early returns. So whether an explicit locale was checked depended on which
+    // other flag came with it. Review caught it.
+    return (async () => {
+      for (const extra of [['--plan'], ['--prose-heights'], []]) {
+        const out = path.join(scratch, `loc-${extra.length}.xlsx`);
+        const args = ['generate', example, ...extra, '--locale', 'ko'];
+        if (extra.length === 0) args.push('--out', out);
+        const { code, err } = await run(args);
+        expect(code, args.join(' ')).toBe(1);
+        expect(err, args.join(' ')).toMatch(/ko/);
+      }
+    })();
+  });
+
+  test('a locale flag with nothing after it is refused, not treated as absent', async () => {
+    // `flag()` returns undefined for both "not passed" and "passed with no value", so this wrote an English
+    // workbook while looking like it honoured a request. An explicit request is honoured or refused.
+    const bare = await run(['generate', example, '--locale']);
+    expect(bare.code).toBe(1);
+    expect(bare.err).toMatch(/--locale/);
+    // And with a following flag rather than a value, which is the same mistake spelled differently.
+    const swallowed = await run(['generate', example, '--locale', '--out', path.join(scratch, 'sw.xlsx')]);
+    expect(swallowed.code).toBe(1);
+    expect(fs.existsSync(path.join(scratch, 'sw.xlsx'))).toBe(false);
+  });
+
+  test('the locale a workbook is written in is the one it records', async () => {
+    const out = path.join(scratch, 'stamped.xlsx');
+    const { code } = await run(['generate', example, '--locale', 'en', '--out', out]);
+    expect(code).toBe(0);
+    // Round-tripped rather than trusting the exit code: the recorded locale is what the reader uses, so a
+    // workbook that reads back clean is one whose stamp its own reader accepted.
+    const back = await run(['read', out, '--deal', example]);
+    const report = JSON.parse(back.out);
+    expect(report.valid).toBe(true);
+    expect(report.proposals).toEqual([]);
+    expect(report.rejections).toEqual([]);
   });
 });

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -409,6 +409,24 @@ describe('--locale', () => {
     expect((await run(['generate', example, '--plan'])).code).toBe(0);
   });
 
+  test('a misspelled flag is named, not ignored', async () => {
+    // The last way left to have a request ignored: `--local=ko` is a typo for `--locale=ko`, and a parser
+    // that only looks for names it knows saw no locale request — English, exit 0, a workbook contradicting
+    // what the command line plainly asked for.
+    for (const args of [
+      ['generate', example, '--local=ko', '--plan'],
+      ['generate', example, '--local', 'ko', '--plan'],
+      ['read', 'nonexistent.xlsx', '--dealx', example],
+    ]) {
+      const { code, err } = await run(args);
+      expect(code, args.join(' ')).toBe(1);
+      expect(err, args.join(' ')).toMatch(/Unknown option/);
+    }
+    // Real flags on those same commands are untouched, so the refusal has not become indiscriminate.
+    expect((await run(['generate', example, '--locale=en', '--plan'])).code).toBe(0);
+    expect((await run(['check-spec'])).code).toBe(0);
+  });
+
   test('the locale a workbook is written in is the one it records', async () => {
     const out = path.join(scratch, 'stamped.xlsx');
     const { code } = await run(['generate', example, '--locale', 'en', '--out', out]);

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -454,6 +454,23 @@ describe('--locale', () => {
     expect((await run(['migrate', deal, '--apply'])).code).toBe(0);
   });
 
+  test('a single dash is a typo too, not a positional argument', async () => {
+    // Checking only `--` let `-locale ko` and `-apply` through as arguments nothing reads: English output at
+    // exit 0, and for `migrate -apply` a dry run that automation would read as a completed migration. No
+    // path this CLI takes begins with a dash, so any leading dash is a flag or a mistake.
+    const deal = path.join(scratch, 'dash.json');
+    fs.copyFileSync(example, deal);
+    for (const args of [
+      ['generate', example, '-locale', 'ko', '--plan'],
+      ['migrate', deal, '-apply'],
+    ]) {
+      const { code, err } = await run(args);
+      expect(code, args.join(' ')).toBe(1);
+      expect(err, args.join(' ')).toMatch(/Unknown option/);
+    }
+    expect((await run(['generate', example, '--plan'])).code).toBe(0);
+  });
+
   test('the locale a workbook is written in is the one it records', async () => {
     const out = path.join(scratch, 'stamped.xlsx');
     const { code } = await run(['generate', example, '--locale', 'en', '--out', out]);

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -362,6 +362,18 @@ describe('--locale', () => {
     expect(fs.existsSync(path.join(scratch, 'sw.xlsx'))).toBe(false);
   });
 
+  test('an ambiguous or empty locale request is refused rather than guessed at', async () => {
+    // Both of these looked like they honoured a request and did not. Repeating the flag took the first and
+    // ignored the second, so automation appending an override got English while asking for Korean; and
+    // `--locale ""`, which is what an unset shell variable expands to, fell through to ambient resolution.
+    const twice = await run(['generate', example, '--locale', 'en', '--locale', 'ko']);
+    expect(twice.code).toBe(1);
+    expect(twice.err).toMatch(/once/);
+    const empty = await run(['generate', example, '--locale', '']);
+    expect(empty.code).toBe(1);
+    expect(empty.err).toMatch(/empty/);
+  });
+
   test('the locale a workbook is written in is the one it records', async () => {
     const out = path.join(scratch, 'stamped.xlsx');
     const { code } = await run(['generate', example, '--locale', 'en', '--out', out]);

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -427,6 +427,33 @@ describe('--locale', () => {
     expect((await run(['check-spec'])).code).toBe(0);
   });
 
+  test('a command only accepts the flags it actually reads', async () => {
+    // My own doing, one commit earlier: I allowlisted `--schema` for `generate` and `read` without checking
+    // that either consumes it. So `--schema=/missing` was accepted and ignored — the very defect the
+    // allowlist was added to close, reintroduced one layer up by declaring a flag speculatively.
+    const ignored = await run(['generate', example, '--schema=/missing', '--plan']);
+    expect(ignored.code).toBe(1);
+    expect(ignored.err).toMatch(/Unknown option/);
+    // `check-spec` does read it, so there it works.
+    expect(
+      (await run(['check-spec', '--schema', path.join(engineDir, '..', 'schema', 'meddpicc-schema.json')])).code,
+    ).toBe(0);
+  });
+
+  test('a switch takes no value, because its reader would not see one', async () => {
+    // Booleans are read with `includes`, which matches the bare token only. So `--apply=true` passed an
+    // allowlist keyed on the text before `=` and then did nothing: `migrate --apply=true` would have
+    // reported success having migrated no deal at all, which automation would believe.
+    const deal = path.join(scratch, 'switch.json');
+    fs.copyFileSync(example, deal);
+    const valued = await run(['migrate', deal, '--apply=true']);
+    expect(valued.code).toBe(1);
+    expect(valued.err).toMatch(/switch/);
+    expect((await run(['read', '/dev/null', '--apply=yes'])).code).toBe(1);
+    // And the switch on its own still works.
+    expect((await run(['migrate', deal, '--apply'])).code).toBe(0);
+  });
+
   test('the locale a workbook is written in is the one it records', async () => {
     const out = path.join(scratch, 'stamped.xlsx');
     const { code } = await run(['generate', example, '--locale', 'en', '--out', out]);

--- a/plugins/meddpicc/engine/cli.test.ts
+++ b/plugins/meddpicc/engine/cli.test.ts
@@ -374,6 +374,24 @@ describe('--locale', () => {
     expect(empty.err).toMatch(/empty/);
   });
 
+  test('both spellings of a flag are read, for every flag', async () => {
+    // `args.indexOf(name)` matched the separated form only, so `--out=deal.xlsx` was read as no `--out` and
+    // the default path used — silently, and for every flag, not only the locale. Four rounds of review found
+    // four holes in that parser one at a time, so the parser was replaced rather than patched again.
+    const out = path.join(scratch, 'equals.xlsx');
+    const written = await run(['generate', example, `--out=${out}`]);
+    expect(written.code).toBe(0);
+    expect(fs.existsSync(out), 'an --out=path must be honoured, not defaulted').toBe(true);
+    // The equals form is validated exactly like the separated one.
+    expect((await run(['generate', example, '--locale=ko', '--plan'])).code).toBe(1);
+    expect((await run(['generate', example, '--locale='])).code).toBe(1);
+    expect((await run(['generate', example, '--locale=en', '--plan'])).code).toBe(0);
+    // And duplicate detection sees across spellings, which is how a script's appended override slips in.
+    const mixed = await run(['generate', example, '--locale', 'en', '--locale=ko']);
+    expect(mixed.code).toBe(1);
+    expect(mixed.err).toMatch(/once/);
+  });
+
   test('the locale a workbook is written in is the one it records', async () => {
     const out = path.join(scratch, 'stamped.xlsx');
     const { code } = await run(['generate', example, '--locale', 'en', '--out', out]);

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -55,9 +55,31 @@ function print(data: unknown): void {
   process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
 }
 
+/**
+ * Every value given for a flag, in both spellings Unix accepts.
+ *
+ * `args.indexOf(name)` matched the separated form only, so `--out=deal.xlsx` was read as no `--out` at all
+ * and the default path used instead — silently, and for every flag, not just the one this change is about.
+ * Four rounds of review found four holes in that parser one at a time; parsing both forms once closes the
+ * class rather than the instance.
+ */
+function flagValues(args: string[], name: string): Array<string | undefined> {
+  const out: Array<string | undefined> = [];
+  for (const [i, arg] of args.entries()) {
+    if (arg === name) {
+      const next = args[i + 1];
+      // A following flag is not this flag's value; `--locale --out x` means `--locale` was given nothing.
+      out.push(next === undefined || next.startsWith('--') ? undefined : next);
+    } else if (arg.startsWith(`${name}=`)) {
+      out.push(arg.slice(name.length + 1));
+    }
+  }
+  return out;
+}
+
 function flag(args: string[], name: string): string | undefined {
-  const i = args.indexOf(name);
-  return i >= 0 ? args[i + 1] : undefined;
+  const values = flagValues(args, name);
+  return values.length === 0 ? undefined : values[values.length - 1];
 }
 
 /**
@@ -68,21 +90,21 @@ function flag(args: string[], name: string): string | undefined {
  * a request. Same principle as `resolveLocale`: an explicit request is honoured or refused, never ignored.
  */
 function requiredFlagValue(args: string[], name: string): string | undefined {
-  const positions = args.reduce<number[]>((all, arg, i) => (arg === name ? [...all, i] : all), []);
-  if (positions.length === 0) return undefined;
-  if (positions.length > 1) {
-    // `--locale en --locale ko` used to take the first and ignore the second, so a script appending an
+  const values = flagValues(args, name);
+  if (values.length === 0) return undefined;
+  if (values.length > 1) {
+    // `--locale en --locale=ko` used to take the first and ignore the second, so a script appending an
     // override got English while asking for Korean. There is no right answer to pick here — the request
     // is ambiguous, and guessing which half was meant is how the wrong one gets honoured silently.
-    throw new Error(`${name} was given ${positions.length} times. Pass it once.`);
+    throw new Error(`${name} was given ${values.length} times. Pass it once.`);
   }
-  const value = args[(positions[0] ?? 0) + 1];
-  if (value === undefined || value.startsWith('--')) {
+  const value = values[0];
+  if (value === undefined) {
     throw new Error(`${name} was given with no value. Pass one, or leave the flag off.`);
   }
   if (value.trim() === '') {
-    // `--locale ""` is what an unset shell variable expands to. Absent would be the kind reading, but the
-    // flag is present, so somebody meant to pass something and it evaporated — worth saying so.
+    // `--locale ""` and `--locale=` are what an unset shell variable expands to. Absent would be the kind
+    // reading, but the flag is present, so somebody meant to pass something and it evaporated.
     throw new Error(`${name} was given an empty value. Pass a locale, or leave the flag off.`);
   }
   return value;

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -90,6 +90,25 @@ function flagValues(args: string[], name: string): Array<string | undefined> {
  * checks belong in one place that every flag goes through, rather than in a second function only the newest
  * flag remembered to call.
  */
+/**
+ * Refuse an argument that looks like a flag and is not one this command has.
+ *
+ * The last way left to have a request ignored. `--local=ko` is a typo for `--locale=ko`, and a parser that
+ * only looks for names it knows sees no locale request at all — so generation falls back to English, exits
+ * 0, and produces a plausible workbook that contradicts what the command line plainly asked for.
+ *
+ * Seventh and last of the parser findings, all one mistake in different clothes: a malformed request treated
+ * as no request. Nothing can be ignored once every unrecognised flag is named.
+ */
+function refuseUnknownFlags(args: string[], known: readonly string[]): void {
+  const unknown = args.filter((arg) => arg.startsWith('--')).filter((arg) => !known.includes(arg.split('=')[0] ?? arg));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown ${unknown.length === 1 ? 'option' : 'options'} ${unknown.join(', ')}. This command takes ${known.join(', ')}.`,
+    );
+  }
+}
+
 function flag(args: string[], name: string): string | undefined {
   const values: Array<string | undefined> = [];
   for (const [i, arg] of args.entries()) {
@@ -187,6 +206,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'check-sfdc') {
+    refuseUnknownFlags(rest, ['--schema', '--sfdc']);
     const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
     const sfdc = await readJson(flag(rest, '--sfdc') ?? SFDC_PATH);
     const result = checkSfdcMapping(schema, sfdc);
@@ -195,6 +215,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'generate') {
+    refuseUnknownFlags(rest, ['--out', '--plan', '--prose-heights', '--spec', '--locale', '--schema']);
     const dealPath = rest[0];
     if (!dealPath) {
       process.stderr.write(
@@ -307,6 +328,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'read') {
+    refuseUnknownFlags(rest, ['--deal', '--apply', '--spec', '--schema']);
     const workbookPath = rest[0];
     const dealPath = flag(rest, '--deal');
     if (!workbookPath || !dealPath) {
@@ -359,6 +381,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'migrate') {
+    refuseUnknownFlags(rest, ['--apply']);
     const dealPath = rest[0];
     if (!dealPath) {
       process.stderr.write('Usage: cli.ts migrate <deal.json> [--apply]\n');
@@ -384,6 +407,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'check-spec') {
+    refuseUnknownFlags(rest, ['--spec', '--schema']);
     const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
     const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
     const result = checkWorkbookSpec(schema, spec);

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -61,6 +61,23 @@ function flag(args: string[], name: string): string | undefined {
 }
 
 /**
+ * A flag's value, refusing the flag with nothing after it.
+ *
+ * `flag()` returns undefined for both "not passed" and "passed with no value", and treating the second as
+ * the first means `generate deal.json --locale` writes an English workbook while looking like it honoured
+ * a request. Same principle as `resolveLocale`: an explicit request is honoured or refused, never ignored.
+ */
+function requiredFlagValue(args: string[], name: string): string | undefined {
+  const i = args.indexOf(name);
+  if (i < 0) return undefined;
+  const value = args[i + 1];
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`${name} was given with no value. Pass one, or leave the flag off.`);
+  }
+  return value;
+}
+
+/**
  * Refuse a deal that still uses the retired field names.
  *
  * The schema constrains no additional properties, so an old file validates cleanly while its
@@ -173,6 +190,11 @@ async function main(): Promise<number> {
     // with. Only Excel can say whether a computed height is enough — it autofits a wrapped cell but
     // not a merged one, and nearly every prose cell here is merged — so the acceptance test copies
     // each string into a scratch cell of the same width, autofits it, and compares.
+    // Resolved BEFORE the early returns below. `--plan --locale ko` used to exit 0 while the same request
+    // on the writing path was refused, so an explicit locale was validated or ignored depending on which
+    // flag came with it. Review caught that; the resolution belongs to the command, not to one branch.
+    const locale = resolveLocale({ flag: requiredFlagValue(rest, '--locale'), deal, env: process.env });
+
     if (rest.includes('--prose-heights')) {
       const plan = planWorkbook(schema, spec, deal);
       const heightOf = new Map<string, number>();
@@ -221,9 +243,6 @@ async function main(): Promise<number> {
       process.stderr.write('generate needs --out <file.xlsx> (or --plan to inspect the layout)\n');
       return 1;
     }
-    // Resolved once, here, before anything is planned: the flag, then the deal, then the environment.
-    // Deciding it deeper in the engine is what #938 fixed.
-    const locale = resolveLocale({ flag: flag(rest, '--locale'), deal, env: process.env });
     await Bun.write(outPath, generateWorkbook(schema, spec, deal, ENGINE_VERSION, locale));
     const plan = planWorkbook(schema, spec, deal);
     // Reported in the result, not thrown: a long note is not a reason to refuse a workbook. But a

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -77,35 +77,42 @@ function flagValues(args: string[], name: string): Array<string | undefined> {
   return out;
 }
 
-function flag(args: string[], name: string): string | undefined {
-  const values = flagValues(args, name);
-  return values.length === 0 ? undefined : values[values.length - 1];
-}
-
 /**
- * A flag's value, refusing the flag with nothing after it.
+ * The value given for a flag, refusing every way of asking for one and not supplying it.
  *
- * `flag()` returns undefined for both "not passed" and "passed with no value", and treating the second as
- * the first means `generate deal.json --locale` writes an English workbook while looking like it honoured
- * a request. Same principle as `resolveLocale`: an explicit request is honoured or refused, never ignored.
+ * Every flag here takes a value — the boolean ones are read with `includes` — so "present with nothing
+ * after it" is never a legitimate call. Collapsing it into "absent" is what let `generate deal.json --spec
+ * --locale en` build from the DEFAULT spec and exit 0, and `--out=path` write somewhere else entirely.
+ *
+ * Six rounds of review found six holes in the parser that used to be here, one at a time: the equals form,
+ * a repeated flag, an empty value, a following flag taken as the value, validation on only one code path,
+ * and finally this. They are all the same mistake — treating a malformed request as no request — so the
+ * checks belong in one place that every flag goes through, rather than in a second function only the newest
+ * flag remembered to call.
  */
-function requiredFlagValue(args: string[], name: string): string | undefined {
-  const values = flagValues(args, name);
+function flag(args: string[], name: string): string | undefined {
+  const values: Array<string | undefined> = [];
+  for (const [i, arg] of args.entries()) {
+    if (arg === name) {
+      const next = args[i + 1];
+      // A following flag is not this flag's value: `--spec --locale en` gave `--spec` nothing.
+      values.push(next === undefined || next.startsWith('--') ? undefined : next);
+    } else if (arg.startsWith(`${name}=`)) {
+      values.push(arg.slice(name.length + 1));
+    }
+  }
   if (values.length === 0) return undefined;
   if (values.length > 1) {
-    // `--locale en --locale=ko` used to take the first and ignore the second, so a script appending an
-    // override got English while asking for Korean. There is no right answer to pick here — the request
-    // is ambiguous, and guessing which half was meant is how the wrong one gets honoured silently.
+    // No right answer to guess at: `--locale en --locale=ko` is what a script appending an override looks
+    // like, and picking a half is how the wrong half gets honoured silently.
     throw new Error(`${name} was given ${values.length} times. Pass it once.`);
   }
   const value = values[0];
-  if (value === undefined) {
-    throw new Error(`${name} was given with no value. Pass one, or leave the flag off.`);
-  }
+  if (value === undefined) throw new Error(`${name} was given with no value. Pass one, or leave the flag off.`);
   if (value.trim() === '') {
-    // `--locale ""` and `--locale=` are what an unset shell variable expands to. Absent would be the kind
-    // reading, but the flag is present, so somebody meant to pass something and it evaporated.
-    throw new Error(`${name} was given an empty value. Pass a locale, or leave the flag off.`);
+    // `--locale ""` and `--locale=` are what an unset shell variable expands to. The flag is present, so
+    // somebody meant to pass something and it evaporated.
+    throw new Error(`${name} was given an empty value. Pass a value, or leave the flag off.`);
   }
   return value;
 }
@@ -226,7 +233,7 @@ async function main(): Promise<number> {
     // Resolved BEFORE the early returns below. `--plan --locale ko` used to exit 0 while the same request
     // on the writing path was refused, so an explicit locale was validated or ignored depending on which
     // flag came with it. Review caught that; the resolution belongs to the command, not to one branch.
-    const locale = resolveLocale({ flag: requiredFlagValue(rest, '--locale'), deal, env: process.env });
+    const locale = resolveLocale({ flag: flag(rest, '--locale'), deal, env: process.env });
 
     if (rest.includes('--prose-heights')) {
       const plan = planWorkbook(schema, spec, deal);

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -100,12 +100,22 @@ function flagValues(args: string[], name: string): Array<string | undefined> {
  * Seventh and last of the parser findings, all one mistake in different clothes: a malformed request treated
  * as no request. Nothing can be ignored once every unrecognised flag is named.
  */
-function refuseUnknownFlags(args: string[], known: readonly string[]): void {
-  const unknown = args.filter((arg) => arg.startsWith('--')).filter((arg) => !known.includes(arg.split('=')[0] ?? arg));
-  if (unknown.length > 0) {
-    throw new Error(
-      `Unknown ${unknown.length === 1 ? 'option' : 'options'} ${unknown.join(', ')}. This command takes ${known.join(', ')}.`,
-    );
+function refuseUnknownFlags(args: string[], takes: { values?: readonly string[]; booleans?: readonly string[] }): void {
+  const values = takes.values ?? [];
+  const booleans = takes.booleans ?? [];
+  const known = [...values, ...booleans];
+  for (const arg of args) {
+    if (!arg.startsWith('--')) continue;
+    const name = arg.split('=')[0] ?? arg;
+    if (!known.includes(name)) {
+      throw new Error(`Unknown option ${arg}. This command takes ${known.join(', ')}.`);
+    }
+    // A boolean is read with `includes`, which matches the bare token only — so `--apply=true` would pass an
+    // allowlist keyed on the text before `=` and then do nothing, and `migrate --apply=true` would report
+    // success having changed not one deal. There is no value to give a switch.
+    if (booleans.includes(name) && arg !== name) {
+      throw new Error(`${name} is a switch and takes no value. Pass ${name} on its own.`);
+    }
   }
 }
 
@@ -206,7 +216,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'check-sfdc') {
-    refuseUnknownFlags(rest, ['--schema', '--sfdc']);
+    refuseUnknownFlags(rest, { values: ['--schema', '--sfdc'] });
     const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
     const sfdc = await readJson(flag(rest, '--sfdc') ?? SFDC_PATH);
     const result = checkSfdcMapping(schema, sfdc);
@@ -215,7 +225,10 @@ async function main(): Promise<number> {
   }
 
   if (command === 'generate') {
-    refuseUnknownFlags(rest, ['--out', '--plan', '--prose-heights', '--spec', '--locale', '--schema']);
+    refuseUnknownFlags(rest, {
+      values: ['--out', '--spec', '--locale'],
+      booleans: ['--plan', '--prose-heights'],
+    });
     const dealPath = rest[0];
     if (!dealPath) {
       process.stderr.write(
@@ -328,7 +341,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'read') {
-    refuseUnknownFlags(rest, ['--deal', '--apply', '--spec', '--schema']);
+    refuseUnknownFlags(rest, { values: ['--deal', '--spec'], booleans: ['--apply'] });
     const workbookPath = rest[0];
     const dealPath = flag(rest, '--deal');
     if (!workbookPath || !dealPath) {
@@ -381,7 +394,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'migrate') {
-    refuseUnknownFlags(rest, ['--apply']);
+    refuseUnknownFlags(rest, { booleans: ['--apply'] });
     const dealPath = rest[0];
     if (!dealPath) {
       process.stderr.write('Usage: cli.ts migrate <deal.json> [--apply]\n');
@@ -407,7 +420,7 @@ async function main(): Promise<number> {
   }
 
   if (command === 'check-spec') {
-    refuseUnknownFlags(rest, ['--spec', '--schema']);
+    refuseUnknownFlags(rest, { values: ['--spec', '--schema'] });
     const schema = await readJson(flag(rest, '--schema') ?? SCHEMA_PATH);
     const spec = (await readJson(flag(rest, '--spec') ?? WORKBOOK_SPEC_PATH)) as WorkbookSpec;
     const result = checkWorkbookSpec(schema, spec);

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import pkg from '../package.json' with { type: 'json' };
 import { computeCompletion } from './completion';
 import { generateWorkbook, planWorkbook } from './generate';
+import { resolveLocale } from './locale';
 
 /**
  * What built the workbook, recorded in the file.
@@ -140,7 +141,7 @@ async function main(): Promise<number> {
     const dealPath = rest[0];
     if (!dealPath) {
       process.stderr.write(
-        'Usage: cli.ts generate <deal.json> [--out <file.xlsx>] [--plan] [--prose-heights] [--spec <workbook-spec.json>]\n',
+        'Usage: cli.ts generate <deal.json> [--out <file.xlsx>] [--plan] [--prose-heights] [--spec <workbook-spec.json>] [--locale <slug>]\n',
       );
       return 1;
     }
@@ -220,7 +221,10 @@ async function main(): Promise<number> {
       process.stderr.write('generate needs --out <file.xlsx> (or --plan to inspect the layout)\n');
       return 1;
     }
-    await Bun.write(outPath, generateWorkbook(schema, spec, deal, ENGINE_VERSION));
+    // Resolved once, here, before anything is planned: the flag, then the deal, then the environment.
+    // Deciding it deeper in the engine is what #938 fixed.
+    const locale = resolveLocale({ flag: flag(rest, '--locale'), deal, env: process.env }).slug;
+    await Bun.write(outPath, generateWorkbook(schema, spec, deal, ENGINE_VERSION, locale));
     const plan = planWorkbook(schema, spec, deal);
     // Reported in the result, not thrown: a long note is not a reason to refuse a workbook. But a
     // merged cell cannot autofit and Excel's tallest row is 409.5 points, so text needing more ends

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -105,7 +105,10 @@ function refuseUnknownFlags(args: string[], takes: { values?: readonly string[];
   const booleans = takes.booleans ?? [];
   const known = [...values, ...booleans];
   for (const arg of args) {
-    if (!arg.startsWith('--')) continue;
+    // Any leading dash, not only two. `-locale ko` and `-apply` are what a person types by mistake, and
+    // checking `--` alone let them through as positional arguments nothing reads: English output, exit 0,
+    // and for `migrate -apply` a dry run reported as success. No path this CLI takes begins with a dash.
+    if (!arg.startsWith('-')) continue;
     const name = arg.split('=')[0] ?? arg;
     if (!known.includes(name)) {
       throw new Error(`Unknown option ${arg}. This command takes ${known.join(', ')}.`);

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -223,7 +223,7 @@ async function main(): Promise<number> {
     }
     // Resolved once, here, before anything is planned: the flag, then the deal, then the environment.
     // Deciding it deeper in the engine is what #938 fixed.
-    const locale = resolveLocale({ flag: flag(rest, '--locale'), deal, env: process.env }).slug;
+    const locale = resolveLocale({ flag: flag(rest, '--locale'), deal, env: process.env });
     await Bun.write(outPath, generateWorkbook(schema, spec, deal, ENGINE_VERSION, locale));
     const plan = planWorkbook(schema, spec, deal);
     // Reported in the result, not thrown: a long note is not a reason to refuse a workbook. But a

--- a/plugins/meddpicc/engine/cli.ts
+++ b/plugins/meddpicc/engine/cli.ts
@@ -68,11 +68,22 @@ function flag(args: string[], name: string): string | undefined {
  * a request. Same principle as `resolveLocale`: an explicit request is honoured or refused, never ignored.
  */
 function requiredFlagValue(args: string[], name: string): string | undefined {
-  const i = args.indexOf(name);
-  if (i < 0) return undefined;
-  const value = args[i + 1];
+  const positions = args.reduce<number[]>((all, arg, i) => (arg === name ? [...all, i] : all), []);
+  if (positions.length === 0) return undefined;
+  if (positions.length > 1) {
+    // `--locale en --locale ko` used to take the first and ignore the second, so a script appending an
+    // override got English while asking for Korean. There is no right answer to pick here — the request
+    // is ambiguous, and guessing which half was meant is how the wrong one gets honoured silently.
+    throw new Error(`${name} was given ${positions.length} times. Pass it once.`);
+  }
+  const value = args[(positions[0] ?? 0) + 1];
   if (value === undefined || value.startsWith('--')) {
     throw new Error(`${name} was given with no value. Pass one, or leave the flag off.`);
+  }
+  if (value.trim() === '') {
+    // `--locale ""` is what an unset shell variable expands to. Absent would be the kind reading, but the
+    // flag is present, so somebody meant to pass something and it evaporated — worth saying so.
+    throw new Error(`${name} was given an empty value. Pass a locale, or leave the flag off.`);
   }
   return value;
 }

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -18,6 +18,7 @@ import { SECTION_RULES } from './completion-rules';
 import { computeElementHint } from './hint';
 import { readPath } from './json-path';
 import { enumLabel, enumLabels } from './labels';
+import { DEFAULT_LOCALE, normalizeLocaleTag, SHIPPED_LOCALES } from './locale';
 import { schemaConstraint } from './schema-path';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER, sectionLabel, statusLabel } from './sections';
 import { estimateRowHeight, MAX_ROW_HEIGHT, neededRowHeight } from './text-metrics';
@@ -1162,8 +1163,6 @@ export function workbookFingerprint(plan: WorkbookPlan, deal: unknown): string {
  * since the stamp is exactly what a reader trusts. When the locale files land, this becomes the
  * default rather than the only option.
  */
-export const DEFAULT_LOCALE = 'en';
-export const SUPPORTED_LOCALES: readonly string[] = [DEFAULT_LOCALE];
 
 /**
  * A stable reference to the schema the workbook was generated against.
@@ -1188,14 +1187,38 @@ export function workbookProperties(
   plan: WorkbookPlan,
   deal: unknown,
   engineVersion?: string,
+  /**
+   * The locale already resolved, because resolving it here was the bug.
+   *
+   * This function runs after the sheet is laid out, so a locale decided here is a locale the planner
+   * could never have known — and the refusal for an unsupported one arrived after all the layout work.
+   * `resolveLocale` in `locale.ts` makes that decision once, from every input, before anything is
+   * planned. Left optional so that a caller with no opinion still records the default rather than
+   * nothing, since a workbook that does not say what language it is in is worse than one that guesses.
+   */
+  locale: string = DEFAULT_LOCALE,
 ): WorkbookProperties {
-  const asked = readPath(deal, 'metadata.locale');
-  const locale = typeof asked === 'string' && asked !== '' ? asked : DEFAULT_LOCALE;
-  if (!SUPPORTED_LOCALES.includes(locale)) {
+  if (!SHIPPED_LOCALES.includes(locale)) {
+    // A caller that resolved through `resolveLocale` cannot reach this. One that passed a raw string can,
+    // and a workbook stamped with a language it is not written in lies to every later reader.
     throw new Error(
-      `metadata.locale asks for "${locale}", and the workbook is not translated yet — it can only be ` +
-        `written in ${SUPPORTED_LOCALES.join(', ')}. Remove the field, or set it to ${DEFAULT_LOCALE}, ` +
-        'until the locale files land',
+      `A workbook cannot be stamped "${locale}": it is not translated into it. ` +
+        `Resolve the locale with resolveLocale, which offers ${SHIPPED_LOCALES.join(', ')}.`,
+    );
+  }
+  // The stamp has to agree with what the deal asked for.
+  //
+  // Moving resolution out to the caller left a hole worth naming: `generateWorkbook` called without a
+  // locale would have stamped English over a deal that explicitly asked for Korean, which is worse than
+  // the refusal it replaced — silently ignoring a request beats no request at all only if nobody asked.
+  // A pre-existing test caught it. This is not resolving the locale a second time; it is checking that
+  // whoever resolved it honoured the deal.
+  const asked = readPath(deal, 'metadata.locale');
+  if (typeof asked === 'string' && asked !== '' && normalizeLocaleTag(asked) !== locale) {
+    throw new Error(
+      `The deal asks for metadata.locale "${asked}", and the workbook is not translated into it — ` +
+        `it is being written in "${locale}", and can be written in ${SHIPPED_LOCALES.join(', ')}. ` +
+        `Remove the field, or set it to ${locale}, until the locale files land.`,
     );
   }
   return {
@@ -1211,7 +1234,9 @@ export function generateWorkbook(
   spec: WorkbookSpec,
   deal: unknown,
   engineVersion?: string,
+  /** Resolved by the caller — see {@link workbookProperties}. Defaults to English. */
+  locale: string = DEFAULT_LOCALE,
 ): Uint8Array {
   const plan = planWorkbook(schema, spec, deal);
-  return buildWorkbook(plan.sheets, workbookProperties(schema, plan, deal, engineVersion));
+  return buildWorkbook(plan.sheets, workbookProperties(schema, plan, deal, engineVersion, locale));
 }

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -18,7 +18,7 @@ import { SECTION_RULES } from './completion-rules';
 import { computeElementHint } from './hint';
 import { readPath } from './json-path';
 import { enumLabel, enumLabels } from './labels';
-import { DEFAULT_LOCALE, normalizeLocaleTag, SHIPPED_LOCALES } from './locale';
+import { DEFAULT_LOCALE, normalizeLocaleTag, type ResolvedLocale, SHIPPED_LOCALES } from './locale';
 import { schemaConstraint } from './schema-path';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER, sectionLabel, statusLabel } from './sections';
 import { estimateRowHeight, MAX_ROW_HEIGHT, neededRowHeight } from './text-metrics';
@@ -1196,8 +1196,9 @@ export function workbookProperties(
    * planned. Left optional so that a caller with no opinion still records the default rather than
    * nothing, since a workbook that does not say what language it is in is worse than one that guesses.
    */
-  locale: string = DEFAULT_LOCALE,
+  resolved: ResolvedLocale = { slug: DEFAULT_LOCALE, from: 'default' },
 ): WorkbookProperties {
+  const locale = resolved.slug;
   if (!SHIPPED_LOCALES.includes(locale)) {
     // A caller that resolved through `resolveLocale` cannot reach this. One that passed a raw string can,
     // and a workbook stamped with a language it is not written in lies to every later reader.
@@ -1206,15 +1207,21 @@ export function workbookProperties(
         `Resolve the locale with resolveLocale, which offers ${SHIPPED_LOCALES.join(', ')}.`,
     );
   }
-  // The stamp has to agree with what the deal asked for.
+  // The deal's request must not be silently DROPPED — which is not the same as insisting the stamp match
+  // it, and getting that distinction wrong was a defect in this change's first version.
   //
-  // Moving resolution out to the caller left a hole worth naming: `generateWorkbook` called without a
-  // locale would have stamped English over a deal that explicitly asked for Korean, which is worse than
-  // the refusal it replaced — silently ignoring a request beats no request at all only if nobody asked.
-  // A pre-existing test caught it. This is not resolving the locale a second time; it is checking that
-  // whoever resolved it honoured the deal.
+  // The hole being closed: `generateWorkbook` called with no locale would have stamped English over a deal
+  // explicitly asking for Korean, worse than the refusal it replaced, since silently ignoring a request
+  // beats no request only if nobody asked. A pre-existing test caught that.
+  //
+  // But `--locale` outranks `metadata.locale` by design, so refusing every mismatch made the documented
+  // override impossible: `--locale en` on a deal saying `ja` resolved to `en` and was then rejected for
+  // disagreeing with the deal. Review caught that one. So the check asks where the locale came from — a
+  // flag is somebody deliberately overriding the file, and anything less specific means the deal's request
+  // went unheard.
   const asked = readPath(deal, 'metadata.locale');
-  if (typeof asked === 'string' && asked !== '' && normalizeLocaleTag(asked) !== locale) {
+  const overridden = resolved.from === 'flag';
+  if (!overridden && typeof asked === 'string' && asked !== '' && normalizeLocaleTag(asked) !== locale) {
     throw new Error(
       `The deal asks for metadata.locale "${asked}", and the workbook is not translated into it — ` +
         `it is being written in "${locale}", and can be written in ${SHIPPED_LOCALES.join(', ')}. ` +
@@ -1235,8 +1242,8 @@ export function generateWorkbook(
   deal: unknown,
   engineVersion?: string,
   /** Resolved by the caller — see {@link workbookProperties}. Defaults to English. */
-  locale: string = DEFAULT_LOCALE,
+  resolved: ResolvedLocale = { slug: DEFAULT_LOCALE, from: 'default' },
 ): Uint8Array {
   const plan = planWorkbook(schema, spec, deal);
-  return buildWorkbook(plan.sheets, workbookProperties(schema, plan, deal, engineVersion, locale));
+  return buildWorkbook(plan.sheets, workbookProperties(schema, plan, deal, engineVersion, resolved));
 }

--- a/plugins/meddpicc/engine/locale.test.ts
+++ b/plugins/meddpicc/engine/locale.test.ts
@@ -65,6 +65,20 @@ describe('resolveLocale — precedence', () => {
     expect(r).toEqual({ slug: DEFAULT_LOCALE, from: 'fallback', unresolved: 'ko-kr' });
   });
 
+  test('LC_MESSAGES sits between LC_ALL and LANG, as POSIX has it', () => {
+    // A workbook's text is user-facing messages, so LC_MESSAGES is the category that governs it. Asked with
+    // a shipped set that includes French, since the point is which variable is consulted.
+    const shipped = ['en', 'fr'];
+    expect(resolveLocale({ env: { LC_MESSAGES: 'fr_FR.UTF-8', LANG: 'en_US.UTF-8' }, shipped })).toEqual({
+      slug: 'fr',
+      from: 'os',
+    });
+    // LC_ALL still outranks it.
+    expect(
+      resolveLocale({ env: { LC_ALL: 'en_US.UTF-8', LC_MESSAGES: 'fr_FR.UTF-8' }, shipped }),
+    ).toEqual({ slug: 'en', from: 'os' });
+  });
+
   test('AppleLocale is consulted, after the POSIX variables', () => {
     // Named for what it checks. It is not platform-gated and does not need to be: nothing sets
     // `AppleLocale` off macOS, so reading it elsewhere finds nothing rather than the wrong thing.

--- a/plugins/meddpicc/engine/locale.test.ts
+++ b/plugins/meddpicc/engine/locale.test.ts
@@ -74,9 +74,10 @@ describe('resolveLocale — precedence', () => {
       from: 'os',
     });
     // LC_ALL still outranks it.
-    expect(
-      resolveLocale({ env: { LC_ALL: 'en_US.UTF-8', LC_MESSAGES: 'fr_FR.UTF-8' }, shipped }),
-    ).toEqual({ slug: 'en', from: 'os' });
+    expect(resolveLocale({ env: { LC_ALL: 'en_US.UTF-8', LC_MESSAGES: 'fr_FR.UTF-8' }, shipped })).toEqual({
+      slug: 'en',
+      from: 'os',
+    });
   });
 
   test('AppleLocale is consulted, after the POSIX variables', () => {

--- a/plugins/meddpicc/engine/locale.test.ts
+++ b/plugins/meddpicc/engine/locale.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, test } from 'bun:test';
+import { workbookProperties } from './generate';
 import { DEFAULT_LOCALE, normalizeLocaleTag, resolveLocale, SHIPPED_LOCALES } from './locale';
+
+/** The smallest plan `workbookProperties` will accept: it only fingerprints the layout, which is empty. */
+const EMPTY_PLAN = {
+  sheets: [],
+  anchors: [],
+  proseCells: [],
+  clippedCells: [],
+  notes: [],
+  namedCells: {},
+  tables: [],
+  inputCells: [],
+  writtenCells: [],
+  // biome-ignore lint/suspicious/noExplicitAny: a stand-in plan, not a real one — only the layout is read.
+} as any;
 
 /** Every ambient source empty, so a test says exactly which inputs it is exercising. */
 const nothing = { env: {} as Record<string, string | undefined> };
@@ -121,6 +136,22 @@ describe('resolveLocale — resolution and refusal', () => {
       unresolved: 'is-is',
     });
     expect(resolveLocale({ env: { LANG: 'C' } })).toEqual({ slug: DEFAULT_LOCALE, from: 'default' });
+  });
+
+  test('a flag may override the deal, and only a flag may', () => {
+    // Two rules that contradict each other unless the origin is carried along, which the first version of
+    // this change got wrong. `--locale` outranks `metadata.locale` by design; a deal's request must not be
+    // silently dropped. Refusing every mismatch made the documented override impossible — review caught it
+    // — and allowing every mismatch would let English be stamped over a deal asking for Korean.
+    const dealInJapanese = { metadata: { locale: 'ja' } };
+    const viaFlag = resolveLocale({ flag: 'en', deal: dealInJapanese });
+    expect(viaFlag).toEqual({ slug: 'en', from: 'flag' });
+    // Generation accepts it, because `from: 'flag'` says a person deliberately overrode the file...
+    expect(() => workbookProperties({}, EMPTY_PLAN, dealInJapanese, undefined, viaFlag)).not.toThrow();
+    // ...and refuses the same slug when nothing more specific asked for it, so the request is not dropped.
+    expect(() =>
+      workbookProperties({}, EMPTY_PLAN, dealInJapanese, undefined, { slug: 'en', from: 'default' }),
+    ).toThrow(/ja/);
   });
 
   test('the shipped set is derived, and today it is English alone', () => {

--- a/plugins/meddpicc/engine/locale.test.ts
+++ b/plugins/meddpicc/engine/locale.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_LOCALE, normalizeLocaleTag, resolveLocale, SHIPPED_LOCALES } from './locale';
+
+/** Every ambient source empty, so a test says exactly which inputs it is exercising. */
+const nothing = { env: {} as Record<string, string | undefined> };
+
+describe('normalizeLocaleTag', () => {
+  test('a POSIX locale loses its codeset and modifier', () => {
+    // `fr_CA.UTF-8@euro` is what a real environment hands over, and none of the tail is a locale.
+    expect(normalizeLocaleTag('fr_CA.UTF-8@euro')).toBe('fr-ca');
+    expect(normalizeLocaleTag('pt_BR.UTF-8')).toBe('pt-br');
+    expect(normalizeLocaleTag('ja_JP')).toBe('ja-jp');
+  });
+
+  test('the canonical form is the lowercase slug', () => {
+    // Not the BCP-47 `pt-BR`: the schema's `metadata.locale` enum and i18n-core's `slug` are lowercase,
+    // and having two spellings of one locale is how a workbook comes to ask for one that does not exist.
+    expect(normalizeLocaleTag('pt-BR')).toBe('pt-br');
+    expect(normalizeLocaleTag('ZH-CN')).toBe('zh-cn');
+  });
+
+  test('nothing useful stays nothing', () => {
+    for (const value of ['', '   ', 'C', 'POSIX', 'UTF-8']) expect(normalizeLocaleTag(value)).toBeUndefined();
+  });
+});
+
+describe('resolveLocale — precedence', () => {
+  test('an explicit flag wins over everything below it', () => {
+    const r = resolveLocale({
+      flag: 'en',
+      deal: { metadata: { locale: 'ja' } },
+      env: { MEDDPICC_LOCALE: 'ko', LC_ALL: 'de_DE.UTF-8', LANG: 'fr_FR.UTF-8' },
+    });
+    expect(r).toEqual({ slug: 'en', from: 'flag' });
+  });
+
+  test("the deal's own locale wins over the environment", () => {
+    const r = resolveLocale({ deal: { metadata: { locale: 'en' } }, env: { LANG: 'fr_FR.UTF-8' } });
+    expect(r).toEqual({ slug: 'en', from: 'deal' });
+  });
+
+  test('MEDDPICC_LOCALE wins over the POSIX variables', () => {
+    const r = resolveLocale({ env: { MEDDPICC_LOCALE: 'en', LC_ALL: 'fr_FR.UTF-8' } });
+    expect(r).toEqual({ slug: 'en', from: 'env' });
+  });
+
+  test('LC_ALL wins over LANG, because that is what POSIX means by it', () => {
+    // Both unshipped, so the assertion is about which one was consulted, not about the answer.
+    const r = resolveLocale({ env: { LC_ALL: 'ko_KR.UTF-8', LANG: 'ja_JP.UTF-8' } });
+    expect(r).toEqual({ slug: DEFAULT_LOCALE, from: 'fallback', unresolved: 'ko-kr' });
+  });
+
+  test('AppleLocale is consulted, after the POSIX variables', () => {
+    // Named for what it checks. It is not platform-gated and does not need to be: nothing sets
+    // `AppleLocale` off macOS, so reading it elsewhere finds nothing rather than the wrong thing.
+    expect(resolveLocale({ env: { AppleLocale: 'en_US' } })).toEqual({ slug: 'en', from: 'os' });
+    // And LANG is preferred over it when both are set.
+    expect(resolveLocale({ env: { LANG: 'ko_KR.UTF-8', AppleLocale: 'en_US' } })).toEqual({
+      slug: DEFAULT_LOCALE,
+      from: 'fallback',
+      unresolved: 'ko-kr',
+    });
+  });
+
+  test('nothing at all is English', () => {
+    expect(resolveLocale(nothing)).toEqual({ slug: DEFAULT_LOCALE, from: 'default' });
+  });
+
+  test('an empty value at a higher rung does not shadow a lower one', () => {
+    // `metadata.locale: ""` is absent, not a request for the empty locale.
+    const r = resolveLocale({ flag: '', deal: { metadata: { locale: '' } }, env: { MEDDPICC_LOCALE: 'en' } });
+    expect(r).toEqual({ slug: 'en', from: 'env' });
+  });
+});
+
+describe('resolveLocale — resolution and refusal', () => {
+  test('a region falls back to its language', () => {
+    // `fr-ca` is not shipped and never will be; French is the answer, once French ships.
+    expect(resolveLocale({ env: { LANG: 'en_GB.UTF-8' } })).toEqual({ slug: 'en', from: 'os' });
+  });
+
+  test('Chinese resolves by script when given one, by region otherwise', () => {
+    for (const [raw, slug] of [
+      ['zh_Hant_TW', 'zh-tw'],
+      ['zh_Hans_CN', 'zh-cn'],
+      ['zh_TW', 'zh-tw'],
+      ['zh_CN', 'zh-cn'],
+      ['zh', 'zh-cn'],
+      ['zh_Hant', 'zh-tw'],
+    ] as const) {
+      // Asked of the resolver's own mapping rather than of what is shipped, since no Chinese locale is.
+      expect(resolveLocale({ flag: raw, shipped: ['en', 'zh-cn', 'zh-tw'] })).toEqual({ slug, from: 'flag' });
+    }
+  });
+
+  test('an explicit locale that is not shipped is refused, and names what is', () => {
+    // Somebody asked for something specific. Handing them English instead is the one answer nobody wants.
+    expect(() => resolveLocale({ flag: 'ko' })).toThrow(/ko/);
+    expect(() => resolveLocale({ flag: 'ko' })).toThrow(/en/);
+    expect(() => resolveLocale({ deal: { metadata: { locale: 'ja' } } })).toThrow(/ja/);
+    expect(() => resolveLocale({ env: { MEDDPICC_LOCALE: 'de' } })).toThrow(/de/);
+  });
+
+  test('an explicit value that names no language is refused, not ignored', () => {
+    // `--locale C` is not a request for a language, but it IS a request, and skipping it would silently
+    // hand back English while looking like it honoured something. Ambient `LANG=C` is the opposite case:
+    // it genuinely means "no locale set", so the chain keeps looking. A surviving mutation found this
+    // gap — the refusal existed and nothing exercised it.
+    expect(() => resolveLocale({ flag: 'C' })).toThrow(/names no language/);
+    expect(() => resolveLocale({ deal: { metadata: { locale: 'POSIX' } } })).toThrow(/names no language/);
+    expect(() => resolveLocale({ env: { MEDDPICC_LOCALE: 'UTF-8' } })).toThrow(/names no language/);
+    // And the ambient one falls through to the next rung rather than throwing.
+    expect(resolveLocale({ env: { LANG: 'C', AppleLocale: 'en_US' } })).toEqual({ slug: 'en', from: 'os' });
+  });
+
+  test('an ambient locale that is not shipped falls back quietly', () => {
+    // A rep with LANG=is_IS wants a workbook, not a lecture about Icelandic.
+    expect(resolveLocale({ env: { LANG: 'is_IS.UTF-8' } })).toEqual({
+      slug: DEFAULT_LOCALE,
+      from: 'fallback',
+      unresolved: 'is-is',
+    });
+    expect(resolveLocale({ env: { LANG: 'C' } })).toEqual({ slug: DEFAULT_LOCALE, from: 'default' });
+  });
+
+  test('the shipped set is derived, and today it is English alone', () => {
+    // A hardcoded locale array in TypeScript fails `scripts/locale-lint.sh`, so the set comes from the
+    // locale files present. There are none yet, which is why this reads as it does.
+    expect([...SHIPPED_LOCALES]).toEqual(['en']);
+  });
+});

--- a/plugins/meddpicc/engine/locale.ts
+++ b/plugins/meddpicc/engine/locale.ts
@@ -1,0 +1,156 @@
+/**
+ * Which language the workbook is written in, decided once.
+ *
+ * The decision used to live inside `workbookProperties`, which runs after the sheet is laid out, and it
+ * read one input: `metadata.locale`. So nothing in planning could know the locale, the refusal for an
+ * unsupported one arrived after all the layout work, and a rep whose machine is in Japanese had no way to
+ * ask for a Japanese sheet.
+ *
+ * Two policies are the reason this is one function rather than a lookup at each use.
+ *
+ * **Explicit and ambient failures are opposites.** Someone passing `--locale ko` asked for something
+ * specific and must be refused rather than quietly handed English. A rep whose `LANG` is `is_IS` should
+ * get a workbook, not an error. Same unsupported locale, opposite correct answers, and only the resolver
+ * knows which input it came from.
+ *
+ * **Reading never detects.** The reader verifies label text to refuse a workbook whose rows have moved, so
+ * once labels are translated, re-detecting at read time would make a Japanese workbook fail every anchor
+ * under a different `LANG` — and be reported as moved rows. The workbook records the locale it was written
+ * in; `read` uses that. Nothing here is called on the reading path.
+ */
+
+/** The language everything falls back to, and the only one shipped until the locale files land. */
+export const DEFAULT_LOCALE = 'en';
+
+/**
+ * The locales that ship, derived rather than declared.
+ *
+ * `scripts/locale-lint.sh` fails a hardcoded locale list in TypeScript — rightly, since the fleet has one
+ * registry and a second copy drifts from it — so this is built from the locale files present. There are
+ * none yet, which is why it is English alone.
+ */
+export const SHIPPED_LOCALES: readonly string[] = [DEFAULT_LOCALE];
+
+/** Where a resolved locale came from, which decides whether an unshipped one is refused or ignored. */
+export type LocaleOrigin = 'flag' | 'deal' | 'env' | 'os' | 'default' | 'fallback';
+
+export interface ResolvedLocale {
+  /** A shipped locale, in canonical lowercase-slug form. */
+  slug: string;
+  from: LocaleOrigin;
+  /** What an ambient source asked for, when it could not be honoured. Present only for `fallback`. */
+  unresolved?: string;
+}
+
+export interface LocaleInputs {
+  /** `--locale`, the most specific request there is. */
+  flag?: string;
+  /** The deal, read for `metadata.locale`. */
+  deal?: unknown;
+  env?: Record<string, string | undefined>;
+  /** Overridable so a test can exercise the mapping for a locale that does not ship yet. */
+  shipped?: readonly string[];
+}
+
+/** Values a POSIX environment uses for "no locale", none of which names a language. */
+const NOT_A_LOCALE = new Set(['c', 'posix', 'utf-8', 'utf8', '']);
+
+/**
+ * A raw locale tag as a canonical lowercase slug, or undefined when it names no language.
+ *
+ * Canonical is the **slug** — `pt-br`, `zh-cn` — matching the `metadata.locale` enum and i18n-core's
+ * `slug` field rather than the BCP-47 `pt-BR`. Two spellings of one locale is how a workbook comes to
+ * record a locale that nothing recognises.
+ */
+export function normalizeLocaleTag(raw: string): string | undefined {
+  // `fr_CA.UTF-8@euro`: the codeset and the modifier are not part of the language.
+  const withoutCodeset = raw.split('.')[0]?.split('@')[0] ?? '';
+  const slug = withoutCodeset.trim().toLowerCase().replace(/_/g, '-');
+  if (slug === '' || NOT_A_LOCALE.has(slug)) return undefined;
+  return slug;
+}
+
+/**
+ * Chinese by script where a script is given, by region otherwise.
+ *
+ * `zh_Hant_TW` and `zh_TW` are the same request written two ways, and bare `zh` has to mean something:
+ * Simplified, which is the larger population and what the fleet registry lists first.
+ */
+function resolveChinese(slug: string): string | undefined {
+  if (slug === 'zh') return 'zh-cn';
+  if (slug.includes('hant')) return 'zh-tw';
+  if (slug.includes('hans')) return 'zh-cn';
+  if (slug.startsWith('zh-')) {
+    const region = slug.split('-').pop();
+    return region === 'tw' || region === 'hk' || region === 'mo' ? 'zh-tw' : 'zh-cn';
+  }
+  return undefined;
+}
+
+/** The shipped locale a normalized tag asks for, longest match first, or undefined for none. */
+function shippedFor(slug: string, shipped: readonly string[]): string | undefined {
+  if (slug.startsWith('zh')) {
+    const chinese = resolveChinese(slug);
+    return chinese !== undefined && shipped.includes(chinese) ? chinese : undefined;
+  }
+  // Exact first, then language-and-region, then language alone: `fr-ca` asks for French when Canadian
+  // French is not a thing we ship, and never for something further away than that.
+  if (shipped.includes(slug)) return slug;
+  const language = slug.split('-')[0];
+  return language !== undefined && shipped.includes(language) ? language : undefined;
+}
+
+/** The first non-empty candidate from each source, in precedence order, with where it came from. */
+function candidates(inputs: LocaleInputs): Array<{ raw: string; from: LocaleOrigin; explicit: boolean }> {
+  const env = inputs.env ?? {};
+  const dealLocale = (inputs.deal as { metadata?: { locale?: unknown } } | undefined)?.metadata?.locale;
+  const ordered: Array<{ raw: unknown; from: LocaleOrigin; explicit: boolean }> = [
+    { raw: inputs.flag, from: 'flag', explicit: true },
+    { raw: dealLocale, from: 'deal', explicit: true },
+    { raw: env.MEDDPICC_LOCALE, from: 'env', explicit: true },
+    // LC_ALL before LANG: POSIX says LC_ALL overrides everything, and reversing them would quietly
+    // honour a setting the operating system considers overridden.
+    { raw: env.LC_ALL, from: 'os', explicit: false },
+    { raw: env.LANG, from: 'os', explicit: false },
+    { raw: env.AppleLocale, from: 'os', explicit: false },
+  ];
+  // An empty string is absence, not a request for the empty locale, so it must not shadow a lower rung.
+  return ordered
+    .filter((c): c is { raw: string; from: LocaleOrigin; explicit: boolean } => typeof c.raw === 'string')
+    .filter((c) => c.raw.trim() !== '');
+}
+
+/**
+ * The locale to write in, or an error when something explicit asked for one that does not ship.
+ *
+ * @throws when a flag, a deal or `MEDDPICC_LOCALE` names a locale that is not shipped. An ambient source
+ * that does the same falls back to {@link DEFAULT_LOCALE} instead, reporting what it wanted.
+ */
+export function resolveLocale(inputs: LocaleInputs): ResolvedLocale {
+  const shipped = inputs.shipped ?? SHIPPED_LOCALES;
+  for (const candidate of candidates(inputs)) {
+    const slug = normalizeLocaleTag(candidate.raw);
+    if (slug === undefined) {
+      // `LANG=C` names no language, so it is not a failed request — keep looking down the chain.
+      if (candidate.explicit) {
+        throw new Error(
+          `--locale or metadata.locale is "${candidate.raw}", which names no language. ` +
+            `The workbook can be written in ${shipped.join(', ')}.`,
+        );
+      }
+      continue;
+    }
+    const match = shippedFor(slug, shipped);
+    if (match !== undefined) return { slug: match, from: candidate.from };
+    if (candidate.explicit) {
+      throw new Error(
+        `A locale of "${candidate.raw}" was asked for, and the workbook is not translated into it yet — ` +
+          `it can be written in ${shipped.join(', ')}. Remove the request, or set it to ${DEFAULT_LOCALE}, ` +
+          'until the locale files land.',
+      );
+    }
+    // Ambient: the machine's language is not one we have, which is not the rep's problem to solve.
+    return { slug: DEFAULT_LOCALE, from: 'fallback', unresolved: slug };
+  }
+  return { slug: DEFAULT_LOCALE, from: 'default' };
+}

--- a/plugins/meddpicc/engine/locale.ts
+++ b/plugins/meddpicc/engine/locale.ts
@@ -108,9 +108,12 @@ function candidates(inputs: LocaleInputs): Array<{ raw: string; from: LocaleOrig
     { raw: inputs.flag, from: 'flag', explicit: true },
     { raw: dealLocale, from: 'deal', explicit: true },
     { raw: env.MEDDPICC_LOCALE, from: 'env', explicit: true },
-    // LC_ALL before LANG: POSIX says LC_ALL overrides everything, and reversing them would quietly
-    // honour a setting the operating system considers overridden.
+    // POSIX order for the language of user-facing messages, which is what a workbook's text is:
+    // LC_ALL overrides everything, then LC_MESSAGES for the message category specifically, then LANG as
+    // the default for every category. Skipping LC_MESSAGES — as this did at first — means a machine set to
+    // French messages with an English LANG gets an English workbook once French ships.
     { raw: env.LC_ALL, from: 'os', explicit: false },
+    { raw: env.LC_MESSAGES, from: 'os', explicit: false },
     { raw: env.LANG, from: 'os', explicit: false },
     { raw: env.AppleLocale, from: 'os', explicit: false },
   ];

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
## What this does

Closes #938. The locale is decided once, early, from every input — and `generate` takes `--locale`.

It used to be decided inside `workbookProperties`, which runs **after** the sheet is laid out, from one
input: `metadata.locale`. So nothing in planning could know the locale, the refusal for an unsupported one
arrived after all the layout work, and a rep whose machine is in Japanese had no way to ask for anything
else.

## The resolution

`engine/locale.ts`, pure and tested: `--locale` > `metadata.locale` > `MEDDPICC_LOCALE` > `LC_ALL` >
`LC_MESSAGES` > `LANG` > macOS `AppleLocale` > `en`. That is POSIX order for the language of user-facing
messages, which is what a workbook's text is.

Tags normalize to the lowercase **slug** — `fr_CA.UTF-8@euro` → `fr-ca`, never BCP-47's `pt-BR` — matching
the `metadata.locale` enum and i18n-core's `slug`, because two spellings of one locale is how a workbook
records one nothing recognises. Chinese resolves by script where given and by region otherwise.

**Two policies are why this is one function.** An explicit request that cannot be honoured is *refused* —
somebody asked for something specific, and English is the one answer nobody wants. An ambient one falls back
*quietly* — a rep with `LANG=is_IS` wants a workbook, not a lecture about Icelandic. Same unsupported locale,
opposite right answers, and only the resolver knows which input it came from.

The shipped set is derived from the locale files present, not a hardcoded array, because
`scripts/locale-lint.sh` fails the latter. Today it is `['en']`.

## What review found: nine holes in the CLI's argument parser

Nine rounds, nine findings, every one confirmed. They were all the same mistake — **a malformed request
treated as no request** — and the fix kept widening as that shape became clear:

| Round | Hole |
| --- | --- |
| 1 | `--locale en` could not override a deal saying `ja`: my own consistency check defeated the precedence it was meant to complement |
| 2 | `--plan --locale ko` exited 0 while the writing path refused it — resolution sat after the early returns |
| 2 | `--locale` with nothing after it read as absent, writing English |
| 3 | `--locale en --locale ko` took the first and ignored the second; `--locale ''` fell through |
| 4 | `--locale=ko` unrecognised — and so were `--out=path` and `--spec=path`, **for every flag, long before this change** |
| 6 | The strict checks lived in a second function only `--locale` called, so `--spec` with no value built from the **default spec** at exit 0 |
| 7 | `--local=ko`, a one-letter typo, read as no request at all |
| 8 | `--apply=true` passed the allowlist and then did nothing: `migrate --apply=true` reported success having migrated no deal |
| 9 | `-locale ko` and `-apply` slipped through, since only `--` was checked |

**Two of those were mine, introduced while generalising a fix.** Round 8 found that I had allowlisted
`--schema` for `generate` and `read` without checking either consumes it — the very defect the allowlist
existed to close, reintroduced one layer up — and that keying the allowlist on the text before `=` let a
value reach a switch whose reader would never see it. Both are recorded in
`.codex-review/verify-8.json`. The pattern in my own errors is worth naming: widening a fix needs the same
verification the narrow fix had.

The parser is now one `flag()` that every value-flag goes through, plus a per-command declaration of what it
takes, by kind. **`--out=path` is honoured now, which it never was.**

## Verification

- **526 engine tests**, 39 shell tests. `biome ci`, `markdownlint`, `codespell`, `textlint` clean, and
  `locale-lint` finds no hardcoded locale list.
- **14 mutations, 14 killed.** Two survived a first, weaker assertion and are recorded rather than quietly
  strengthened: the refusal for an explicit value naming no language (`--locale C`) existed with nothing
  exercising it, and the flag-versus-deal override rule needed pinning in both directions.
- **English output is unchanged** — every OOXML part byte-equal to `origin/main` except
  `docProps/custom.xml`, which carries the version bump. English is still what everything resolves to.

## Deliberately not here

The locale is **not** threaded into `planWorkbook`. Nothing there reads a locale until translated strings
exist, and a parameter nothing uses is speculative. It lands with the loader.

Filed **#946** for what the parser work leaves: stray positional arguments are still unchecked, and a
command's flag declaration can drift from what it reads — which is exactly how the `--schema` mistake got in.

**v7.2.0.**
