### PR TITLE
fix: make plugin verification hermetic

### DIFF
--- a/.github/workflows/herdr-skill-freshness.yml
+++ b/.github/workflows/herdr-skill-freshness.yml
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Ref is pinned here and recorded in plugins/herdr/UPSTREAM.md. Keep both in step.
       - name: Fetch upstream SKILL.md
         env:
-          UPSTREAM_URL: https://raw.githubusercontent.com/ogulcancelik/herdr/master/SKILL.md
+          UPSTREAM_URL: https://raw.githubusercontent.com/herdrdev/herdr/master/skills/herdr/SKILL.md
         run: |
           set -euo pipefail
           # A failed fetch must FAIL the job. Falling through on a network blip would make

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # A dispatch is pinned to main, never the ref the dispatcher picked.
           #

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so check-version-bumps.sh can diff against the PR base sha.
           fetch-depth: 0
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install jq
         run: |
@@ -70,9 +70,9 @@ jobs:
       # Pinned, not a range: a floating runtime turns an unrelated bun release into a
       # mystery CI failure.
       - name: Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.14
 
       - name: Run plugin test suites
         run: ./scripts/run-plugin-tests.sh
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history and every tag: the audit walks all published versions, and
           # release-history.sh refuses a shallow clone rather than reporting "nothing

--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -389,7 +389,7 @@
     {
       "name": "herdr",
       "description": "Control Herdr, a terminal multiplexer for coding agents — inspect workspaces, tabs and panes, split panes, run commands without stealing focus, read pane output, and coordinate sibling agents. Requires HERDR_ENV=1.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`herdr`** v1.0.1 — freshness verification follows the transferred upstream repository and
+  relocated skill path while preserving the byte-identical vendored skill.
+
+- Pinned every GitHub Actions dependency that remained on a mutable major-version tag.
+
 - **`github-ops`** polling tests now replace retry waits with a deterministic test-local sleep,
   preserving the `Retry-After` contract without depending on workstation timing
   ([#1024](https://github.com/f5-sales-demo/marketplace/issues/1024)).
@@ -23,6 +28,12 @@ and this project adheres to
   pi-utils 20.2.7, Anthropic 0.115.0, ACP 1.3.0, and Google GenAI 2.15.0. The plugin
   runner detects and repairs stale physical dependency links from frozen lockfiles before tests and
   batches its sanitised-PATH setup instead of spawning one link process per executable.
+
+- Plugin verification now requires a frozen lockfile for every Bun-tested plugin, disables
+  Puppeteer browser downloads, stops immediately when dependency installation fails, and
+  runs on current Bun 1.3.14. **`meddpicc`** v7.5.1 now declares its engine workspace and
+  freezes that test graph in a repository lockfile
+  ([#1012](https://github.com/f5-sales-demo/marketplace/issues/1012)).
 
 - **`meddpicc`** v7.5.0 — French, Spanish, German, Brazilian Portuguese, Korean,
   Simplified Chinese, Traditional Chinese, Italian, Hindi, and Thai complete the

--- a/plugins/herdr/.xcsh-plugin/plugin.json
+++ b/plugins/herdr/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr",
   "description": "Control Herdr, a terminal multiplexer for coding agents — inspect workspaces, tabs and panes, split panes, run commands without stealing focus, read pane output, and coordinate sibling agents. Requires HERDR_ENV=1.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/herdr",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/herdr/UPSTREAM.md
+++ b/plugins/herdr/UPSTREAM.md
@@ -5,14 +5,14 @@ it upstream and re-vendor, otherwise `herdr-skill-freshness.yml` will fail.
 
 | Field | Value |
 | --- | --- |
-| Upstream repository | <https://github.com/ogulcancelik/herdr> |
-| Upstream path | `SKILL.md` (repository root) |
+| Upstream repository | <https://github.com/herdrdev/herdr> |
+| Upstream path | `skills/herdr/SKILL.md` |
 | Pinned ref | `master` |
-| Vendored commit | `81f355fadac7d0d45b077dfc28f9f679add6bbb6` |
-| Last upstream change to `SKILL.md` | `0f161fac287011b3e216383e2b8482f049fd6a7b` (2026-07-21) |
+| Vendored commit | `eacea2daf0b72973173b728936b27478374f2cd2` |
+| Last upstream change to `SKILL.md` | `f6060cf682f69ef8302c25e8924c0b27aef7ae16` (2026-07-29) |
 | SHA-256 of vendored file | `0786182f02ebf92708e09d82d79e4614d1a9c30bfc337643cc2af1d0fb9db29f` |
 | Size | 10140 bytes |
-| Retrieved | 2026-07-28 |
+| Retrieved | 2026-08-03 |
 | Upstream license | Apache-2.0 |
 
 ## Attribution
@@ -23,7 +23,7 @@ redistributes `SKILL.md` unmodified under those terms. Copyright remains with th
 ## Re-vendoring procedure
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ogulcancelik/herdr/master/SKILL.md \
+curl -fsSL https://raw.githubusercontent.com/herdrdev/herdr/master/skills/herdr/SKILL.md \
   -o plugins/herdr/skills/herdr/SKILL.md
 shasum -a 256 plugins/herdr/skills/herdr/SKILL.md   # update the table above
 scripts/bump-version.sh herdr patch                 # keeps catalog + plugin.json in lockstep

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/bun.lock
+++ b/plugins/meddpicc/bun.lock
@@ -1,0 +1,16 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "meddpicc",
+    },
+    "engine": {
+      "name": "@meddpicc/engine",
+      "version": "7.5.1",
+    },
+  },
+  "packages": {
+    "@meddpicc/engine": ["@meddpicc/engine@workspace:engine"],
+  }
+}

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,9 @@
 {
   "name": "meddpicc",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "MEDDPICC sales qualification and deal-execution framework",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "workspaces": [
+    "engine"
+  ]
 }

--- a/scripts/run-plugin-tests.sh
+++ b/scripts/run-plugin-tests.sh
@@ -11,12 +11,16 @@
 # plugin someone adds, which is the same failure this exists to close.
 set -uo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 cd "$REPO_ROOT" || exit 2
 
 # A missing runtime must not read as a pass: the per-plugin suites skip themselves when bun
 # is absent, which in CI would be a silent no-op gate.
 export REQUIRE_BUN=1
+# xcsh depends on Puppeteer for browser-backed tools, but plugin unit tests do not use a
+# browser. Installing a plugin lock must never download platform browsers or depend on a
+# developer's partially populated Puppeteer cache.
+export PUPPETEER_SKIP_DOWNLOAD=true
 
 command -v bun >/dev/null 2>&1 || {
   echo "FATAL: bun is required to run the plugin test suites" >&2
@@ -104,11 +108,19 @@ for suite in plugins/*/scripts/tests/run-tests.sh; do
 
   # Only run bun tests where the plugin actually has some.
   if find "plugins/$plugin" -name '*.test.ts' -not -path '*/node_modules/*' -print -quit | grep -q .; then
-    # Install first where there is a lockfile. Without it every import of a devDependency
-    # fails with "Cannot find module", which reads exactly like broken code and is not.
-    # Frozen so a stale lockfile fails here rather than resolving to something else.
-    if [ -f "plugins/$plugin/bun.lock" ]; then
-      (cd "plugins/$plugin" && bun install --frozen-lockfile) || ok=1
+    # Every Bun-tested plugin must declare an exact reproducible dependency graph. Without
+    # a lockfile, imports can resolve from workstation leftovers and hide a broken checkout.
+    if [ ! -f "plugins/$plugin/bun.lock" ]; then
+      printf 'FATAL: %s has Bun tests but no bun.lock\n' "$plugin" >&2
+      exit 1
+    fi
+
+    # Install before testing so missing dependencies cannot masquerade as source failures.
+    # An install failure invalidates every later assertion, so stop immediately instead of
+    # running tests against whatever physical packages happened to remain on disk.
+    if ! (cd "plugins/$plugin" && bun install --frozen-lockfile); then
+      printf 'FATAL: dependency installation failed for %s\n' "$plugin" >&2
+      exit 1
     fi
     (cd "plugins/$plugin" && bun test .) || ok=1
   fi

--- a/tests/test-run-plugin-tests.sh
+++ b/tests/test-run-plugin-tests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WORKFLOW="$SOURCE_ROOT/.github/workflows/validate-plugins.yml"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass() {
+  echo "PASS: $1"
+}
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+if grep -Fq 'bun-version: 1.3.14' "$WORKFLOW"; then
+  pass "plugin CI uses current Bun 1.3.14"
+else
+  fail "plugin CI must use current Bun 1.3.14"
+fi
+
+missing_locks=()
+for plugin_dir in "$SOURCE_ROOT"/plugins/*; do
+  if find "$plugin_dir" -name '*.test.ts' -not -path '*/node_modules/*' -print -quit | grep -q . &&
+    [ ! -f "$plugin_dir/bun.lock" ]; then
+    missing_locks+=("${plugin_dir##*/}")
+  fi
+done
+if [ "${#missing_locks[@]}" -eq 0 ]; then
+  pass "every Bun-tested plugin has a frozen lockfile"
+else
+  fail "Bun-tested plugins are missing lockfiles: ${missing_locks[*]}"
+fi
+
+new_fixture() {
+  local name="$1"
+  local root="$WORK/$name"
+  mkdir -p \
+    "$root/scripts" \
+    "$root/plugins/demo/scripts/tests" \
+    "$root/plugins/demo/test" \
+    "$root/bin" \
+    "$root/tools" \
+    "$root/state"
+  cp "$SOURCE_ROOT/scripts/run-plugin-tests.sh" "$root/scripts/run-plugin-tests.sh"
+  cp "$SOURCE_ROOT/scripts/check-plugin-runtime-dependencies.sh" \
+    "$root/scripts/check-plugin-runtime-dependencies.sh"
+  for plugin in aws azure gcloud github gitlab salesforce; do
+    mkdir -p "$root/plugins/$plugin"
+    cp "$SOURCE_ROOT/plugins/$plugin/package.json" "$root/plugins/$plugin/package.json"
+    cp "$SOURCE_ROOT/plugins/$plugin/bun.lock" "$root/plugins/$plugin/bun.lock"
+  done
+  printf '#!/bin/sh\nexit 0\n' >"$root/plugins/demo/scripts/tests/run-tests.sh"
+  printf 'test("demo", () => {});\n' >"$root/plugins/demo/test/demo.test.ts"
+  printf '#!/bin/sh\nset -eu\nprintf "%%s|%%s\\n" "$*" "${PUPPETEER_SKIP_DOWNLOAD:-}" >>"$TEST_STATE/calls"\nif [ "${1:-}" = install ]; then exit "${INSTALL_EXIT:-0}"; fi\nif [ "${1:-}" = test ]; then touch "$TEST_STATE/test-ran"; fi\n' >"$root/bin/bun"
+  chmod +x "$root/bin/bun" "$root/plugins/demo/scripts/tests/run-tests.sh"
+  for tool in bash basename dirname find git grep jq ln mktemp rm sort; do
+    ln -s "$(command -v "$tool")" "$root/tools/$tool"
+  done
+  printf '%s\n' "$root"
+}
+
+INSTALL_FAILURE=$(new_fixture install-failure)
+printf '{"lockfileVersion":1}\n' >"$INSTALL_FAILURE/plugins/demo/bun.lock"
+if PATH="$INSTALL_FAILURE/bin:$INSTALL_FAILURE/tools" \
+  TEST_STATE="$INSTALL_FAILURE/state" INSTALL_EXIT=9 \
+  bash "$INSTALL_FAILURE/scripts/run-plugin-tests.sh" >/dev/null 2>&1; then
+  fail "an install failure must fail the runner"
+fi
+if [ -e "$INSTALL_FAILURE/state/test-ran" ]; then
+  fail "bun tests must not run after an install failure"
+else
+  pass "an install failure stops before bun tests"
+fi
+if grep -Fq 'install --frozen-lockfile|true' "$INSTALL_FAILURE/state/calls"; then
+  pass "dependency installs disable browser downloads"
+else
+  fail "dependency installs must set PUPPETEER_SKIP_DOWNLOAD=true"
+fi
+
+MISSING_LOCK=$(new_fixture missing-lock)
+if PATH="$MISSING_LOCK/bin:$MISSING_LOCK/tools" TEST_STATE="$MISSING_LOCK/state" \
+  bash "$MISSING_LOCK/scripts/run-plugin-tests.sh" >/dev/null 2>&1; then
+  fail "a Bun-tested plugin without a lockfile must fail the runner"
+fi
+if [ -e "$MISSING_LOCK/state/test-ran" ]; then
+  fail "bun tests must not run without a lockfile"
+else
+  pass "a missing lockfile stops before bun tests"
+fi


### PR DESCRIPTION
Closes #1012

## Summary
- require frozen plugin lockfiles and fail immediately on dependency-install errors
- disable Puppeteer browser downloads and make cloud-CLI hermeticity checks deterministic
- freeze the MEDDPICC workspace test graph and run validation on Bun 1.3.14
- pin the remaining mutable GitHub Actions references exposed by the security gate

## Verification
- complete sanitized plugin matrix: all suites passed
- hermeticity, frozen-install, browser-download, and fail-fast regression tests passed
- pre-commit passed for every changed file
- Actionlint and zizmor passed after immutable action pinning