### PR TITLE
feat(release): bump plugin versions for github v2.0.1, aws v1.2.6, and azure v1.2.6

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -234,7 +234,7 @@
     {
       "name": "azure",
       "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -259,7 +259,7 @@
     {
       "name": "aws",
       "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -334,7 +334,7 @@
     {
       "name": "github",
       "description": "Poweruser GitHub & Git Operations plugin combining direct native CLI mastery (git and gh) with complete Git SOPs workflow governance (issue-driven development, PR lifecycle, CI polling, auto-merge, post-merge teardown, and rate limit management)",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`github`** v2.0.1 — system prompt optimization aligning agent prompts, system prompt guidelines, and workflow skills with Anthropic 8-point system prompting standard.
+
+- **`aws`** v1.2.6 — system prompt optimization aligning agent prompts, system prompt guidelines, and workflow skills with Anthropic 8-point system prompting standard.
+
+- **`azure`** v1.2.6 — system prompt optimization aligning agent prompts, system prompt guidelines, and workflow skills with Anthropic 8-point system prompting standard.
+
 - **`sales-engineer`** bumped to v1.0.9
 
 - **`devcontainer`** bumped to v1.1.11

--- a/plugins/aws/.xcsh-plugin/plugin.json
+++ b/plugins/aws/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws",
   "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/aws",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/azure/.xcsh-plugin/plugin.json
+++ b/plugins/azure/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "azure",
   "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/azure",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/github/.xcsh-plugin/plugin.json
+++ b/plugins/github/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "description": "Poweruser GitHub & Git Operations plugin combining direct native CLI mastery (git and gh) with complete Git SOPs workflow governance (issue-driven development, feature branching, PR lifecycle, CI polling, auto-merge, and post-merge teardown)",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"


### PR DESCRIPTION
## Summary
Bump plugin manifest versions and changelog entries so Release Plugins workflow automatically cuts tags and releases.

Closes #1105