### PR TITLE
Tell a revised translation from a moved row (v7.3.0)

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.2.2",
+      "version": "7.3.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`meddpicc`** v7.3.0 — a workbook now records the words it put in its label cells, so a revised
+  translation is no longer reported as rows having moved.
+
+  `MeddpiccFingerprint` covers the deal's identity and the input-cell layout, and deliberately not the
+  displayed text: a workbook on someone's desk has to survive an edit to the JSON that moves no cell.
+  Revising a label moves no cell either. So the stamp matched to the character while every label
+  anchor read different words, and the only conclusion available was the wrong one — measured on the
+  example deal, 115 revised strings produced five rejections all announcing that the rows had moved
+  and that no cell could be trusted. Nothing had moved, and the sheet in front of the reader looked
+  untouched.
+
+  The new `MeddpiccAnchorText` property is a hash of exactly the strings the reader compares, which is
+  what makes the three cases exhaustive — if it differs then some anchor differs, so there is no
+  fourth case where it disagrees and the workbook still reads back. An anchor failure now says which
+  happened:
+
+  - **the hash matches** — the rows really have moved, and no cell can be trusted to be the one it was;
+  - **the hash differs** — the labels were revised afterwards. The cells are probably still where you
+    left them, but the labels were the evidence that nothing had moved and they no longer match, so
+    there is nothing left to certify the addresses with;
+  - **the property is absent** — the workbook predates the stamp and cannot answer. It names both
+    possibilities and asserts neither, because the advice is the same either way and picking the wrong
+    one sends somebody hunting for an edit they never made.
+
+  Nothing is refused that was not refused before: an unchanged workbook still reads back, and the
+  hash is only consulted once an anchor has already failed.
+
 - **`salesforce`** v1.3.7 — replaces legacy account, opportunity, My Domain, and email fixtures with
   canonical Example values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ and this project adheres to
   happened:
 
   - **the hash matches** — the rows really have moved, and no cell can be trusted to be the one it was;
-  - **the hash differs** — the labels were revised afterwards. The cells are probably still where you
-    left them, but the labels were the evidence that nothing had moved and they no longer match, so
-    there is nothing left to certify the addresses with;
+  - **the hash differs** — the labels were revised afterwards, so they can no longer confirm that the
+    rows are where they were, whether or not anything moved as well. It does not claim the cells are
+    still in place: the hash proves the two label sets differ and is silent on everything else, and a
+    workbook can have both a revised translation and a locally tidied sheet;
   - **the property is absent** — the workbook predates the stamp and cannot answer. It names both
     possibilities and asserts neither, because the advice is the same either way and picking the wrong
     one sends somebody hunting for an edit they never made.

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.2.2",
+  "version": "7.3.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -35,6 +35,7 @@ import {
 import {
   A1,
   buildWorkbook,
+  ANCHOR_TEXT_PROPERTY,
   type CellSpec,
   type ConditionalFormat,
   columnLetter,
@@ -1179,6 +1180,30 @@ export function workbookFingerprint(plan: WorkbookPlan, deal: unknown): string {
  * number somebody has to remember to bump is worse than no version at all, because a stale one lies.
  * A content hash is derived, so it cannot drift.
  */
+/**
+ * The words this plan puts in its anchor cells, in the order it writes them.
+ *
+ * The companion to {@link workbookFingerprint}, and deliberately separate from it. The fingerprint
+ * answers "is this the same deal, laid out the same way", and a workbook must keep matching it through
+ * an edit to the JSON that moves no cell — so it cannot cover displayed text. That left one symptom
+ * with two causes and no way to tell them apart: revise a translation and every address is identical,
+ * the fingerprint matches to the character, and every anchor reads different words. Measured on the
+ * example deal: 115 revised strings, the same fingerprint, and five rejections all announcing that the
+ * rows had moved. Nothing had moved.
+ *
+ * Scoped to the anchors because they are exactly what the reader compares. A hash over more than that
+ * — every dropdown label, the rubric's prose — could differ while every anchor still matched, and the
+ * reader would then have to either refuse a workbook that reads back perfectly or say something it
+ * could not act on. Anchors keep the three cases exhaustive.
+ *
+ * Addresses are not included: they belong to the fingerprint, and a hash that covered both could not
+ * say which of the two had changed, which is the whole point.
+ */
+export function anchorTextHash(plan: WorkbookPlan): string {
+  const rendered = plan.anchors.map((anchor) => anchor.text).join('\n');
+  return createHash('sha256').update(rendered).digest('hex').slice(0, 32);
+}
+
 export function schemaHash(schema: unknown): string {
   return createHash('sha256').update(JSON.stringify(schema)).digest('hex');
 }
@@ -1238,6 +1263,7 @@ export function workbookProperties(
   }
   return {
     [FINGERPRINT_PROPERTY]: workbookFingerprint(plan, deal),
+    [ANCHOR_TEXT_PROPERTY]: anchorTextHash(plan),
     [SCHEMA_HASH_PROPERTY]: schemaHash(schema),
     [LOCALE_PROPERTY]: locale,
     ...(engineVersion === undefined ? {} : { [ENGINE_VERSION_PROPERTY]: engineVersion }),

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -34,8 +34,8 @@ import {
 } from './workbook-spec';
 import {
   A1,
-  buildWorkbook,
   ANCHOR_TEXT_PROPERTY,
+  buildWorkbook,
   type CellSpec,
   type ConditionalFormat,
   columnLetter,

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.2.2",
+  "version": "7.3.0",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { BOOLEAN_NO, BOOLEAN_YES, dateToSerial, generateWorkbook, planWorkbook } from './generate';
+import {
+  anchorTextHash,
+  BOOLEAN_NO,
+  BOOLEAN_YES,
+  dateToSerial,
+  generateWorkbook,
+  planWorkbook,
+  workbookFingerprint,
+} from './generate';
 import { readPath } from './json-path';
 import { enumLabel } from './labels';
 import { readWorkbook, readWorkbookCells, readWorkbookProperty, serialToDate } from './read-workbook';
 import { sectionLabel } from './sections';
 import { validateDeal } from './validate';
 import { specTables, type WorkbookSpec } from './workbook-spec';
-import { buildWorkbook, columnLetter } from './xlsx';
+import { ANCHOR_TEXT_PROPERTY, buildWorkbook, columnLetter } from './xlsx';
 import { readZip, writeZip } from './zip';
 
 const here = import.meta.dir;
@@ -1352,5 +1360,137 @@ describe('metadata.locale', () => {
     expect(locales).toContain('ko');
     for (const slug of locales) expect(slug).toMatch(/^[a-z]{2}(-[a-z]{2})?$/);
     expect(new Set(locales).size).toBe(locales.length);
+  });
+});
+
+/**
+ * A retranslation is not a moved row.
+ *
+ * `workbookFingerprint` covers the deal's identity and the input-cell LAYOUT, and nothing else — by
+ * design, so a workbook on someone's desk survives an edit to the JSON that moves no cell. Revising a
+ * translation moves no cell either: every address is identical and the stamp matches, while every
+ * anchor now reads different words. Measured on the example deal before this: 115 revised spec strings,
+ * the same fingerprint to the character, and five rejections all saying "the rows appear to have
+ * moved". Nothing had moved, and the advice that follows from that reading — regenerate, then redo the
+ * edit — is right by accident while the diagnosis is wrong.
+ *
+ * So the workbook records a hash of the text it rendered INTO THE ANCHORS — exactly the strings the
+ * reader compares, no more — and an anchor failure is explained by comparing it. Scoping it to the
+ * anchors is what makes the three states exhaustive: if the hash differs then some anchor's text
+ * differs, so the anchor check must fail, and there is no fourth case where the hash disagrees while
+ * the workbook still reads back. A workbook generated before the property existed cannot answer the
+ * question at all, and says so rather than guessing.
+ */
+describe('telling a retranslation from a moved row', () => {
+  /** The spec with every displayed string revised, as a re-translation would leave it. */
+  function retranslated(): WorkbookSpec {
+    const revised = clone(spec) as unknown;
+    let changed = 0;
+    const walk = (node: unknown): void => {
+      if (Array.isArray(node)) {
+        for (const item of node) walk(item);
+        return;
+      }
+      if (node && typeof node === 'object') {
+        const record = node as Record<string, unknown>;
+        for (const key of ['text', 'header', 'label']) {
+          const value = record[key];
+          if (typeof value === 'string' && value.length > 3) {
+            record[key] = `${value} (rev)`;
+            changed++;
+          }
+        }
+        for (const value of Object.values(record)) walk(value);
+      }
+    };
+    walk(revised);
+    if (changed < 50) throw new Error(`only ${changed} strings revised — the fixture is not exercising a retranslation`);
+    return revised as WorkbookSpec;
+  }
+
+  /** Strip one provenance property, as a workbook generated before it existed would lack it. */
+  function withoutProperty(bytes: Uint8Array, name: string): Uint8Array {
+    const part = 'docProps/custom.xml';
+    const entries = readZip(bytes);
+    const entry = entries.get(part);
+    if (!entry) throw new Error(`no ${part}`);
+    const xml = new TextDecoder().decode(entry.data);
+    const pattern = new RegExp(`<property\\b[^>]*name="${name}"[^>]*>[\\s\\S]*?</property>`);
+    // Removing something absent would leave the fixture identical and the test vacuous.
+    if (!pattern.test(xml)) throw new Error(`property ${name} not present, so removing it proves nothing`);
+    const stripped = xml.replace(pattern, '');
+    const rewritten = writeZip(
+      [...entries.values()].map((e) =>
+        e.name === part ? { name: e.name, data: new TextEncoder().encode(stripped) } : { name: e.name, raw: e },
+      ),
+    );
+    if (readWorkbookProperty(rewritten, name) !== null) throw new Error(`${name} survived removal`);
+    return rewritten;
+  }
+
+  const reasons = (bytes: Uint8Array, withSpec: WorkbookSpec): string =>
+    readWorkbook(schema, withSpec, exampleDeal, bytes)
+      .rejections.map((r) => r.reason)
+      .join(' | ');
+
+  test('the fixture really is a retranslation: same stamp, same addresses, different words', () => {
+    const revised = retranslated();
+    const before = planWorkbook(schema, spec, exampleDeal);
+    const after = planWorkbook(schema, revised, exampleDeal);
+    // If either of these stopped being true the rest of this block would be testing nothing.
+    expect(workbookFingerprint(after, exampleDeal)).toBe(workbookFingerprint(before, exampleDeal));
+    expect(after.anchors.map((a) => a.address)).toEqual(before.anchors.map((a) => a.address));
+    expect(after.anchors.map((a) => a.text)).not.toEqual(before.anchors.map((a) => a.text));
+  });
+
+  test('a workbook is stamped with the anchor text it rendered', () => {
+    const bytes = generateWorkbook(schema, spec, exampleDeal, '0.0.0');
+    const stamped = readWorkbookProperty(bytes, ANCHOR_TEXT_PROPERTY);
+    expect(stamped).toBe(anchorTextHash(planWorkbook(schema, spec, exampleDeal)));
+    expect(stamped).not.toBe(anchorTextHash(planWorkbook(schema, retranslated(), exampleDeal)));
+  });
+
+  test('revised labels are reported as a retranslation, not as moved rows', () => {
+    const bytes = generateWorkbook(schema, spec, exampleDeal, '0.0.0');
+    const said = reasons(bytes, retranslated());
+    expect(said).toMatch(/labels were revised/i);
+    expect(said).not.toMatch(/rows appear to have moved/);
+    // It must COMMIT to the retranslation, not hedge. Hedging is the pre-stamp answer, and it would
+    // otherwise satisfy a looser assertion even with the stamp removed entirely.
+    expect(said).not.toMatch(/predates|either the rows/i);
+  });
+
+  test('genuinely moved rows are still reported as moved rows', () => {
+    // Same spec both sides, so the text hash agrees and only the sheet has changed: two element
+    // rows swapped, which is what tidying a sheet looks like.
+    const bytes = generateWorkbook(schema, spec, exampleDeal, '0.0.0');
+    const plan = planWorkbook(schema, spec, exampleDeal);
+    const anchor = plan.anchors.find((a) => a.text === sectionLabel('metrics'));
+    if (!anchor) throw new Error('no anchor for the metrics element');
+    const moved = withCell(
+      bytes,
+      anchor.sheet,
+      anchor.address,
+      `<c r="${anchor.address}" t="inlineStr"><is><t>Economic Buyer</t></is></c>`,
+    );
+    const said = reasons(moved, spec);
+    expect(said).toMatch(/rows appear to have moved/);
+    expect(said).not.toMatch(/revised|predates/i);
+  });
+
+  test('a workbook predating the stamp says it cannot tell which happened', () => {
+    const bytes = withoutProperty(generateWorkbook(schema, spec, exampleDeal, '0.0.0'), ANCHOR_TEXT_PROPERTY);
+    const said = reasons(bytes, retranslated());
+    // Honest about the ambiguity: it names both possibilities and asserts neither.
+    expect(said).toMatch(/either the rows have moved/i);
+    expect(said).toMatch(/labels were revised/i);
+    expect(said).toMatch(/predates/i);
+  });
+
+  test('an unchanged workbook still reads back, so the new stamp gates nothing on its own', () => {
+    const bytes = generateWorkbook(schema, spec, exampleDeal, '0.0.0');
+    const report = readWorkbook(schema, spec, exampleDeal, bytes);
+    expect(report.rejections).toEqual([]);
+    expect(report.ok).toBe(true);
   });
 });

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -1404,7 +1404,8 @@ describe('telling a retranslation from a moved row', () => {
       }
     };
     walk(revised);
-    if (changed < 50) throw new Error(`only ${changed} strings revised — the fixture is not exercising a retranslation`);
+    if (changed < 50)
+      throw new Error(`only ${changed} strings revised — the fixture is not exercising a retranslation`);
     return revised as WorkbookSpec;
   }
 

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -1479,6 +1479,27 @@ describe('telling a retranslation from a moved row', () => {
     expect(said).not.toMatch(/revised|predates/i);
   });
 
+  test('a retranslation does not claim the rows are still in place — it cannot know that', () => {
+    // Version skew and a tidy-up in the same file: the labels were revised AND a row was moved. The
+    // hash proves the label sets differ and nothing more, so any claim about where the cells are is
+    // unsupported — which is the same overclaim, pointed the other way, that this change exists to
+    // remove. It may only say what the labels can no longer do.
+    const bytes = generateWorkbook(schema, spec, exampleDeal, '0.0.0');
+    const plan = planWorkbook(schema, spec, exampleDeal);
+    const anchor = plan.anchors.find((a) => a.text === sectionLabel('metrics'));
+    if (!anchor) throw new Error('no anchor for the metrics element');
+    const alsoMoved = withCell(
+      bytes,
+      anchor.sheet,
+      anchor.address,
+      `<c r="${anchor.address}" t="inlineStr"><is><t>Economic Buyer</t></is></c>`,
+    );
+    const said = reasons(alsoMoved, retranslated());
+    expect(said).toMatch(/labels were revised/i);
+    expect(said).not.toMatch(/probably still|still where you left/i);
+    expect(said).toMatch(/no longer confirm|cannot confirm/i);
+  });
+
   test('a workbook predating the stamp says it cannot tell which happened', () => {
     const bytes = withoutProperty(generateWorkbook(schema, spec, exampleDeal, '0.0.0'), ANCHOR_TEXT_PROPERTY);
     const said = reasons(bytes, retranslated());

--- a/plugins/meddpicc/engine/read-workbook.ts
+++ b/plugins/meddpicc/engine/read-workbook.ts
@@ -649,12 +649,14 @@ export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown,
         'the rows appear to have moved, so no cell in this workbook can be trusted to be the one it ' +
         `was. ${advice}`;
     } else {
-      // Nothing has necessarily moved — but the labels were the evidence that nothing had, and they
-      // no longer match, so there is nothing left to certify the addresses with.
+      // Says what the hash supports and no more. It proves the two label sets differ; it is silent on
+      // whether anything ELSE changed, and a workbook can easily have both — a translation revised
+      // upstream while somebody tidied the sheet locally. An earlier version of this message added
+      // "its cells are probably still where you left them", which the hash cannot evidence; review
+      // caught it, and it is the same overclaim as the moved-rows one this change exists to remove.
       cause =
-        'these labels were revised after this workbook was generated. Its cells are probably still ' +
-        'where you left them, but the labels can no longer confirm that, so it cannot be read back ' +
-        `safely. ${advice}`;
+        'these labels were revised after this workbook was generated, so they can no longer confirm ' +
+        `that its rows are where they were — whether or not anything moved as well. ${advice}`;
     }
     return {
       ok: false,

--- a/plugins/meddpicc/engine/read-workbook.ts
+++ b/plugins/meddpicc/engine/read-workbook.ts
@@ -27,6 +27,7 @@
  *   edit on every read, and the reader would cry wolf until nobody read it.
  */
 import {
+  anchorTextHash,
   BOOLEAN_NO,
   BOOLEAN_YES,
   dateToSerial,
@@ -41,7 +42,7 @@ import { canonicalEnumValue } from './labels';
 import { schemaConstraint } from './schema-path';
 import { type ValidationResult, validateDeal } from './validate';
 import type { ValueType, WorkbookSpec } from './workbook-spec';
-import { FINGERPRINT_PROPERTY, SCHEMA_HASH_PROPERTY } from './xlsx';
+import { ANCHOR_TEXT_PROPERTY, FINGERPRINT_PROPERTY, SCHEMA_HASH_PROPERTY } from './xlsx';
 import { readZip } from './zip';
 
 const EXCEL_EPOCH_UTC = Date.UTC(1899, 11, 30);
@@ -627,6 +628,34 @@ export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown,
     })
     .slice(0, MAX_REPORTED_ANCHORS);
   if (moved.length > 0) {
+    // The same symptom has two causes, and until the workbook recorded its anchor text there was no
+    // way to tell them apart. Either the sheet's rows moved under the labels, or the labels themselves
+    // were revised — a retranslation moves no cell, so the fingerprint still matches exactly.
+    //
+    // Naming the wrong one is not harmless: "no cell can be trusted to be the one it was" sends
+    // somebody looking for an edit they did not make, and the sheet in front of them looks untouched.
+    const wroteText = readWorkbookProperty(bytes, ANCHOR_TEXT_PROPERTY);
+    const advice = 'Regenerate it from the current deal, then make the edit again';
+    let cause: string;
+    if (wroteText === null) {
+      // Generated before this property existed, so the workbook cannot answer. Name both
+      // possibilities rather than picking one: the advice is the same either way, and asserting the
+      // wrong one sends somebody hunting for an edit they never made.
+      cause =
+        'either the rows have moved or these labels were revised since it was generated, and this ' +
+        `workbook predates the stamp that would tell which. ${advice}`;
+    } else if (wroteText === anchorTextHash(plan)) {
+      cause =
+        'the rows appear to have moved, so no cell in this workbook can be trusted to be the one it ' +
+        `was. ${advice}`;
+    } else {
+      // Nothing has necessarily moved — but the labels were the evidence that nothing had, and they
+      // no longer match, so there is nothing left to certify the addresses with.
+      cause =
+        'these labels were revised after this workbook was generated. Its cells are probably still ' +
+        'where you left them, but the labels can no longer confirm that, so it cannot be read back ' +
+        `safely. ${advice}`;
+    }
     return {
       ok: false,
       cellsRead: 0,
@@ -635,10 +664,7 @@ export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown,
       rejections: moved.map((anchor) => ({
         sheet: anchor.sheet,
         address: anchor.address,
-        reason:
-          `should still read "${anchor.text}" but does not — the rows appear to have moved, ` +
-          'so no cell in this workbook can be trusted to be the one it was. Regenerate it from the ' +
-          'current deal, then make the edit again',
+        reason: `should still read "${anchor.text}" but does not — ${cause}`,
       })),
       deal: working,
       valid: true,

--- a/plugins/meddpicc/engine/xlsx.ts
+++ b/plugins/meddpicc/engine/xlsx.ts
@@ -1068,6 +1068,18 @@ export const ENGINE_VERSION_PROPERTY = 'MeddpiccEngineVersion';
 export const LOCALE_PROPERTY = 'MeddpiccLocale';
 
 /**
+ * The words the workbook put in its anchor cells.
+ *
+ * Named for what it actually covers. `FINGERPRINT_PROPERTY` deliberately ignores displayed text — a
+ * workbook has to survive an edit to the deal that moves no cell — so revising a translation leaves it
+ * identical while every anchor now reads different words, and the reader's only available conclusion
+ * was "the rows have moved". This distinguishes the two. Anchors and nothing more: they are exactly
+ * the strings the reader compares, so a difference here always shows up as an anchor failure and never
+ * as a refusal of a workbook that would have read back fine.
+ */
+export const ANCHOR_TEXT_PROPERTY = 'MeddpiccAnchorText';
+
+/**
  * A custom document property, which is where a stamp belongs: Excel carries it through a save
  * untouched, and it is not a cell, so nobody can retype it by accident or wonder what the
  * hidden sheet full of hex is for.

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "7.2.2",
+  "version": "7.3.0",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
Closes #963. Part of #925 — the first of the three blocking findings left on localisation.

A workbook now records the words it put in its label cells, so a revised translation is no longer
reported as rows having moved.

## The defect

`MeddpiccFingerprint` covers the deal's identity and the input-cell layout, and deliberately not the
displayed text: a workbook on someone's desk has to survive an edit to the JSON that moves no cell.
Revising a label moves no cell either — so the stamp matched to the character while every anchor read
different words, and the only conclusion available was the wrong one.

Measured on the example deal before this change: 115 revised spec strings, an identical fingerprint,
identical addresses, and five rejections all announcing that *the rows appear to have moved* and that
*no cell in this workbook can be trusted to be the one it was*. Nothing had moved, and the sheet in
front of the reader looked untouched.

## What changed

`MeddpiccAnchorText` is a hash of exactly the strings the reader compares — the anchors, and nothing
more. That scope is what makes the three cases exhaustive: if the hash differs then some anchor's text
differs, so the anchor check must fail. There is no fourth case where the hash disagrees while the
workbook still reads back, and therefore nothing is refused that was not refused before.

An anchor failure now says which happened:

- **hash matches** — the rows really have moved; no cell can be trusted to be the one it was.
- **hash differs** — the labels were revised afterwards, so they can no longer confirm that the rows are
  where they were, *whether or not anything moved as well*.
- **property absent** — the workbook predates the stamp and cannot answer. It names both possibilities
  and asserts neither, because the advice is the same either way and picking the wrong one sends
  somebody hunting for an edit they never made.

Addresses are deliberately not in the hash: they belong to the fingerprint, and one hash covering both
could not say which of the two had changed, which is the entire point.

## Verification

543 engine tests, 285 plugin-suite tests, 4 root shell suites, `biome ci` exit 0, codespell and
textlint clean. **Excel UAT 19/19, exit 0** on the final code.

Six new tests cover all three states plus the two ways this could be fooled. Four mutations, all
killed: removing the stamp, forcing the equal branch, forcing the differing branch, and removing the
absent branch. Two of my own assertions were too loose to distinguish the states — the pre-stamp
message also contains the word "labels", so the retranslation test would have passed with the feature
removed entirely; they now require the message to *commit* rather than hedge.

The first test in the block asserts the fixture really is a retranslation — same fingerprint, same
addresses, different words — because if that stopped being true the rest of the block would be
testing nothing.

## The review finding, which was right

The hash proves the two label sets differ and is silent on everything else. An earlier version of the
"hash differs" message added *its cells are probably still where you left them*, which the hash cannot
evidence: a workbook can easily have both a translation revised upstream and a sheet tidied locally.
That is the same unsupported claim as the moved-rows one this change exists to remove, pointed the
other way. There is now a test for the combined case, and I checked the other two messages for the
same class rather than only patching the one that was flagged — both say only what their evidence
supports.

## Note

`biome ci` had two pre-existing errors on `main` (unsorted imports in `generate.ts`, one formatting
difference). Biome is not in this repo's lint gate, which is why they went unnoticed; `biome check
--write` fixed them here as a side effect. The diff is otherwise pure addition.
