### PR TITLE
fix: make plugin version bumps converge, and refuse ambiguous release notes

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -60,21 +60,15 @@ jobs:
               continue
             fi
 
-            # Extract release notes from CHANGELOG.md
-            # Look for lines mentioning this plugin
-            # in the Unreleased or latest section
-            BODY=""
-            if [[ -f CHANGELOG.md ]]; then
-              BODY=$(
-                sed -n '/^## \[/,/^## \[/{//!p}' \
-                  CHANGELOG.md \
-                  | head -20 \
-                  | grep -i "$NAME" || true
-              )
-            fi
-
-            if [[ -z "$BODY" ]]; then
-              BODY="Released **${NAME}** v${NEW_VER}"
+            # Select the release note for exactly this version. Delegated to a script so it
+            # can be tested (tests/test-release-notes.sh); the previous inline selection
+            # matched on plugin name alone and published salesforce/v1.3.5 with notes for a
+            # v1.3.4 that was never tagged. The script exits non-zero on an ambiguous or
+            # stale changelog, which fails the release rather than publishing a wrong note.
+            if ! BODY=$(scripts/release-notes.sh "$NAME" "$NEW_VER" CHANGELOG.md); then
+              echo "::error::Refusing to publish ${TAG}: CHANGELOG.md does not" \
+                "unambiguously describe ${NAME} v${NEW_VER} (see log above)."
+              exit 1
             fi
 
             gh release create "$TAG" \

--- a/scripts/auto-bump-version.sh
+++ b/scripts/auto-bump-version.sh
@@ -6,7 +6,10 @@
 # Must exit 0 — we add files; we never block the commit.
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Exported so bump-version.sh, invoked below, operates on the same root — and so both can
+# be pointed at a throwaway repository under test.
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+export REPO_ROOT
 MARKETPLACE="$REPO_ROOT/.xcsh-plugin/marketplace.json"
 
 # Version files to exclude from "content changed" detection.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -7,7 +7,11 @@
 #   ./scripts/bump-version.sh --all <major|minor|patch>
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Honour an inherited REPO_ROOT so the script can be exercised against a throwaway
+# repository. Deriving it solely from $0 meant every invocation mutated the checkout the
+# script lives in, which is why the CHANGELOG behaviour below had no test until a bad
+# release note reached production.
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 MARKETPLACE="$REPO_ROOT/.xcsh-plugin/marketplace.json"
 
 # ── Helpers ──────────────────────────────────────────────────
@@ -91,6 +95,10 @@ fi
 # ── Bump each plugin ────────────────────────────────────────
 
 CHANGELOG_ENTRIES=()
+# Parallel to CHANGELOG_ENTRIES: what to relabel, and to what, when an entry for this
+# plugin is already sitting in [Unreleased].
+CHANGELOG_NAMES=()
+CHANGELOG_VERSIONS=()
 JSON_FILES=("$MARKETPLACE")
 
 for name in "${PLUGINS[@]}"; do
@@ -140,6 +148,8 @@ for name in "${PLUGINS[@]}"; do
   # trip the Lint Code Base textlint terminology rule for names like azure/github/gitlab
   # (code spans are exempt). The release-notes grep in release-plugins.yml still matches.
   CHANGELOG_ENTRIES+=("- **\`$name\`** bumped to v$NEW_VER")
+  CHANGELOG_NAMES+=("$name")
+  CHANGELOG_VERSIONS+=("$NEW_VER")
 done
 
 # ── Format the written JSON with Biome ──────────────────────
@@ -157,13 +167,111 @@ fi
 
 # ── Update CHANGELOG.md ─────────────────────────────────────
 
+# Relabel the plugin's existing [Unreleased] entry to the new version, if it has one.
+# Returns 0 when it rewrote a line, 1 when there was nothing to rewrite.
+#
+# Why this exists: a branch bumps once per commit, and the squash-merge publishes ONE
+# release. Appending a line per bump therefore ships release notes listing versions that
+# were never tagged — salesforce/v1.3.5 went out describing a v1.3.4 that does not exist.
+# Rewriting in place makes N bumps converge on one entry at the current version.
+#
+# Both shapes are handled: the placeholder this script writes ("bumped to vX.Y.Z") and the
+# hand-written prose a contributor replaces it with ("vX.Y.Z — describes the change"). Only
+# the first match inside [Unreleased] is touched, so entries under earlier release headings
+# are never rewritten.
+#
+# Prose is only relabelled when its version has no release tag. This repository leaves
+# entries for shipped releases under [Unreleased] indefinitely, so the newest prose entry
+# is often a description of an ALREADY-PUBLISHED version — relabelling that would silently
+# reattribute shipped work to the version being cut and destroy the real note. Measured:
+# without this guard, three bumps rewrote "v1.3.5 — schema is discovered at runtime" into
+# "v1.3.8", losing what v1.3.5 actually was. When tags are unavailable (shallow clone) the
+# check fails closed and prose is left alone, which is the safe direction.
+already_released() {
+  local name="$1" version="$2"
+  [[ -n "$(git -C "$REPO_ROOT" tag -l "${name}/v${version}" 2>/dev/null)" ]]
+}
+
+# The first [Unreleased] entry for this plugin, as "form<TAB>version", or nothing.
+find_changelog_entry() {
+  local name="$1" file="$2"
+  NAME="$name" awk '
+    BEGIN { in_unreleased = 0 }
+    /^## \[Unreleased\]$/ { in_unreleased = 1; next }
+    /^## \[/ { in_unreleased = 0 }
+    in_unreleased {
+      prefix = "- **`" ENVIRON["NAME"] "`** "
+      if (index($0, prefix) == 1) {
+        rest = substr($0, length(prefix) + 1)
+        if (match(rest, /^bumped to v[0-9]+\.[0-9]+\.[0-9]+/)) {
+          print "placeholder\t" substr(rest, 12, RLENGTH - 11); exit
+        }
+        if (match(rest, /^v[0-9]+\.[0-9]+\.[0-9]+/)) {
+          print "prose\t" substr(rest, 2, RLENGTH - 1); exit
+        }
+      }
+    }
+  ' "$file"
+}
+
+relabel_changelog_entry() {
+  local name="$1" newver="$2" file="$3"
+
+  local found form version
+  found=$(find_changelog_entry "$name" "$file")
+  [[ -n "$found" ]] || return 1
+  form=${found%%$'\t'*}
+  version=${found##*$'\t'}
+
+  if [[ "$form" == "prose" ]] && already_released "$name" "$version"; then
+    return 1
+  fi
+
+  NAME="$name" NEWVER="$newver" awk '
+    BEGIN { updated = 0; in_unreleased = 0 }
+    /^## \[Unreleased\]$/ { in_unreleased = 1; print; next }
+    /^## \[/ { in_unreleased = 0 }
+    {
+      if (in_unreleased && !updated) {
+        prefix = "- **`" ENVIRON["NAME"] "`** "
+        if (index($0, prefix) == 1) {
+          rest = substr($0, length(prefix) + 1)
+          if (sub(/^bumped to v[0-9]+\.[0-9]+\.[0-9]+/, "bumped to v" ENVIRON["NEWVER"], rest) ||
+              sub(/^v[0-9]+\.[0-9]+\.[0-9]+/, "v" ENVIRON["NEWVER"], rest)) {
+            print prefix rest
+            updated = 1
+            next
+          }
+        }
+      }
+      print
+    }
+    END { exit(updated ? 0 : 1) }
+  ' "$file" >"$file.tmp"
+  local rc=$?
+  if [[ $rc -eq 0 ]]; then
+    command mv "$file.tmp" "$file"
+  else
+    rm -f "$file.tmp"
+  fi
+  return $rc
+}
+
 CHANGELOG="$REPO_ROOT/CHANGELOG.md"
 if [[ -f "$CHANGELOG" ]]; then
+  # Relabel in place where an entry already exists; only the rest need inserting.
+  PENDING_ENTRIES=()
+  for i in "${!CHANGELOG_NAMES[@]}"; do
+    if ! relabel_changelog_entry "${CHANGELOG_NAMES[$i]}" "${CHANGELOG_VERSIONS[$i]}" "$CHANGELOG"; then
+      PENDING_ENTRIES+=("${CHANGELOG_ENTRIES[$i]}")
+    fi
+  done
+
   # Build the insertion block: a leading blank line, entries separated by blank lines
   # (matching the loose-list style under "## [Unreleased]"), and a trailing newline.
   INSERT=$'\n'
   first=true
-  for entry in "${CHANGELOG_ENTRIES[@]}"; do
+  for entry in "${PENDING_ENTRIES[@]+"${PENDING_ENTRIES[@]}"}"; do
     if $first; then
       INSERT+="$entry"
       first=false
@@ -175,12 +283,15 @@ if [[ -f "$CHANGELOG" ]]; then
 
   # Insert immediately after the "## [Unreleased]" line. Portable in-place edit
   # (awk + temp file via ENVIRON, preserving real newlines) — avoids the GNU-only
-  # `sed -i` that breaks on BSD/macOS.
-  export INSERT
-  awk '
-    { print }
-    !inserted && /^## \[Unreleased\]$/ { printf "%s", ENVIRON["INSERT"]; inserted = 1 }
-  ' "$CHANGELOG" >"$CHANGELOG.tmp" && command mv "$CHANGELOG.tmp" "$CHANGELOG"
+  # `sed -i` that breaks on BSD/macOS. Skipped entirely when every entry was relabelled
+  # in place, so a repeat bump does not leave a stray blank line behind.
+  if [[ ${#PENDING_ENTRIES[@]} -gt 0 ]]; then
+    export INSERT
+    awk '
+      { print }
+      !inserted && /^## \[Unreleased\]$/ { printf "%s", ENVIRON["INSERT"]; inserted = 1 }
+    ' "$CHANGELOG" >"$CHANGELOG.tmp" && command mv "$CHANGELOG.tmp" "$CHANGELOG"
+  fi
   echo ""
   echo "Updated CHANGELOG.md — edit the entries before committing."
 fi

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# release-notes.sh — select the CHANGELOG entry for the plugin version being tagged.
+#
+# Usage: release-notes.sh <plugin-name> <version> [changelog-path]
+#
+# Prints the release body on stdout. Exits non-zero, with the reason on stderr, when the
+# changelog cannot be trusted to describe this release.
+#
+# Why it refuses rather than guessing: the previous inline version matched on plugin name
+# alone and published whatever came back. salesforce/v1.3.5 shipped with three lines — two
+# stale placeholders and an entry for a v1.3.4 that was never tagged. A release note naming
+# a version nobody can install is worse than no note, and it is invisible after the fact,
+# so ambiguity has to fail the build instead of reaching the release page.
+#
+# Lives here rather than inline in release-plugins.yml so it can be tested; untestable
+# bash embedded in YAML is how the original defect survived review.
+set -euo pipefail
+
+NAME="${1:?usage: release-notes.sh <plugin-name> <version> [changelog]}"
+VERSION="${2:?usage: release-notes.sh <plugin-name> <version> [changelog]}"
+CHANGELOG="${3:-CHANGELOG.md}"
+
+# Escape regex metacharacters. Version strings contain dots, which would otherwise match
+# any character — "1.3.5" would accept "1x3x5". Plugin names are identifiers today, but
+# nothing in the schema forbids a metacharacter, so both are escaped.
+escape_re() { printf '%s' "$1" | sed 's/[][\.*^$(){}?+|/\\]/\\&/g'; }
+
+NAME_RE=$(escape_re "$NAME")
+VERSION_RE=$(escape_re "$VERSION")
+
+# The [Unreleased] section: lines between the first two "## [" headings.
+#
+# awk, not `sed -n '/^## \[/,/^## \[/{//!p}'`. That sed form is a GNU extension and BSD sed
+# rejects it outright, so the workflow's copy worked in CI and could not be reproduced on a
+# maintainer's macOS checkout — which is part of why the release-note defect went unnoticed.
+unreleased_section() {
+  awk '
+    /^## \[/ { seen++; if (seen >= 2) exit; next }
+    seen == 1 { print }
+  ' "$CHANGELOG"
+}
+
+# An entry for this plugin at any version. Accepts the placeholder the bump script writes
+# ("bumped to vX.Y.Z") and the hand-written prose that replaces it ("vX.Y.Z — ...").
+ENTRY_RE="^- \\*\\*\`?${NAME_RE}\`?\\*\\* (bumped to )?v"
+
+if [[ ! -f "$CHANGELOG" ]]; then
+  printf 'Released **%s** v%s\n' "$NAME" "$VERSION"
+  exit 0
+fi
+
+ALL=$(unreleased_section | grep -iE "${ENTRY_RE}[0-9]+\.[0-9]+\.[0-9]+" || true)
+
+# Entries for OTHER versions are ignored, not treated as an error. This repository keeps
+# every past entry under [Unreleased] rather than moving them beneath a released heading,
+# so older versions of a plugin are always present and legitimately so — rejecting them
+# would block every future release. Anchoring to the exact version is what fixes the
+# original defect: the old selection matched on plugin name and swept the neighbours in.
+MATCHING=$(printf '%s\n' "$ALL" | grep -iE "${ENTRY_RE}${VERSION_RE}([^0-9]|$)" || true)
+
+COUNT=$(printf '%s\n' "$MATCHING" | grep -c . || true)
+
+if [[ "$COUNT" -eq 0 ]]; then
+  # No note for this exact version — including the case where the plugin has entries for
+  # other versions only. Not an error: a plugin may be released without a changelog note,
+  # and inventing one from a neighbouring version is the defect this script exists to stop.
+  printf 'Released **%s** v%s\n' "$NAME" "$VERSION"
+  exit 0
+fi
+
+if [[ "$COUNT" -gt 1 ]]; then
+  {
+    echo "release-notes: ${COUNT} [Unreleased] entries for '${NAME}' v${VERSION};"
+    echo "               refusing to publish an ambiguous release note."
+    printf '%s\n' "$MATCHING" | sed 's/^/               /'
+  } >&2
+  exit 1
+fi
+
+printf '%s\n' "$MATCHING"

--- a/tests/test-bump-version-changelog.sh
+++ b/tests/test-bump-version-changelog.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Hermetic test for the CHANGELOG side of scripts/bump-version.sh — the entry that
+# becomes a published release note.
+#
+# Builds throwaway repositories, so it never inspects the repository it lives in.
+# No network.
+#
+# What this guards: a pull request with N commits touching one plugin runs the bump N
+# times, and the squash-merge publishes ONE release. Appending a line per run therefore
+# ships a release whose notes list versions that were never released — which reached
+# production once already (salesforce/v1.3.5 shipped notes for a v1.3.4 that has no tag).
+# Repeated bumps must converge on one entry at the current version.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/bump-version.sh"
+
+FAIL=0
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# A minimal repository with one plugin at 1.0.0 and an empty [Unreleased] section.
+new_repo() {
+  local dir="${WORK}/$1"
+  mkdir -p "$dir/.xcsh-plugin" "$dir/plugins/demo/.xcsh-plugin"
+  git -C "$dir" init -q -b main 2>/dev/null
+  git -C "$dir" config user.email bump@test
+  git -C "$dir" config user.name "Bump Test"
+  cat >"$dir/.xcsh-plugin/marketplace.json" <<'JSON'
+{ "plugins": [{ "name": "demo", "version": "1.0.0" }] }
+JSON
+  cat >"$dir/plugins/demo/.xcsh-plugin/plugin.json" <<'JSON'
+{ "name": "demo", "version": "1.0.0" }
+JSON
+  cat >"$dir/CHANGELOG.md" <<'MD'
+# Changelog
+
+## [Unreleased]
+
+## [0.9.0]
+
+- **`demo`** bumped to v0.9.0
+MD
+  echo "$dir"
+}
+
+# REPO_ROOT points the script at the throwaway repository. Without it the script derives
+# its root from its own path and would bump the checkout under test.
+bump() {
+  (cd "$1" && REPO_ROOT="$1" bash "$SCRIPT" demo patch) >/dev/null 2>&1
+}
+
+# Lines the release workflow would read: those between the first two "## [" headings,
+# capped at 20, mentioning the plugin. Mirrors release-plugins.yml exactly.
+release_lines() {
+  python3 - "$1" <<'PY'
+import sys
+lines = open(sys.argv[1] + '/CHANGELOG.md').read().split('\n')
+idx = [i for i, l in enumerate(lines) if l.startswith('## [')]
+for l in lines[idx[0] + 1:idx[1]][:20]:
+    if 'demo' in l.lower():
+        print(l)
+PY
+}
+
+check() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "[OK] $label"
+  else
+    echo "[FAIL] $label"
+    echo "       expected: $expected"
+    echo "       actual:   $actual"
+    FAIL=1
+  fi
+}
+
+# ── One bump produces exactly one entry ─────────────────────
+repo=$(new_repo single)
+bump "$repo"
+check "one bump -> one entry" \
+  "- **\`demo\`** bumped to v1.0.1" \
+  "$(release_lines "$repo")"
+
+# ── Repeated bumps converge rather than accumulate ──────────
+repo=$(new_repo repeated)
+bump "$repo"
+bump "$repo"
+bump "$repo"
+check "three bumps -> one entry, at the final version" \
+  "- **\`demo\`** bumped to v1.0.3" \
+  "$(release_lines "$repo")"
+
+version=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['plugins'][0]['version'])" \
+  "$repo/.xcsh-plugin/marketplace.json")
+check "manifest agrees with the entry" "1.0.3" "$version"
+
+# ── A hand-written prose entry is adopted, not duplicated ───
+# Contributors replace the placeholder with real prose. A later bump on the same branch
+# must relabel that prose, not bury it under a fresh placeholder — this is exactly how
+# the salesforce v1.3.4/v1.3.5 mismatch was produced.
+repo=$(new_repo prose)
+bump "$repo"
+python3 - "$repo" <<'PY'
+import sys
+p = sys.argv[1] + '/CHANGELOG.md'
+s = open(p).read().replace(
+    '- **`demo`** bumped to v1.0.1',
+    '- **`demo`** v1.0.1 — did a real thing worth describing.')
+open(p, 'w').write(s)
+PY
+bump "$repo"
+check "prose entry is relabelled, not duplicated" \
+  "- **\`demo\`** v1.0.2 — did a real thing worth describing." \
+  "$(release_lines "$repo")"
+
+# ── A shipped release's prose is never reattributed ─────────
+# This repository leaves entries for published releases under [Unreleased]. Relabelling one
+# would silently move a shipped description onto the version being cut and destroy the real
+# note — observed: three bumps rewrote "v1.3.5 — schema is discovered at runtime" to v1.3.8.
+repo=$(new_repo released_prose)
+python3 - "$repo" <<'PY'
+import sys
+p = sys.argv[1] + '/CHANGELOG.md'
+s = open(p).read().replace(
+    '## [Unreleased]\n',
+    '## [Unreleased]\n\n- **`demo`** v1.0.0 — shipped, and tagged, months ago.\n')
+open(p, 'w').write(s)
+PY
+git -C "$repo" add -A >/dev/null 2>&1
+git -C "$repo" commit -qm baseline >/dev/null 2>&1
+git -C "$repo" tag "demo/v1.0.0"
+bump "$repo"
+check "a tagged version's prose is left intact" \
+  "$(printf -- '- **`demo`** bumped to v1.0.1\n- **`demo`** v1.0.0 — shipped, and tagged, months ago.')" \
+  "$(release_lines "$repo")"
+
+# Untagged prose is still the current branch's work, so it is relabelled as before.
+repo=$(new_repo untagged_prose)
+bump "$repo"
+python3 - "$repo" <<'PY'
+import sys
+p = sys.argv[1] + '/CHANGELOG.md'
+s = open(p).read().replace(
+    '- **`demo`** bumped to v1.0.1',
+    '- **`demo`** v1.0.1 — written on this branch, not released yet.')
+open(p, 'w').write(s)
+PY
+bump "$repo"
+check "untagged prose is still relabelled" \
+  "- **\`demo\`** v1.0.2 — written on this branch, not released yet." \
+  "$(release_lines "$repo")"
+
+# ── Entries from earlier releases are left alone ────────────
+repo=$(new_repo history)
+bump "$repo"
+older=$(grep -c -- '- \*\*`demo`\*\* bumped to v0.9.0' "$repo/CHANGELOG.md")
+check "the released 0.9.0 entry survives untouched" "1" "$older"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "bump-version changelog tests FAILED"
+  exit 1
+fi
+echo "bump-version changelog tests passed"

--- a/tests/test-release-notes.sh
+++ b/tests/test-release-notes.sh
@@ -65,21 +65,24 @@ assert_refuses() {
 }
 
 # ── The happy paths ─────────────────────────────────────────
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v1.0.1
 MD
 )
 assert_body "placeholder entry for the tagged version" \
   '- **`demo`** bumped to v1.0.1' "$f" 1.0.1
 
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** v1.0.1 — describes the change in prose.
 MD
 )
 assert_body "prose entry for the tagged version" \
   '- **`demo`** v1.0.1 — describes the change in prose.' "$f" 1.0.1
 
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`other`** bumped to v3.0.0
 MD
 )
@@ -87,7 +90,8 @@ assert_body "no entry for this plugin falls back to a generic note" \
   'Released **demo** v1.0.1' "$f" 1.0.1
 
 # Another plugin's entry at a different version must not be mistaken for staleness.
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v1.0.1
 
 - **`other`** v9.9.9 — unrelated plugin, unrelated version.
@@ -100,7 +104,8 @@ assert_body "another plugin's entry is ignored" \
 # Exactly the shape that shipped as salesforce/v1.3.5: a placeholder for the tagged version
 # plus a prose entry labelled with a version that was never tagged. The old selection
 # matched on plugin name and published both. Only the tagged version may appear.
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v1.0.2
 
 - **`demo`** v1.0.1 — describes the change, but for the wrong version.
@@ -109,7 +114,8 @@ MD
 assert_body "the salesforce v1.3.5 shape publishes only the tagged version" \
   '- **`demo`** bumped to v1.0.2' "$f" 1.0.2
 
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v1.0.3
 
 - **`demo`** bumped to v1.0.2
@@ -122,7 +128,8 @@ assert_body "accumulated placeholders yield only the tagged one" \
 
 # This repository keeps entries for past releases under [Unreleased] indefinitely. Treating
 # those as an error would block every future release, so they must be silently skipped.
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v2.0.0
 
 - **`demo`** v1.5.0 — shipped months ago, still listed here by house style.
@@ -134,7 +141,8 @@ assert_body "historical entries under [Unreleased] do not block a release" \
   '- **`demo`** bumped to v2.0.0' "$f" 2.0.0
 
 # ── The one genuine refusal: real ambiguity ─────────────────
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v1.0.1
 
 - **`demo`** v1.0.1 — a duplicate at the same version.
@@ -144,7 +152,8 @@ assert_refuses "two entries at the tagged version is ambiguous" "$f" 1.0.1
 
 # ── Version matching is exact ───────────────────────────────
 # The dot in "1.0.1" must not behave as a regex wildcard.
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v1x0x1
 MD
 )
@@ -153,7 +162,8 @@ assert_body "a dot in the version is not a wildcard" \
 
 # A longer version starting with the same digits is a different release, so it must not be
 # mistaken for the tagged one.
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v1.0.10
 MD
 )
@@ -161,7 +171,8 @@ assert_body "v1.0.10 is not mistaken for v1.0.1" \
   'Released **demo** v1.0.1' "$f" 1.0.1
 
 # ── Earlier release sections are out of scope ───────────────
-f=$(changelog <<'MD'
+f=$(
+  changelog <<'MD'
 - **`demo`** bumped to v1.0.1
 MD
 )

--- a/tests/test-release-notes.sh
+++ b/tests/test-release-notes.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Hermetic test for scripts/release-notes.sh — the gate between CHANGELOG.md and a
+# published GitHub release body. Builds throwaway changelogs; never reads the repository
+# it lives in. No network.
+#
+# The case that matters most is "refuses": salesforce/v1.3.5 was published with notes
+# describing a v1.3.4 that has no tag, because the old inline selection matched on plugin
+# name and accepted whatever it found. A wrong release note cannot be spotted after the
+# fact, so the build has to stop.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/release-notes.sh"
+
+FAIL=0
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+n=0
+changelog() {
+  n=$((n + 1))
+  local f="${WORK}/CHANGELOG-${n}.md"
+  {
+    echo "# Changelog"
+    echo
+    echo "## [Unreleased]"
+    echo
+    cat
+    echo
+    echo "## [0.9.0]"
+    echo
+    echo '- **`demo`** bumped to v0.9.0'
+  } >"$f"
+  echo "$f"
+}
+
+assert_body() {
+  local label="$1" expected="$2" file="$3" version="$4"
+  local actual rc=0
+  actual=$(bash "$SCRIPT" demo "$version" "$file" 2>/dev/null) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "[FAIL] $label -> exited $rc, expected success"
+    FAIL=1
+  elif [ "$actual" = "$expected" ]; then
+    echo "[OK] $label"
+  else
+    echo "[FAIL] $label"
+    echo "       expected: $expected"
+    echo "       actual:   $actual"
+    FAIL=1
+  fi
+}
+
+assert_refuses() {
+  local label="$1" file="$2" version="$3"
+  local rc=0
+  bash "$SCRIPT" demo "$version" "$file" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "[OK] $label -> refused (exit $rc)"
+  else
+    echo "[FAIL] $label -> published, expected refusal"
+    FAIL=1
+  fi
+}
+
+# ── The happy paths ─────────────────────────────────────────
+f=$(changelog <<'MD'
+- **`demo`** bumped to v1.0.1
+MD
+)
+assert_body "placeholder entry for the tagged version" \
+  '- **`demo`** bumped to v1.0.1' "$f" 1.0.1
+
+f=$(changelog <<'MD'
+- **`demo`** v1.0.1 — describes the change in prose.
+MD
+)
+assert_body "prose entry for the tagged version" \
+  '- **`demo`** v1.0.1 — describes the change in prose.' "$f" 1.0.1
+
+f=$(changelog <<'MD'
+- **`other`** bumped to v3.0.0
+MD
+)
+assert_body "no entry for this plugin falls back to a generic note" \
+  'Released **demo** v1.0.1' "$f" 1.0.1
+
+# Another plugin's entry at a different version must not be mistaken for staleness.
+f=$(changelog <<'MD'
+- **`demo`** bumped to v1.0.1
+
+- **`other`** v9.9.9 — unrelated plugin, unrelated version.
+MD
+)
+assert_body "another plugin's entry is ignored" \
+  '- **`demo`** bumped to v1.0.1' "$f" 1.0.1
+
+# ── Neighbouring versions are excluded, not published ───────
+# Exactly the shape that shipped as salesforce/v1.3.5: a placeholder for the tagged version
+# plus a prose entry labelled with a version that was never tagged. The old selection
+# matched on plugin name and published both. Only the tagged version may appear.
+f=$(changelog <<'MD'
+- **`demo`** bumped to v1.0.2
+
+- **`demo`** v1.0.1 — describes the change, but for the wrong version.
+MD
+)
+assert_body "the salesforce v1.3.5 shape publishes only the tagged version" \
+  '- **`demo`** bumped to v1.0.2' "$f" 1.0.2
+
+f=$(changelog <<'MD'
+- **`demo`** bumped to v1.0.3
+
+- **`demo`** bumped to v1.0.2
+
+- **`demo`** bumped to v1.0.1
+MD
+)
+assert_body "accumulated placeholders yield only the tagged one" \
+  '- **`demo`** bumped to v1.0.3' "$f" 1.0.3
+
+# This repository keeps entries for past releases under [Unreleased] indefinitely. Treating
+# those as an error would block every future release, so they must be silently skipped.
+f=$(changelog <<'MD'
+- **`demo`** bumped to v2.0.0
+
+- **`demo`** v1.5.0 — shipped months ago, still listed here by house style.
+
+- **`demo`** v1.0.0 — older still.
+MD
+)
+assert_body "historical entries under [Unreleased] do not block a release" \
+  '- **`demo`** bumped to v2.0.0' "$f" 2.0.0
+
+# ── The one genuine refusal: real ambiguity ─────────────────
+f=$(changelog <<'MD'
+- **`demo`** bumped to v1.0.1
+
+- **`demo`** v1.0.1 — a duplicate at the same version.
+MD
+)
+assert_refuses "two entries at the tagged version is ambiguous" "$f" 1.0.1
+
+# ── Version matching is exact ───────────────────────────────
+# The dot in "1.0.1" must not behave as a regex wildcard.
+f=$(changelog <<'MD'
+- **`demo`** bumped to v1x0x1
+MD
+)
+assert_body "a dot in the version is not a wildcard" \
+  'Released **demo** v1.0.1' "$f" 1.0.1
+
+# A longer version starting with the same digits is a different release, so it must not be
+# mistaken for the tagged one.
+f=$(changelog <<'MD'
+- **`demo`** bumped to v1.0.10
+MD
+)
+assert_body "v1.0.10 is not mistaken for v1.0.1" \
+  'Released **demo** v1.0.1' "$f" 1.0.1
+
+# ── Earlier release sections are out of scope ───────────────
+f=$(changelog <<'MD'
+- **`demo`** bumped to v1.0.1
+MD
+)
+assert_body "the released 0.9.0 entry below is not considered stale" \
+  '- **`demo`** bumped to v1.0.1' "$f" 1.0.1
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "release-notes tests FAILED"
+  exit 1
+fi
+echo "release-notes tests passed"


### PR DESCRIPTION
Fixes #943

## What was wrong

A branch bumps once per commit; the squash-merge publishes **one** release. `bump-version.sh` appended a changelog line per bump, so a multi-commit PR shipped a release whose notes listed versions that were never tagged. That already reached production: `salesforce/v1.3.5` went out describing a **v1.3.4** that has no tag. #939 corrected that one instance by hand — which fixed one occurrence and prevented none.

Reproduced from `main` before this change, three commits:

```
after commit 1: 1.3.6
after commit 2: 1.3.7
after commit 3: 1.3.8

- **`salesforce`** bumped to v1.3.8
- **`salesforce`** bumped to v1.3.7
- **`salesforce`** bumped to v1.3.6
- **`salesforce`** v1.3.5 — …        ← all four would land in the v1.3.8 release notes
```

## Two changes

**`bump-version.sh` converges instead of appending.** It relabels the plugin's existing `[Unreleased]` entry, so N bumps leave one line at the current version. Both shapes are handled — the placeholder it writes, and the prose a contributor replaces it with, which is exactly how the v1.3.4/v1.3.5 mismatch arose.

**Release-note selection moves out of inline YAML into `scripts/release-notes.sh`,** anchored to the version being tagged rather than the plugin name. It refuses to publish when two entries claim the same version.

Same three-commit probe, after:

```
after commit 3: 1.3.8

- **`salesforce`** bumped to v1.3.8
- **`salesforce`** v1.3.5 — …        ← the shipped release's note, untouched

release note for v1.3.8:
- **`salesforce`** bumped to v1.3.8  ← one line, correct
```

## Two things the probe caught in my own fix

Both were found by running against the **real** changelog rather than fixtures, and both would have been worse than the bug being fixed.

1. **Rejecting older entries blocked every release.** My first cut treated any other version of the plugin in `[Unreleased]` as drift. This repository keeps entries for shipped releases there indefinitely, so tagging v1.3.5 against real `main` failed on a `v1.3.0` line 840 lines down. The version anchor alone fixes the actual defect; the staleness rule was over-reach and is gone.

2. **Relabelling rewrote a shipped release's description.** Three bumps turned `v1.3.5 — schema is discovered at runtime` into `v1.3.8`, destroying what v1.3.5 actually was. Prose is now only relabelled when its version has **no release tag**; placeholders are always safe to relabel. With tags unavailable (shallow clone) the check fails closed and prose is left alone.

## Testability

Neither script could be tested before: both derived `REPO_ROOT` from `$0`, so every invocation mutated the checkout they lived in. That is *why* this behaviour had no test until a bad release note reached production. Both now honour an inherited `REPO_ROOT`.

The `[Unreleased]` scan also moves from `sed -n '/^## \[/,/^## \[/{//!p}'` to awk. That sed form is a GNU extension which BSD sed rejects outright — the workflow's copy worked in CI and silently produced nothing on a macOS checkout, so the behaviour could not be reproduced locally.

New hermetic tests, building throwaway repositories, never reading the repo they run in:

```
tests/test-bump-version-changelog.sh   7 cases  — convergence, prose handling, tag guard
tests/test-release-notes.sh           11 cases  — selection, ambiguity, exact-version matching
```

Including the exact shape that shipped, and a case asserting historical entries do not block a release.

## Verification

```
tests/test-bump-version-changelog.sh   passed
tests/test-release-notes.sh            passed
tests/test-check-repo-hygiene.sh       passed  (unchanged, no regression)
pre-commit (all changed files)         13 hooks pass, incl. GitHub Actions security
release-notes.sh against real main     one correct line for v1.3.5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
