### PR TITLE
MEDDPICC: a serialization contract for text the writer does not control (v7.2.1)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v7.2.1 — a serialization contract for text the writer does not control. No behaviour
+  change: the generated workbook is byte-identical, same sha256, because no value in play today contains
+  any of these characters.
+
+  Three hazards, all silent, none of them an XML problem — Excel's own grammar is what breaks, so escaping
+  the XML leaves the text intact and wrong.
+
+  - **A comma in a dropdown value became two entries.** The inline list is a quoted, comma-joined string
+    with no escape for a comma, so `Yes, please` offered `Yes` and a second entry beginning with a space — and the reverse map would
+    then fail to recognise whichever a rep picked. Refused at build time, naming the value and the range;
+    escaping is not an option, and backing the validation with a hidden range is a much larger change that
+    buys nothing while no value needs it.
+  - **A quote in a dropdown value ended the list early**, the whole list being one quoted string. Refused
+    the same way.
+  - **A quote in a formula word closed its string early.** `He said "yes"` emitted `"He said "yes""` where
+    Excel needs `"He said ""yes"""`, leaving Excel to parse the remainder as syntax. Now doubled — and
+    **verified in Excel**, which evaluates the emitted formula to `He said "yes"` and echoes it back
+    doubled, since only Excel can settle its own grammar.
+  - The **255-character cap** on an inline list was already enforced and had **no test** — the other `255`
+    assertions in that file are about the print header. Covered now, because CJK and Devanagari
+    translations are what will push a list toward it.
+
+  Latent today, in the same way #929 was: localisation (#925) is what makes it live, where 192
+  model-authored strings per locale meet punctuation that is unremarkable in prose.
+
 - **`meddpicc`** v7.2.0 — the locale is decided once, early, from every input. `generate` takes
   `--locale`. English output is unchanged, because English is still what everything resolves to.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,12 @@ and this project adheres to
     then fail to recognise whichever a rep picked. Refused at build time, naming the value and the range;
     escaping is not an option, and backing the validation with a hidden range is a much larger change that
     buys nothing while no value needs it.
-  - **A quote in a dropdown value ended the list early**, the whole list being one quoted string. Refused
-    the same way.
+  - **A quote in a dropdown value ended the list early**, the whole list being one quoted string. Not
+    refused, though: unlike a comma, a quote **is** representable by doubling. Verified in Excel — a list
+    written `"He said ""yes"",No"` reads back as `He said "yes",No` and offers the two entries intended. My
+    first version refused it, which review rightly called an avoidable outage the first time a translation
+    used ordinary punctuation. The 255-character budget is measured on the escaped text, since that is what
+    Excel receives and a value full of quotation marks costs twice what it looks like.
   - **A quote in a formula word closed its string early.** `He said "yes"` emitted `"He said "yes""` where
     Excel needs `"He said ""yes"""`, leaving Excel to parse the remainder as syntax. Now doubled — and
     **verified in Excel**, which evaluates the emitted formula to `He said "yes"` and echoes it back
@@ -31,6 +35,9 @@ and this project adheres to
   - The **255-character cap** on an inline list was already enforced and had **no test** — the other `255`
     assertions in that file are about the print header. Covered now, because CJK and Devanagari
     translations are what will push a list toward it.
+  - **All four sinks share one helper.** A label reaches an Excel formula in four places, and the first
+    version escaped one: review found a section label in an `INDEX/MATCH`, the compiled completion statuses,
+    and the words the conditional formats compare. `excelString` is what they all call now.
 
   Latent today, in the same way #929 was: localisation (#925) is what makes it live, where 192
   model-authored strings per locale meet punctuation that is unremarkable in prose.

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/completion-formula.ts
+++ b/plugins/meddpicc/engine/completion-formula.ts
@@ -25,7 +25,7 @@
 import { entryFieldsOf, type Predicate, type SectionRule } from './completion-rules';
 import { type InputCell, sheetPrefix } from './generate';
 import { statusLabel } from './sections';
-import { columnIndex } from './xlsx';
+import { columnIndex, excelString } from './xlsx';
 
 /** Where the deal's paths ended up on the sheet. Built from the plan, never from a coordinate. */
 export interface CellResolver {
@@ -241,5 +241,7 @@ export function compilePredicate(predicate: Predicate, resolve: CellResolver): s
 export function compileStatus(rule: SectionRule, resolve: CellResolver): string {
   const complete = compilePredicate(rule.complete, resolve);
   const started = compilePredicate(rule.started, resolve);
-  return `IF(${complete},"${statusLabel('complete')}",IF(${started},"${statusLabel('partial')}","${statusLabel('not_started')}"))`;
+  // Through `excelString`, like every other label that reaches a formula: a translated status carrying a
+  // quotation mark would otherwise close the string it sits in.
+  return `IF(${complete},${excelString(statusLabel('complete'))},IF(${started},${excelString(statusLabel('partial'))},${excelString(statusLabel('not_started'))}))`;
 }

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -5,7 +5,7 @@ import { computeCompletion } from './completion';
 import type { WorkbookPlan } from './generate';
 import { BOOLEAN_NO, BOOLEAN_YES, dateToSerial, FORMULA_WORDS, generateWorkbook, planWorkbook } from './generate';
 import { ENUM_LABELS, enumLabel } from './labels';
-import { QUALIFICATION_ELEMENTS, SECTION_ORDER, sectionLabel, statusLabel } from './sections';
+import { QUALIFICATION_ELEMENTS, SECTION_LABELS, SECTION_ORDER, sectionLabel, statusLabel } from './sections';
 import { estimateRowHeight, MAX_ROW_HEIGHT } from './text-metrics';
 import { specTables, type WorkbookSpec } from './workbook-spec';
 import { A1, COMPLETION_STATUSES, columnIndex, columnLetter } from './xlsx';
@@ -1200,14 +1200,11 @@ describe('a formula word carries text the writer does not control', () => {
   });
 
   test('a word whose value contains a quote is emitted doubled', () => {
-    // The direct case. FORMULA_WORDS is built from enum labels, so the only way to reach this today is to
-    // ask the resolver for a word that carries one — which is exactly what a translation will do.
     const withQuote = clone(spec);
     const block = withQuote.sheets[0].blocks.find((b) => b.cells?.some((c) => typeof c.formula === 'string'));
     const cell = block?.cells?.find((c) => typeof c.formula === 'string');
     if (!cell) throw new Error('no formula cell in the spec');
     cell.formula = 'IF(1=1,{{word:quoteCarrier}},"")';
-    // Registered for this test only; the resolver refuses a word it has never heard of, which is its own guard.
     FORMULA_WORDS.quoteCarrier = 'He said "yes"';
     try {
       const emitted = planWorkbook(schema, withQuote, deal)
@@ -1217,9 +1214,63 @@ describe('a formula word carries text the writer does not control', () => {
         .filter((f): f is string => typeof f === 'string')
         .find((f) => f.includes('He said'));
       expect(emitted).toContain('"He said ""yes"""');
-      expect((emitted?.match(/"/g) ?? []).length % 2).toBe(0);
     } finally {
       delete FORMULA_WORDS.quoteCarrier;
+    }
+  });
+
+  test('a completion status carrying a quote is doubled in the compiled formula', () => {
+    // The second of four sinks, and the one my first attempt missed. That attempt asserted "some formula
+    // contains a doubled quote", which the WORD sink satisfied on its own — so reverting this sink left the
+    // test green. The assertion has to name this sink's own text.
+    ENUM_LABELS.complete = 'Done "fully"';
+    try {
+      const formulas = planWorkbook(schema, clone(spec), deal)
+        .sheets.flatMap((sh) => sh.rows)
+        .flatMap((r) => r.cells)
+        .map((c) => c.formula)
+        .filter((f): f is string => typeof f === 'string')
+        .filter((f) => f.includes('Done'));
+      expect(formulas.length).toBeGreaterThan(0);
+      for (const f of formulas) expect(f, f).toContain('"Done ""fully"""');
+    } finally {
+      ENUM_LABELS.complete = 'Complete';
+    }
+  });
+
+  test('every conditional-format rule builds its literal with excelString', () => {
+    // The third sink cannot be reached at runtime: CF_PRESETS is a module constant built at import from
+    // `enumLabel`, so mutating a label afterwards cannot change it — and a hand-quoted literal and an
+    // excelString one are the same bytes for today's quote-free labels. There is nothing to observe.
+    //
+    // So this reads the source, narrowly: every `formulas:` entry inside the CF_PRESETS block must call
+    // excelString. A source check is the honest tool for "this construction must not appear", and scoping it
+    // to one block keeps it from being brittle.
+    const src = fs.readFileSync(path.join(here, 'xlsx.ts'), 'utf8');
+    const start = src.indexOf('export const CF_PRESETS');
+    const block = src.slice(start, src.indexOf('\n};', start));
+    // Every rule that interpolates a LABEL must go through excelString. A rule with a literal Excel string
+    // in it — `overdueDate` compares against `""`, the empty string — is not a label and is out of scope.
+    const labelRules = block.split('\n').filter((l) => l.includes('formulas:') && l.includes('enumLabel('));
+    expect(labelRules.length).toBeGreaterThan(0);
+    for (const line of labelRules) expect(line.trim(), line.trim()).toContain('excelString(');
+  });
+
+  test('the INDEX/MATCH section-label sink is not reachable from the shipped spec', () => {
+    // Stated rather than claimed covered. `sectionLabel` reaches a formula only through the keyed-table
+    // INDEX/MATCH path, and the shipped spec never takes it — a quote injected into SECTION_LABELS appears in
+    // zero formulas. It goes through excelString like the others, but nothing here exercises it, and saying
+    // so beats a test that looks like coverage and is not.
+    (SECTION_LABELS as Record<string, string>).metrics = 'Met "rics"';
+    try {
+      const formulas = planWorkbook(schema, clone(spec), deal)
+        .sheets.flatMap((sh) => sh.rows)
+        .flatMap((r) => r.cells)
+        .map((c) => c.formula)
+        .filter((f): f is string => typeof f === 'string');
+      expect(formulas.filter((f) => f.includes('Met ')).length).toBe(0);
+    } finally {
+      (SECTION_LABELS as Record<string, string>).metrics = 'Metrics';
     }
   });
 });

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { computeCompletion } from './completion';
 import type { WorkbookPlan } from './generate';
-import { BOOLEAN_NO, BOOLEAN_YES, dateToSerial, generateWorkbook, planWorkbook } from './generate';
+import { BOOLEAN_NO, BOOLEAN_YES, dateToSerial, FORMULA_WORDS, generateWorkbook, planWorkbook } from './generate';
 import { ENUM_LABELS, enumLabel } from './labels';
 import { QUALIFICATION_ELEMENTS, SECTION_ORDER, sectionLabel, statusLabel } from './sections';
 import { estimateRowHeight, MAX_ROW_HEIGHT } from './text-metrics';
@@ -1172,5 +1172,54 @@ describe('planWorkbook — the row a wash asks about is its own table’s row', 
     const rangeOf = (ref: string) => formats.find((f) => f.sqref.startsWith(`${ref}:`))?.rowRange;
     expect(rangeOf(left.ref('owner', 0))).toBe(`$B${left.firstDataRow}:$I${left.firstDataRow}`);
     expect(rangeOf(right.ref('role', 0))).toBe(`$J${right.firstDataRow}:$Q${right.firstDataRow}`);
+  });
+});
+
+describe('a formula word carries text the writer does not control', () => {
+  test('a literal quote is doubled, as Excel requires', () => {
+    // `"He said "yes""` closes the string at the first inner quote; Excel needs `"He said ""yes"""`. Latent
+    // while every FORMULA_WORDS value is one plain word, and live once #925 supplies translations, where a
+    // quotation mark is unremarkable.
+    //
+    // Exercised through the real resolver by giving a spec formula a word whose value contains a quote —
+    // asserting balance over today's formulas would pass with the bug present, since none has a quote in it.
+    const quoted = clone(spec);
+    const block = quoted.sheets[0].blocks.find((b) => b.cells?.some((c) => typeof c.formula === 'string'));
+    const cell = block?.cells?.find((c) => typeof c.formula === 'string');
+    if (!cell) throw new Error('no formula cell in the spec — the fixture needs revisiting');
+    cell.formula = 'IF(1=1,{{word:statusComplete}},"")';
+    const emitted = planWorkbook(schema, quoted, deal)
+      .sheets.flatMap((sh) => sh.rows)
+      .flatMap((r) => r.cells)
+      .map((c) => c.formula)
+      .filter((f): f is string => typeof f === 'string');
+    // Every emitted formula must have balanced quotes: an odd count means one ended a string it should not.
+    for (const formula of emitted) {
+      expect((formula.match(/"/g) ?? []).length % 2, formula).toBe(0);
+    }
+  });
+
+  test('a word whose value contains a quote is emitted doubled', () => {
+    // The direct case. FORMULA_WORDS is built from enum labels, so the only way to reach this today is to
+    // ask the resolver for a word that carries one — which is exactly what a translation will do.
+    const withQuote = clone(spec);
+    const block = withQuote.sheets[0].blocks.find((b) => b.cells?.some((c) => typeof c.formula === 'string'));
+    const cell = block?.cells?.find((c) => typeof c.formula === 'string');
+    if (!cell) throw new Error('no formula cell in the spec');
+    cell.formula = 'IF(1=1,{{word:quoteCarrier}},"")';
+    // Registered for this test only; the resolver refuses a word it has never heard of, which is its own guard.
+    FORMULA_WORDS.quoteCarrier = 'He said "yes"';
+    try {
+      const emitted = planWorkbook(schema, withQuote, deal)
+        .sheets.flatMap((sh) => sh.rows)
+        .flatMap((r) => r.cells)
+        .map((c) => c.formula)
+        .filter((f): f is string => typeof f === 'string')
+        .find((f) => f.includes('He said'));
+      expect(emitted).toContain('"He said ""yes"""');
+      expect((emitted?.match(/"/g) ?? []).length % 2).toBe(0);
+    } finally {
+      delete FORMULA_WORDS.quoteCarrier;
+    }
   });
 });

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -530,7 +530,14 @@ function resolveFormula(
           `${ctx.sheet}: {{word:${ref.target}}} names no word — have ${Object.keys(FORMULA_WORDS).join(', ')}`,
         );
       }
-      replacement = `"${word}"`;
+      // A literal quote inside an Excel string is written doubled. Without that, `He said "yes"` emits
+      // `"He said "yes""`, which closes the string at the first inner quote and leaves Excel parsing the
+      // rest as syntax — a repair prompt, or worse, a formula that means something else.
+      //
+      // Latent while every word here is one plain enum label, and live the moment #925 supplies
+      // translations: a quotation mark is unremarkable in prose, and the words a formula compares against
+      // are exactly the dropdown values a translation replaces.
+      replacement = `"${word.replace(/"/g, '""')}"`;
     } else if (ref.kind === 'ref') {
       const target = named.get(ref.target);
       if (!target) throw new Error(`${ctx.sheet}: {{ref:${ref.target}}} names no cell`);

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -39,6 +39,7 @@ import {
   type ConditionalFormat,
   columnLetter,
   ENGINE_VERSION_PROPERTY,
+  excelString,
   FINGERPRINT_PROPERTY,
   LOCALE_PROPERTY,
   SCHEMA_HASH_PROPERTY,
@@ -537,7 +538,7 @@ function resolveFormula(
       // Latent while every word here is one plain enum label, and live the moment #925 supplies
       // translations: a quotation mark is unremarkable in prose, and the words a formula compares against
       // are exactly the dropdown values a translation replaces.
-      replacement = `"${word.replace(/"/g, '""')}"`;
+      replacement = excelString(word);
     } else if (ref.kind === 'ref') {
       const target = named.get(ref.target);
       if (!target) throw new Error(`${ctx.sheet}: {{ref:${ref.target}}} names no cell`);
@@ -572,7 +573,7 @@ function resolveFormula(
         const valueRange = `${prefix}${A1(col, found.firstDataRow)}:${A1(col, last)}`;
         const keyRange = `${prefix}${A1(keyCol, found.firstDataRow)}:${A1(keyCol, last)}`;
         // The key column displays a label, so that is what MATCH has to look for.
-        replacement = `INDEX(${valueRange},MATCH("${sectionLabel(rowKey)}",${keyRange},0))`;
+        replacement = `INDEX(${valueRange},MATCH(${excelString(sectionLabel(rowKey))},${keyRange},0))`;
       } else {
         // An empty table still needs a syntactically valid range, so span at least one row.
         const last = found.firstDataRow + Math.max(found.rowCount, 1) - 1;

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -1061,8 +1061,24 @@ describe('text the writer does not control', () => {
     expect(() => buildWorkbook([withDropdown(['Yes, please', 'No'])], {})).toThrow(/Yes, please/);
   });
 
-  test('a quote in a dropdown value is refused, because it ends the list early', () => {
-    expect(() => buildWorkbook([withDropdown(['He said "yes"', 'No'])], {})).toThrow(/quote|"/i);
+  test('a quote in a dropdown value is doubled, not refused', () => {
+    // Unlike a comma, a quote IS representable: doubled, as in any Excel string. Verified in Excel — a list
+    // written `"He said ""yes"",No"` reads back as `He said "yes",No` and offers the two entries intended.
+    // My first version refused it, which would have been an avoidable outage the first time a translation
+    // used ordinary punctuation.
+    const parts = readZip(buildWorkbook([withDropdown(['He said "yes"', 'No'])], {}));
+    const xml = dec(parts.get('xl/worksheets/sheet1.xml')?.data as Uint8Array);
+    // The emitted payload carries the doubled form, XML-escaped on top of that.
+    expect(xml).toContain('He said &quot;&quot;yes&quot;&quot;,No');
+  });
+
+  test('the 255-character budget is measured on what Excel receives', () => {
+    // Escaping happens first, so a value full of quotation marks costs twice what it looks like. Measuring
+    // the unescaped text would let a list through that Excel then drops.
+    const quoteHeavy = Array.from({ length: 8 }, (_, i) => `${'"'.repeat(16)}value${i}`);
+    expect(quoteHeavy.join(',').length).toBeLessThanOrEqual(255);
+    expect(quoteHeavy.map((v) => v.replace(/"/g, '""')).join(',').length).toBeGreaterThan(255);
+    expect(() => buildWorkbook([withDropdown(quoteHeavy)], {})).toThrow(/255/);
   });
 
   test('an ordinary dropdown is unaffected', () => {

--- a/plugins/meddpicc/engine/xlsx.test.ts
+++ b/plugins/meddpicc/engine/xlsx.test.ts
@@ -1042,3 +1042,41 @@ describe('the two levels of an empty-cell wash', () => {
     expect(dxfOf('wantedInRow')).toBe('watch');
   });
 });
+
+describe('text the writer does not control', () => {
+  /** The smallest sheet that carries one dropdown. */
+  const withDropdown = (values: string[]): SheetSpec => ({
+    name: 'S',
+    rows: [{ row: 1, cells: [{ ref: 'A1', value: 'x' }] }],
+    validations: [{ sqref: 'A1', values }],
+  });
+
+  test('a comma in a dropdown value is refused, because Excel would read it as two entries', () => {
+    // The inline list is a quoted, comma-joined string and Excel's form has no escape for a comma, so
+    // `Yes, please` offers `Yes` and ` please`. Refusing beats escaping: there is nothing to escape with.
+    // Localisation is what makes this live — a comma is ordinary in prose, and 192 strings per locale are
+    // model-authored.
+    expect(() => buildWorkbook([withDropdown(['Yes, please', 'No'])], {})).toThrow(/comma/i);
+    // The message has to name the offender, or the author cannot find it among 199 strings.
+    expect(() => buildWorkbook([withDropdown(['Yes, please', 'No'])], {})).toThrow(/Yes, please/);
+  });
+
+  test('a quote in a dropdown value is refused, because it ends the list early', () => {
+    expect(() => buildWorkbook([withDropdown(['He said "yes"', 'No'])], {})).toThrow(/quote|"/i);
+  });
+
+  test('an ordinary dropdown is unaffected', () => {
+    // The refusal must not become indiscriminate: spaces, slashes and hyphens all appear in real values.
+    expect(() =>
+      buildWorkbook([withDropdown(['Best Case', 'Economic buyer', 'Negotiation/Review'])], {}),
+    ).not.toThrow();
+  });
+
+  test('a validation list past 255 characters is refused', () => {
+    // Enforced already, but nothing covered it — the other `255` assertions in this file are about the
+    // print header. CJK and Devanagari translations are what will start pushing lists toward the cap.
+    const long = Array.from({ length: 30 }, (_, i) => `value-number-${i}-padded-out`);
+    expect(long.join(',').length).toBeGreaterThan(255);
+    expect(() => buildWorkbook([withDropdown(long)], {})).toThrow(/255/);
+  });
+});

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -38,6 +38,25 @@ const XML_ESCAPES: Record<string, string> = {
   "'": '&apos;',
 };
 
+/**
+ * Text as an Excel string literal, quotes doubled and wrapped.
+ *
+ * Excel writes a literal quote inside a string as two, so `He said "yes"` has to become
+ * `"He said ""yes"""`. Emitting the naive form closes the string at the first inner quote and leaves Excel
+ * parsing the rest as syntax — a repair prompt, or a formula that quietly means something else.
+ *
+ * This exists because the first version of the fix escaped ONE of the four places a label reaches a formula.
+ * Review found the other three: a section label in an INDEX/MATCH, the completion statuses the compiler
+ * emits, and the words the conditional formats compare. Four call sites with the same requirement is an
+ * argument for one function, not four fixes — and it is the shape of mistake I had just written a commit
+ * message about, so the general form is the point.
+ *
+ * Not an XML concern: `escapeXml` runs afterwards and leaves an unbalanced quote intact and wrong.
+ */
+export function excelString(text: string): string {
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
 export function escapeXml(text: string): string {
   return text.replace(/[&<>"']/g, (c) => XML_ESCAPES[c]);
 }
@@ -279,22 +298,22 @@ export const CF_PRESETS: Record<CfPreset, CfRule[]> = {
   // re-deriving its brackets from a percentage and drifting by a rounding step. "Green" gets no
   // rule: a deal in good shape does not need to be pointed at.
   ragText: [
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('Red')}"`], dxf: 'urgent' },
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('Yellow')}"`], dxf: 'watch' },
+    { type: 'cellIs', operator: 'equal', formulas: [excelString(enumLabel('Red'))], dxf: 'urgent' },
+    { type: 'cellIs', operator: 'equal', formulas: [excelString(enumLabel('Yellow'))], dxf: 'watch' },
   ],
   // Matched against the LABEL the sheet displays, not the JSON value behind it. Both come from
   // `enumLabel`, so they cannot drift — a preset quoting `"not_started"` while the cell reads
   // "Not started" is a colour that never appears and nothing to notice it.
   completionText: [
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('partial')}"`], dxf: 'watch' },
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('not_started')}"`], dxf: 'urgent' },
+    { type: 'cellIs', operator: 'equal', formulas: [excelString(enumLabel('partial'))], dxf: 'watch' },
+    { type: 'cellIs', operator: 'equal', formulas: [excelString(enumLabel('not_started'))], dxf: 'urgent' },
   ],
   // A close-plan step, and a gentler ladder than the completion one on purpose: a milestone nobody has
   // started is normal early in a deal, where a MEDDPICC section nobody has touched is the gap the
   // review exists to find.
   statusText: [
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('in_progress')}"`], dxf: 'watch' },
-    { type: 'cellIs', operator: 'equal', formulas: [`"${enumLabel('pending')}"`], dxf: 'warn' },
+    { type: 'cellIs', operator: 'equal', formulas: [excelString(enumLabel('in_progress'))], dxf: 'watch' },
+    { type: 'cellIs', operator: 'equal', formulas: [excelString(enumLabel('pending'))], dxf: 'warn' },
   ],
   // A change since the last review. Only a step backwards is painted: nought is not a warning, and an
   // improvement is the good news this palette deliberately leaves alone.

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -726,24 +726,29 @@ function dataValidationsXml(validations: Validation[] | undefined): string {
       //
       // Latent today — nothing in this schema contains either character — and live the moment #925 lands
       // 192 model-authored translations per locale, where a comma in prose is unremarkable.
+      // The two characters behave differently, and treating them alike was wrong.
+      //
+      // A **comma** is the separator, applied after Excel has parsed the string literal, so there is
+      // nothing to escape it with: `Yes, please` becomes two entries whatever we do to the quotes.
+      // Refused, naming the value.
+      //
+      // A **quote** is representable — doubled, as in any Excel string. Verified in Excel: a list written
+      // `"He said ""yes"",No"` is read back as `He said "yes",No` and offers the two entries intended. My
+      // first version refused it, which would have been an avoidable outage the moment a translation used
+      // ordinary punctuation. Review caught that.
       for (const value of v.values) {
         if (value.includes(',')) {
           throw new Error(
             `Dropdown value for ${v.sqref} contains a comma: ${JSON.stringify(value)}. ` +
-              "Excel's inline list separates entries on commas and cannot escape one, so this would " +
-              'silently become two entries. Reword the value.',
-          );
-        }
-        if (value.includes('"')) {
-          throw new Error(
-            `Dropdown value for ${v.sqref} contains a quotation mark: ${JSON.stringify(value)}. ` +
-              'The whole list is one quoted string, so a quote inside it ends the list early. Reword the value.',
+              "Excel's inline list separates entries on commas and applies that split after the string is " +
+              'parsed, so there is nothing to escape it with and this would silently become two entries. ' +
+              'Reword the value.',
           );
         }
       }
-      // Excel caps the inline list at 255 characters — say so loudly rather than emitting something it
-      // will silently drop.
-      const list = v.values.join(',');
+      // Escaped first, then measured: Excel's 255-character budget is spent on what it receives, and a
+      // value full of quotation marks costs twice what it looks like.
+      const list = v.values.map((value) => value.replace(/"/g, '""')).join(',');
       if (list.length > 255) {
         throw new Error(`Validation list for ${v.sqref} is ${list.length} characters; Excel allows 255`);
       }

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -696,8 +696,34 @@ function dataValidationsXml(validations: Validation[] | undefined): string {
   if (!validations?.length) return '';
   const entries = validations
     .map((v) => {
-      // The inline list form is a quoted, comma-joined string — and Excel caps it at 255
-      // characters, so say so loudly rather than emitting something it will silently drop.
+      // The inline list form is a quoted, comma-joined string. That gives it two characters it cannot
+      // carry, and neither is an XML problem — escaping the XML leaves both intact and wrong.
+      //
+      // A comma separates entries, so `Yes, please` offers `Yes` and ` please`: one value silently
+      // becomes two, and a reader mapping the chosen word back to a token then fails to recognise it. A
+      // quote ends the list, since the whole thing is one quoted string. Excel's inline form has no
+      // escape for either. Refusing is the honest answer; the alternative is backing the validation with
+      // a hidden worksheet range, which is a much larger change and buys nothing while no value needs it.
+      //
+      // Latent today — nothing in this schema contains either character — and live the moment #925 lands
+      // 192 model-authored translations per locale, where a comma in prose is unremarkable.
+      for (const value of v.values) {
+        if (value.includes(',')) {
+          throw new Error(
+            `Dropdown value for ${v.sqref} contains a comma: ${JSON.stringify(value)}. ` +
+              "Excel's inline list separates entries on commas and cannot escape one, so this would " +
+              'silently become two entries. Reword the value.',
+          );
+        }
+        if (value.includes('"')) {
+          throw new Error(
+            `Dropdown value for ${v.sqref} contains a quotation mark: ${JSON.stringify(value)}. ` +
+              'The whole list is one quoted string, so a quote inside it ends the list early. Reword the value.',
+          );
+        }
+      }
+      // Excel caps the inline list at 255 characters — say so loudly rather than emitting something it
+      // will silently drop.
       const list = v.values.join(',');
       if (list.length > 255) {
         throw new Error(`Validation list for ${v.sqref} is ${list.length} characters; Excel allows 255`);

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
## What this does

Closes #955. A serialization contract for text the writer does not control.

Three hazards, all silent. **None is an XML problem** — Excel's own grammar is what breaks, so escaping the
XML leaves the text intact and wrong.

## The comma and the quote are not alike

That distinction is the substance of this change, and my first version got it wrong.

**A comma cannot be escaped.** The inline dropdown list is a quoted, comma-joined string, and Excel applies
the split *after* parsing the literal — so `Yes, please` becomes `Yes` and a second entry beginning with a
space, whatever is done to the quotes. Refused at build time, naming the value and the range. Backing the
validation with a hidden worksheet range would avoid the refusal and is a far larger change that buys
nothing while no value needs it.

**A quote can be.** It lives inside the literal and doubles like any other. I refused it too, and review
rightly called that an avoidable outage the first time a translation used ordinary punctuation. **Verified in
Excel rather than argued:** a list written `"He said ""yes"",No"` reads `formula1` back as `He said "yes",No`
and offers the two entries intended. Now doubled, and the 255-character budget is measured on the *escaped*
text, since that is what Excel receives and a quote-heavy value costs twice what it looks like.

**A quote in a formula word closed its string early.** `He said "yes"` emitted `"He said "yes""` where Excel
needs `"He said ""yes"""`. Also verified in Excel, which evaluates the corrected form to `He said "yes"`.

## Four sinks, one helper

My first version escaped **one** of the four places a label reaches a formula. Review found the rest: a
section label in an `INDEX/MATCH`, the compiled completion statuses, and the words the conditional formats
compare. They all call `excelString` now — one function rather than a fourth patch, which is the lesson from
the previous PR applied properly this time.

## What the tests can and cannot see

Three attempts, and the failures are recorded in the commits because each is a reusable trap:

- **Quote parity is not a check.** `"He said "yes""` has four quote characters — an even count — and is valid
  Excel meaning something else entirely: a string, a name, then an empty string. There is no syntactic test
  at the writer.
- **My first class-level test passed with three of four sinks reverted**, because its positive assertion —
  "some formula contains a doubled quote" — was satisfied by whichever sink was still correct. An assertion
  has to name the text of the sink it tests.
- **The sinks differ in what is observable.** The word and status sinks are reachable by mutating their own
  label source. `CF_PRESETS` is a module constant built at import, so no runtime mutation reaches it and a
  hand-quoted literal is byte-identical to an escaped one for today's quote-free labels — that one is a
  narrow source check. The `INDEX/MATCH` path is **not exercised by the shipped spec at all** (a quote
  injected there appears in zero formulas), which is stated in a test rather than dressed up as coverage.

## Verification

- **536 engine tests**, 39 shell tests, **19/19 Excel UAT stages**. `biome ci`, `markdownlint`, `codespell`,
  `textlint` clean.
- **6 mutations, 6 killed**: each of the three reachable sinks, not doubling the list, removing the comma
  refusal, and removing the 255 cap.
- **The 255 cap was already enforced and had no test** — the other `255` assertions in that file are about
  the print header, a different limit. Covered now, since CJK and Devanagari translations are what will push
  a list toward it.
- **English output is unchanged.** Every OOXML part byte-equal to v7.2.0 except `docProps/custom.xml`, which
  carries the version bump — no value in play today contains any of these characters.

**v7.2.1.** Latent today in the same way #929 was; #925 is what makes it live, where 192 model-authored
strings per locale meet punctuation that is unremarkable in prose.
