### PR TITLE
fix(meddpicc): sanitize identity-bearing examples

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.5.3",
+      "version": "7.5.4",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to
 
 - **`osint-framework`** bumped to v1.0.5
 
-- **`meddpicc`** bumped to v7.5.3
+- **`meddpicc`** v7.5.4 replaces identity-shaped fixtures with reserved role aliases, requires
+  sanitized synthetic inputs and access-controlled artifact storage, and correctly decodes XML
+  entities split across Excel shared-string runs.
 
 - **`devcontainer`** bumped to v1.1.8
 

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/README.md
+++ b/plugins/meddpicc/README.md
@@ -4,9 +4,19 @@ MEDDPICC sales qualification and deal-execution framework plugin for Claude Code
 
 ## Overview
 
-This plugin turns MEDDPICC from a checkbox exercise into a **living deal intelligence system**. Qualification data accumulates over weeks and months as you feed in meeting notes, emails, call transcripts, OSINT scans, competitive intel, and Salesforce updates. Every piece of evidence is extracted, mapped to the correct MEDDPICC element, and persisted incrementally to a structured JSON deal file.
+This plugin turns MEDDPICC from a checkbox exercise into a **living deal intelligence system**. Qualification data accumulates as you feed in sanitized meeting notes, emails, call transcripts, competitive intel, and Salesforce updates. Every piece of evidence is extracted, mapped to the correct MEDDPICC element, and persisted incrementally to a structured JSON deal file.
 
 The system supports the full deal lifecycle: initial qualification, ongoing intelligence ingestion, weekly structured reviews, champion assessment, and mutual action plan creation.
+
+## Identity and data safety
+
+Use this plugin only with synthetic demo data. Never provide legal or full names, personal contact
+details, raw CRM exports, unsanitized correspondence, or other real employee, customer, or
+third-party data. Replace each person with a stable role alias such as `<ECONOMIC_BUYER>`,
+`<CHAMPION>`, or `<SELLER_1>` before analysis. If an input has not been sanitized, stop and ask the
+user to supply a sanitized copy before continuing.
+
+Deal JSON and generated workbooks are unencrypted files. Store them only at an explicit access-controlled location outside a Git worktree, share them only within the authorized demo scope, and delete them when the demo or review is complete.
 
 ## What is MEDDPICC?
 
@@ -62,14 +72,14 @@ Output: JSON deal file (source of truth) + Markdown scorecard. Add `render` or `
 
 ### Deal update (`/meddpicc:update-deal`)
 
-The **primary ongoing interaction**. Accepts any unstructured text, extracts MEDDPICC-relevant intelligence, and proposes updates to the deal JSON. Supported sources include meeting notes, email threads, call transcripts, OSINT reports, competitive intel, Salesforce exports, presentation feedback, and news articles.
+The **primary ongoing interaction**. Accepts pre-sanitized unstructured text, extracts MEDDPICC-relevant intelligence, and proposes updates to the deal JSON. Supported sources include sanitized meeting notes, email threads, call transcripts, competitive intel, Salesforce exports, presentation feedback, and news articles.
 
 The extraction protocol scans for signals mapped to each MEDDPICC element (KPIs, budget statements, procurement steps, pain language, champion actions, competitor mentions, etc.) and presents a structured diff before writing:
 
-- Evidence is **appended** with `[YYYY-MM-DD source-type]` prefixes — history is never overwritten
+- Evidence is **appended** with `[YYYY-MM-DD source-type]` prefixes until the user deletes the demo artifact under the retention guidance above
 - Score changes are **recommended with reasoning** and require user confirmation
 - Conflicts with existing data are **flagged** for reconciliation
-- New stakeholders are **detected** and offered for addition
+- New stakeholder aliases are **detected** and offered for addition
 
 ### Deal review (`/meddpicc:deal-review`)
 
@@ -107,7 +117,7 @@ Every task has a named owner, specific date, exit criteria, and dependencies.
 
 ## Agents
 
-**`deal-analyst`** — Read-only research agent that analyzes deal health from local files (meeting notes, CRM exports, account plans, proposals). Produces a structured MEDDPICC assessment report with evidence citations, gap analysis, and prioritized actions. Uses WebSearch for competitive intelligence. Does not modify files.
+**`deal-analyst`** — Read-only research agent that analyzes deal health from explicitly supplied, sanitized local files (meeting notes, CRM exports, account plans, proposals). Produces a structured MEDDPICC assessment report with evidence citations, gap analysis, and prioritized actions. Uses WebSearch for company-level competitive intelligence only. Does not modify files.
 
 Use the deal-analyst when you want an independent assessment of deal health without changing the deal file, or when you want to analyze multiple deal artifacts in bulk.
 
@@ -118,7 +128,7 @@ Deals are stored as JSON files conforming to the [MEDDPICC schema](schema/meddpi
 - **Metadata** — deal identification, stage, financials, client interactions, Salesforce integration, completion tracking
 - **Qualification** — all 8 MEDDPICC elements with definitions, questions, responses, scores, score definitions, evidence, and notes
 - **Three Whys** — Why Anything, Why Us, Why Now (for both your own company and the partner)
-- **Stakeholders** — name, title, role in deal, veto power, beliefs needed, sentiment, relationship owner
+- **Stakeholders** — role alias, title, role in deal, veto power, beliefs needed, sentiment, relationship-owner alias
 - **Sales Strategy** — differentiated value proposition and win strategy
 - **Close Plan** — milestones and critical actions with dates and owners
 - **Team** — internal and partner team members assigned to the deal
@@ -181,7 +191,7 @@ Walks through a guided interview: metadata first, then each MEDDPICC element wit
 ### Import from Salesforce
 
 ```text
-/meddpicc:qualify-deal Example Corp --sfdc 006Hs00000AbCdEfG
+/meddpicc:qualify-deal Example Corp --sfdc 006000000000000AAA
 ```
 
 Pre-populates the deal JSON from Salesforce fields, then asks targeted questions for missing sections.
@@ -204,10 +214,10 @@ The AI extracts MEDDPICC signals, presents a proposed update diff with score rec
 ```text
 /meddpicc:update-deal Example Corp
 FW: RE: API Gateway eval - internal update
-Hey John, wanted to give you a heads up. The architecture review
+Hello <ACCOUNT_EXECUTIVE>, wanted to give you a heads up. The architecture review
 board approved us for the shortlist. Vendor A pricing came in at
 $85K/yr vs your $120K. Legal confirmed their standard review takes
-3 weeks. Talk soon, Barney
+3 weeks. Talk soon, <CHAMPION>
 ```
 
 ### Run a weekly deal review
@@ -221,7 +231,7 @@ Loads the deal file, snapshots scores for delta tracking, inspects evidence chan
 ### Test your champion
 
 ```text
-/meddpicc:champion-test Barney Rubble Director of Platform Engineering
+/meddpicc:champion-test <CHAMPION> Director of Platform Engineering
 ```
 
 Scores Power, Personal Win, Access, Intel, and Action (0-3 each) to classify the contact and produce a development plan.

--- a/plugins/meddpicc/agents/deal-analyst.md
+++ b/plugins/meddpicc/agents/deal-analyst.md
@@ -18,9 +18,15 @@ that assesses deal health and identifies qualification gaps. Your
 job is to gather evidence, apply the MEDDPICC framework, and
 produce structured analysis reports.
 
+Use synthetic demo data only. Read only files the user explicitly
+supplies and confirms are sanitized. Never search for, repeat, or report
+legal or full names, personal contact details, social handles, or other
+personal identifiers. Use role aliases in every output. Limit WebSearch
+to company-level competitive intelligence; never search for a person.
+
 **You do:**
 
-- Read deal documentation, CRM exports, meeting notes, and account
+- Read explicitly supplied sanitized deal documentation, CRM exports, meeting notes, and account
   plans from local files
 - Search for competitive intelligence via WebSearch
 - Analyze stakeholder maps and organizational charts
@@ -39,7 +45,7 @@ produce structured analysis reports.
 
 ### Step 1 — Gather available evidence
 
-Search local files for deal-related documentation:
+Review only the sanitized files explicitly supplied for the task:
 
 - Meeting notes, call summaries, email threads
 - Account plans, stakeholder maps

--- a/plugins/meddpicc/commands/champion-test.md
+++ b/plugins/meddpicc/commands/champion-test.md
@@ -1,7 +1,9 @@
 ---
-description: Test whether your contact is a true MEDDPICC champion
-argument-hint: "[contact name]"
+description: Test whether your aliased contact is a true MEDDPICC champion
+argument-hint: "[contact role alias]"
 ---
+
+# Champion Test
 
 Invoke the `meddpicc:champion-test` skill to assess whether
 "$ARGUMENTS" meets the criteria for a true MEDDPICC champion.

--- a/plugins/meddpicc/commands/qualify-deal.md
+++ b/plugins/meddpicc/commands/qualify-deal.md
@@ -3,12 +3,15 @@ description: Score and qualify a deal using the MEDDPICC framework with structur
 argument-hint: "[deal name or account] [--import] [--sfdc <opportunity-id>]"
 ---
 
+# Qualify Deal
+
 Invoke the `meddpicc:deal-qualification` skill to produce a
 MEDDPICC scorecard for the deal "$ARGUMENTS".
 
-Start by inventorying the current workspace: list the files, read
-any `*.json` conforming to the MEDDPICC schema, and treat call
-notes, briefings and transcripts alongside them as evidence. If a
+Start from only the files the user explicitly supplies and confirms
+are sanitized. Read any supplied `*.json` conforming to the MEDDPICC
+schema, and treat sanitized call notes, briefings, and transcripts
+alongside them as evidence. If a
 deal file for "$ARGUMENTS" already exists, resume from it rather
 than re-interviewing.
 
@@ -19,7 +22,7 @@ than re-interviewing.
 - `--import`: resume an existing partial deal JSON or import from
   an existing file
 - `--sfdc <id>`: import deal data from a Salesforce opportunity ID
-  before starting the guided interview
+  before starting the guided interview, after removing identity fields
 
 **Output:** JSON deal file (source of truth) + Markdown scorecard.
 Add "render" or "export" for the spreadsheet too. That is generated

--- a/plugins/meddpicc/commands/update-deal.md
+++ b/plugins/meddpicc/commands/update-deal.md
@@ -1,7 +1,9 @@
 ---
-description: Ingest meeting notes, emails, transcripts, OSINT reports, or any intel into a MEDDPICC deal file
-argument-hint: "[account or deal name] — then paste or describe the source"
+description: Ingest sanitized deal intelligence into a MEDDPICC deal file
+argument-hint: "[account or deal alias] — then provide a sanitized source"
 ---
+
+# Update Deal
 
 Invoke the `meddpicc:deal-update` skill to extract MEDDPICC
 intelligence from "$ARGUMENTS" and update the matching deal JSON file.
@@ -9,12 +11,12 @@ intelligence from "$ARGUMENTS" and update the matching deal JSON file.
 **Accepted sources:**
 
 - Meeting notes or call summaries
-- Email threads (paste directly)
-- Online meeting transcripts
-- OSINT or competitive intelligence reports
-- Salesforce opportunity exports
+- Sanitized email excerpts
+- Sanitized online meeting transcripts
+- Company-level competitive intelligence reports
+- Sanitized Salesforce opportunity exports
 - Presentation or demo feedback
-- Any text containing deal-relevant information
+- Sanitized text containing deal-relevant information
 
 **Output:** Proposed update diff (for your review) → confirmed
 changes written to the deal JSON via `jq` → updated MEDDPICC scorecard.

--- a/plugins/meddpicc/engine/completion-formula.test.ts
+++ b/plugins/meddpicc/engine/completion-formula.test.ts
@@ -84,11 +84,11 @@ describe('cellResolver — what a deal path is on the sheet', () => {
 
   test('a sheet name needing quotes gets them, and an apostrophe in one is doubled', () => {
     const cells = [
-      { jsonPath: 'a', sheet: "Bob's Deal Review", address: 'D20', valueType: 'string' as const },
+      { jsonPath: 'a', sheet: "Seller's Deal Review", address: 'D20', valueType: 'string' as const },
       { jsonPath: 'b', sheet: 'Plain', address: 'D21', valueType: 'string' as const },
     ];
     const resolve = cellResolver(cells, 'Elsewhere');
-    expect(resolve.cell('a')).toBe("'Bob''s Deal Review'!$D$20");
+    expect(resolve.cell('a')).toBe("'Seller''s Deal Review'!$D$20");
     expect(resolve.cell('b')).toBe('Plain!$D$21');
   });
 

--- a/plugins/meddpicc/engine/generate.ts
+++ b/plugins/meddpicc/engine/generate.ts
@@ -211,7 +211,7 @@ export interface PlannedTable {
  * disagree, and neither says so.
  *
  * A plain list row has no such identity: row one is simply the first stakeholder. Swap two names there
- * and the sheet says "David Park" beside "SVP Infrastructure", the deal ends up saying exactly that,
+ * and the sheet says "<DECISION_MAKER>" beside "SVP Infrastructure", the deal ends up saying exactly that,
  * and the two agree. The reader has transcribed a sheet somebody made odd, which is its job. Sorting a
  * single column of a list is the way to make that happen by accident — and it makes the SHEET wrong
  * before any reading occurs, so no read-back policy can recover it. Regenerate instead; the skills say

--- a/plugins/meddpicc/engine/json-path.test.ts
+++ b/plugins/meddpicc/engine/json-path.test.ts
@@ -3,14 +3,14 @@ import { readPath, writePath } from './json-path';
 
 const deal = () => ({
   metadata: { accountName: 'Example Corp', revenue: { acv: 85000 } },
-  stakeholders: [{ name: 'Sarah' }, { name: 'Marcus' }],
+  stakeholders: [{ name: '<STAKEHOLDER_1>' }, { name: '<STAKEHOLDER_2>' }],
   qualification: { metrics: { responses: ['first', 'second'] } },
 });
 
 describe('readPath', () => {
   test('follows properties and indexes', () => {
     expect(readPath(deal(), 'metadata.revenue.acv')).toBe(85000);
-    expect(readPath(deal(), 'stakeholders[1].name')).toBe('Marcus');
+    expect(readPath(deal(), 'stakeholders[1].name')).toBe('<STAKEHOLDER_2>');
     expect(readPath(deal(), 'qualification.metrics.responses[0]')).toBe('first');
   });
 
@@ -40,8 +40,8 @@ describe('writePath', () => {
 
   test('appends at the end of a list', () => {
     const d = deal();
-    expect(writePath(d, 'stakeholders[2].name', 'Dana')).toBeNull();
-    expect(d.stakeholders.map((s) => s.name)).toEqual(['Sarah', 'Marcus', 'Dana']);
+    expect(writePath(d, 'stakeholders[2].name', '<STAKEHOLDER_3>')).toBeNull();
+    expect(d.stakeholders.map((s) => s.name)).toEqual(['<STAKEHOLDER_1>', '<STAKEHOLDER_2>', '<STAKEHOLDER_3>']);
   });
 
   test('builds a list that does not exist yet, but only from its first row', () => {
@@ -58,7 +58,7 @@ describe('writePath', () => {
 
   test('refuses to leave a hole in a list', () => {
     const d = deal();
-    expect(writePath(d, 'stakeholders[4].name', 'Dana')).toMatch(/row 5.*row 3/);
+    expect(writePath(d, 'stakeholders[4].name', '<STAKEHOLDER_5>')).toMatch(/row 5.*row 3/);
     expect(d).toEqual(deal());
   });
 

--- a/plugins/meddpicc/engine/legacy.test.ts
+++ b/plugins/meddpicc/engine/legacy.test.ts
@@ -189,10 +189,10 @@ describe('migrateDeal', () => {
   test('two non-empty lists are never merged — that would invent people', () => {
     // Concatenating would duplicate whoever appears in both, and no order is defensible.
     const legacy = asLegacyDeal();
-    legacy.team.internal = [{ name: 'Someone Else', role: 'AE' }];
+    legacy.team.internal = [{ name: '<LEGACY_TEAM_MEMBER>', role: 'AE' }];
     const result = migrateDeal(legacy);
     expect(result.conflicts).toHaveLength(1);
-    expect(shape(result.deal).team.internal).toEqual([{ name: 'Someone Else', role: 'AE' }]);
+    expect(shape(result.deal).team.internal).toEqual([{ name: '<LEGACY_TEAM_MEMBER>', role: 'AE' }]);
     expect(shape(result.deal).team.f5).toEqual(shape(asLegacyDeal()).team.f5);
   });
 

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/engine/read-workbook.test.ts
+++ b/plugins/meddpicc/engine/read-workbook.test.ts
@@ -286,7 +286,7 @@ describe('proposals', () => {
     const { sheet, address } = addressOf(exampleDeal, 'metadata.reviewer');
     const report = read(exampleDeal, setBlank(generateWorkbook(schema, spec, exampleDeal), sheet, address));
     expect(report.proposals).toHaveLength(1);
-    expect(report.proposals[0]).toMatchObject({ kind: 'clear', from: 'Jane Smith', to: null });
+    expect(report.proposals[0]).toMatchObject({ kind: 'clear', from: '<ACCOUNT_EXECUTIVE>', to: null });
     expect((report.deal as { metadata: Record<string, unknown> }).metadata.reviewer).toBeUndefined();
   });
 
@@ -396,12 +396,12 @@ describe('list rows', () => {
     const { sheet, address } = addressOf(exampleDeal, listPath(count, 'name'));
     const report = read(
       exampleDeal,
-      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Dana Reyes'),
+      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, '<NEW_STAKEHOLDER_1>'),
     );
     expect(report.rejections).toEqual([]);
     const stakeholders = (report.deal as { stakeholders: Array<{ name: string }> }).stakeholders;
     expect(stakeholders).toHaveLength(count + 1);
-    expect(stakeholders[count].name).toBe('Dana Reyes');
+    expect(stakeholders[count].name).toBe('<NEW_STAKEHOLDER_1>');
   });
 
   test('two fields of the same new row make one item, not two', () => {
@@ -409,12 +409,12 @@ describe('list rows', () => {
     let bytes = generateWorkbook(schema, spec, exampleDeal);
     const name = addressOf(exampleDeal, listPath(count, 'name'));
     const title = addressOf(exampleDeal, listPath(count, 'title'));
-    bytes = setText(bytes, name.sheet, name.address, 'Dana Reyes');
+    bytes = setText(bytes, name.sheet, name.address, '<NEW_STAKEHOLDER_1>');
     bytes = setText(bytes, title.sheet, title.address, 'VP Platform');
     const report = read(exampleDeal, bytes);
     const stakeholders = (report.deal as { stakeholders: Array<{ name: string; title: string }> }).stakeholders;
     expect(stakeholders).toHaveLength(count + 1);
-    expect(stakeholders[count]).toMatchObject({ name: 'Dana Reyes', title: 'VP Platform' });
+    expect(stakeholders[count]).toMatchObject({ name: '<NEW_STAKEHOLDER_1>', title: 'VP Platform' });
   });
 
   test('skipping a row is refused — an array cannot have a hole', () => {
@@ -422,7 +422,7 @@ describe('list rows', () => {
     const { sheet, address } = addressOf(exampleDeal, listPath(count + 1, 'name'));
     const report = read(
       exampleDeal,
-      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Dana Reyes'),
+      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, '<NEW_STAKEHOLDER_1>'),
     );
     expect(report.proposals).toEqual([]);
     expect(report.rejections).toHaveLength(1);
@@ -435,8 +435,8 @@ describe('list rows', () => {
     const count = exampleDeal.stakeholders.length;
     let bytes = generateWorkbook(schema, spec, exampleDeal);
     for (const [offset, who] of [
-      [0, 'Dana Reyes'],
-      [1, 'Sam Okafor'],
+      [0, '<NEW_STAKEHOLDER_1>'],
+      [1, '<NEW_STAKEHOLDER_2>'],
     ] as const) {
       const at = addressOf(exampleDeal, listPath(count + offset, 'name'));
       bytes = setText(bytes, at.sheet, at.address, who);
@@ -444,7 +444,7 @@ describe('list rows', () => {
     const report = read(exampleDeal, bytes);
     expect(report.rejections).toEqual([]);
     const stakeholders = (report.deal as { stakeholders: Array<{ name: string }> }).stakeholders;
-    expect(stakeholders.map((s) => s.name).slice(count)).toEqual(['Dana Reyes', 'Sam Okafor']);
+    expect(stakeholders.map((s) => s.name).slice(count)).toEqual(['<NEW_STAKEHOLDER_1>', '<NEW_STAKEHOLDER_2>']);
   });
 
   test('answering the last question first is refused — the answers before it are still blank', () => {
@@ -622,7 +622,12 @@ describe('a list holds exactly its padded rows — anything below is reported', 
     const deal = fullDeal();
     const count = (deal.stakeholders as unknown[]).length;
     const at = firstUnmappedCell(deal, 'name');
-    const edited = addCell(generateWorkbook(schema, spec, deal), at.sheet, at.address, text(at.address, 'Dana Reyes'));
+    const edited = addCell(
+      generateWorkbook(schema, spec, deal),
+      at.sheet,
+      at.address,
+      text(at.address, '<NEW_STAKEHOLDER_1>'),
+    );
 
     const report = read(deal, edited);
     expect(report.proposals).toEqual([]);
@@ -638,7 +643,7 @@ describe('a list holds exactly its padded rows — anything below is reported', 
     let bytes = generateWorkbook(schema, spec, deal);
     const refs: string[] = [];
     for (const [field, value] of [
-      ['name', 'Dana Reyes'],
+      ['name', '<NEW_STAKEHOLDER_1>'],
       ['title', 'VP Platform'],
       ['roleInDeal', 'Influencer'],
     ] as const) {
@@ -1006,7 +1011,7 @@ describe('one column of a list, re-ordered, is refused', () => {
    * pattern is refused by name, while any ordinary edit — which changes the set — passes.
    *
    * Measured before this guard: swapping B56 and B57 gave `ok: true`, no rejections, two proposals, and
-   * David Park ended up with Sarah Chen's title.
+   * <DECISION_MAKER> ended up with <ECONOMIC_BUYER>'s title.
    */
   function swapCells(bytes: Uint8Array, sheetName: string, a: string, b: string): Uint8Array {
     const entries = readZip(bytes);
@@ -1068,7 +1073,7 @@ describe('one column of a list, re-ordered, is refused', () => {
     const { sheet, address } = nameCell(0);
     const report = read(
       exampleDeal,
-      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, 'Dana Reyes'),
+      setText(generateWorkbook(schema, spec, exampleDeal), sheet, address, '<NEW_STAKEHOLDER_1>'),
     );
     expect(report.rejections).toEqual([]);
     expect(report.proposals).toHaveLength(1);
@@ -1079,7 +1084,7 @@ describe('one column of a list, re-ordered, is refused', () => {
     let bytes = generateWorkbook(schema, spec, exampleDeal);
     for (const index of [0, 1]) {
       const { sheet, address } = nameCell(index);
-      bytes = setText(bytes, sheet, address, 'Dana Reyes');
+      bytes = setText(bytes, sheet, address, '<NEW_STAKEHOLDER_1>');
     }
     const report = read(exampleDeal, bytes);
     expect(report.rejections).toEqual([]);
@@ -1137,8 +1142,8 @@ describe('one column of a list, re-ordered, is refused', () => {
     );
     // …and then rename a third, which breaks the multiset.
     const third = addressOf(exampleDeal, 'stakeholders[2].name');
-    bytes = setText(bytes, third.sheet, third.address, 'Dana Reyes');
-    expect(names[2]).not.toBe('Dana Reyes');
+    bytes = setText(bytes, third.sheet, third.address, '<NEW_STAKEHOLDER_1>');
+    expect(names[2]).not.toBe('<NEW_STAKEHOLDER_1>');
     const report = read(exampleDeal, bytes);
     expect(report.ok).toBe(false);
     expect(report.proposals).toEqual([]);
@@ -1156,8 +1161,8 @@ describe('one column of a list, re-ordered, is refused', () => {
     const copied = addressOf(exampleDeal, 'stakeholders[2].name');
     bytes = setText(bytes, copied.sheet, copied.address, names[0]);
     const renamed = addressOf(exampleDeal, 'stakeholders[3].name');
-    bytes = setText(bytes, renamed.sheet, renamed.address, 'Dana Reyes');
-    expect(names).not.toContain('Dana Reyes');
+    bytes = setText(bytes, renamed.sheet, renamed.address, '<NEW_STAKEHOLDER_1>');
+    expect(names).not.toContain('<NEW_STAKEHOLDER_1>');
     const report = read(exampleDeal, bytes);
     expect(report.rejections).toEqual([]);
     expect(report.proposals).toHaveLength(2);

--- a/plugins/meddpicc/engine/read-workbook.ts
+++ b/plugins/meddpicc/engine/read-workbook.ts
@@ -90,7 +90,10 @@ function unescapeXml(text: string): string {
 function joinTextRuns(xml: string): string {
   // Phonetic hints also live in <t>, and they are annotation, not content.
   const withoutPhonetics = xml.replace(/<rPh[\s\S]*?<\/rPh>/g, '');
-  return [...withoutPhonetics.matchAll(/<t(?:\s[^>]*)?>([\s\S]*?)<\/t>/g)].map((m) => unescapeXml(m[1])).join('');
+  // Excel may split a rich-text run in the middle of an entity (`&` / `lt;`). Join the encoded
+  // fragments first and decode once, otherwise the entity survives as literal text.
+  const encoded = [...withoutPhonetics.matchAll(/<t(?:\s[^>]*)?>([\s\S]*?)<\/t>/g)].map((m) => m[1]).join('');
+  return unescapeXml(encoded);
 }
 
 function attribute(attrs: string, name: string): string | undefined {
@@ -709,7 +712,7 @@ export function readWorkbook(schema: unknown, spec: WorkbookSpec, deal: unknown,
   // stakeholder. That leaves one real hazard: sorting or pasting a SINGLE column detaches its values
   // from the rest of their rows, and a faithful reader then writes the scrambled pairing into the deal,
   // losing the original on `--apply`. Measured before this guard: swapping two stakeholder names gave
-  // `ok` true, no rejections, and David Park ended up with Sarah Chen's title.
+  // `ok` true, no rejections, and <DECISION_MAKER> ended up with <ECONOMIC_BUYER>'s title.
   //
   // The signal is precise. A column holding the SAME SET of values in a DIFFERENT ORDER has been
   // re-ordered — nobody edits two people's names into each other's, and no ordinary edit leaves the

--- a/plugins/meddpicc/engine/vendor-neutral.test.ts
+++ b/plugins/meddpicc/engine/vendor-neutral.test.ts
@@ -104,7 +104,7 @@ describe('the plugin names no vendor', () => {
     // the camelCase cases are exactly the ones an earlier `\bf5\b` version let through.
     for (const line of [
       '  "viewOfF5": "Positive",',
-      '  "f5Owner": "Jane Smith",',
+      '  "f5Owner": "<ACCOUNT_EXECUTIVE>",',
       '  "whyF5": "...",',
       '  "label": "Why F5?"',
       '  "jsonPath": "team.f5"',
@@ -112,7 +112,7 @@ describe('the plugin names no vendor', () => {
     ]) {
       expect(VENDOR.test(line)).toBe(true);
     }
-    for (const line of ['  "sentiment": "Positive",', '  "relationshipOwner": "Jane Smith",']) {
+    for (const line of ['  "sentiment": "Positive",', '  "relationshipOwner": "<ACCOUNT_EXECUTIVE>",']) {
       expect(VENDOR.test(line)).toBe(false);
     }
   });

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "7.5.3",
+  "version": "7.5.4",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0",
   "workspaces": [

--- a/plugins/meddpicc/schema/example-deal.json
+++ b/plugins/meddpicc/schema/example-deal.json
@@ -23,11 +23,11 @@
       "objective": "Present POC results to steering committee"
     },
     "reviewDate": "2026-05-05",
-    "reviewer": "Jane Smith",
+    "reviewer": "<ACCOUNT_EXECUTIVE>",
     "salesforce": {
-      "opportunityId": "006Hs00000AbCdEfG",
-      "accountId": "001Hs00000XyZaBcD",
-      "ownerId": "005Hs00000JkLmNoP",
+      "opportunityId": "006000000000000AAA",
+      "accountId": "001000000000000AAA",
+      "ownerId": "005000000000000AAA",
       "stageName": "Negotiation/Review",
       "lastSyncDate": "2026-05-05T14:30:00Z"
     },
@@ -70,7 +70,7 @@
       "definition": "The individual with final budget authority and political power to fund the purchase",
       "questions": ["Who makes the buying decision?", "How are we engaged with them to address their priorities?"],
       "responses": [
-        "Sarah Chen, SVP Infrastructure — confirmed budget authority for all platform security investments up to $500K",
+        "<ECONOMIC_BUYER>, SVP Infrastructure — confirmed budget authority for all platform security investments up to $500K",
         "Direct meeting held 2026-04-20. She is focused on reducing security incidents before Q3 board review. Follow-up scheduled May 15."
       ],
       "score": 3,
@@ -81,8 +81,8 @@
         "3": "Aligned — Direct access achieved; EB priorities and personal win documented",
         "4": "Sponsoring — EB is actively sponsoring the deal through procurement"
       },
-      "evidence": "Meeting notes from 2026-04-20 one-on-one with Sarah Chen. Champion confirmed her budget authority.",
-      "notes": "Sarah reports to CIO; CIO is supportive but not directly involved"
+      "evidence": "Meeting notes from 2026-04-20 one-on-one with <ECONOMIC_BUYER>. Champion confirmed the buyer's budget authority.",
+      "notes": "<ECONOMIC_BUYER> reports to CIO; CIO is supportive but not directly involved"
     },
     "decisionCriteria": {
       "definition": "The requirements the customer will use to evaluate options — technical, business, operational, and commercial",
@@ -169,7 +169,7 @@
       "definition": "A powerful internal advocate who sells for you when you're not in the room",
       "questions": ["Who will benefit most from this transaction?", "Can they influence the buying process?"],
       "responses": [
-        "Mike Torres, Director of Platform Engineering — he owns the API gateway team and will be directly measured on MTTR improvement",
+        "<CHAMPION>, Director of Platform Engineering — this stakeholder owns the API gateway team and will be directly measured on MTTR improvement",
         "Yes — he reports to the CTO, introduced us to the EB, and is running the POC internally. Shared competitor pricing last week."
       ],
       "score": 4,
@@ -180,8 +180,8 @@
         "3": "Validated — Named individual with influence and credibility; personal win documented",
         "4": "Mobilizing — Champion is actively coaching you, sharing intel, and taking concrete actions weekly"
       },
-      "evidence": "Mike scheduled the EB meeting, shared competitor pricing (Vendor A quote), and presented our POC results at the architecture review board on 2026-04-28.",
-      "notes": "Mike's personal win: his team gets headcount if MTTR target is met with automation"
+      "evidence": "<CHAMPION> scheduled the EB meeting, shared competitor pricing (Vendor A quote), and presented our POC results at the architecture review board on 2026-04-28.",
+      "notes": "<CHAMPION>'s personal win: the platform team gets headcount if the MTTR target is met with automation"
     },
     "competition": {
       "definition": "Any alternative the buyer might choose — another vendor, internal build, or do nothing",
@@ -220,44 +220,44 @@
   },
   "stakeholders": [
     {
-      "name": "Sarah Chen",
+      "name": "<ECONOMIC_BUYER>",
       "title": "SVP Infrastructure",
       "roleInDeal": "Economic buyer",
       "mustSayYes": true,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "We will reduce security incidents by 60% within 6 months and the TCO stays under $100K/yr",
       "sentiment": "Positive",
-      "relationshipOwner": "Jane Smith"
+      "relationshipOwner": "<ACCOUNT_EXECUTIVE>"
     },
     {
-      "name": "David Park",
+      "name": "<DECISION_MAKER>",
       "title": "CTO",
       "roleInDeal": "Decision maker",
       "mustSayYes": true,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "Our platform integrates with their existing Kubernetes platform without migration risk and passes architecture review",
       "sentiment": "Positive",
-      "relationshipOwner": "Bob Johnson"
+      "relationshipOwner": "<SOLUTIONS_ENGINEER>"
     },
     {
-      "name": "Mike Torres",
+      "name": "<CHAMPION>",
       "title": "Director of Platform Engineering",
       "roleInDeal": "Influencer",
       "mustSayYes": false,
       "canSayNo": false,
       "whatTheyNeedToBelieve": "Our platform makes his team more productive and helps him hit the MTTR target that gets him headcount",
       "sentiment": "Positive",
-      "relationshipOwner": "Jane Smith"
+      "relationshipOwner": "<ACCOUNT_EXECUTIVE>"
     },
     {
-      "name": "Lisa Wang",
+      "name": "<SECURITY_STAKEHOLDER>",
       "title": "CISO",
       "roleInDeal": "Influencer",
       "mustSayYes": false,
       "canSayNo": true,
       "whatTheyNeedToBelieve": "Our platform meets SOC2 and regulatory requirements without creating new compliance gaps",
       "sentiment": "Neutral",
-      "relationshipOwner": "Bob Johnson"
+      "relationshipOwner": "<SOLUTIONS_ENGINEER>"
     }
   ],
   "salesStrategy": {
@@ -295,19 +295,19 @@
     "criticalActions": [
       {
         "action": "Schedule competitive differentiation demo vs Vendor A",
-        "owner": "Bob Johnson (SE)",
+        "owner": "<SOLUTIONS_ENGINEER> (SE)",
         "dueDate": "2026-05-19",
         "status": "pending"
       },
       {
         "action": "Begin paper process discovery with procurement contact",
-        "owner": "Jane Smith (AE)",
+        "owner": "<ACCOUNT_EXECUTIVE> (AE)",
         "dueDate": "2026-05-15",
         "status": "pending"
       },
       {
         "action": "Get specific dates and owners for architecture review board and procurement gates",
-        "owner": "Jane Smith (AE)",
+        "owner": "<ACCOUNT_EXECUTIVE> (AE)",
         "dueDate": "2026-05-12",
         "status": "pending"
       }
@@ -315,13 +315,33 @@
   },
   "team": {
     "internal": [
-      { "name": "Jane Smith", "role": "Account Executive", "dateRequiredFrom": "2026-03-01", "assignedToDeal": true },
-      { "name": "Bob Johnson", "role": "Solutions Engineer", "dateRequiredFrom": "2026-04-01", "assignedToDeal": true },
-      { "name": "Amy Chen", "role": "CSM", "dateRequiredFrom": "2026-06-15", "assignedToDeal": false }
+      {
+        "name": "<ACCOUNT_EXECUTIVE>",
+        "role": "Account Executive",
+        "dateRequiredFrom": "2026-03-01",
+        "assignedToDeal": true
+      },
+      {
+        "name": "<SOLUTIONS_ENGINEER>",
+        "role": "Solutions Engineer",
+        "dateRequiredFrom": "2026-04-01",
+        "assignedToDeal": true
+      },
+      { "name": "<CUSTOMER_SUCCESS_MANAGER>", "role": "CSM", "dateRequiredFrom": "2026-06-15", "assignedToDeal": false }
     ],
     "partner": [
-      { "name": "Tom Rivera", "role": "Lead Engineer", "dateRequiredFrom": "2026-06-01", "assignedToDeal": true },
-      { "name": "Priya Patel", "role": "Project Manager", "dateRequiredFrom": "2026-06-01", "assignedToDeal": false }
+      {
+        "name": "<PARTNER_ENGINEER>",
+        "role": "Lead Engineer",
+        "dateRequiredFrom": "2026-06-01",
+        "assignedToDeal": true
+      },
+      {
+        "name": "<PARTNER_PROJECT_MANAGER>",
+        "role": "Project Manager",
+        "dateRequiredFrom": "2026-06-01",
+        "assignedToDeal": false
+      }
     ]
   },
   "scoring": {

--- a/plugins/meddpicc/schema/meddpicc-schema.json
+++ b/plugins/meddpicc/schema/meddpicc-schema.json
@@ -23,7 +23,7 @@
         },
         "accountTeam": {
           "type": "string",
-          "description": "The account team owning the relationship (the sellers), e.g. \"Randy Dotson and Tyler Brown\". Distinct from `team.internal`, which is the specialist bench assigned to the deal."
+          "description": "The account team owning the relationship (the sellers), using role-based aliases such as \"<SELLER_1> and <SELLER_2>\". Never store legal or full names. Distinct from `team.internal`, which is the specialist bench assigned to the deal."
         },
         "dealName": {
           "type": "string",
@@ -118,7 +118,7 @@
         },
         "reviewer": {
           "type": "string",
-          "description": "Person conducting the review"
+          "description": "Role-based alias for the person conducting the review; never store legal or full names"
         },
         "salesforce": {
           "type": "object",
@@ -467,7 +467,8 @@
           "name": {
             "type": "string",
             "minLength": 1,
-            "pattern": "\\S"
+            "pattern": "\\S",
+            "description": "Role-based stakeholder alias; never store legal or full names"
           },
           "title": {
             "type": "string",
@@ -498,7 +499,7 @@
           },
           "relationshipOwner": {
             "type": "string",
-            "description": "Team member responsible for this relationship"
+            "description": "Role-based alias for the team member responsible for this relationship; never store legal or full names"
           }
         },
         "required": ["name", "title", "roleInDeal"]
@@ -552,7 +553,8 @@
                 "type": "string"
               },
               "owner": {
-                "type": "string"
+                "type": "string",
+                "description": "Role-based owner alias; never store legal or full names"
               },
               "dueDate": {
                 "type": "string",
@@ -577,7 +579,8 @@
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "description": "Role-based internal team alias; never store legal or full names"
               },
               "role": {
                 "type": "string"
@@ -598,7 +601,8 @@
             "type": "object",
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "description": "Role-based partner team alias; never store legal or full names"
               },
               "role": {
                 "type": "string"

--- a/plugins/meddpicc/scripts/tests/test_security.sh
+++ b/plugins/meddpicc/scripts/tests/test_security.sh
@@ -20,3 +20,67 @@ test_no_hardcoded_credentials() {
     return 1
   fi
 }
+
+# Identity-bearing examples must be visibly synthetic. Plausible names are not
+# acceptable test data because their provenance cannot be established later.
+test_identity_examples_use_reserved_placeholders() {
+  local deal="$PLUGIN_ROOT/schema/example-deal.json"
+  local values invalid
+
+  values=$(jq -r '
+    [
+      .metadata.reviewer,
+      (.stakeholders[] | .name, .relationshipOwner),
+      (.closePlan.criticalActions[].owner | sub(" \\([^)]*\\)$"; "")),
+      (.team.internal[].name),
+      (.team.partner[].name)
+    ] | .[]
+  ' "$deal")
+  invalid=$(grep -Ev '^<[A-Z][A-Z0-9_]*>$' <<<"$values" || true)
+  if [ -n "$invalid" ]; then
+    echo "Identity examples must use <RESERVED_PLACEHOLDER> values:"
+    printf '%s\n' "$invalid"
+    return 1
+  fi
+
+  local account_team_description
+  account_team_description=$(jq -r '.properties.metadata.properties.accountTeam.description' \
+    "$PLUGIN_ROOT/schema/meddpicc-schema.json")
+  if grep -Eq '[A-Z][a-z]{2,}[[:space:]]+[A-Z][a-z]{2,}' <<<"$account_team_description"; then
+    echo "accountTeam schema documentation contains a plausible person name"
+    return 1
+  fi
+}
+
+test_identity_schema_documents_role_aliases() {
+  jq -e '
+    [
+      .properties.metadata.properties.accountTeam.description,
+      .properties.metadata.properties.reviewer.description,
+      .properties.stakeholders.items.properties.name.description,
+      .properties.stakeholders.items.properties.relationshipOwner.description,
+      .properties.closePlan.properties.criticalActions.items.properties.owner.description,
+      .properties.team.properties.internal.items.properties.name.description,
+      .properties.team.properties.partner.items.properties.name.description
+    ]
+    | all(type == "string" and test("alias"; "i") and test("full names"; "i"))
+  ' "$PLUGIN_ROOT/schema/meddpicc-schema.json" >/dev/null || {
+    echo "Every identity-bearing schema field must require aliases and prohibit full names"
+    return 1
+  }
+}
+
+test_identity_output_templates_use_alias_labels() {
+  local unsafe
+  unsafe=$(grep -rIin -E '\[(Contact Name|Name|Account Name|Customer Name|Your Company)\]' \
+    --include='*.md' \
+    "$PLUGIN_ROOT/README.md" \
+    "$PLUGIN_ROOT/agents" \
+    "$PLUGIN_ROOT/commands" \
+    "$PLUGIN_ROOT/skills" || true)
+  if [ -n "$unsafe" ]; then
+    echo "Identity-bearing output templates must use role or organization aliases:"
+    printf '%s\n' "$unsafe"
+    return 1
+  fi
+}

--- a/plugins/meddpicc/scripts/uat-generate-excel.sh
+++ b/plugins/meddpicc/scripts/uat-generate-excel.sh
@@ -1502,7 +1502,7 @@ echo "PASS: edits made in Excel round-trip into the deal JSON, and applying them
 # found it; this is the case it named.
 nameless="$WORK/nameless.json"
 jq '.team.internal = [{"role": "Solutions Engineer"}]
-  | .closePlan.milestones = [{"owner": "Jane Smith", "targetDate": "2026-06-01"}]' "$DEAL" >"$nameless" ||
+  | .closePlan.milestones = [{"owner": "<ACCOUNT_EXECUTIVE>", "targetDate": "2026-06-01"}]' "$DEAL" >"$nameless" ||
   fail "could not build the nameless-entry deal"
 bun "$PLUGIN_ROOT/engine/cli.ts" validate "$nameless" >/dev/null || fail "the nameless-entry deal does not validate"
 nameless_out="$WORK/nameless.xlsx"
@@ -1583,7 +1583,7 @@ done
 wait_until_ready "$GROWN_BOOK" "$grown_sheet" "$name_col$last_row" ||
   fail "Excel never finished opening $GROWN_BOOK"
 excel_do "the overflowing stakeholder row" "  set wb to workbook \"$GROWN_BOOK\"
-  set value of range \"$name_col$grown_row\" of worksheet \"$grown_sheet\" of wb to \"Dana Reyes\"
+  set value of range \"$name_col$grown_row\" of worksheet \"$grown_sheet\" of wb to \"<NEW_STAKEHOLDER_1>\"
   set value of range \"$title_col$grown_row\" of worksheet \"$grown_sheet\" of wb to \"VP Platform\"
   set value of range \"$role_col$grown_row\" of worksheet \"$grown_sheet\" of wb to \"Influencer\"
   save wb

--- a/plugins/meddpicc/skills/champion-test/SKILL.md
+++ b/plugins/meddpicc/skills/champion-test/SKILL.md
@@ -15,13 +15,17 @@ Assess whether an internal contact meets the bar for a true MEDDPICC
 champion — someone with power, a personal win, and willingness to
 take action on your behalf.
 
+Use synthetic demo data only. Refer to the contact by a role alias such
+as `<CHAMPION>`; never request, persist, or repeat a legal or full name
+or personal contact detail.
+
 ## Assessment Protocol
 
 ### Step 1 — Gather context
 
 Ask the user:
 
-- Who is the contact? (name, title, role)
+- What is the contact's role alias, title, and role?
 - How long have you been working with them?
 - What have they done for you so far?
 - What's their relationship to the Economic Buyer?
@@ -88,9 +92,9 @@ Based on the classification:
 ## Output Format
 
 ```text
-## Champion Assessment: [Contact Name]
+## Champion Assessment: [Role Alias]
 
-### Contact: [Name], [Title]
+### Contact: [Role Alias], [Title]
 ### Account: <ACCOUNT_NAME>
 ### Assessment Date: [date]
 

--- a/plugins/meddpicc/skills/deal-qualification/SKILL.md
+++ b/plugins/meddpicc/skills/deal-qualification/SKILL.md
@@ -18,6 +18,15 @@ structured data into a JSON file that validates against the MEDDPICC
 schema, score each element 0-4, identify gaps, and recommend next
 actions.
 
+## Identity safety gate
+
+Use synthetic demo data only. Before reading or writing a deal, require
+all people to be represented by stable role aliases such as
+`<ECONOMIC_BUYER>`, `<CHAMPION>`, or `<SELLER_1>`. Never persist or
+repeat legal or full names, email addresses, phone numbers, social
+handles, or other personal identifiers. If source material contains
+them, stop and ask for a sanitized copy.
+
 ## Schema
 
 The deal data model is defined in
@@ -125,7 +134,7 @@ Stakeholders require `name`, `title`, and `roleInDeal`. Initialize
 the array if absent:
 
 ```bash
-jq --argjson item '{"name":"Jane","title":"VP","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"...","sentiment":"Neutral","relationshipOwner":"John Smith"}' \
+jq --argjson item '{"name":"<NEW_STAKEHOLDER>","title":"VP","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"...","sentiment":"Neutral","relationshipOwner":"<RELATIONSHIP_OWNER>"}' \
   'if .stakeholders then .stakeholders += [$item] else .stakeholders = [$item] end' \
   "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
 ```
@@ -244,10 +253,11 @@ User invokes with an existing complete deal.
 Deal JSON files are stored at a configurable path:
 
 1. If the user specifies a path, use it
-2. Otherwise, use the current working directory
-3. File naming: `{accountName}-{dealName}.json` (slugified —
+2. Otherwise, stop and ask the user for an explicit access-controlled
+   location outside any Git worktree
+3. File naming: `{accountAlias}-{dealAlias}.json` (slugified —
    lowercase, spaces replaced with hyphens, special characters
-   removed)
+   removed). Never place a real account or customer name in the path.
 
 ## Scoring Protocol
 

--- a/plugins/meddpicc/skills/deal-review/SKILL.md
+++ b/plugins/meddpicc/skills/deal-review/SKILL.md
@@ -16,6 +16,14 @@ This is the operational heartbeat of MEDDPICC — it keeps deals real
 and forecastable. Reviews read from and write to structured JSON deal
 files.
 
+## Identity safety gate
+
+Use synthetic demo data only. Require role aliases for every person and
+never persist or repeat legal or full names, contact details, social
+handles, or other personal identifiers. If the deal file or new review
+material contains them, stop and ask for a sanitized copy before making
+any write.
+
 ## Schema
 
 The deal data model is defined in
@@ -81,7 +89,7 @@ exact keys in all `jq` paths — display name ≠ key.
 Handle both `null` and `""` as empty with `// ""`:
 
 ```bash
-jq --arg new "[2026-05-20 weekly-review] Fred confirmed ARB slot June 2" \
+jq --arg new "[2026-05-20 weekly-review] <CHAMPION> confirmed ARB slot June 2" \
   '.qualification.metrics.evidence = (
     ((.qualification.metrics.evidence // "") | if . == "" then $new else . + "\n" + $new end)
   )' "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
@@ -225,7 +233,7 @@ For the final writes:
    interaction discussed:
 
    ```bash
-   jq --arg date "2026-05-20" --arg reviewer "John Smith" \
+   jq --arg date "2026-05-20" --arg reviewer "<REVIEWER>" \
       --arg lastDate "2026-05-20" --arg lastOutcome "Weekly review" \
      '.metadata.reviewDate = $date |
       .metadata.reviewer = $reviewer |
@@ -240,8 +248,8 @@ For the final writes:
 
 ## Output Format
 
-```
-## Deal Review: [Account Name]
+```text
+## Deal Review: [Account Alias]
 ### Date: [today's date]
 ### Stage: [stage] → [recommended stage change, if any]
 ### Score: [X/32] ([percentage]%) — [Red/Yellow/Green]

--- a/plugins/meddpicc/skills/deal-update/SKILL.md
+++ b/plugins/meddpicc/skills/deal-update/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: deal-update
 description: >-
-  Ingest unstructured intelligence into a MEDDPICC deal file. Accepts
-  any source — meeting notes, email threads, call transcripts, OSINT
-  reports, Salesforce updates, competitive intel briefs, presentation
-  feedback, or any text containing deal-relevant information. Extracts
+  Ingest sanitized unstructured intelligence into a MEDDPICC deal file.
+  Accepts sanitized meeting notes, email threads, call transcripts,
+  Salesforce updates, competitive intel briefs, presentation feedback,
+  or other sanitized deal-relevant text. Extracts
   MEDDPICC elements, proposes updates with a structured diff, and writes
   confirmed changes to the deal JSON. Use when the user says "here are
   my meeting notes", "update the deal with this", "I got an email from",
@@ -20,18 +20,25 @@ MEDDPICC deal file. This is the **primary ongoing interaction** for
 keeping a deal's qualification data current as new information
 arrives throughout the deal cycle.
 
+## Identity safety gate
+
+Accept only synthetic or pre-sanitized inputs. Every person must use a
+stable role alias such as `<ECONOMIC_BUYER>` or `<CHAMPION>`. Never
+persist or repeat legal or full names, email addresses, phone numbers,
+social handles, or other personal identifiers. If an input contains
+them, stop and ask for a sanitized copy; do not write a partial update.
+
 ## Supported Input Types
 
 - Meeting notes and call summaries
-- Email threads (forwarded or pasted)
-- Online meeting transcripts (Zoom, Teams, Google Meet)
-- OSINT research reports
+- Sanitized email excerpts
+- Sanitized online meeting transcripts
 - Competitive intelligence briefs
-- Salesforce opportunity exports or field summaries
+- Sanitized Salesforce opportunity exports or field summaries
 - Presentation or demo feedback
-- Internal Slack/Teams conversations
-- Customer-facing documents (RFPs, SOWs, evaluation matrices)
-- Prospect site or public filings analysis
+- Sanitized internal collaboration excerpts
+- Sanitized customer-facing documents (RFPs, SOWs, evaluation matrices)
+- Company-level public filings analysis
 - News articles about the account or competitors
 
 ## Engine (deterministic source of truth)
@@ -120,7 +127,7 @@ Stakeholders require `name`, `title`, and `roleInDeal` (schema
 required fields). Initialize the array if absent:
 
 ```bash
-jq --argjson s '{"name":"Jane Doe","title":"CISO","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"Meets compliance","sentiment":"Neutral","relationshipOwner":"John Smith"}' \
+jq --argjson s '{"name":"<NEW_STAKEHOLDER>","title":"CISO","roleInDeal":"Influencer","mustSayYes":false,"canSayNo":true,"whatTheyNeedToBelieve":"Meets compliance","sentiment":"Neutral","relationshipOwner":"<RELATIONSHIP_OWNER>"}' \
   'if .stakeholders then .stakeholders += [$s] else .stakeholders = [$s] end' \
   "$DEAL_FILE" > "$DEAL_FILE.tmp" && mv "$DEAL_FILE.tmp" "$DEAL_FILE"
 ```
@@ -270,15 +277,15 @@ Read the deal JSON and load current scores and evidence for all
 Before writing anything, display a structured summary of all
 proposed changes:
 
-```
-## Proposed Updates: [Account Name]
+```text
+## Proposed Updates: [Account Alias]
 ### Source: [source-type] — [date]
 
 | # | Element | Update Type | Current Value (truncated) | Proposed Change |
 |---|---------|-------------|--------------------------|-----------------|
 | 1 | Pain | evidence append | "" | "[2026-05-06 meeting] 3 incidents in Q1..." |
-| 2 | Champion | evidence append | "Barney..." | "[2026-05-06 meeting] Barney presented to steering..." |
-| 3 | Economic Buyer | response update | "Fred Flinstone" | "Fred confirmed $500K budget in today's meeting" |
+| 2 | Champion | evidence append | "<CHAMPION>..." | "[2026-05-06 meeting] <CHAMPION> presented to steering..." |
+| 3 | Economic Buyer | response update | "<ECONOMIC_BUYER>" | "The buyer confirmed $500K budget in today's meeting" |
 
 ### Score Recommendations
 
@@ -292,7 +299,7 @@ Current overall: X/32 (Y%) [Rating] → Proposed: X/32 (Y%) [Rating]
 
 ### Flags
 - [CONFLICT] Competition: Input says Vendor A is "not in the running" — contradicts existing note that customer is actively evaluating Vendor A. Clarify before updating.
-- [NEW STAKEHOLDER] Lisa Wang (CISO) mentioned — add to stakeholder list?
+- [NEW STAKEHOLDER] <SECURITY_STAKEHOLDER> (CISO) mentioned — add to stakeholder list?
 ```
 
 **Rules:**
@@ -345,8 +352,8 @@ Display the full MEDDPICC scorecard in the deal-qualification
 output format, highlighting which elements changed and by how
 much since this ingestion session.
 
-```
-## MEDDPICC Scorecard: [Account Name] (Updated)
+```text
+## MEDDPICC Scorecard: [Account Alias] (Updated)
 ### Source ingested: [source-type] — [date]
 ### Elements updated: [list]
 ### Overall: X/32 (Y%) — [Rating] (was Z/32 before this update)

--- a/plugins/meddpicc/skills/mutual-action-plan/SKILL.md
+++ b/plugins/meddpicc/skills/mutual-action-plan/SKILL.md
@@ -20,6 +20,10 @@ seller and buyer agree to. It converts the Decision Process and
 Paper Process into a concrete, actionable roadmap with dates, owners,
 and exit criteria.
 
+Use synthetic demo data only. Represent every owner and stakeholder by
+a stable role alias; never request, persist, or repeat legal or full
+names or personal contact details.
+
 ## MAP Design Protocol
 
 ### Step 1 — Gather inputs
@@ -49,7 +53,7 @@ full template.
 
 Every task must have:
 
-- **Owner:** Named person (customer or seller side)
+- **Owner:** Role alias (customer or seller side)
 - **Date:** Specific date, not "TBD"
 - **Exit criteria:** How we know this step is complete
 - **Dependencies:** What must happen first

--- a/plugins/meddpicc/skills/mutual-action-plan/references/map-template.md
+++ b/plugins/meddpicc/skills/mutual-action-plan/references/map-template.md
@@ -6,7 +6,7 @@ Customer-facing plan template. Customize for each deal.
 
 ```
 # Mutual Action Plan
-## [Customer Name] × [Your Company]
+## [Customer Alias] × [Seller Organization Alias]
 
 ### Business Context
 
@@ -25,48 +25,48 @@ Customer-facing plan template. Customize for each deal.
 
 | # | Milestone | Owner (Customer) | Owner (Seller) | Target Date | Exit Criteria |
 | - | --------- | ---------------- | -------------- | ----------- | ------------- |
-| 1 | Kickoff & requirements alignment | [name] | [name] | [date] | Requirements documented and prioritized |
-| 2 | Technical deep-dive / architecture review | [name] | [name] | [date] | Architecture approach agreed |
-| 3 | Proof of Value — setup | [name] | [name] | [date] | Environment provisioned, test plan approved |
-| 4 | Proof of Value — execution | [name] | [name] | [date] | All test cases executed |
-| 5 | Proof of Value — results review | [name] | [name] | [date] | Results documented, PASS/FAIL assessed |
-| 6 | Business case review | [name] | [name] | [date] | Value model validated by customer |
-| 7 | Executive briefing | [name] | [name] | [date] | EB alignment and sponsorship confirmed |
+| 1 | Kickoff & requirements alignment | [role alias] | [role alias] | [date] | Requirements documented and prioritized |
+| 2 | Technical deep-dive / architecture review | [role alias] | [role alias] | [date] | Architecture approach agreed |
+| 3 | Proof of Value — setup | [role alias] | [role alias] | [date] | Environment provisioned, test plan approved |
+| 4 | Proof of Value — execution | [role alias] | [role alias] | [date] | All test cases executed |
+| 5 | Proof of Value — results review | [role alias] | [role alias] | [date] | Results documented, PASS/FAIL assessed |
+| 6 | Business case review | [role alias] | [role alias] | [date] | Value model validated by customer |
+| 7 | Executive briefing | [role alias] | [role alias] | [date] | EB alignment and sponsorship confirmed |
 
 ### Procurement Roadmap
 
 | # | Step | Owner | Target Date | Notes |
 | - | ---- | ----- | ----------- | ----- |
-| 1 | Vendor onboarding / portal registration | [name] | [date] | |
-| 2 | Security questionnaire submission | [name] | [date] | |
-| 3 | Security review completion | [name] | [date] | |
-| 4 | Legal review — DPA, SLA, terms | [name] | [date] | |
-| 5 | Legal redline resolution | [name] | [date] | |
-| 6 | Quote / proposal delivery | [name] | [date] | |
-| 7 | Internal approval chain | [name] | [date] | |
-| 8 | Signature | [name] | [date] | |
+| 1 | Vendor onboarding / portal registration | [role alias] | [date] | |
+| 2 | Security questionnaire submission | [role alias] | [date] | |
+| 3 | Security review completion | [role alias] | [date] | |
+| 4 | Legal review — DPA, SLA, terms | [role alias] | [date] | |
+| 5 | Legal redline resolution | [role alias] | [date] | |
+| 6 | Quote / proposal delivery | [role alias] | [date] | |
+| 7 | Internal approval chain | [role alias] | [date] | |
+| 8 | Signature | [role alias] | [date] | |
 
 ### Implementation Readiness
 
 | # | Activity | Owner | Target Date | Depends On |
 | - | -------- | ----- | ----------- | ---------- |
-| 1 | Implementation kickoff | [name] | [date] | Signature |
-| 2 | Environment provisioning | [name] | [date] | Kickoff |
-| 3 | Configuration & integration | [name] | [date] | Provisioning |
-| 4 | User training | [name] | [date] | Configuration |
-| 5 | Go-live | [name] | [date] | Training |
-| 6 | 30-day success review | [name] | [date] | Go-live |
+| 1 | Implementation kickoff | [role alias] | [date] | Signature |
+| 2 | Environment provisioning | [role alias] | [date] | Kickoff |
+| 3 | Configuration & integration | [role alias] | [date] | Provisioning |
+| 4 | User training | [role alias] | [date] | Configuration |
+| 5 | Go-live | [role alias] | [date] | Training |
+| 6 | 30-day success review | [role alias] | [date] | Go-live |
 
 ### Stakeholders
 
 | Role | Customer | Seller |
 | ---- | -------- | ------ |
-| Executive Sponsor | [name, title] | [name, title] |
-| Project Lead | [name, title] | [name, title] |
-| Technical Lead | [name, title] | [name, title] |
-| Procurement | [name, title] | [name, title] |
-| Legal | [name, title] | [name, title] |
-| Security | [name, title] | [name, title] |
+| Executive Sponsor | [role alias, title] | [role alias, title] |
+| Project Lead | [role alias, title] | [role alias, title] |
+| Technical Lead | [role alias, title] | [role alias, title] |
+| Procurement | [role alias, title] | [role alias, title] |
+| Legal | [role alias, title] | [role alias, title] |
+| Security | [role alias, title] | [role alias, title] |
 
 ### Success Metrics
 

--- a/plugins/meddpicc/skills/mutual-action-plan/references/map-template.md
+++ b/plugins/meddpicc/skills/mutual-action-plan/references/map-template.md
@@ -4,7 +4,7 @@ Customer-facing plan template. Customize for each deal.
 
 ---
 
-```
+```markdown
 # Mutual Action Plan
 ## [Customer Alias] × [Seller Organization Alias]
 


### PR DESCRIPTION
Closes #1013

## Summary

- replace person-shaped fixtures and output-template name slots with reserved role aliases
- replace CRM identifiers with documented zero-value sentinels
- require synthetic, pre-sanitized inputs and access-controlled, non-Git artifact storage
- add identity-field and output-template regression guards
- decode Excel XML entities after joining split rich-text runs
- release MEDDPICC v7.5.4

## Security review

- staged enforce-mode PII scan: no findings
- repository Gitleaks scan: no leaks
- broad identity-field and person-name-shape review: no MEDDPICC findings
- audit mode raised two unchanged repository-wide manual-review items: a generic feature display label and a metadata-free storefront SVG; both were manually cleared as non-PII

This remediates the current tree. Historical Git objects and tags remain a separate, coordinated incident-response decision and are not rewritten by this PR.

## Verification

- `bash plugins/meddpicc/scripts/tests/run-tests.sh identity` — 3 passed
- `bun test plugins/meddpicc/engine/legacy.test.ts` — 25 passed
- `bun test` — 611 passed
- `shellcheck plugins/meddpicc/scripts/tests/test_security.sh` — passed
- `markdownlint-cli2` on changed Markdown — 0 issues
- `git diff --check` — passed
- optional Excel UAT — skipped because it requires explicit opt-in
