### PR TITLE
fix: replace ACME placeholders

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.2.1",
+      "version": "7.2.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -157,7 +157,7 @@
     {
       "name": "osint-framework",
       "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -187,7 +187,7 @@
     {
       "name": "salesforce-legacy",
       "description": "[ARCHIVED] Original Claude Code-only Salesforce CLI automation. Replaced by unified salesforce plugin with native xcsh tool support.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -202,7 +202,7 @@
     {
       "name": "salesforce",
       "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`salesforce`** v1.3.7 — replaces legacy account, opportunity, My Domain, and email fixtures with
+  canonical Example values.
+
+- **`salesforce-legacy`** v1.0.2 — uses the canonical `example-corp` My Domain prefix in setup
+  documentation.
+
+- **`osint-framework`** v1.0.3 — replaces legacy business-search examples with Example Corp.
+
+- **`meddpicc`** v7.2.2 — replaces the legacy deal fixture with Example Corp and Example Partners.
+
 - **`meddpicc`** v7.2.1 — a serialization contract for text the writer does not control. No behaviour
   change: every part of the generated workbook is byte-identical except `docProps/custom.xml`, which
   records the engine version, because no value in play today contains any of these characters. (The

--- a/docs/ar/plugins/salesforce.mdx
+++ b/docs/ar/plugins/salesforce.mdx
@@ -53,8 +53,8 @@ sf --version
 ### الخطوة 1: العثور على نطاق Salesforce الخاص بك
 
 انظر إلى عنوان URL الخاص بـ Salesforce في المتصفح. إذا كنت تصل إلى Salesforce عبر
-`https://acme.lightning.force.com`، فإن نطاق تسجيل الدخول هو
-`https://acme.my.salesforce.com`.
+`https://example-corp.lightning.force.com`، فإن نطاق تسجيل الدخول هو
+`https://example-corp.my.salesforce.com`.
 
 <Aside type="tip">
   إذا كانت شركتك تستخدم SSO، فيجب عليك تحديد نطاقك المخصص باستخدام

--- a/docs/de/plugins/salesforce.mdx
+++ b/docs/de/plugins/salesforce.mdx
@@ -54,8 +54,8 @@ Die Ausgabe sollte in etwa so aussehen: `@salesforce/cli/2.x.x`.
 ### Schritt 1: Ihre Salesforce-Domain finden
 
 Schauen Sie in Ihrem Browser auf Ihre Salesforce-URL. Wenn Sie Salesforce unter
-`https://acme.lightning.force.com` aufrufen, ist Ihre Login-Domain
-`https://acme.my.salesforce.com`.
+`https://example-corp.lightning.force.com` aufrufen, ist Ihre Login-Domain
+`https://example-corp.my.salesforce.com`.
 
 <Aside type="tip">
   Wenn Ihr Unternehmen SSO verwendet, müssen Sie Ihre benutzerdefinierte Domain mit

--- a/docs/en/plugins/salesforce.mdx
+++ b/docs/en/plugins/salesforce.mdx
@@ -49,8 +49,8 @@ You should see output like `@salesforce/cli/2.x.x`.
 ### Step 1: Find your Salesforce domain
 
 Look at your Salesforce URL in the browser. If you access Salesforce at
-`https://acme.lightning.force.com`, your login domain is
-`https://acme.my.salesforce.com`.
+`https://example-corp.lightning.force.com`, your login domain is
+`https://example-corp.my.salesforce.com`.
 
 <Aside type="tip">
   If your company uses SSO, you must specify your custom domain with

--- a/docs/es/plugins/salesforce.mdx
+++ b/docs/es/plugins/salesforce.mdx
@@ -54,8 +54,8 @@ Debería ver una salida como `@salesforce/cli/2.x.x`.
 ### Paso 1: Encuentre su dominio de Salesforce
 
 Consulte la URL de Salesforce en el navegador. Si accede a Salesforce en
-`https://acme.lightning.force.com`, su dominio de inicio de sesión es
-`https://acme.my.salesforce.com`.
+`https://example-corp.lightning.force.com`, su dominio de inicio de sesión es
+`https://example-corp.my.salesforce.com`.
 
 <Aside type="tip">
   Si su empresa utiliza SSO, debe especificar su dominio personalizado con

--- a/docs/fr/plugins/salesforce.mdx
+++ b/docs/fr/plugins/salesforce.mdx
@@ -54,8 +54,8 @@ Vous devriez voir une sortie du type `@salesforce/cli/2.x.x`.
 ### Étape 1 : Trouver votre domaine Salesforce
 
 Regardez votre URL Salesforce dans le navigateur. Si vous accédez à Salesforce à l'adresse
-`https://acme.lightning.force.com`, votre domaine de connexion est
-`https://acme.my.salesforce.com`.
+`https://example-corp.lightning.force.com`, votre domaine de connexion est
+`https://example-corp.my.salesforce.com`.
 
 <Aside type="tip">
   Si votre entreprise utilise SSO, vous devez spécifier votre domaine personnalisé avec

--- a/docs/hi/plugins/salesforce.mdx
+++ b/docs/hi/plugins/salesforce.mdx
@@ -50,8 +50,8 @@ sf --version
 ### चरण 1: अपना Salesforce डोमेन खोजें
 
 ब्राउज़र में अपना Salesforce URL देखें। यदि आप Salesforce को
-`https://acme.lightning.force.com` पर एक्सेस करते हैं, तो आपका लॉगिन डोमेन
-`https://acme.my.salesforce.com` है।
+`https://example-corp.lightning.force.com` पर एक्सेस करते हैं, तो आपका लॉगिन डोमेन
+`https://example-corp.my.salesforce.com` है।
 
 <Aside type="tip">
   यदि आपकी कंपनी SSO का उपयोग करती है, तो आपको

--- a/docs/it/plugins/salesforce.mdx
+++ b/docs/it/plugins/salesforce.mdx
@@ -53,8 +53,8 @@ Dovrebbe essere visualizzato un output simile a `@salesforce/cli/2.x.x`.
 ### Passaggio 1: Individuare il dominio Salesforce
 
 Controllare l'URL di Salesforce nel browser. Se si accede a Salesforce tramite
-`https://acme.lightning.force.com`, il dominio di login è
-`https://acme.my.salesforce.com`.
+`https://example-corp.lightning.force.com`, il dominio di login è
+`https://example-corp.my.salesforce.com`.
 
 <Aside type="tip">
   Se l'azienda utilizza SSO, è necessario specificare il dominio personalizzato con

--- a/docs/ja/plugins/salesforce.mdx
+++ b/docs/ja/plugins/salesforce.mdx
@@ -46,7 +46,7 @@ sf --version
 
 ### ステップ 1: Salesforce ドメインを確認する
 
-ブラウザーで Salesforce の URL を確認します。`https://acme.lightning.force.com` で Salesforce にアクセスしている場合、ログインドメインは `https://acme.my.salesforce.com` です。
+ブラウザーで Salesforce の URL を確認します。`https://example-corp.lightning.force.com` で Salesforce にアクセスしている場合、ログインドメインは `https://example-corp.my.salesforce.com` です。
 
 <Aside type="tip">
   会社が SSO を使用している場合は、`--instance-url` でカスタムドメインを指定する必要があります。これにより、汎用の Salesforce ログインページではなく、SSO プロバイダーを経由してリダイレクトされます。

--- a/docs/ko/plugins/salesforce.mdx
+++ b/docs/ko/plugins/salesforce.mdx
@@ -49,8 +49,8 @@ sf --version
 ### 1단계: Salesforce 도메인 찾기
 
 브라우저에서 Salesforce URL을 확인합니다. Salesforce에
-`https://acme.lightning.force.com`으로 접속한다면, 로그인 도메인은
-`https://acme.my.salesforce.com`입니다.
+`https://example-corp.lightning.force.com`으로 접속한다면, 로그인 도메인은
+`https://example-corp.my.salesforce.com`입니다.
 
 <Aside type="tip">
   회사에서 SSO를 사용하는 경우, 로그인이 일반 Salesforce 로그인 페이지 대신

--- a/docs/pt-br/plugins/salesforce.mdx
+++ b/docs/pt-br/plugins/salesforce.mdx
@@ -54,8 +54,8 @@ Você deverá ver uma saída como `@salesforce/cli/2.x.x`.
 ### Etapa 1: Encontre seu domínio Salesforce
 
 Verifique a URL do Salesforce no navegador. Se você acessa o Salesforce em
-`https://acme.lightning.force.com`, seu domínio de login é
-`https://acme.my.salesforce.com`.
+`https://example-corp.lightning.force.com`, seu domínio de login é
+`https://example-corp.my.salesforce.com`.
 
 <Aside type="tip">
   Se sua empresa utiliza SSO, você deve especificar seu domínio personalizado com

--- a/docs/th/plugins/salesforce.mdx
+++ b/docs/th/plugins/salesforce.mdx
@@ -51,8 +51,8 @@ sf --version
 ### ขั้นตอนที่ 1: ค้นหาโดเมน Salesforce ของคุณ
 
 ดู URL ของ Salesforce ในเบราว์เซอร์ หากคุณเข้าถึง Salesforce ที่
-`https://acme.lightning.force.com` โดเมนสำหรับเข้าสู่ระบบของคุณคือ
-`https://acme.my.salesforce.com`
+`https://example-corp.lightning.force.com` โดเมนสำหรับเข้าสู่ระบบของคุณคือ
+`https://example-corp.my.salesforce.com`
 
 <Aside type="tip">
   หากบริษัทของคุณใช้ SSO คุณต้องระบุโดเมนที่กำหนดเองด้วย

--- a/docs/zh-cn/plugins/salesforce.mdx
+++ b/docs/zh-cn/plugins/salesforce.mdx
@@ -48,8 +48,8 @@ sf --version
 ### 第一步：查找您的 Salesforce 域名
 
 在浏览器中查看您的 Salesforce URL。如果您通过
-`https://acme.lightning.force.com` 访问 Salesforce，则您的登录域名为
-`https://acme.my.salesforce.com`。
+`https://example-corp.lightning.force.com` 访问 Salesforce，则您的登录域名为
+`https://example-corp.my.salesforce.com`。
 
 <Aside type="tip">
   如果您的公司使用 SSO，必须通过 `--instance-url` 指定自定义域名，

--- a/docs/zh-tw/plugins/salesforce.mdx
+++ b/docs/zh-tw/plugins/salesforce.mdx
@@ -49,8 +49,8 @@ sf --version
 ### 步驟一：找到您的 Salesforce 網域
 
 查看瀏覽器中的 Salesforce URL。若您透過
-`https://acme.lightning.force.com` 存取 Salesforce，則您的登入網域為
-`https://acme.my.salesforce.com`。
+`https://example-corp.lightning.force.com` 存取 Salesforce，則您的登入網域為
+`https://example-corp.my.salesforce.com`。
 
 <Aside type="tip">
   若您的公司使用 SSO，您必須透過 `--instance-url` 指定自訂網域，

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/README.md
+++ b/plugins/meddpicc/README.md
@@ -173,7 +173,7 @@ Or add to your marketplace configuration for automatic installation.
 ### Create a new deal (day 0)
 
 ```text
-/meddpicc:qualify-deal Acme Corp
+/meddpicc:qualify-deal Example Corp
 ```
 
 Walks through a guided interview: metadata first, then each MEDDPICC element with scoring and evidence collection.
@@ -181,7 +181,7 @@ Walks through a guided interview: metadata first, then each MEDDPICC element wit
 ### Import from Salesforce
 
 ```text
-/meddpicc:qualify-deal Acme Corp --sfdc 006Hs00000AbCdEfG
+/meddpicc:qualify-deal Example Corp --sfdc 006Hs00000AbCdEfG
 ```
 
 Pre-populates the deal JSON from Salesforce fields, then asks targeted questions for missing sections.
@@ -189,7 +189,7 @@ Pre-populates the deal JSON from Salesforce fields, then asks targeted questions
 ### Ingest meeting notes
 
 ```text
-/meddpicc:update-deal Acme Corp
+/meddpicc:update-deal Example Corp
 Here are my notes from today's call with the CTO:
 - Confirmed $500K budget for API security modernization
 - Board mandate to fix API incidents by Q3
@@ -202,7 +202,7 @@ The AI extracts MEDDPICC signals, presents a proposed update diff with score rec
 ### Ingest an email from your champion
 
 ```text
-/meddpicc:update-deal Acme Corp
+/meddpicc:update-deal Example Corp
 FW: RE: API Gateway eval - internal update
 Hey John, wanted to give you a heads up. The architecture review
 board approved us for the shortlist. Vendor A pricing came in at
@@ -213,7 +213,7 @@ $85K/yr vs your $120K. Legal confirmed their standard review takes
 ### Run a weekly deal review
 
 ```text
-/meddpicc:deal-review Acme Corp
+/meddpicc:deal-review Example Corp
 ```
 
 Loads the deal file, snapshots scores for delta tracking, inspects evidence changes, and produces a forecast assessment with action items.
@@ -229,7 +229,7 @@ Scores Power, Personal Win, Access, Intel, and Action (0-3 each) to classify the
 ### Build a Mutual Action Plan
 
 ```text
-/meddpicc:build-map Acme Corp
+/meddpicc:build-map Example Corp
 ```
 
 Creates a customer-facing document working backward from the target close date, tied to MEDDPICC elements.
@@ -237,7 +237,7 @@ Creates a customer-facing document working backward from the target close date, 
 ### Export to spreadsheet
 
 ```text
-/meddpicc:qualify-deal Acme Corp render
+/meddpicc:qualify-deal Example Corp render
 ```
 
 Generates an Excel workbook from the deal JSON, built from the workbook spec: one laid-out

--- a/plugins/meddpicc/engine/generate.test.ts
+++ b/plugins/meddpicc/engine/generate.test.ts
@@ -107,7 +107,7 @@ describe('planWorkbook — form layout', () => {
     expect(input).toBeDefined();
     expect(input?.sheet).toBe(SHEET);
     const [, col, row] = /^([A-Z]+)(\d+)$/.exec(input?.address ?? '') ?? [];
-    expect(cellAt(input?.address ?? '')?.value).toBe('Acme Corporation');
+    expect(cellAt(input?.address ?? '')?.value).toBe('Example Corp');
     // The label is the nearest `fieldLabel` to its left on the same row — a value with no label
     // beside it is a value nobody can read.
     const labels = theSheet()

--- a/plugins/meddpicc/engine/json-path.test.ts
+++ b/plugins/meddpicc/engine/json-path.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readPath, writePath } from './json-path';
 
 const deal = () => ({
-  metadata: { accountName: 'Acme', revenue: { acv: 85000 } },
+  metadata: { accountName: 'Example Corp', revenue: { acv: 85000 } },
   stakeholders: [{ name: 'Sarah' }, { name: 'Marcus' }],
   qualification: { metrics: { responses: ['first', 'second'] } },
 });

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -177,7 +177,7 @@ describe('readWorkbookCells', () => {
     const cells = readWorkbookCells(generateWorkbook(schema, spec, exampleDeal));
     expect([...cells.keys()]).toEqual(spec.sheets.map((s) => s.name));
     const { sheet, address } = addressOf(exampleDeal, 'metadata.accountName');
-    expect(cells.get(sheet)?.get(address)?.text).toBe('Acme Corporation');
+    expect(cells.get(sheet)?.get(address)?.text).toBe('Example Corp');
   });
 
   test('a formula cell is reported as a formula, with no value to mistake for one', () => {
@@ -237,7 +237,7 @@ describe('proposals', () => {
         address,
         valueType: 'string',
         kind: 'set',
-        from: 'Acme Corporation',
+        from: 'Example Corp',
         to: 'Globex Corporation',
       },
     ]);

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }

--- a/plugins/meddpicc/schema/example-deal.json
+++ b/plugins/meddpicc/schema/example-deal.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "dealId": "deal-acme-dc-modernization-2026",
-    "accountName": "Acme Corporation",
+    "dealId": "deal-example-corp-dc-modernization-2026",
+    "accountName": "Example Corp",
     "dealName": "DC Modernization Phase 2",
     "dealStatus": "Qualified",
     "closeDate": "2026-06-30",
@@ -212,10 +212,10 @@
       "whyNow": "Board mandate deadline is Q3 2026; regulatory audit in September; every month of delay is another month of exposure to SLA penalties"
     },
     "partner": {
-      "name": "PartnerCo",
-      "whyAnything": "Acme needs implementation support — their platform team is at capacity with the Kubernetes migration",
-      "whyThisPartner": "PartnerCo has 3 certified engineers on our stack and prior Acme relationship from the load balancer deployment",
-      "whyNow": "PartnerCo has a team available in June; if we wait, they're committed to another project through Q4"
+      "name": "Example Partners",
+      "whyAnything": "Example Corp needs implementation support — their platform team is at capacity with the Kubernetes migration",
+      "whyThisPartner": "Example Partners has 3 certified engineers on our stack and a prior Example Corp relationship from the load balancer deployment",
+      "whyNow": "Example Partners has a team available in June; if we wait, they're committed to another project through Q4"
     }
   },
   "stakeholders": [
@@ -261,7 +261,7 @@
     }
   ],
   "salesStrategy": {
-    "differentiatedValueProposition": "We are the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Acme's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
+    "differentiatedValueProposition": "We are the only vendor that provides unified application and API security with native Kubernetes integration — eliminating the need to deploy separate tools for north-south and east-west API protection. This directly addresses Example Corp's MTTR target by providing a single pane of glass for API discovery, threat detection, and incident response across all 3 data centers.",
     "winStrategy": "Lead with the pain: $400K SLA penalties and board mandate create urgency. Differentiate on Kubernetes-native integration (Vendor A can't match this). Use the POC to prove MTTR improvement quantitatively. Get EB alignment on business case before architecture review board. Neutralize Vendor A's price advantage by quantifying the cost of deploying and managing a separate API discovery tool."
   },
   "closePlan": {

--- a/plugins/osint-framework/.xcsh-plugin/plugin.json
+++ b/plugins/osint-framework/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "osint-framework",
   "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/osint-framework/package.json
+++ b/plugins/osint-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osint-framework",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "OSINT Framework tool catalog and investigation skills — 1,064 intelligence-gathering tools across 34 categories",
   "license": "Apache-2.0"
 }

--- a/plugins/osint-framework/skills/business-records/SKILL.md
+++ b/plugins/osint-framework/skills/business-records/SKILL.md
@@ -101,7 +101,7 @@ curl -s "https://data.sec.gov/submissions/CIK${CIK}.json" \
 
 ```bash
 if [ -n "${OPENCORPORATES_API_KEY:-}" ]; then
-  curl -s "https://api.opencorporates.com/v0.4/companies/search?q=acme+corp&api_token=${OPENCORPORATES_API_KEY}" \
+  curl -s "https://api.opencorporates.com/v0.4/companies/search?q=example+corp&api_token=${OPENCORPORATES_API_KEY}" \
 | jq '.results.companies[] |
 else
   echo "[skip] OpenCorporates requires API key (set OPENCORPORATES_API_KEY)"

--- a/plugins/osint-framework/skills/compliance-risk/SKILL.md
+++ b/plugins/osint-framework/skills/compliance-risk/SKILL.md
@@ -81,7 +81,7 @@ curl -s "https://offshoreleaks.icij.org/api/v1/search?q=company+name&limit=10" \
 ### Companies House UK -- Company Search
 
 ```bash
-curl -s "https://api.company-information.service.gov.uk/search/companies?q=acme+ltd" \
+curl -s "https://api.company-information.service.gov.uk/search/companies?q=example+corp" \
   -H "Authorization: Basic $(echo -n 'YOUR_API_KEY:' | base64)" \
 | jq '.items[] |
 ```

--- a/plugins/osint-framework/skills/osint-catalog/references/correlation-engine.md
+++ b/plugins/osint-framework/skills/osint-catalog/references/correlation-engine.md
@@ -18,7 +18,7 @@ creating, querying, and reporting on graph data.
 | Type | Description | Example |
 | ------ | ------------- | --------- |
 | `person` | A human individual | `"John Smith"` |
-| `company` | A business or organization | `"Acme Corp"` |
+| `company` | A business or organization | `"Example Corp"` |
 | `domain` | A DNS domain name | `"example.com"` |
 | `ip` | An IPv4 or IPv6 address | `"198.51.100.1"` |
 | `email` | An email address | `"john@example.com"` |

--- a/plugins/salesforce-legacy/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce-legacy/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce-legacy",
   "description": "[ARCHIVED] Original Claude Code-only Salesforce CLI automation. Replaced by unified salesforce plugin with native xcsh tool support.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/salesforce",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/salesforce-legacy/README.md
+++ b/plugins/salesforce-legacy/README.md
@@ -27,8 +27,8 @@ skills for Salesforce development.
 ### Workstation (browser available)
 
 Find your Salesforce domain from your browser URL
-(`https://acme.lightning.force.com` means your domain is
-`acme.my.salesforce.com`), then run:
+(`https://example-corp.lightning.force.com` means your domain is
+`example-corp.my.salesforce.com`), then run:
 
 ```bash
 sf org login web --alias my-org --set-default --instance-url https://YOUR-DOMAIN.my.salesforce.com

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/salesforce/README.md
+++ b/plugins/salesforce/README.md
@@ -91,8 +91,8 @@ conversation.
 ### Workstation (browser available)
 
 Find your Salesforce domain from your browser URL
-(`https://acme.lightning.force.com` means your domain is
-`acme.my.salesforce.com`), then run:
+(`https://example-corp.lightning.force.com` means your domain is
+`example-corp.my.salesforce.com`), then run:
 
 ```bash
 sf org login web --alias my-org --set-default --instance-url https://YOUR-DOMAIN.my.salesforce.com

--- a/plugins/salesforce/benchmarks/fixtures/data-query.json
+++ b/plugins/salesforce/benchmarks/fixtures/data-query.json
@@ -6,7 +6,7 @@
     "records": [
       {
         "attributes": { "type": "Opportunity", "url": "/services/data/v60.0/sobjects/Opportunity/0060000000000001" },
-        "Name": "Acme Renewal",
+        "Name": "Example Corp Renewal",
         "Amount": 50000,
         "StageName": "Closed Won"
       },

--- a/plugins/salesforce/benchmarks/scenarios.ts
+++ b/plugins/salesforce/benchmarks/scenarios.ts
@@ -126,7 +126,7 @@ const scenarios: Scenario[] = [
       );
       return checkResult(result, {
         isError: false,
-        contains: ['2 records returned', 'Acme Renewal', 'Closed Won'],
+        contains: ['2 records returned', 'Example Corp Renewal', 'Closed Won'],
       });
     },
   },

--- a/plugins/salesforce/package.json
+++ b/plugins/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-salesforce",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Salesforce pipeline intelligence for xcsh — native tools, context discovery, pipeline reports",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Salesforce",
-    "version": "1.3.6",
+    "version": "1.3.7",
     "description": "Salesforce pipeline intelligence",
     "extensions": [
       "src/index.ts"

--- a/plugins/salesforce/test/context/salesforce-context.test.ts
+++ b/plugins/salesforce/test/context/salesforce-context.test.ts
@@ -74,7 +74,7 @@ describe('buildSalesforceHint', () => {
       },
       territories: ['West', 'Central'],
       activeAccounts: [
-        { name: 'Acme', oppCount: 3 },
+        { name: 'Example Corp', oppCount: 3 },
         { name: 'Globex', oppCount: 2 },
       ],
       collectedAt: new Date().toISOString(),

--- a/plugins/salesforce/test/pipeline-report/generator.test.ts
+++ b/plugins/salesforce/test/pipeline-report/generator.test.ts
@@ -34,8 +34,8 @@ const BARE_LINE_ITEM = ['Id', 'Quantity', 'UnitPrice', 'TotalPrice'];
 function oppRow(over: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     Id: '006000000000001',
-    Name: 'Acme Expansion',
-    Account: { Name: 'Acme' },
+    Name: 'Example Corp Expansion',
+    Account: { Name: 'Example Corp' },
     Amount: 120000,
     ForecastCategoryName: 'Commit',
     StageName: 'Negotiation',
@@ -83,7 +83,7 @@ describe('generatePipelineReport — an org without the custom schema', () => {
     );
     const data = await generatePipelineReport({ ...BASE, capabilities }, fn);
     expect(data.netNew.accounts.length).toBe(1);
-    expect(data.netNew.accounts[0].name).toBe('Acme');
+    expect(data.netNew.accounts[0].name).toBe('Example Corp');
     expect(data.netNew.totals.platform).toBe(120000);
   });
 

--- a/plugins/salesforce/test/sf/formatters.test.ts
+++ b/plugins/salesforce/test/sf/formatters.test.ts
@@ -163,9 +163,9 @@ describe('formatOrgDetail', () => {
 
 describe('flattenRecord', () => {
   it('flattens nested objects with dot notation', () => {
-    const record = { Account: { Name: 'Acme', Id: '001' }, Amount: 1000 };
+    const record = { Account: { Name: 'Example Corp', Id: '001' }, Amount: 1000 };
     const flat = flattenRecord(record);
-    expect(flat['Account.Name']).toBe('Acme');
+    expect(flat['Account.Name']).toBe('Example Corp');
     expect(flat['Account.Id']).toBe('001');
     expect(flat.Amount).toBe(1000);
   });
@@ -178,10 +178,10 @@ describe('flattenRecord', () => {
   });
 
   it('skips nested attributes key', () => {
-    const record = { Account: { attributes: { type: 'Account' }, Name: 'Acme' } };
+    const record = { Account: { attributes: { type: 'Account' }, Name: 'Example Corp' } };
     const flat = flattenRecord(record);
     expect(flat['Account.attributes']).toBeUndefined();
-    expect(flat['Account.Name']).toBe('Acme');
+    expect(flat['Account.Name']).toBe('Example Corp');
   });
 
   it('skips null values', () => {
@@ -224,11 +224,11 @@ describe('formatQueryResults', () => {
     const result: SfQueryResult = {
       totalSize: 1,
       done: true,
-      records: [{ attributes: { type: 'Opportunity' }, Account: { Name: 'Acme' }, Amount: 5000 }],
+      records: [{ attributes: { type: 'Opportunity' }, Account: { Name: 'Example Corp' }, Amount: 5000 }],
     };
     const output = formatQueryResults(result);
     expect(output).toContain('Account.Name');
-    expect(output).toContain('Acme');
+    expect(output).toContain('Example Corp');
     expect(output).not.toContain('attributes');
   });
 

--- a/plugins/salesforce/test/wizard.test.ts
+++ b/plugins/salesforce/test/wizard.test.ts
@@ -224,7 +224,7 @@ describe('runSetupWizard — sf installed, web auth', () => {
       '--version': { stdout: 'v2', stderr: '', code: 0 },
       'org display': {
         stdout: JSON.stringify({
-          result: { username: 'admin@acme.com', instanceUrl: 'https://acme.my.salesforce.com' },
+          result: { username: 'admin@example.com', instanceUrl: 'https://example-corp.my.salesforce.com' },
         }),
         stderr: '',
         code: 0,
@@ -232,7 +232,7 @@ describe('runSetupWizard — sf installed, web auth', () => {
     });
     const { ctx, notifications } = buildMockCtx({
       selectResponses: ['Custom domain (SSO / federated)'],
-      inputResponses: ['https://acme.my.salesforce.com'],
+      inputResponses: ['https://example-corp.my.salesforce.com'],
     });
 
     await runSetupWizard(pi, ctx, sfInstalled);


### PR DESCRIPTION
## Summary

Replace the repository's fictitious ACME organization, account, deal, tenant, and domain examples with the canonical Example pattern. Managed policy references explaining RFC 8555 remain unchanged.

## Related Issue

Closes #960

## Changes

- use `Example Corp` and `example-corp` across Salesforce documentation, all localized copies, benchmarks, tests, and wizard fixtures
- use `Example Corp` and `Example Partners` in MEDDPICC documentation, deal data, and engine tests
- use Example Corp in OSINT search and correlation examples
- replace the unsafe `admin@acme.com` fixture with `admin@example.com`
- patch-bump MEDDPICC to 7.2.2, OSINT Framework to 1.0.3, Salesforce Legacy to 1.0.2, and Salesforce to 1.3.7

## Verification evidence

- `./scripts/validate-plugins.sh` — passed
- `bun test .` in `plugins/meddpicc` — 536 passed
- `bun test .` in `plugins/salesforce` — 284 passed
- `PUPPETEER_SKIP_DOWNLOAD=true ./scripts/run-plugin-tests.sh` — all plugin suites passed
- `pre-commit run` — all applicable hooks passed, including repository hygiene, locale lint, Markdown, Biome, spelling, EditorConfig, and secrets detection
- CI-equivalent textlint command from `CONTRIBUTING.md` — passed for all changed English prose
- `./scripts/check-version-bumps.sh origin/main` — all four plugin version bumps verified
- tracked-content audit — no ACME occurrence remains outside managed governance documents

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
