### PR TITLE
fix: release notes over 64 KiB die on SIGPIPE, blocking every release

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -87,12 +87,22 @@ fi
 # The leading "- " is stripped and continuations dedented by two, so the note reads as
 # prose on the release page instead of one oversized list item; nested bullets keep their
 # relative depth. Trailing blank lines are dropped.
+# Reads to EOF rather than exiting at the end of the entry.
+#
+# `exit` here was a reader quitting on a writer still writing. Below the 64 KiB pipe buffer the
+# writer finishes first and nothing notices; above it the writer blocks, takes SIGPIPE when awk
+# leaves, and `pipefail` makes 141 the status of a script that just printed the correct note. The
+# workflow read that as an ambiguous changelog and refused to publish, which is why meddpicc/v7.2.0
+# was merged and never tagged.
+#
+# `done` stops the emitting; the input is consumed either way. Reading a few spare kilobytes costs
+# nothing next to guessing whether the other end of a pipe has finished.
 unreleased_section | awk -v start="$MATCHING" '
   index($0, start) == 1 && !started { started = 1; print substr($0, 3); next }
-  started {
-    # A new top-level list item ends this entry.
-    if ($0 ~ /^- /) { exit }
-    if ($0 ~ /^[^ \t]/ && $0 != "") { exit }
+  started && !done {
+    # A new top-level list item, or any unindented line, ends this entry.
+    if ($0 ~ /^- /) { done = 1; next }
+    if ($0 ~ /^[^ \t]/ && $0 != "") { done = 1; next }
     if ($0 == "") { blanks++; next }
     while (blanks > 0) { print ""; blanks-- }
     print substr($0, 3)

--- a/tests/test-release-notes.sh
+++ b/tests/test-release-notes.sh
@@ -213,6 +213,32 @@ MD
 assert_body "the released 0.9.0 entry below is not considered stale" \
   '**`demo`** bumped to v1.0.1' "$f" 1.0.1
 
+# ── A changelog bigger than the pipe buffer ─────────────────
+#
+# The case that shipped. `awk` stops at the next top-level entry, and it used to stop by
+# calling `exit` — while the writer feeding it was still writing. On a small changelog the
+# writer finishes first and the output fits the 64 KiB pipe buffer, so nothing notices. Once
+# the [Unreleased] section passes that buffer the writer blocks, the reader quits, the writer
+# takes SIGPIPE, and `pipefail` makes 141 the script's status — after it has printed exactly
+# the right note. The workflow then reports an ambiguous changelog, which is not the problem.
+#
+# So the fixture has to be large AND the matched entry has to be followed by another. Every
+# small fixture above passes with the bug present, which is why it reached a release.
+big=$(
+  {
+    echo '- **`demo`** bumped to v1.2.3'
+    echo
+    for i in $(seq 1 900); do
+      echo "- **\`filler\${i}\`** v1.0.0 — padding, long enough that the writer blocks on a full pipe."
+      echo
+      echo "  Continuation prose for padding entry \${i}, adding bulk past the 64 KiB pipe buffer."
+      echo
+    done
+  } | changelog
+)
+assert_body "a note is emitted from an [Unreleased] section larger than the pipe buffer" \
+  '**`demo`** bumped to v1.2.3' "$big" 1.2.3
+
 if [ "$FAIL" -ne 0 ]; then
   echo "release-notes tests FAILED"
   exit 1


### PR DESCRIPTION
## What this does

Closes #951. `Release Plugins` failed on `main` and **`meddpicc/v7.2.0` was never tagged**, because
`scripts/release-notes.sh` printed exactly the right release note and then exited **141**.

The workflow reported this, about a changelog that is fine:

```
::error::Refusing to publish meddpicc/v7.2.0: CHANGELOG.md does not unambiguously describe meddpicc v7.2.0
```

## Cause

The final statement is a pipeline whose reader quits early — `awk` called `exit` at the end of the matched
entry while `unreleased_section` was still writing. The writer takes SIGPIPE, and `set -o pipefail` makes
141 the status of a script that has already emitted the correct bytes.

**Size-dependent, which is why the script's own tests pass.** Below the 64 KiB pipe buffer the writer
finishes before the reader leaves:

| `[Unreleased]` section | matched entry | exit |
| --- | --- | --- |
| small fixture | followed by another | 0 |
| small fixture | last entry | 0 |
| 168 KB fixture | followed by another | **141** |
| **real `CHANGELOG.md` — 67,996 bytes** | followed by another | **141** |

The real section had just crossed the buffer, so this was latent when #948 landed and became live when the
changelog grew. Every plugin release is blocked while it stays over 64 KiB, and the error points at the
wrong thing.

## Fix

`done` stops the emitting; the input is consumed to EOF either way. Reading a few spare kilobytes costs
nothing next to guessing whether the other end of a pipe has finished.

## Verification

- The new test fails before this change with `exited 141, expected success`, and passes after. It needs a
  fixture **larger than the pipe buffer** with the matched entry followed by another — every small fixture
  in that file passes with the bug present, which is how it reached a release.
- `scripts/release-notes.sh meddpicc 7.2.0 CHANGELOG.md` exits 0 and emits the 32-line note.
- **The note is byte-identical before and after** — `diff` of the two outputs is empty. Only the exit status
  changed, which is the property a fix like this should be able to claim.
- `shellcheck`, `shfmt -d`, `codespell` clean; `check-version-bumps` reports no plugin content changes.

## After this merges

`meddpicc/v7.2.0` still needs cutting. The commit that should have released it (#947) has already landed, so
the version diff will not reappear on this merge — the failed run has to be re-run against `a16641c`. I will
do that and confirm the tag and release exist.
