### PR TITLE
docs: resolve Markdown lint violations

### DIFF
--- a/.plans/2026-07-22-cli-plugin-parity-design.md
+++ b/.plans/2026-07-22-cli-plugin-parity-design.md
@@ -15,7 +15,7 @@ a fair question was raised: was that a one-off, or is there systemic inconsisten
 An audit confirmed systemic inconsistency across three tiers:
 
 | Capability | Azure | aws | gcloud | GitLab | salesforce | GitHub |
-|---|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- | --- |
 | Native tools | 6 | 0 | 0 | 4 | 4 | 9 |
 | `*_exec` passthrough | yes | no | no | no | SOQL-only | no |
 | `*_help` discovery tool | yes | no | no | no | no | no |

--- a/.plans/cli-plugin-contract.md
+++ b/.plans/cli-plugin-contract.md
@@ -50,7 +50,7 @@ harness can gate mutations centrally.
 Legend: ✅ present · ◑ partial · ❌ missing
 
 | Dimension | Azure | aws | gcloud | GitLab | salesforce | GitHub |
-|---|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- | --- |
 | 1 argv/no-shell | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 1 control-char hygiene | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | 1 signal-aware exec | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/docs/en/plugins/f5xc-docs-tools.mdx
+++ b/docs/en/plugins/f5xc-docs-tools.mdx
@@ -17,7 +17,7 @@ incomplete frontmatter.
 
 ## Installation
 
-```
+```text
 /plugin install f5xc-docs-tools@f5-sales-demo-marketplace
 ```
 
@@ -84,7 +84,7 @@ description of the issue.
 
 ### /review-mdx
 
-```
+```text
 /f5xc-docs-tools:review-mdx [path-or-glob]
 ```
 
@@ -93,12 +93,12 @@ Runs the `mdx-content-reviewer` skill on demand.
 **Arguments:**
 
 | Argument | Required | Description |
-|----------|----------|-------------|
+| --- | --- | --- |
 | `path-or-glob` | No | File path or glob pattern to scope the review. Defaults to all `docs/**/*.mdx` files. |
 
 **Examples:**
 
-```
+```text
 # Review all MDX files in docs/
 /f5xc-docs-tools:review-mdx
 
@@ -134,7 +134,7 @@ The plugin validates imports against these sources:
 ## Component Quick Reference
 
 | Component | Required Props | Optional Props |
-|-----------|---------------|----------------|
+| --- | --- | --- |
 | Screenshot | `alt` + at least one of `light` or `dark` | — |
 | Aside | `type` | `title` |
 | Code | `code`, `lang` | `title`, `frame`, `mark`, `ins`, `del` |
@@ -151,7 +151,7 @@ The plugin validates imports against these sources:
 Common issues the plugin catches:
 
 | Pitfall | Problem | Fix |
-|---------|---------|-----|
+| --- | --- | --- |
 | Bare `&lt;` | MDX interprets as JSX tag | Use `&amp;lt;`, inline code, or rephrase |
 | Unescaped `\{` `\}` | MDX treats as JSX expression | Use inline code, escape with `\`, or use code block |
 | Braces in filenames | Astro cannot process the file | Never use `\{` or `\}` in `.mdx` filenames |

--- a/docs/en/plugins/f5xc-firecrawl.mdx
+++ b/docs/en/plugins/f5xc-firecrawl.mdx
@@ -17,7 +17,7 @@ inside the devcontainer.
 
 ## Installation
 
-```
+```text
 /plugin install f5xc-firecrawl@f5-sales-demo-marketplace
 ```
 
@@ -27,7 +27,7 @@ inside the devcontainer.
 
 Scrape a single URL and extract content as markdown.
 
-```
+```text
 /scrape https://docs.example.com/getting-started
 /scrape https://example.com --format markdown,links --wait 2000
 ```
@@ -36,7 +36,7 @@ Scrape a single URL and extract content as markdown.
 
 Scrape multiple URLs at once.
 
-```
+```text
 /batch-scrape https://example.com https://example.org https://example.net
 ```
 
@@ -44,16 +44,16 @@ Scrape multiple URLs at once.
 
 Crawl multiple pages from a starting URL.
 
-```
+```text
 /crawl https://docs.example.com --limit 20 --depth 2
 /crawl https://docs.example.com --include /api/* --exclude /blog/*
 ```
 
 ### /map
 
-Discover all URLs on a website.
+Discover all URLs on a site.
 
-```
+```text
 /map https://docs.example.com
 /map https://docs.example.com --search api --subdomains
 ```
@@ -62,7 +62,7 @@ Discover all URLs on a website.
 
 Search the web and optionally scrape results.
 
-```
+```text
 /search "firecrawl web scraping" --limit 10
 /search "AI tools 2026" --scrape --time month
 ```
@@ -71,7 +71,7 @@ Search the web and optionally scrape results.
 
 LLM-powered structured data extraction from web pages.
 
-```
+```text
 /extract https://example.com "Extract the main heading and any links"
 /extract https://example.com/pricing --schema '{"plans": [{"name": "string", "price": "string"}]}'
 ```
@@ -85,7 +85,7 @@ LLM-powered structured data extraction from web pages.
 
 Generate an llms.txt file for a site.
 
-```
+```text
 /llmstxt https://docs.example.com
 ```
 
@@ -93,7 +93,7 @@ Generate an llms.txt file for a site.
 
 ### web-scraper
 
-Auto-activates when you ask to scrape a URL, crawl a website, map
+Auto-activates when you ask to scrape a URL, crawl a site, map
 site URLs, search the web, extract structured data, generate llms.txt,
 batch scrape multiple URLs, or convert a web page to markdown.
 Delegates immediately to the firecrawl-operator agent.
@@ -107,7 +107,7 @@ against the local firecrawl API. Supports 11 protocols covering all
 v1 endpoints. Read-only agent (no Write, Edit, or Agent tools).
 
 | Protocol | Endpoint | Type |
-|----------|----------|------|
+| --- | --- | --- |
 | HEALTH | `GET /` | Sync |
 | SCRAPE | `POST /v1/scrape` | Sync |
 | BATCH_SCRAPE | `POST /v1/batch/scrape` | Async |
@@ -125,7 +125,7 @@ v1 endpoints. Read-only agent (no Write, Edit, or Agent tools).
 The plugin requires the firecrawl stack running in the devcontainer:
 
 | Component | Port | Purpose |
-|-----------|------|---------|
+| --- | --- | --- |
 | Firecrawl API | 3002 | All scrape/crawl/map/search/extract endpoints |
 | Playwright | 3000 | JavaScript rendering engine |
 | Redis | 6379 | Job queue backend |

--- a/docs/en/plugins/index.mdx
+++ b/docs/en/plugins/index.mdx
@@ -13,7 +13,7 @@ branding, and development operations.
 ## Plugin Catalog
 
 | Plugin | Version | Category | Description |
-|--------|---------|----------|-------------|
+| --- | --- | --- | --- |
 | [f5xc-docs-tools](/marketplace/en/plugins/f5xc-docs-tools/) | 1.1.2 | Productivity | MDX content validation and review tools |
 | [f5xc-sales-engineer](/marketplace/en/plugins/f5xc-sales-engineer/) | 1.0.6 | Productivity | Sales Engineer persona framework — demo execution, presentation, Q&A, environment management |
 | [f5xc-github-ops](/marketplace/en/plugins/f5xc-github-ops/) | 2.2.2 | Productivity | GitHub operations automation — issue-driven development, PR lifecycle, CI polling |
@@ -37,7 +37,7 @@ Each plugin can include:
 
 ## Installing a Plugin
 
-```
+```text
 /plugin install f5xc-docs-tools@f5-sales-demo-marketplace
 /plugin install f5xc-sales-engineer@f5-sales-demo-marketplace
 /plugin install f5xc-github-ops@f5-sales-demo-marketplace

--- a/docs/en/plugins/osint-framework.mdx
+++ b/docs/en/plugins/osint-framework.mdx
@@ -18,7 +18,7 @@ graph for cross-investigation correlation.
 
 ## Installation
 
-```
+```text
 /plugin install osint-framework@f5-sales-demo-marketplace
 ```
 
@@ -30,7 +30,7 @@ Run a full OSINT investigation against any target. Automatically
 detects the target type (email, domain, IP, username, company,
 person name) and routes to the correct category skills.
 
-```
+```text
 /osint-investigate j.smith@example.com
 /osint-investigate example.com
 /osint-investigate 198.51.100.1
@@ -41,7 +41,7 @@ person name) and routes to the correct category skills.
 
 Search the tool catalog for tools matching a capability query.
 
-```
+```text
 /osint-search subdomain enumeration
 /osint-search email breach check
 /osint-search satellite imagery
@@ -52,7 +52,7 @@ Search the tool catalog for tools matching a capability query.
 Browse the full tool catalog by category. Without arguments shows
 all 34 categories with tool counts.
 
-```
+```text
 /osint-catalog
 /osint-catalog domain
 /osint-catalog threat-intel
@@ -68,7 +68,7 @@ or describe any open-source intelligence task. Routes to the
 correct category skill based on target type.
 
 | Target | Routes To |
-|--------|----------|
+| --- | --- |
 | Username or handle | `username-recon` |
 | Email address | `email-recon` |
 | Domain name | `domain-recon` |
@@ -83,7 +83,7 @@ Each category has a dedicated skill with CLI tools, web resources,
 investigation workflow, cross-category pivots, and OPSEC notes.
 
 | Category | Tools | Key CLI Tools |
-|----------|-------|--------------|
+| --- | --- | --- |
 | `username-recon` | 18 | sherlock, maigret, sylva |
 | `email-recon` | 28 | holehe, h8mail, theHarvester |
 | `domain-recon` | 131 | subfinder, amass, whois, dig |
@@ -151,7 +151,7 @@ All API calls use the `osint_curl` helper with built-in exponential
 backoff on HTTP 429/503. Key limits:
 
 | API | Free Limit | Env Var |
-|-----|-----------|---------|
+| --- | --- | --- |
 | ipinfo.io | 1,000/day | — |
 | crt.sh | 60/min | — |
 | NVD | 5/30s (no key) | `NVD_API_KEY` |

--- a/docs/en/plugins/salesforce.mdx
+++ b/docs/en/plugins/salesforce.mdx
@@ -20,7 +20,7 @@ through the CLI agent.
 
 ## Installation
 
-```
+```text
 /plugin install salesforce@f5-sales-demo-marketplace
 ```
 
@@ -68,7 +68,7 @@ Replace `YOUR-DOMAIN` with your company domain from Step 1. Your browser
 opens — complete the SSO or login flow and authorize the app. You should
 see:
 
-```
+```text
 Successfully authorized your-email@company.com with org ID 00DXXXXXXXXXXXXXXX
 ```
 
@@ -90,7 +90,7 @@ remote session), export the SFDX auth URL from your workstation:
 sf org display --verbose --target-org my-org
 ```
 
-Copy the **Sfdx Auth Url** value (starts with `force://`). In the
+Copy the **Sfdx Auth URL** value (starts with `force://`). In the
 container, run:
 
 ```bash
@@ -107,7 +107,7 @@ echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=- --alias=my-org 
 ### Authentication methods reference
 
 | Method | Best For | Requires |
-|--------|----------|----------|
+| --- | --- | --- |
 | Web Login | Workstations with a browser | Browser + SSO |
 | SFDX URL | Containers, CI/CD, portable auth | Auth URL from an authenticated session |
 | JWT Bearer | Automated pipelines | Connected App + private key + consumer key |
@@ -119,7 +119,7 @@ echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=- --alias=my-org 
 ### Environment variables
 
 | Variable | Purpose |
-|----------|---------|
+| --- | --- |
 | `SF_ACCESS_TOKEN` | Bearer token for access-token auth |
 | `SFDX_AUTH_URL` | Force auth URL for SFDX URL auth |
 | `SF_ORG_INSTANCE_URL` | Org instance URL |
@@ -134,7 +134,7 @@ echo "$SFDX_AUTH_URL" | sf org login sfdx-url --sfdx-url-stdin=- --alias=my-org 
 Check your Salesforce org connection status, CLI version, and
 authenticated orgs.
 
-```
+```text
 /salesforce:sf-status
 ```
 
@@ -145,7 +145,7 @@ org alias, username, instance URL, connected status, and API version.
 
 Authenticate to a Salesforce org. Optionally provide an alias.
 
-```
+```text
 /salesforce:sf-login
 /salesforce:sf-login my-org
 ```
@@ -163,7 +163,7 @@ Top-level intent router. Automatically activates when you mention
 Salesforce, org management, or data queries in natural language.
 
 | You say | Routes to |
-|---------|-----------|
+| --- | --- |
 | "login to salesforce", "authenticate org" | `salesforce-auth` skill |
 | "check org status", "list orgs" | `cli-operator` agent |
 | "show me opportunities", "look up case" | `cli-operator` agent (SOQL query) |
@@ -193,7 +193,7 @@ keep the main session context lean.
 
 **Response format:**
 
-```
+```text
 ## Result: [SUCCESS | FAILURE | PARTIAL]
 ### Command Executed
 ### Output Summary
@@ -203,7 +203,7 @@ keep the main session context lean.
 ## Usage Guide: Account Management
 
 <Aside type="note">
-  The prompts below are not hard-coded features of the plugin. They work
+  The prompts below are not hardcoded features of the plugin. They work
   because the cli-operator agent can run any `sf` CLI command, including
   arbitrary SOQL queries. Results depend on your org's data model and
   your user permissions. The prompts here have been tested and verified
@@ -225,13 +225,13 @@ to your role, accounts, and territory.
 
 After authenticating, verify everything works:
 
-```
+```text
 /salesforce:sf-status
 ```
 
 Then try a simple natural language query:
 
-```
+```text
 list my authenticated salesforce orgs
 ```
 
@@ -242,7 +242,7 @@ username, instance URL, and connection status.
 
 Discover which accounts you are assigned to:
 
-```
+```text
 what salesforce accounts am I on the account team for? My email is your-email@company.com
 ```
 
@@ -255,7 +255,7 @@ were not populated.
 
 Compare your account coverage with a teammate to find gaps:
 
-```
+```text
 In salesforce, find all accounts where Colleague Name is on the account team. Then for each of those accounts, check if your-email@company.com is also on the account team. Show me two lists: accounts where we are BOTH tagged, and accounts where only my colleague is tagged but I am missing.
 ```
 
@@ -273,7 +273,7 @@ overlap — this reveals which accounts you need to be added to.
 
 See all open opportunities across your accounts:
 
-```
+```text
 show me all open salesforce opportunities on Colleague Name's account team accounts, sorted by close date, include the stage, amount, and probability
 ```
 
@@ -286,7 +286,7 @@ past-due close dates or null amounts.
 
 Get the full picture on a specific deal:
 
-```
+```text
 show me a detailed view of the OPPORTUNITY NAME opportunity in salesforce - include the opportunity team members, any activities or tasks, and the account contacts
 ```
 
@@ -299,7 +299,7 @@ history showing how the deal amount and close date have moved over time.
 
 Check for open support cases on your accounts:
 
-```
+```text
 show me all open salesforce cases across Colleague Name's account team accounts, grouped by account, sorted by most recent first
 ```
 
@@ -311,7 +311,7 @@ years old with no activity) are flagged as hygiene candidates.
 
 Get a forecast-ready view of your pipeline:
 
-```
+```text
 for Colleague Name's accounts, show me a quarterly pipeline summary - group the open opportunities by close date quarter with count, total amount, and weighted amount for each quarter
 ```
 
@@ -324,7 +324,7 @@ opportunities are grouped separately.
 
 Deep dive into a specific customer:
 
-```
+```text
 give me a full account overview for ACCOUNT NAME in salesforce including contacts, open opportunities, and recent cases
 ```
 
@@ -336,7 +336,7 @@ stages and amounts, and recent support cases with status.
 
 Look up a specific support case by number:
 
-```
+```text
 look up salesforce case CASE-NUMBER and show me the case details, the customer account, and who owns it
 ```
 
@@ -351,25 +351,25 @@ and runs it.
 
 ### Specific fields
 
-```
+```text
 query salesforce for all Contacts at ACCOUNT NAME - show Name, Title, Email, Phone, and Department
 ```
 
 ### Date filtering
 
-```
+```text
 show me all salesforce opportunities that closed won in the last 90 days on ACCOUNT NAME
 ```
 
 ### Aggregation
 
-```
+```text
 count all open salesforce cases grouped by priority and status across my accounts
 ```
 
 ### Custom objects
 
-```
+```text
 query the CUSTOM_OBJECT__c object in salesforce for records where Status__c = 'Active'
 ```
 
@@ -392,7 +392,7 @@ npx skills add forcedotcom/afv-library
 ```
 
 | Topic | Skill |
-|-------|-------|
+| --- | --- |
 | Apex classes and services | `generating-apex` |
 | Apex tests | `generating-apex-test` |
 | Flows | `generating-flow` |

--- a/docs/en/reference.mdx
+++ b/docs/en/reference.mdx
@@ -15,20 +15,20 @@ The marketplace manifest lives at
 ### Top-level fields
 
 | Field | Required | Description |
-|-------|----------|-------------|
+| --- | --- | --- |
 | `$schema` | No | JSON Schema URL for validation |
 | `name` | Yes | Unique marketplace identifier |
-| `version` | No | Marketplace schema version (semver) |
+| `version` | No | Marketplace schema version (SemVer) |
 | `metadata.description` | Yes | Human-readable marketplace description |
 | `owner.name` | Yes | Organization or user that owns the marketplace |
-| `owner.url` | No | URL to the owner's profile or website |
+| `owner.url` | No | URL to the owner's profile or site |
 | `owner.email` | No | Contact email |
 | `plugins` | Yes | Array of plugin entries |
 
 ### Plugin entry fields
 
 | Field | Required | Description |
-|-------|----------|-------------|
+| --- | --- | --- |
 | `name` | Yes | Plugin identifier (must match `plugin.json`) |
 | `description` | Yes | Short description of the plugin |
 | `version` | Yes | Semantic version string |
@@ -47,7 +47,7 @@ The `source` field in marketplace.json supports multiple
 formats:
 
 | Type | Example | Description |
-|------|---------|-------------|
+| --- | --- | --- |
 | Relative path | `./plugins/example-plugin` | Plugin in same repository |
 | GitHub shorthand | `owner/repo` | Plugin at repository root |
 | GitHub with path | `owner/repo/path/to/plugin` | Plugin in subdirectory |
@@ -60,12 +60,12 @@ Each plugin has a manifest at
 `.claude-plugin/plugin.json` inside its directory.
 
 | Field | Required | Description |
-|-------|----------|-------------|
+| --- | --- | --- |
 | `name` | Yes | Plugin identifier |
 | `description` | Yes | What the plugin does |
 | `version` | Yes | Semantic version |
 | `author.name` | Yes | Plugin author |
-| `author.url` | No | URL to the author's profile or website |
+| `author.url` | No | URL to the author's profile or site |
 | `homepage` | No | Documentation URL |
 | `keywords` | No | Search keywords |
 | `license` | No | SPDX license identifier |
@@ -73,7 +73,7 @@ Each plugin has a manifest at
 
 ## Plugin Directory Layout
 
-```
+```text
 plugins/example-plugin/
   .claude-plugin/
     plugin.json          # Plugin manifest (required)
@@ -94,7 +94,7 @@ Plugins can use these variables in their skill and command
 files:
 
 | Variable | Description |
-|----------|-------------|
+| --- | --- |
 | `$\{CLAUDE_PLUGIN_ROOT\}` | Absolute path to the plugin's root directory |
 
 ## Validation
@@ -149,13 +149,13 @@ Add to `.claude/settings.json` in any repository:
 
 Verify the marketplace was added:
 
-```
+```text
 /plugin marketplace list
 ```
 
 If missing, re-add it:
 
-```
+```text
 /plugin marketplace add f5-sales-demo/marketplace
 ```
 

--- a/plugins/aws/src/prompts/aws-ec2-describe-instances.md
+++ b/plugins/aws/src/prompts/aws-ec2-describe-instances.md
@@ -1,15 +1,17 @@
-Describe Amazon EC2 instances via `aws ec2 describe-instances`.
+# Describe Amazon EC2 instances
+
+Use `aws ec2 describe-instances`.
 
 ## Usage
 
-```
+```bash
 aws ec2 describe-instances [--region REGION] [--instance-ids ID ...] [--filters ...] --output json
 ```
 
 ## Parameters
 
 | Parameter | Description |
-|-----------|-------------|
+| --- | --- |
 | `region` | Optional AWS region (e.g. `us-east-1`) |
 | `instanceIds` | Optional list of instance IDs (e.g. `i-0123456789abcdef0`) |
 | `filters` | Optional list of `Name=...,Values=...` filter expressions |

--- a/plugins/azure/src/prompts/az-account-show.md
+++ b/plugins/azure/src/prompts/az-account-show.md
@@ -1,23 +1,25 @@
-Show or list Azure subscriptions via `az account`.
+# Show or list Azure subscriptions
+
+Use `az account`.
 
 ## Actions
 
 **show** — Get details of the current (or specified) subscription.
 
-```
+```bash
 az account show [--subscription NAME_OR_ID]
 ```
 
 **list** — List subscriptions for the logged-in account. By default only 'Enabled' subscriptions are shown.
 
-```
+```bash
 az account list [--all] [--refresh]
 ```
 
 ## Flags
 
 | Flag | Applies To | Description |
-|------|-----------|-------------|
+| --- | --- | --- |
 | `--subscription`, `-s`, `-n` | show | Name or ID of subscription |
 | `--all` | list | Include subscriptions that are not 'Enabled' |
 | `--refresh` | list | Retrieve up-to-date subscriptions from server |

--- a/plugins/azure/src/prompts/az-group-list.md
+++ b/plugins/azure/src/prompts/az-group-list.md
@@ -1,23 +1,25 @@
-List or show Azure resource groups via `az group`.
+# List or show Azure resource groups
+
+Use `az group`.
 
 ## Actions
 
 **list** — List all resource groups in the current subscription.
 
-```
+```bash
 az group list [--subscription NAME_OR_ID] [--tag KEY[=VALUE]]
 ```
 
 **show** — Get details of a specific resource group.
 
-```
+```bash
 az group show --name NAME [--subscription NAME_OR_ID]
 ```
 
 ## Flags
 
 | Flag | Applies To | Description |
-|------|-----------|-------------|
+| --- | --- | --- |
 | `--subscription` | list, show | Name or ID of subscription |
 | `--tag` | list | Filter by tag in `key[=value]` format |
 | `--name`, `-n` | show | Resource group name (required for show) |

--- a/plugins/azure/src/prompts/az-resource-list.md
+++ b/plugins/azure/src/prompts/az-resource-list.md
@@ -1,15 +1,17 @@
-List Azure resources via `az resource list`.
+# List Azure resources
+
+Use `az resource list`.
 
 ## Usage
 
-```
+```bash
 az resource list [--resource-group NAME] [--resource-type TYPE] [--location LOCATION] [--name NAME] [--tag KEY[=VALUE]] [--subscription NAME_OR_ID]
 ```
 
 ## Flags
 
 | Flag | Description |
-|------|-------------|
+| --- | --- |
 | `--resource-group`, `-g` | Filter by resource group name |
 | `--resource-type` | Filter by type (e.g. `Microsoft.Compute/virtualMachines`). Accepts `namespace/type` format. |
 | `--location`, `-l` | Filter by region |

--- a/plugins/azure/src/prompts/az-vm-list.md
+++ b/plugins/azure/src/prompts/az-vm-list.md
@@ -1,15 +1,17 @@
-List Azure Virtual Machines via `az vm list`.
+# List Azure virtual machines
+
+Use `az vm list`.
 
 ## Usage
 
-```
+```bash
 az vm list [--resource-group NAME] [--show-details] [--vmss VMSS_ID] [--subscription NAME_OR_ID]
 ```
 
 ## Flags
 
 | Flag | Description |
-|------|-------------|
+| --- | --- |
 | `--resource-group`, `-g` | Filter by resource group |
 | `--show-details`, `-d` | Include public IP, FQDN, and power state. **Runs slower.** |
 | `--vmss` | List VMs in a specific Virtual Machine Scale Set |

--- a/plugins/herdr/UPSTREAM.md
+++ b/plugins/herdr/UPSTREAM.md
@@ -4,7 +4,7 @@
 it upstream and re-vendor, otherwise `herdr-skill-freshness.yml` will fail.
 
 | Field | Value |
-|---|---|
+| --- | --- |
 | Upstream repository | <https://github.com/ogulcancelik/herdr> |
 | Upstream path | `SKILL.md` (repository root) |
 | Pinned ref | `master` |

--- a/plugins/platform/skills/console-discover/SKILL.md
+++ b/plugins/platform/skills/console-discover/SKILL.md
@@ -24,7 +24,7 @@ YAML files matching the `f5-sales-demo/console` catalog schemas.
 ## Environment Variables
 
 | Variable | Required | Default | Purpose |
-| ---------- | ---------- | --------- | --------- |
+| --- | --- | --- | --- |
 | `F5XC_API_URL` | No | Auto-detected from browser URL | Tenant URL |
 | `F5XC_NAMESPACE` | No | — | Default namespace for route patterns |
 
@@ -38,7 +38,7 @@ skill. Execute session health check. If re-auth needed, invoke
 
 ### Step 2: Navigate to console home
 
-```
+```text
 navigate_page(url=<tenant-url>/web/home)
 wait_for(text=["Dashboard", "Home"], timeout=15000)
 take_snapshot()
@@ -57,7 +57,7 @@ with their:
 
 For collapsed menu sections, click to expand and re-snapshot:
 
-```
+```text
 click(uid=<collapsed-section-uid>)
 take_snapshot()
 ```
@@ -89,12 +89,13 @@ tree:
 
 For each discovered route, navigate to it and classify the page:
 
-```
+```text
 navigate_page(url=<route-url>)
 take_snapshot()
 ```
 
 Determine:
+
 - **Screen type**: list, detail, form, wizard, dashboard, settings
 - **Primary controls**: buttons, search, filters
 - **Table presence**: columns, row actions
@@ -106,18 +107,19 @@ Record the classification for `console-inspect` to process later.
 
 Write the navigation tree YAML to the console catalog:
 
-```
+```text
 catalog/navigation/console-tree.yaml
 ```
 
 For each classified route, write a skeleton route file:
 
-```
+```text
 catalog/routes/<area>/<name>.yaml
 ```
 
 Report:
-```
+
+```text
 ## Discovery: COMPLETE
 - Sections found: <count>
 - Routes discovered: <count>
@@ -135,6 +137,7 @@ in the console repo after writing files.
 ## Incremental Discovery
 
 When re-running discovery:
+
 1. Read existing `catalog/navigation/console-tree.yaml`
 2. Compare with freshly discovered tree
 3. Mark new entries as `confidence: "draft"`

--- a/plugins/platform/skills/console-inspect/SKILL.md
+++ b/plugins/platform/skills/console-inspect/SKILL.md
@@ -25,7 +25,7 @@ and workflow YAML files for the `f5-sales-demo/console` catalog.
 ## Environment Variables
 
 | Variable | Required | Default | Purpose |
-| ---------- | ---------- | --------- | --------- |
+| --- | --- | --- | --- |
 | `F5XC_API_URL` | No | Auto-detected from browser URL | Tenant URL |
 | `F5XC_NAMESPACE` | No | — | Namespace for parameterized routes |
 
@@ -33,7 +33,7 @@ and workflow YAML files for the `f5-sales-demo/console` catalog.
 
 ### Step 1: Navigate to target route
 
-```
+```text
 navigate_page(url=<target-route>)
 wait_for(text=[<expected-heading>], timeout=15000)
 take_snapshot()
@@ -53,7 +53,8 @@ From the snapshot, determine the screen type:
 #### For list screens
 
 Extract table metadata:
-```
+
+```javascript
 evaluate_script(function="() => {
   const headers = [...document.querySelectorAll('th')].map(th => ({
     label: th.textContent.trim(),
@@ -64,7 +65,8 @@ evaluate_script(function="() => {
 ```
 
 Extract row actions by clicking the actions menu on any row:
-```
+
+```text
 click(uid=<first-row-actions-button>)
 take_snapshot()
 ```
@@ -75,13 +77,15 @@ selectors.
 #### For form screens
 
 Click the "Add" or "Create" button to open the creation form:
-```
+
+```text
 click(uid=<add-button>)
 take_snapshot()
 ```
 
 Extract all form fields:
-```
+
+```javascript
 evaluate_script(function="() => {
   const fields = [...document.querySelectorAll('input, select, textarea')].map(el => ({
     type: el.tagName.toLowerCase() === 'select' ? 'select' : el.type,
@@ -95,7 +99,8 @@ evaluate_script(function="() => {
 ```
 
 For each collapsible section, expand it and re-extract:
-```
+
+```text
 click(uid=<collapsed-section>)
 take_snapshot()
 ```
@@ -103,12 +108,14 @@ take_snapshot()
 #### For detail screens
 
 Extract tab labels and their content areas:
-```
+
+```text
 take_snapshot()
 ```
 
 Click through each tab and record its structure:
-```
+
+```text
 click(uid=<tab-uid>)
 take_snapshot()
 ```
@@ -174,6 +181,7 @@ metadata:
 
 Generate step-by-step workflows from the observed interaction
 sequence. Each step records:
+
 - action (navigate, click, fill, select, assert)
 - selector (prefer data-testid, fallback to CSS)
 - wait_for condition
@@ -183,14 +191,14 @@ sequence. Each step records:
 
 Take a screenshot of each key state for documentation:
 
-```
+```text
 take_screenshot(filePath="<console-repo>/docs/screenshots/<resource>-list.png")
 take_screenshot(filePath="<console-repo>/docs/screenshots/<resource>-create.png")
 ```
 
 ### Step 7: Report results
 
-```
+```text
 ## Inspection: COMPLETE
 - Resource: <name>
 - Screen type: <type>

--- a/plugins/platform/skills/console-run/SKILL.md
+++ b/plugins/platform/skills/console-run/SKILL.md
@@ -36,6 +36,7 @@ session. This skill translates user intent into a call to the
 ### Step 1: Parse user intent
 
 Extract from the user's request:
+
 - **Resource**: which F5 XC resource (e.g., http-load-balancer,
   origin-pool, app-firewall, health-check, tcp-load-balancer,
   service-policy, namespace)
@@ -52,6 +53,7 @@ Check if the browser is authenticated. If not, invoke
 ### Step 3: Resolve catalog path
 
 Determine the catalog path:
+
 1. Check `CONSOLE_CATALOG_PATH` env var
 2. Fall back to `~/GIT/f5-sales-demo/console`
 3. Verify the path exists and contains `catalog/workflows/`
@@ -59,12 +61,14 @@ Determine the catalog path:
 ### Step 4: Verify workflow exists
 
 Check that the workflow file exists:
-```
+
+```text
 {catalog_path}/catalog/workflows/{resource}/{operation}.yaml
 ```
 
 If not found, list available workflows:
-```
+
+```bash
 ls {catalog_path}/catalog/workflows/{resource}/
 ```
 
@@ -75,7 +79,7 @@ is missing.
 
 Call the `catalog_workflow_runner` tool:
 
-```
+```yaml
 catalog_workflow_runner(
   catalog_path: "{resolved_catalog_path}",
   resource: "{resource}",
@@ -97,7 +101,7 @@ The user can request fast mode by saying "quickly" or "fast".
 
 Present the workflow results to the user:
 
-```
+```text
 ## Console Workflow: {operation} {resource}
 Status: {PASS/FAIL}
 Duration: {total_duration}
@@ -131,6 +135,7 @@ verify namespace selection, retry with different parameters).
 User: "Create an HTTP load balancer called demo-lb in the demo namespace with domain app.example.com"
 
 Extracted:
+
 - Resource: http-load-balancer
 - Operation: create
 - Params: name=demo-lb, namespace=demo, domains=["app.example.com"]
@@ -138,6 +143,7 @@ Extracted:
 User: "Delete the origin pool named backend-pool"
 
 Extracted:
+
 - Resource: origin-pool
 - Operation: delete
 - Params: name=backend-pool, namespace=(from F5XC_NAMESPACE)


### PR DESCRIPTION
## Summary

- normalize Markdown tables and structural formatting for the newly enforced fleet rules
- tag schematic and command fences where the same touched files exposed untagged blocks
- keep translated content untouched for its planned final regeneration

Closes #999

## Testing

- markdownlint-cli 0.49.1 and governed prose gate on every changed Markdown/MDX file
- shellcheck and shfmt over every tracked shell script
- version-bump, release-history, and release-notes shell suites
- `git diff --check origin/main...HEAD`
