### PR TITLE
fix(ci): harden plugin workflows

### DIFF
--- a/.github/workflows/herdr-skill-freshness.yml
+++ b/.github/workflows/herdr-skill-freshness.yml
@@ -1,7 +1,7 @@
 ---
 name: Herdr Skill Freshness
 
-# `plugins/herdr/skills/herdr/SKILL.md` is vendored verbatim from ogulcancelik/herdr.
+# `plugins/herdr/skills/herdr/SKILL.md` is vendored verbatim from herdrdev/herdr.
 # Nothing in this repo can detect upstream edits, so without this job the vendored copy
 # silently rots — and it documents a CLI whose command surface changes.
 #
@@ -37,8 +37,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      # Ref is pinned here and recorded in plugins/herdr/UPSTREAM.md. Keep both in step.
+      # The tracked branch and path are recorded in plugins/herdr/UPSTREAM.md. Keep both in step.
       - name: Fetch upstream SKILL.md
         env:
           UPSTREAM_URL: https://raw.githubusercontent.com/herdrdev/herdr/master/skills/herdr/SKILL.md
@@ -67,10 +69,10 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<'MD'
           ## Herdr skill drift detected
 
-          The vendored `SKILL.md` no longer matches upstream `ogulcancelik/herdr@master`.
+          The vendored `SKILL.md` no longer matches upstream `herdrdev/herdr@master`.
 
           ```bash
-          curl -fsSL https://raw.githubusercontent.com/ogulcancelik/herdr/master/SKILL.md \
+          curl -fsSL https://raw.githubusercontent.com/herdrdev/herdr/master/skills/herdr/SKILL.md \
             -o plugins/herdr/skills/herdr/SKILL.md
           scripts/bump-version.sh herdr patch
           # then update the table in plugins/herdr/UPSTREAM.md

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -24,8 +24,7 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.sha }}
@@ -35,6 +34,8 @@ jobs:
   release:
     name: Create plugin releases
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # `gh release create` writes the release and its tag
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -57,6 +58,7 @@ jobs:
           # published a version, and refuses outright on a shallow clone rather than drawing
           # conclusions from a history it cannot see.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Select the releases to cut
         env:

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           # Full history so check-version-bumps.sh can diff against the PR base sha.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install jq
         run: |
@@ -60,6 +61,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install jq
         run: |
@@ -98,6 +101,7 @@ jobs:
           # missing" from a history it cannot see.
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       # This lives here, not in Release Plugins, because the failure it looks for is
       # Release Plugins not finishing. A check inside the workflow that broke cannot report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ and this project adheres to
 - **`herdr`** v1.0.1 — freshness verification follows the transferred upstream repository and
   relocated skill path while preserving the byte-identical vendored skill.
 
-- Pinned every GitHub Actions dependency that remained on a mutable major-version tag.
+- Pinned every GitHub Actions dependency that remained on a mutable major-version tag, disabled
+  persisted checkout credentials, and limited release write permission to the release job
+  ([#1021](https://github.com/f5-sales-demo/marketplace/issues/1021)).
 
 - **`github-ops`** polling tests now replace retry waits with a deterministic test-local sleep,
   preserving the `Retry-After` contract without depending on workstation timing


### PR DESCRIPTION
## Summary

Repair the scheduled workflow-security audit and finish the Herdr transfer cleanup. Every checkout now drops persisted credentials, release write access is confined to the release job, and all Herdr freshness remediation text points at the canonical repository and path.

## Related Issue

Closes #1021

## Changes

- add `persist-credentials: false` to all affected checkout steps
- replace workflow-wide release write access with job-scoped `contents: write`
- update stale `ogulcancelik/herdr` comments and remediation commands
- document the completed hardening in the changelog

The pinned `actions/checkout` v7.0.1, `oven-sh/setup-bun` v2.2.0, and Bun 1.3.14 versions were verified as current. The vendored Herdr skill remains byte-identical to the canonical upstream file.

## Verification evidence

- Red reproduction: the scheduled auditor command reported 7 findings (1 high and 6 credential/permission findings).
- `pipx run zizmor --no-config --no-ignores --persona=auditor` over the full workflow inventory: no findings.
- `actionlint` and `yamllint` on the three changed workflows: passed.
- Live upstream fetch plus `cmp`: vendored Herdr `SKILL.md` matches byte-for-byte.
- `./scripts/validate-plugins.sh`: all validation checks passed.
- `./scripts/run-plugin-tests.sh`: all plugin suites passed.
- `pre-commit run`: every applicable hook passed.
- `bash scripts/check-pii.sh --scope staged --mode enforce`: clean.
- `gitleaks protect --staged --redact --no-banner`: no leaks found.
- `bash scripts/agy-pre-push-review.sh`: no blocking, medium, or nit findings; independent HEAD PII and repository-hygiene checks passed.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions