### PR TITLE
Make a failed plugin release re-cuttable, and notice when one is missing

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -7,6 +7,22 @@ on:
     paths:
       - "plugins/**"
       - ".xcsh-plugin/marketplace.json"
+  # The manual path, for a release that failed for a reason outside itself.
+  #
+  # meddpicc/v7.2.0 had no way back: re-running the failed job replays the original commit's
+  # code and fails identically, a fix under scripts/ matches neither `paths:` entry, and the
+  # version-diff detection sees 7.2.0 on both sides once the bump has landed. It was cut by
+  # hand. This input is that hand, made repeatable.
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: "Plugin name, as it appears in .xcsh-plugin/marketplace.json"
+        required: true
+        type: string
+      version:
+        description: "Version to release, without the leading v (e.g. 7.2.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -23,40 +39,56 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          fetch-depth: 2
+          # Full history: release-history.sh reads the whole mainline to decide which commit
+          # published a version, and refuses outright on a shallow clone rather than drawing
+          # conclusions from a history it cannot see.
+          fetch-depth: 0
 
-      - name: Detect version changes and create releases
+      - name: Select the releases to cut
+        env:
+          # Through the environment, never interpolated into the script body: a
+          # `${{ inputs.* }}` expansion is textual substitution into the shell source.
+          PLUGIN: ${{ inputs.plugin }}
+          VERSION: ${{ inputs.version }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            # release-history.sh exits non-zero when no commit on main ever set that
+            # version, which is what stops a dispatch publishing something that was never
+            # on main. It prints the publishing commit, so the tag lands there.
+            if ! SHA=$(scripts/release-history.sh "$PLUGIN" "$VERSION"); then
+              echo "::error::Refusing to release ${PLUGIN} v${VERSION}: no commit on main" \
+                "ever published that version (see above)."
+              exit 1
+            fi
+            printf '%s %s %s\n' "$PLUGIN" "$VERSION" "$SHA" > releases.txt
+          else
+            # The versions this push published. Same source of truth as the manual path,
+            # rather than a second copy of the manifest diff living in YAML. Verified
+            # equivalent to that diff across all 37 release commits in this repository.
+            scripts/release-history.sh \
+              | awk -v sha="$GITHUB_SHA" '$3 == sha' > releases.txt
+          fi
+
+          if [[ ! -s releases.txt ]]; then
+            echo "No plugin version was published here; nothing to release."
+          fi
+          cat releases.txt
+
+      - name: Create releases
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          MARKETPLACE=".xcsh-plugin/marketplace.json"
+          while read -r NAME VERSION SHA; do
+            [[ -n "$NAME" ]] || continue
+            TAG="${NAME}/v${VERSION}"
 
-          # Get previous marketplace.json (may not exist for first commit)
-          PREV_MARKETPLACE=$(
-            git show HEAD~1:"$MARKETPLACE" 2>/dev/null \
-              || echo '{"plugins":[]}'
-          )
-
-          PLUGIN_COUNT=$(jq '.plugins | length' "$MARKETPLACE")
-
-          for i in $(seq 0 $((PLUGIN_COUNT - 1))); do
-            NAME=$(jq -r ".plugins[$i].name" "$MARKETPLACE")
-            NEW_VER=$(jq -r ".plugins[$i].version" "$MARKETPLACE")
-            OLD_VER=$(echo "$PREV_MARKETPLACE" | jq -r --arg n "$NAME" \
-              '(.plugins[] | select(.name == $n) | .version) // "0.0.0"')
-
-            if [[ "$NEW_VER" == "$OLD_VER" ]]; then
-              continue
-            fi
-
-            TAG="${NAME}/v${NEW_VER}"
-            echo "Version change detected: $NAME $OLD_VER → $NEW_VER"
-
-            # Skip if release already exists
             if gh release view "$TAG" > /dev/null 2>&1; then
-              echo "  Release $TAG already exists, skipping"
+              echo "Release $TAG already exists, nothing to do."
               continue
             fi
 
@@ -65,16 +97,20 @@ jobs:
             # matched on plugin name alone and published salesforce/v1.3.5 with notes for a
             # v1.3.4 that was never tagged. The script exits non-zero on an ambiguous or
             # stale changelog, which fails the release rather than publishing a wrong note.
-            if ! BODY=$(scripts/release-notes.sh "$NAME" "$NEW_VER" CHANGELOG.md); then
+            if ! BODY=$(scripts/release-notes.sh "$NAME" "$VERSION" CHANGELOG.md); then
               echo "::error::Refusing to publish ${TAG}: CHANGELOG.md does not" \
-                "unambiguously describe ${NAME} v${NEW_VER} (see log above)."
+                "unambiguously describe ${NAME} v${VERSION} (see log above)."
               exit 1
             fi
 
+            # --target takes the commit that published the version, not `main`: main may have
+            # moved on by the time this job runs, and a re-cut is by definition tagging
+            # something already in the past. It must be a FULL sha — GitHub rejects an
+            # abbreviated one, which is how the hand-cut of v7.2.0 first failed.
             gh release create "$TAG" \
-              --title "${NAME} v${NEW_VER}" \
+              --title "${NAME} v${VERSION}" \
               --notes "$BODY" \
-              --target main
+              --target "$SHA"
 
-            echo "  Created release: $TAG"
-          done
+            echo "  Created release: $TAG at $SHA"
+          done < releases.txt

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -39,6 +39,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          # A dispatch is pinned to main, never the ref the dispatcher picked.
+          #
+          # workflow_dispatch offers a branch selector, and checkout defaults to that ref.
+          # Since release-history.sh reads the checkout it is given, dispatching from a
+          # feature branch would let that branch's manifest satisfy the "was this ever on
+          # main" guard and publish an official release of unmerged code. Pinning the
+          # checkout is what makes the guard mean what it says.
+          #
+          # A push checks out its own commit rather than main's tip, so the selection stays
+          # correct if another push lands while this job is queued.
+          ref: >-
+            ${{ github.event_name == 'workflow_dispatch'
+            && github.event.repository.default_branch
+            || github.sha }}
           # Full history: release-history.sh reads the whole mainline to decide which commit
           # published a version, and refuses outright on a shallow clone rather than drawing
           # conclusions from a history it cannot see.

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -82,3 +82,26 @@ jobs:
       # broke twice. Replacing the CLIs with sleeping stubs makes any such test name itself.
       - name: Check tests do not depend on a real cloud CLI
         run: ./scripts/check-tests-are-hermetic.sh
+
+  release-tags:
+    name: Check published versions are tagged
+    # Push only. On a pull request the version being bumped is legitimately untagged — the
+    # tag is created at merge — so running this there would fail every release PR.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history and every tag: the audit walks all published versions, and
+          # release-history.sh refuses a shallow clone rather than reporting "nothing
+          # missing" from a history it cannot see.
+          fetch-depth: 0
+          fetch-tags: true
+
+      # This lives here, not in Release Plugins, because the failure it looks for is
+      # Release Plugins not finishing. A check inside the workflow that broke cannot report
+      # that the workflow broke. Validate Plugins runs on every push to main with no paths
+      # filter, so the next commit of any kind surfaces a stuck release.
+      - name: Check every published plugin version has a tag
+        run: ./scripts/check-release-tags.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to
 ## [Unreleased]
 
 - **`meddpicc`** v7.2.1 — a serialization contract for text the writer does not control. No behaviour
-  change: the generated workbook is byte-identical, same sha256, because no value in play today contains
-  any of these characters.
+  change: every part of the generated workbook is byte-identical except `docProps/custom.xml`, which
+  records the engine version, because no value in play today contains any of these characters. (The
+  entry first claimed the whole file was byte-identical with the same sha256. That was measured before
+  the version bump and stopped being true with it.)
 
   Three hazards, all silent, none of them an XML problem — Excel's own grammar is what breaks, so escaping
   the XML leaves the text intact and wrong.

--- a/scripts/check-release-tags.sh
+++ b/scripts/check-release-tags.sh
@@ -25,10 +25,33 @@ fi
 
 TIP=$(git rev-parse HEAD)
 
+# Plugins the marketplace currently offers. A plugin that has been withdrawn or renamed
+# away cannot be installed, so a missing tag for it names no release anyone can cut — the
+# five f5xc-* v1.0.0 entries left behind by the org rename would otherwise hold main red
+# for good. Every version of a plugin still on offer stays in scope, which is what keeps a
+# meddpicc/v7.2.0-shaped gap reportable.
+CURRENT=""
+for path in .xcsh-plugin/marketplace.json .claude-plugin/marketplace.json; do
+  if [ -f "$path" ]; then
+    CURRENT=$(jq -r '.plugins[]?.name // empty' "$path")
+    break
+  fi
+done
+if [ -z "$CURRENT" ]; then
+  echo "check-release-tags.sh: no marketplace manifest found, or it lists no plugins;" >&2
+  echo "  refusing to report every published version as out of scope." >&2
+  exit 1
+fi
+
 MISSING=0
 CHECKED=0
+WITHDRAWN=0
 while read -r name version sha; do
   [ -n "$name" ] || continue
+  if ! printf '%s\n' "$CURRENT" | grep -qxF "$name"; then
+    WITHDRAWN=$((WITHDRAWN + 1))
+    continue
+  fi
   # A version published by the tip commit is still being released: the release job runs
   # alongside whatever triggered this audit, so demanding its tag would fail every
   # legitimate release. One commit later, the same gap is real and gets reported.
@@ -37,12 +60,22 @@ while read -r name version sha; do
     continue
   fi
   CHECKED=$((CHECKED + 1))
-  if git rev-parse -q --verify "refs/tags/${name}/v${version}" >/dev/null; then
+  # ^{commit} dereferences an annotated tag to the commit it wraps; a lightweight tag is
+  # already one. Without it the two sides of the comparison are different kinds of object
+  # and an annotated tag would never match.
+  if ! tagged=$(git rev-parse -q --verify "refs/tags/${name}/v${version}^{commit}"); then
+    MISSING=1
+    echo "::error::No tag ${name}/v${version} — that version was published by ${sha} and never" \
+      "released. Re-cut it: gh workflow run 'Release Plugins' -f plugin=${name} -f version=${version}"
     continue
   fi
-  MISSING=1
-  echo "::error::No tag ${name}/v${version} — that version was published by ${sha} and never" \
-    "released. Re-cut it: gh workflow run 'Release Plugins' -f plugin=${name} -f version=${version}"
+  # An existing tag on the wrong commit is worse than a missing one: it reads as released
+  # while shipping a different revision than the version claims.
+  if [ "$tagged" != "$sha" ]; then
+    MISSING=1
+    echo "::error::Tag ${name}/v${version} points at ${tagged}, but that version was published" \
+      "by ${sha}. Whoever installs it gets a different revision than the version names."
+  fi
 done <<<"$HISTORY"
 
 if [ "$MISSING" -ne 0 ]; then
@@ -50,6 +83,7 @@ if [ "$MISSING" -ne 0 ]; then
   exit 1
 fi
 
-# Say what was checked. "0 versions, no problems found" is not a pass, and a silent exit 0
-# reads identically to one.
-echo "check-release-tags.sh: ${CHECKED} published plugin version(s) all carry their tags."
+# Say what was checked, and what was deliberately not. "0 versions, no problems found" is
+# not a pass, and a silent exit 0 reads identically to one.
+echo "check-release-tags.sh: ${CHECKED} published plugin version(s) all carry their tags;" \
+  "${WITHDRAWN} belonging to plugins no longer offered were out of scope."

--- a/scripts/check-release-tags.sh
+++ b/scripts/check-release-tags.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# check-release-tags.sh — every plugin version ever published on main must carry its tag.
+#
+# Usage: check-release-tags.sh
+#
+# The gap this closes is a quiet one. When `Release Plugins` fails for a reason outside the
+# release itself — meddpicc/v7.2.0 died on a SIGPIPE in the note script — nothing downstream
+# disagrees: main is green, the version files say 7.2.0, the changelog says 7.2.0, and only
+# the absent tag knows. The next version then bumps past it and the gap is invisible for
+# good, because a check against the current manifest alone would only ever ask about the
+# newest version.
+#
+# So this walks the whole published history, not just the manifest at HEAD.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+# release-history.sh refuses a shallow clone; let that refusal through rather than
+# reporting "nothing missing" from a history this checkout cannot see.
+if ! HISTORY=$("${HERE}/release-history.sh"); then
+  echo "check-release-tags.sh: cannot read the release history (see above); refusing to" >&2
+  echo "  report on tags it could not check." >&2
+  exit 1
+fi
+
+TIP=$(git rev-parse HEAD)
+
+MISSING=0
+CHECKED=0
+while read -r name version sha; do
+  [ -n "$name" ] || continue
+  # A version published by the tip commit is still being released: the release job runs
+  # alongside whatever triggered this audit, so demanding its tag would fail every
+  # legitimate release. One commit later, the same gap is real and gets reported.
+  if [ "$sha" = "$TIP" ]; then
+    echo "in flight: ${name} v${version} published by the tip commit; its release has not finished"
+    continue
+  fi
+  CHECKED=$((CHECKED + 1))
+  if git rev-parse -q --verify "refs/tags/${name}/v${version}" >/dev/null; then
+    continue
+  fi
+  MISSING=1
+  echo "::error::No tag ${name}/v${version} — that version was published by ${sha} and never" \
+    "released. Re-cut it: gh workflow run 'Release Plugins' -f plugin=${name} -f version=${version}"
+done <<<"$HISTORY"
+
+if [ "$MISSING" -ne 0 ]; then
+  echo "check-release-tags.sh: published versions are missing their tags (see above)." >&2
+  exit 1
+fi
+
+# Say what was checked. "0 versions, no problems found" is not a pass, and a silent exit 0
+# reads identically to one.
+echo "check-release-tags.sh: ${CHECKED} published plugin version(s) all carry their tags."

--- a/scripts/release-history.sh
+++ b/scripts/release-history.sh
@@ -62,17 +62,19 @@ FOUND_SHA=""
 
 while read -r sha; do
   [ -n "$sha" ] || continue
-  parent_set="${NL}$(versions_at "${sha}^")${NL}"
   while read -r name version; do
     [ -n "$name" ] || continue
     key="${name} ${version}"
-    # Already published by an earlier commit: a version can carry only one tag, so a
-    # version that reappears (after a downgrade, or a revert) is not a second release.
+    # First sighting anywhere on the mainline is the release. Everything else follows from
+    # that one rule: a commit that edits the manifest without changing this version is
+    # skipped because the version is already seen, and so is a version that reappears after
+    # a downgrade or a revert — it can only ever carry one tag.
+    #
+    # An earlier draft also compared against the parent commit's set, mirroring the
+    # HEAD-vs-HEAD~1 diff the release workflow does. That is the right rule for the
+    # workflow, which sees two commits; here it was unreachable, and a mutation test proved
+    # it by deleting the comparison without failing anything.
     case "$SEEN" in
-    *"${NL}${key}${NL}"*) continue ;;
-    esac
-    # Unchanged from the parent: this commit edited the manifest, not this version.
-    case "$parent_set" in
     *"${NL}${key}${NL}"*) continue ;;
     esac
     SEEN="${SEEN}${key}${NL}"

--- a/scripts/release-history.sh
+++ b/scripts/release-history.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# release-history.sh — which commit published which plugin version.
+#
+# Usage:
+#   release-history.sh                     # "<plugin> <version> <sha>" per release, oldest first
+#   release-history.sh <plugin> <version>  # the sha that published it; exit 1 if it never was
+#
+# A plugin version is "published" by the commit that first set it in
+# .xcsh-plugin/marketplace.json on the mainline. That commit — not whatever main happens to
+# be later — is what a tag should point at, and it is the only evidence that a version
+# asked for by hand was ever really on main.
+#
+# Lives here rather than inline in release-plugins.yml so it can be tested. The release
+# path already learned that lesson once: the note selection was untestable bash in YAML and
+# published salesforce/v1.3.5 with notes for a version that has no tag (see release-notes.sh).
+set -euo pipefail
+
+MANIFEST=".xcsh-plugin/marketplace.json"
+
+if [ "$#" -ne 0 ] && [ "$#" -ne 2 ]; then
+  echo "usage: release-history.sh [<plugin> <version>]" >&2
+  exit 1
+fi
+
+WANT_NAME="${1:-}"
+WANT_VERSION="${2:-}"
+
+# A shallow clone answers `git log` with a handful of commits and no error. An audit built
+# on that finds nothing missing and passes — green, and blind. Refuse instead: a checkout
+# that cannot see the history cannot make a claim about it.
+if [ "$(git rev-parse --is-shallow-repository 2>/dev/null || echo unknown)" != "false" ]; then
+  echo "release-history.sh: refusing to read a shallow repository — the history would be" >&2
+  echo "  silently short and every conclusion drawn from it wrong. Check out with" >&2
+  echo "  fetch-depth: 0 (actions/checkout) or run 'git fetch --unshallow'." >&2
+  exit 1
+fi
+
+# The name/version pairs recorded at one commit, one per line. A commit from before the
+# manifest existed, or one whose manifest cannot be parsed, contributes nothing rather than
+# aborting the walk: old history is not something a release today can fix.
+versions_at() {
+  git show "${1}:${MANIFEST}" 2>/dev/null |
+    jq -r '.plugins[]? | select(.name != null and .version != null) | "\(.name) \(.version)"' 2>/dev/null ||
+    true
+}
+
+# --first-parent follows what landed on main, so a version that only ever existed on a
+# side branch is not treated as published.
+#
+# SEEN is a newline-delimited list, not an associative array: macOS ships bash 3.2, where
+# `declare -A` is a syntax error. CI runs bash 5 and would never have said so — the same
+# split that made the old GNU-only sed in the note selection work in CI and fail on a
+# maintainer's checkout. A hundred-odd releases make the linear scan free.
+#
+# Both membership tests are in-shell rather than `grep`. Spawning two greps per plugin per
+# commit cost 42 seconds of the 45 this took on the real history, and this runs on every
+# push to main. The newline sentinels around each key are what keep the substring test
+# honest: an unanchored match would let "demo 1.0" satisfy "demo 1.0.1".
+NL=$'\n'
+SEEN="$NL"
+FOUND_SHA=""
+
+while read -r sha; do
+  [ -n "$sha" ] || continue
+  parent_set="${NL}$(versions_at "${sha}^")${NL}"
+  while read -r name version; do
+    [ -n "$name" ] || continue
+    key="${name} ${version}"
+    # Already published by an earlier commit: a version can carry only one tag, so a
+    # version that reappears (after a downgrade, or a revert) is not a second release.
+    case "$SEEN" in
+    *"${NL}${key}${NL}"*) continue ;;
+    esac
+    # Unchanged from the parent: this commit edited the manifest, not this version.
+    case "$parent_set" in
+    *"${NL}${key}${NL}"*) continue ;;
+    esac
+    SEEN="${SEEN}${key}${NL}"
+    if [ -z "$WANT_NAME" ]; then
+      printf '%s %s %s\n' "$name" "$version" "$sha"
+    elif [ "$name" = "$WANT_NAME" ] && [ "$version" = "$WANT_VERSION" ]; then
+      FOUND_SHA="$sha"
+    fi
+  done <<<"$(versions_at "$sha")"
+done <<<"$(git log --first-parent --reverse --format='%H' -- "$MANIFEST")"
+
+if [ -n "$WANT_NAME" ]; then
+  if [ -z "$FOUND_SHA" ]; then
+    echo "release-history.sh: ${WANT_NAME} v${WANT_VERSION} was never published on this" >&2
+    echo "  branch — no commit sets that version in ${MANIFEST}. Refusing to name a commit" >&2
+    echo "  for a release that did not happen." >&2
+    exit 1
+  fi
+  printf '%s\n' "$FOUND_SHA"
+fi

--- a/scripts/release-history.sh
+++ b/scripts/release-history.sh
@@ -15,7 +15,13 @@
 # published salesforce/v1.3.5 with notes for a version that has no tag (see release-notes.sh).
 set -euo pipefail
 
-MANIFEST=".xcsh-plugin/marketplace.json"
+# Every path the marketplace manifest has ever lived at, newest first. The rename in
+# e4723c3 (.claude-plugin → .xcsh-plugin) is not cosmetic here: a log limited to the current
+# path stops at the rename, hiding 57 commits of release history and attributing all 29
+# versions that existed at the time to the refactor that moved the file. A re-cut would then
+# tag the rename instead of the release. Add to this list, never replace it.
+MANIFEST_PATHS=(".xcsh-plugin/marketplace.json" ".claude-plugin/marketplace.json")
+MANIFEST="${MANIFEST_PATHS[0]}"
 
 if [ "$#" -ne 0 ] && [ "$#" -ne 2 ]; then
   echo "usage: release-history.sh [<plugin> <version>]" >&2
@@ -38,10 +44,17 @@ fi
 # The name/version pairs recorded at one commit, one per line. A commit from before the
 # manifest existed, or one whose manifest cannot be parsed, contributes nothing rather than
 # aborting the walk: old history is not something a release today can fix.
+# Reads whichever manifest path exists at that commit, preferring the current one.
 versions_at() {
-  git show "${1}:${MANIFEST}" 2>/dev/null |
-    jq -r '.plugins[]? | select(.name != null and .version != null) | "\(.name) \(.version)"' 2>/dev/null ||
-    true
+  local ref="$1" path raw
+  for path in "${MANIFEST_PATHS[@]}"; do
+    raw=$(git show "${ref}:${path}" 2>/dev/null) || continue
+    [ -n "$raw" ] || continue
+    printf '%s' "$raw" |
+      jq -r '.plugins[]? | select(.name != null and .version != null) | "\(.name) \(.version)"' 2>/dev/null ||
+      true
+    return 0
+  done
 }
 
 # --first-parent follows what landed on main, so a version that only ever existed on a
@@ -84,7 +97,7 @@ while read -r sha; do
       FOUND_SHA="$sha"
     fi
   done <<<"$(versions_at "$sha")"
-done <<<"$(git log --first-parent --reverse --format='%H' -- "$MANIFEST")"
+done <<<"$(git log --first-parent --reverse --format='%H' -- "${MANIFEST_PATHS[@]}")"
 
 if [ -n "$WANT_NAME" ]; then
   if [ -z "$FOUND_SHA" ]; then

--- a/tests/test-release-history.sh
+++ b/tests/test-release-history.sh
@@ -363,6 +363,20 @@ else
   printf '       output: %s\n' "$out"
 fi
 
+# Scoping to the current manifest has a failure mode of its own: if that manifest is
+# missing or lists nothing, every published version is "no longer offered" and the audit
+# passes having checked nothing. That is the same vacuous green the shallow clone would
+# give, arrived at from the other direction.
+d=$(new_repo)
+commit_manifest "$d" demo=1.0.0 >/dev/null
+printf '%s\n' '{"plugins":[]}' >"${d}/${MANIFEST}"
+git -C "$d" add -A && git -C "$d" commit -qm "empty the manifest"
+commit_other "$d" >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+assert_refused "an empty manifest is refused, not treated as everything being out of scope" \
+  "$rc" "$out" "out of scope"
+
 # An annotated tag counts. The workflow creates lightweight ones, but a hand-cut release
 # — which is how meddpicc/v7.2.0 was finally published — can be either.
 d=$(new_repo)

--- a/tests/test-release-history.sh
+++ b/tests/test-release-history.sh
@@ -178,6 +178,28 @@ assert_eq "history predating the manifest is not an error" \
   "demo 1.0.0 ${a}" \
   "$(run_in "$d" "$HISTORY")"
 
+# The manifest has been renamed once already — .claude-plugin/marketplace.json became
+# .xcsh-plugin/marketplace.json in e4723c3. A path-limited log that knows only the new name
+# stops dead at the rename: 57 commits of real release history become invisible and every
+# version that existed at the rename is attributed to the rename commit, so a re-cut would
+# tag a refactor instead of the release.
+d=$(new_repo)
+mkdir -p "${d}/.claude-plugin"
+printf '%s\n' '{"plugins":[{"name":"demo","version":"1.0.0"}]}' >"${d}/.claude-plugin/marketplace.json"
+git -C "$d" add -A && git -C "$d" commit -qm "old path 1.0.0"
+old_a=$(git -C "$d" rev-parse HEAD)
+printf '%s\n' '{"plugins":[{"name":"demo","version":"1.1.0"}]}' >"${d}/.claude-plugin/marketplace.json"
+git -C "$d" add -A && git -C "$d" commit -qm "old path 1.1.0"
+old_b=$(git -C "$d" rev-parse HEAD)
+git -C "$d" mv .claude-plugin/marketplace.json .xcsh-plugin/marketplace.json
+git -C "$d" commit -qm "rename the manifest"
+after=$(commit_manifest "$d" demo=2.0.0)
+assert_eq "a manifest rename does not truncate or re-attribute the history" \
+  "demo 1.0.0 ${old_a}
+demo 1.1.0 ${old_b}
+demo 2.0.0 ${after}" \
+  "$(run_in "$d" "$HISTORY")"
+
 # Lookup mode: the publishing commit for one version, and a refusal for one never published.
 d=$(new_repo)
 a=$(commit_manifest "$d" demo=1.0.0)
@@ -281,6 +303,63 @@ if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'demo/v1.1.0'; then
   ok "once the tip moves on, the untagged version is reported (exit ${rc})"
 else
   bad "the audit stayed quiet about an untagged version after the tip moved on"
+  printf '       output: %s\n' "$out"
+fi
+
+# A plugin the marketplace no longer offers is out of scope. Five f5xc-* plugins were
+# renamed away in the org rename and never tagged at v1.0.0; nobody can install them, so
+# there is no release to re-cut and reporting them would leave main permanently red with
+# nothing actionable in it. Versions of plugins still on offer are unaffected — which is
+# what keeps the meddpicc/v7.2.0 case above reportable.
+d=$(new_repo)
+commit_manifest "$d" old=1.0.0 >/dev/null
+b=$(commit_manifest "$d" old=1.0.0 keep=1.0.0)
+git -C "$d" tag "keep/v1.0.0" "$b"
+commit_manifest "$d" keep=1.0.0 >/dev/null
+commit_other "$d" >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ] && ! printf '%s' "$out" | grep -q 'old/v1.0.0'; then
+  ok "a version of a plugin no longer offered is out of scope"
+else
+  bad "the audit reported a withdrawn plugin (exit ${rc}) — nothing to re-cut, permanently red"
+  printf '       output: %s\n' "$out"
+fi
+if printf '%s' "$out" | grep -qi 'withdrawn\|no longer'; then
+  ok "the audit says what it skipped rather than skipping silently"
+else
+  bad "the audit skipped a withdrawn plugin without saying so"
+  printf '       output: %s\n' "$out"
+fi
+# ...and the plugin that IS still offered is still audited: same fixture, tag removed.
+git -C "$d" tag -d "keep/v1.0.0" >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+assert_refused "a still-offered plugin is audited across its whole history" "$rc" "$out" "keep/v1.0.0"
+
+# A tag that exists but points somewhere else is worse than a missing one: it looks
+# released, and whoever installs it gets a different revision than the version claims. The
+# old workflow tagged `main` rather than the publishing commit, so this was reachable
+# whenever main moved between the merge and the release job. All 80 in-scope tags happen to
+# be correct today, which is exactly why the check is cheap to start enforcing now.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+b=$(commit_manifest "$d" demo=2.0.0)
+git -C "$d" tag "demo/v1.0.0" "$a"
+git -C "$d" tag "demo/v2.0.0" "$a" # wrong: v2.0.0 was published by $b
+commit_other "$d" >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'demo/v2.0.0'; then
+  ok "a tag pointing at the wrong commit is reported (exit ${rc})"
+else
+  bad "the audit accepted a tag that points at the wrong commit"
+  printf '       output: %s\n' "$out"
+fi
+if printf '%s' "$out" | grep -q "${b:0:9}"; then
+  ok "the mispointed-tag report names the commit the tag should be on"
+else
+  bad "the mispointed-tag report did not name the correct commit"
   printf '       output: %s\n' "$out"
 fi
 

--- a/tests/test-release-history.sh
+++ b/tests/test-release-history.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# Hermetic test for scripts/release-history.sh and scripts/check-release-tags.sh — the
+# record of which commit published which plugin version, and the audit that notices when
+# a published version never got a tag.
+#
+# Every case runs against a throwaway repository built here. Never against the repository
+# this test lives in: the audit walks all of history, so asserting against the real release
+# record would make the test's result depend on the next release anyone cuts.
+#
+# The case that matters most is the shallow clone. `git log` in a depth-1 checkout reports
+# almost no history, so an audit that trusted it would find nothing missing and pass —
+# green, and blind. That is the failure this whole file exists to make impossible.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HISTORY="${REPO_ROOT}/scripts/release-history.sh"
+AUDIT="${REPO_ROOT}/scripts/check-release-tags.sh"
+
+MANIFEST=".xcsh-plugin/marketplace.json"
+
+FAIL=0
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# Each fixture gets its own directory from mktemp, not a counter. A counter incremented
+# inside `$(new_repo)` increments in a subshell and is lost, so every fixture would land in
+# one directory and inherit the previous case's commits and tags — the tests would still
+# report OK, against a history nobody wrote.
+new_repo() {
+  local dir
+  dir=$(mktemp -d "${WORK}/repo-XXXXXX")
+  mkdir -p "${dir}/.xcsh-plugin"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email test@example.com
+  git -C "$dir" config user.name "Test"
+  git -C "$dir" config commit.gpgsign false
+  printf '%s\n' "$dir"
+}
+
+# commit_manifest <dir> <name=version>... — writes the manifest and prints the new sha.
+commit_manifest() {
+  local dir="$1"
+  shift
+  local json='{"plugins":[' first=1 pair
+  for pair in "$@"; do
+    [ "$first" -eq 1 ] || json+=','
+    first=0
+    json+="{\"name\":\"${pair%%=*}\",\"version\":\"${pair#*=}\"}"
+  done
+  json+=']}'
+  printf '%s\n' "$json" >"${dir}/${MANIFEST}"
+  git -C "$dir" add -A
+  # --allow-empty is deliberately NOT passed: a case that meant to change the manifest and
+  # did not is a broken fixture, and `git commit` refusing is how it says so.
+  git -C "$dir" commit -qm "manifest: $*"
+  git -C "$dir" rev-parse HEAD
+}
+
+# A refusal must be a refusal, not a crash. `bash missing-script.sh` exits 127, which would
+# satisfy a bare `rc -ne 0` and let every "refuses" case pass before the script was written.
+assert_refused() {
+  local label="$1" rc="$2" out="$3" want_match="${4:-}"
+  if [ "$rc" -ne 1 ]; then
+    bad "${label} — expected exit 1, got ${rc}"
+    printf '       output: %s\n' "$out"
+    return
+  fi
+  if [ -n "$want_match" ] && ! printf '%s' "$out" | grep -qi -- "$want_match"; then
+    bad "${label} — exit 1 but the reason never mentioned '${want_match}'"
+    printf '       output: %s\n' "$out"
+    return
+  fi
+  ok "$label"
+}
+
+# commit_other <dir> — a commit that does not touch the manifest.
+commit_other() {
+  local dir="$1"
+  printf 'x %s\n' "$RANDOM" >>"${dir}/README.md"
+  git -C "$dir" add -A
+  git -C "$dir" commit -qm "unrelated"
+  git -C "$dir" rev-parse HEAD
+}
+
+ok() {
+  printf '[OK] %s\n' "$1"
+}
+bad() {
+  printf '[FAIL] %s\n' "$1"
+  FAIL=1
+}
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    ok "$label"
+  else
+    bad "$label"
+    printf '       expected: %s\n' "$(printf '%s' "$expected" | tr '\n' '|')"
+    printf '       actual:   %s\n' "$(printf '%s' "$actual" | tr '\n' '|')"
+  fi
+}
+
+# Runs a script inside a fixture repo and prints its stdout. Fails the test on non-zero.
+run_in() {
+  local dir="$1" script="$2"
+  shift 2
+  (cd "$dir" && bash "$script" "$@")
+}
+
+# ---------------------------------------------------------------------------
+# release-history.sh — what was published, and by which commit
+# ---------------------------------------------------------------------------
+
+# Three bumps of one plugin, oldest first, each attributed to its own commit.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+b=$(commit_manifest "$d" demo=1.1.0)
+c=$(commit_manifest "$d" demo=2.0.0)
+assert_eq "three bumps listed oldest first, each with its publishing commit" \
+  "demo 1.0.0 ${a}
+demo 1.1.0 ${b}
+demo 2.0.0 ${c}" \
+  "$(run_in "$d" "$HISTORY")"
+
+# A commit that rewrites the manifest without changing any version publishes nothing.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+printf '%s\n' '{"plugins":[{"name":"demo","version":"1.0.0","description":"new"}]}' >"${d}/${MANIFEST}"
+git -C "$d" add -A && git -C "$d" commit -qm "description only"
+assert_eq "a manifest edit that changes no version publishes nothing" \
+  "demo 1.0.0 ${a}" \
+  "$(run_in "$d" "$HISTORY")"
+
+# Two plugins bumped in one commit are two releases at the same sha.
+d=$(new_repo)
+a=$(commit_manifest "$d" alpha=1.0.0 beta=1.0.0)
+assert_eq "two plugins bumped in one commit are two releases at that commit" \
+  "alpha 1.0.0 ${a}
+beta 1.0.0 ${a}" \
+  "$(run_in "$d" "$HISTORY")"
+
+# A plugin added later is published at the commit that added it.
+d=$(new_repo)
+a=$(commit_manifest "$d" alpha=1.0.0)
+b=$(commit_manifest "$d" alpha=1.0.0 beta=0.1.0)
+assert_eq "a plugin added later is published at the commit that added it" \
+  "alpha 1.0.0 ${a}
+beta 0.1.0 ${b}" \
+  "$(run_in "$d" "$HISTORY")"
+
+# Removing a plugin publishes nothing and does not retract what it already published.
+d=$(new_repo)
+a=$(commit_manifest "$d" alpha=1.0.0 beta=1.0.0)
+commit_manifest "$d" alpha=1.0.0 >/dev/null
+assert_eq "removing a plugin publishes nothing and retracts nothing" \
+  "alpha 1.0.0 ${a}
+beta 1.0.0 ${a}" \
+  "$(run_in "$d" "$HISTORY")"
+
+# A version that reappears after a downgrade was published once, by the earlier commit.
+# It can only ever carry one tag, so the later appearance is not a second release.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+b=$(commit_manifest "$d" demo=2.0.0)
+commit_manifest "$d" demo=1.0.0 >/dev/null
+assert_eq "a version reappearing after a downgrade is still one release, the earlier one" \
+  "demo 1.0.0 ${a}
+demo 2.0.0 ${b}" \
+  "$(run_in "$d" "$HISTORY")"
+
+# Commits before the manifest existed are not an error.
+d=$(new_repo)
+commit_other "$d" >/dev/null
+a=$(commit_manifest "$d" demo=1.0.0)
+assert_eq "history predating the manifest is not an error" \
+  "demo 1.0.0 ${a}" \
+  "$(run_in "$d" "$HISTORY")"
+
+# Lookup mode: the publishing commit for one version, and a refusal for one never published.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+b=$(commit_manifest "$d" demo=1.1.0)
+assert_eq "lookup returns the publishing commit" "$b" "$(run_in "$d" "$HISTORY" demo 1.1.0)"
+assert_eq "lookup returns the publishing commit for an older version" \
+  "$a" "$(run_in "$d" "$HISTORY" demo 1.0.0)"
+
+rc=0
+out=$( (cd "$d" && bash "$HISTORY" demo 9.9.9 2>&1)) || rc=$?
+assert_refused "lookup refuses a version that was never on main" "$rc" "$out" "9.9.9"
+
+rc=0
+out=$( (cd "$d" && bash "$HISTORY" nosuch 1.0.0 2>&1)) || rc=$?
+assert_refused "lookup refuses an unknown plugin" "$rc" "$out" "nosuch"
+
+# ---------------------------------------------------------------------------
+# The shallow clone — the case that would make every audit vacuous
+# ---------------------------------------------------------------------------
+
+d=$(new_repo)
+commit_manifest "$d" demo=1.0.0 >/dev/null
+commit_manifest "$d" demo=2.0.0 >/dev/null
+commit_manifest "$d" demo=3.0.0 >/dev/null
+shallow="${WORK}/shallow"
+git clone -q --depth 1 "file://${d}" "$shallow" 2>/dev/null
+
+rc=0
+out=$( (cd "$shallow" && bash "$HISTORY" 2>&1)) || rc=$?
+assert_refused "release-history refuses a shallow clone instead of under-reporting" \
+  "$rc" "$out" "shallow"
+
+rc=0
+out=$( (cd "$shallow" && bash "$AUDIT" 2>&1)) || rc=$?
+assert_refused "the audit refuses a shallow clone instead of passing blind" \
+  "$rc" "$out" "shallow"
+
+# ---------------------------------------------------------------------------
+# check-release-tags.sh — every published version must carry a tag
+# ---------------------------------------------------------------------------
+
+# All tagged: clean.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+b=$(commit_manifest "$d" demo=1.1.0)
+git -C "$d" tag "demo/v1.0.0" "$a"
+git -C "$d" tag "demo/v1.1.0" "$b"
+commit_other "$d" >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "the audit passes when every published version carries a tag"
+else
+  bad "the audit failed on a fully tagged history (exit ${rc})"
+  printf '       output: %s\n' "$out"
+fi
+
+# The v7.2.0 case: a version published, never tagged, and a later version tagged over it.
+# Auditing only the current manifest would call this clean, which is exactly how the real
+# one stayed invisible until someone went looking for the tag.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+b=$(commit_manifest "$d" demo=1.1.0)
+c=$(commit_manifest "$d" demo=1.2.0)
+git -C "$d" tag "demo/v1.0.0" "$a"
+git -C "$d" tag "demo/v1.2.0" "$c"
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'demo/v1.1.0'; then
+  ok "the audit names a version that was skipped and superseded (exit ${rc})"
+else
+  bad "the audit missed a published version with no tag"
+  printf '       output: %s\n' "$out"
+fi
+if printf '%s' "$out" | grep -q "$b"; then
+  ok "the audit reports the commit that published the untagged version"
+else
+  bad "the audit did not say which commit published the untagged version"
+fi
+
+# A version published by the tip commit is still being released; the release job runs
+# alongside this audit, so demanding its tag would fail on every legitimate release.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+git -C "$d" tag "demo/v1.0.0" "$a"
+commit_manifest "$d" demo=1.1.0 >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "a version published by the tip commit is in flight, not missing"
+else
+  bad "the audit failed a release that is still in flight (exit ${rc})"
+  printf '       output: %s\n' "$out"
+fi
+
+# ...but only for the tip. One commit later, the same untagged version is a real gap.
+commit_other "$d" >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'demo/v1.1.0'; then
+  ok "once the tip moves on, the untagged version is reported (exit ${rc})"
+else
+  bad "the audit stayed quiet about an untagged version after the tip moved on"
+  printf '       output: %s\n' "$out"
+fi
+
+# An annotated tag counts. The workflow creates lightweight ones, but a hand-cut release
+# — which is how meddpicc/v7.2.0 was finally published — can be either.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+git -C "$d" tag -a "demo/v1.0.0" -m "hand cut" "$a"
+commit_other "$d" >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  ok "an annotated tag satisfies the audit"
+else
+  bad "the audit rejected an annotated tag (exit ${rc})"
+  printf '       output: %s\n' "$out"
+fi
+
+# A tag whose name merely contains the version does not count for it.
+d=$(new_repo)
+a=$(commit_manifest "$d" demo=1.0.0)
+git -C "$d" tag "demo/v1.0.0-rc1" "$a"
+commit_other "$d" >/dev/null
+rc=0
+out=$(run_in "$d" "$AUDIT" 2>&1) || rc=$?
+assert_refused "a prerelease tag does not satisfy the release it resembles" \
+  "$rc" "$out" "demo/v1.0.0"
+
+if [ "$FAIL" -ne 0 ]; then
+  printf '\nFAILED\n'
+  exit 1
+fi
+printf '\nAll release-history tests passed.\n'


### PR DESCRIPTION
Closes #954

`Release Plugins` had no way to finish a job it started. When it failed for a reason outside the
release itself — meddpicc/v7.2.0 died on a SIGPIPE in the note script — re-running replayed the
original commit's code, a fix under `scripts/` matched neither `paths:` entry, and the version diff
was already consumed. It was cut by hand. The failure was also quiet: main green, version files
right, only the absent tag disagreeing.

## What changed

- **`workflow_dispatch` with `plugin` and `version`.** Refuses a version no commit on main ever
  published, and tags the commit that did.
- **`--target` is the publishing commit, not `main`.** Main may have moved by the time the job runs,
  and a re-cut is by definition tagging the past. Full sha — GitHub rejects an abbreviated one.
- **`scripts/release-history.sh`** — which commit published which version. Both workflow paths read
  it, so the manifest diff no longer lives twice. Verified equivalent to the old inline diff across
  all 37 release commits in this repository: zero disagreements.
- **`scripts/check-release-tags.sh`**, wired into `Validate Plugins` on push. It lives there rather
  than in `Release Plugins` because the failure it looks for *is* `Release Plugins` not finishing —
  a check inside the workflow that broke cannot report that the workflow broke.

## Verification

27 hermetic tests, all against throwaway repositories. 12 mutations, all killed. `shellcheck`,
`shfmt`, `codespell`, `actionlint`, `yamllint` clean from the repo root.

Both paths run against the real repository: the push path selects `meddpicc 7.2.1` at main's tip,
and the dispatch path resolves `meddpicc 7.2.0` to `a16641c` — the exact commit the tag was hand-cut
at. The audit reports 80 in-scope versions, all tagged.

## Four things the review and the mutation tests found

- **The dispatch could have published unmerged code.** `workflow_dispatch` has a branch selector and
  checkout follows it, so a feature branch's manifest would have satisfied the "was this ever on
  main" guard. The checkout is now pinned to the default branch, which is what makes the guard mean
  what it says.
- **The manifest rename truncated the history.** `.claude-plugin/marketplace.json` became
  `.xcsh-plugin/…` in e4723c3; a log limited to the current path hid 57 commits and attributed all
  29 versions alive at the rename to the refactor that moved the file — so a re-cut of any of them
  would have tagged a rename. Both paths are read now: 102 versions became 158, and none are
  attributed to e4723c3.
- **The audit is scoped to plugins still on offer.** Five `f5xc-*` v1.0.0 entries were left untagged
  by the org rename. Nobody can install them, so there is no release to cut and reporting them would
  have held main red for good. Every version of a plugin still offered stays in scope, which is what
  keeps a v7.2.0-shaped gap reportable.
- **A tag on the wrong commit now fails too.** Existence alone was checked; a mispointed tag reads as
  released while shipping a different revision. All 80 in-scope tags are correct today, so enforcing
  it costs nothing and closes the class.

Two guards were unreachable or untested and only mutation testing said so: a parent-commit comparison
that `SEEN` already covered (deleted), and the empty-manifest refusal, which had no test — without it
a manifest that lists nothing makes every version "out of scope" and the audit passes having checked
nothing.

`declare -A` is deliberately absent: macOS ships bash 3.2, and CI's bash 5 would never have said so.

## Also

Corrects the published v7.2.1 changelog note. It claimed the workbook was "byte-identical, same
sha256"; that was measured before the version bump and stopped being true with it —
`docProps/custom.xml` records the engine version. Measured: the stamp appears exactly once.
