### PR TITLE
fix: publish the whole changelog entry, not its first line

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -77,4 +77,24 @@ if [[ "$COUNT" -gt 1 ]]; then
   exit 1
 fi
 
-printf '%s\n' "$MATCHING"
+# Emit the whole entry, not just its first line.
+#
+# A changelog entry here is a block: the "- **`name`** vX.Y.Z …" line, then indented
+# continuation paragraphs and nested bullets, ending at the next top-level "- " entry.
+# Selecting with a line-oriented grep published only the summary line, so every release
+# note this workflow ever cut was a sentence truncated mid-clause.
+#
+# The leading "- " is stripped and continuations dedented by two, so the note reads as
+# prose on the release page instead of one oversized list item; nested bullets keep their
+# relative depth. Trailing blank lines are dropped.
+unreleased_section | awk -v start="$MATCHING" '
+  index($0, start) == 1 && !started { started = 1; print substr($0, 3); next }
+  started {
+    # A new top-level list item ends this entry.
+    if ($0 ~ /^- /) { exit }
+    if ($0 ~ /^[^ \t]/ && $0 != "") { exit }
+    if ($0 == "") { blanks++; next }
+    while (blanks > 0) { print ""; blanks-- }
+    print substr($0, 3)
+  }
+'

--- a/tests/test-release-notes.sh
+++ b/tests/test-release-notes.sh
@@ -71,7 +71,41 @@ f=$(
 MD
 )
 assert_body "placeholder entry for the tagged version" \
-  '- **`demo`** bumped to v1.0.1' "$f" 1.0.1
+  '**`demo`** bumped to v1.0.1' "$f" 1.0.1
+
+# ── A multi-line entry is published whole ───────────────────
+# Entries in this repository are blocks: a summary line, indented continuation paragraphs,
+# and nested bullets. Selecting with a line-oriented grep published only the first line, so
+# salesforce/v1.0.5 went out as a sentence cut mid-clause. The leading "- " is stripped and
+# continuations dedented by two, so the body reads as prose rather than one giant list item.
+MULTILINE_EXPECTED=$(
+  cat <<'EXPECTED'
+**`demo`** v1.0.1 — the summary line, which wraps
+onto a second line.
+
+A paragraph of cause, indented to match.
+
+- **A nested bullet.** With its own
+  continuation.
+- A second nested bullet.
+EXPECTED
+)
+f=$(
+  changelog <<'MD'
+- **`demo`** v1.0.1 — the summary line, which wraps
+  onto a second line.
+
+  A paragraph of cause, indented to match.
+
+  - **A nested bullet.** With its own
+    continuation.
+  - A second nested bullet.
+
+- **`other`** v2.0.0 — a different plugin entry, which must not leak in.
+MD
+)
+assert_body "a multi-line entry is emitted whole, dedented" \
+  "$MULTILINE_EXPECTED" "$f" 1.0.1
 
 f=$(
   changelog <<'MD'
@@ -79,7 +113,7 @@ f=$(
 MD
 )
 assert_body "prose entry for the tagged version" \
-  '- **`demo`** v1.0.1 — describes the change in prose.' "$f" 1.0.1
+  '**`demo`** v1.0.1 — describes the change in prose.' "$f" 1.0.1
 
 f=$(
   changelog <<'MD'
@@ -98,7 +132,7 @@ f=$(
 MD
 )
 assert_body "another plugin's entry is ignored" \
-  '- **`demo`** bumped to v1.0.1' "$f" 1.0.1
+  '**`demo`** bumped to v1.0.1' "$f" 1.0.1
 
 # ── Neighbouring versions are excluded, not published ───────
 # Exactly the shape that shipped as salesforce/v1.3.5: a placeholder for the tagged version
@@ -112,7 +146,7 @@ f=$(
 MD
 )
 assert_body "the salesforce v1.3.5 shape publishes only the tagged version" \
-  '- **`demo`** bumped to v1.0.2' "$f" 1.0.2
+  '**`demo`** bumped to v1.0.2' "$f" 1.0.2
 
 f=$(
   changelog <<'MD'
@@ -124,7 +158,7 @@ f=$(
 MD
 )
 assert_body "accumulated placeholders yield only the tagged one" \
-  '- **`demo`** bumped to v1.0.3' "$f" 1.0.3
+  '**`demo`** bumped to v1.0.3' "$f" 1.0.3
 
 # This repository keeps entries for past releases under [Unreleased] indefinitely. Treating
 # those as an error would block every future release, so they must be silently skipped.
@@ -138,7 +172,7 @@ f=$(
 MD
 )
 assert_body "historical entries under [Unreleased] do not block a release" \
-  '- **`demo`** bumped to v2.0.0' "$f" 2.0.0
+  '**`demo`** bumped to v2.0.0' "$f" 2.0.0
 
 # ── The one genuine refusal: real ambiguity ─────────────────
 f=$(
@@ -177,7 +211,7 @@ f=$(
 MD
 )
 assert_body "the released 0.9.0 entry below is not considered stale" \
-  '- **`demo`** bumped to v1.0.1' "$f" 1.0.1
+  '**`demo`** bumped to v1.0.1' "$f" 1.0.1
 
 if [ "$FAIL" -ne 0 ]; then
   echo "release-notes tests FAILED"


### PR DESCRIPTION
Fixes #949

## What was wrong

`release-notes.sh` selects with `grep`, which is line-oriented. A changelog entry here is a **block** — summary line, indented continuation paragraphs, nested bullets. So every release this workflow has ever cut carried one line of it.

`salesforce/v1.3.5` currently reads, in full:

```
- **`salesforce`** v1.3.5 — schema is discovered at runtime instead of guessed, and a rejected column
```

A sentence stopped mid-clause, with three paragraphs of cause and four sub-bullets left behind.

## Fix

Read the entry as a block, ending at the next top-level `- ` item. Strip the leading `- ` and dedent continuations by two, so the note reads as prose on the release page instead of one oversized list item; nested bullets keep their relative depth.

Against the real changelog, v1.3.5 goes from **1 line to 26**, with nothing bleeding in from the `meddpicc` entry that follows it:

```
**`salesforce`** v1.3.5 — schema is discovered at runtime instead of guessed, and a rejected column
now says which one. Three defects compounded into a query the agent could not recover from.

The query prompt told the model to read `Opportunity.CompetitorName`, which exists on no org — it
belongs to the child `OpportunityCompetitor` object. …

- **New `sf_describe` tool.** Returns an object's real fields filtered by a concept match …
```

## Unchanged

Exact-version anchoring, the refusal when two entries claim one version, and the generic fallback all behave as before — the guarantees from #943 are intact and still covered.

## Verification

```
tests/test-release-notes.sh            12 cases pass (11 existing + multi-line)
tests/test-bump-version-changelog.sh    7 cases pass
tests/test-check-repo-hygiene.sh        passes, unchanged
shfmt -i 2                              clean
pre-commit (changed files)              9 hooks pass
```

The new case asserts the block is emitted whole and dedented, and that a following plugin's entry does not leak in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)