### PR TITLE
fix: publish deterministic plugin namespacing versions

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "docs-tools",
       "description": "MDX content validation and review tools for f5-sales-demo docs repos",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -28,7 +28,7 @@
     {
       "name": "sales-engineer",
       "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -43,7 +43,7 @@
     {
       "name": "docs-pipeline",
       "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -58,7 +58,7 @@
     {
       "name": "brand",
       "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -73,7 +73,7 @@
     {
       "name": "meddpicc",
       "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-      "version": "7.5.6",
+      "version": "7.5.7",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -98,7 +98,7 @@
     {
       "name": "devcontainer",
       "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5-sales-demo devcontainer",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -113,7 +113,7 @@
     {
       "name": "platform",
       "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
-      "version": "3.1.5",
+      "version": "3.1.6",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -142,7 +142,7 @@
     {
       "name": "osint-framework",
       "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -157,7 +157,7 @@
     {
       "name": "firecrawl",
       "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -172,7 +172,7 @@
     {
       "name": "salesforce",
       "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting. Bridge to forcedotcom/afv-library skills for Apex, LWC, Flow, SOQL, metadata, and deployment.",
-      "version": "1.3.11",
+      "version": "1.3.12",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -210,7 +210,7 @@
     {
       "name": "cloudstatus",
       "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -234,7 +234,7 @@
     {
       "name": "azure",
       "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -259,7 +259,7 @@
     {
       "name": "aws",
       "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -284,7 +284,7 @@
     {
       "name": "gcloud",
       "description": "Google Cloud CLI integration — container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -309,7 +309,7 @@
     {
       "name": "gitlab",
       "description": "GitLab CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status via glab CLI",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -334,7 +334,7 @@
     {
       "name": "github",
       "description": "Poweruser GitHub & Git Operations plugin combining direct native CLI mastery (git and gh) with complete Git SOPs workflow governance (issue-driven development, PR lifecycle, CI polling, auto-merge, post-merge teardown, and rate limit management)",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "author": {
         "name": "f5-sales-demo"
       },
@@ -363,7 +363,7 @@
     {
       "name": "herdr",
       "description": "Control Herdr, a terminal multiplexer for coding agents — inspect workspaces, tabs and panes, split panes, run commands without stealing focus, read pane output, and coordinate sibling agents. Requires HERDR_ENV=1.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,57 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`docs-tools`** v1.1.5 — publishes the deterministic namespacing metadata introduced by
+  #1111 as an installable plugin version.
+
+- **`sales-engineer`** v1.0.10 — publishes the deterministic namespacing metadata introduced by
+  #1111 as an installable plugin version.
+
+- **`docs-pipeline`** v1.0.5 — publishes the deterministic namespacing metadata introduced by
+  #1111 as an installable plugin version.
+
+- **`brand`** v1.0.5 — publishes the deterministic namespacing metadata introduced by #1111 as an
+  installable plugin version.
+
+- **`meddpicc`** v7.5.7 — publishes the deterministic namespacing metadata introduced by #1111 as
+  an installable plugin version.
+
+- **`devcontainer`** v1.1.12 — publishes the deterministic namespacing metadata introduced by
+  #1111 as an installable plugin version.
+
+- **`platform`** v3.1.6 — publishes the deterministic namespacing metadata introduced by #1111 as
+  an installable plugin version.
+
+- **`osint-framework`** v1.0.7 — publishes the deterministic namespacing metadata introduced by
+  #1111 as an installable plugin version.
+
+- **`firecrawl`** v1.1.3 — publishes the deterministic namespacing metadata introduced by #1111 as
+  an installable plugin version.
+
+- **`salesforce`** v1.3.12 — publishes the deterministic namespacing metadata introduced by #1111
+  as an installable plugin version.
+
+- **`cloudstatus`** v1.3.3 — publishes the deterministic namespacing metadata introduced by #1111
+  as an installable plugin version.
+
+- **`azure`** v1.2.7 — publishes the deterministic namespacing metadata introduced by #1111 as an
+  installable plugin version.
+
+- **`aws`** v1.2.7 — publishes the deterministic namespacing metadata introduced by #1111 as an
+  installable plugin version.
+
+- **`gcloud`** v1.2.7 — publishes the deterministic namespacing metadata introduced by #1111 as an
+  installable plugin version.
+
+- **`gitlab`** v1.2.6 — publishes the deterministic namespacing metadata introduced by #1111 as an
+  installable plugin version.
+
+- **`github`** v2.0.2 — publishes the deterministic namespacing metadata introduced by #1111 as an
+  installable plugin version.
+
+- **`herdr`** v1.0.2 — restores the byte-identical upstream skill and records its canonical
+  `skill://herdr:herdr` integration URI outside the vendored file.
+
 - **`github`** v2.0.1 — system prompt optimization aligning agent prompts, system prompt guidelines, and workflow skills with Anthropic 8-point system prompting standard.
 
 - **`aws`** v1.2.6 — system prompt optimization aligning agent prompts, system prompt guidelines, and workflow skills with Anthropic 8-point system prompting standard.

--- a/plugins/aws/.xcsh-plugin/plugin.json
+++ b/plugins/aws/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aws",
   "description": "AWS CLI integration — container-adapted auth, context injection, CLI operator agent, SSO expiry detection, and welcome screen status",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/aws",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/aws/package.json
+++ b/plugins/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-aws",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "description": "AWS CLI status for xcsh welcome screen",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "AWS",
-    "version": "1.2.5",
+    "version": "1.2.7",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/azure/.xcsh-plugin/plugin.json
+++ b/plugins/azure/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "azure",
   "description": "Azure CLI integration — native xcsh tools, container-adapted auth, context injection, CLI operator agent, and welcome screen status",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/azure",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/azure/package.json
+++ b/plugins/azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-azure",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "description": "Azure CLI tools for xcsh — native az command execution, subscription/resource/VM management, and welcome screen status",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Azure",
-    "version": "1.2.5",
+    "version": "1.2.7",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/brand/.xcsh-plugin/plugin.json
+++ b/plugins/brand/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "brand",
   "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards across all content types",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/brand",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/brand/package.json
+++ b/plugins/brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brand",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "F5 corporate branding enforcement — colors, typography, logos, icons, accessibility, and visual identity standards",
   "license": "Apache-2.0"
 }

--- a/plugins/cloudstatus/.xcsh-plugin/plugin.json
+++ b/plugins/cloudstatus/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudstatus",
   "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API — status checks, incident tracking, maintenance windows, trend analysis, regional impact assessment, and stakeholder briefings",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/cloudstatus",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/cloudstatus/package.json
+++ b/plugins/cloudstatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudstatus",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Cloud service status monitoring and operational intelligence via Atlassian Statuspage.io API",
   "license": "Apache-2.0"
 }

--- a/plugins/devcontainer/.xcsh-plugin/plugin.json
+++ b/plugins/devcontainer/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer",
   "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance for the f5-sales-demo devcontainer",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/devcontainer",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/devcontainer/package.json
+++ b/plugins/devcontainer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devcontainer",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance",
   "license": "Apache-2.0"
 }

--- a/plugins/docs-pipeline/.xcsh-plugin/plugin.json
+++ b/plugins/docs-pipeline/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-pipeline",
   "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring, managed files, local preview",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/docs-pipeline",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/docs-pipeline/package.json
+++ b/plugins/docs-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-pipeline",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Documentation pipeline architecture — config ownership, release dispatch chain, content authoring",
   "license": "Apache-2.0"
 }

--- a/plugins/docs-tools/.xcsh-plugin/plugin.json
+++ b/plugins/docs-tools/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-tools",
   "description": "MDX content validation and review tools for f5-sales-demo docs repos",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/docs-tools",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/docs-tools/package.json
+++ b/plugins/docs-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-tools",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "MDX content validation and review tools",
   "license": "Apache-2.0"
 }

--- a/plugins/firecrawl/.xcsh-plugin/plugin.json
+++ b/plugins/firecrawl/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "firecrawl",
   "description": "Local self-hosted firecrawl web scraping — scrape, crawl, and map websites via the local firecrawl API on port 3002. No API keys, no subscriptions, fully open-source.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/firecrawl",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/firecrawl/package.json
+++ b/plugins/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firecrawl",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Local self-hosted firecrawl web scraping via local firecrawl API",
   "license": "Apache-2.0"
 }

--- a/plugins/gcloud/.xcsh-plugin/plugin.json
+++ b/plugins/gcloud/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gcloud",
   "description": "Google Cloud CLI integration — container-adapted auth, context injection, CLI operator agent, token expiry detection, and welcome screen status",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/gcloud",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/gcloud/package.json
+++ b/plugins/gcloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-gcloud",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Google Cloud CLI status for xcsh welcome screen",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GCloud",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/github/.xcsh-plugin/plugin.json
+++ b/plugins/github/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github",
   "description": "Poweruser GitHub & Git Operations plugin combining direct native CLI mastery (git and gh) with complete Git SOPs workflow governance (issue-driven development, feature branching, PR lifecycle, CI polling, auto-merge, and post-merge teardown)",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-github",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "GitHub CLI integration for xcsh — native tools for repos, issues, PRs, diffs, Actions, and search",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GitHub",
-    "version": "2.0.0",
+    "version": "2.0.2",
     "description": "GitHub CLI integration",
     "extensions": [
       "src/index.ts"

--- a/plugins/gitlab/.xcsh-plugin/plugin.json
+++ b/plugins/gitlab/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gitlab",
   "description": "GitLab CLI integration — native xcsh tools (glab_setup, glab_issue_list, glab_issue_view, glab_search), welcome screen status, and issue management via glab CLI",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/gitlab/package.json
+++ b/plugins/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-gitlab",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "GitLab CLI integration for xcsh — native tools, welcome screen status, issue management",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "GitLab",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "GitLab CLI integration",
     "extensions": [
       "src/index.ts"

--- a/plugins/herdr/.xcsh-plugin/plugin.json
+++ b/plugins/herdr/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr",
   "description": "Control Herdr, a terminal multiplexer for coding agents — inspect workspaces, tabs and panes, split panes, run commands without stealing focus, read pane output, and coordinate sibling agents. Requires HERDR_ENV=1.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/herdr",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/herdr/UPSTREAM.md
+++ b/plugins/herdr/UPSTREAM.md
@@ -3,6 +3,9 @@
 `skills/herdr/SKILL.md` is vendored **verbatim** from the Herdr project. Do not edit it here; change
 it upstream and re-vendor, otherwise `herdr-skill-freshness.yml` will fail.
 
+The marketplace registers this vendored skill under the canonical URI
+`skill://herdr:herdr`. Keep integration metadata here rather than adding it to the upstream file.
+
 | Field | Value |
 | --- | --- |
 | Upstream repository | <https://github.com/herdrdev/herdr> |

--- a/plugins/herdr/skills/herdr/SKILL.md
+++ b/plugins/herdr/skills/herdr/SKILL.md
@@ -3,8 +3,6 @@ name: herdr
 description: "Control Herdr, a terminal multiplexer for coding agents. Use only when the user explicitly mentions Herdr or asks to use Herdr to inspect or control panes, tabs, workspaces, commands, or another agent. Do not use merely because a task could benefit from a background terminal, delegation, or parallel work. Requires HERDR_ENV=1."
 ---
 
-**Canonical skill URI**: `skill://herdr:herdr`
-
 # Herdr
 
 Herdr organizes terminals into workspaces, tabs, and panes, recognizes coding agents running inside panes, and exposes the current session through the `herdr` CLI.

--- a/plugins/meddpicc/.xcsh-plugin/plugin.json
+++ b/plugins/meddpicc/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "meddpicc",
   "description": "MEDDPICC sales qualification and deal-execution framework — evidence-based deal management, stakeholder mapping, mutual action plans, and forecast integrity for complex enterprise B2B sales",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/meddpicc",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/meddpicc/engine/package.json
+++ b/plugins/meddpicc/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meddpicc/engine",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "private": true,
   "type": "module"
 }

--- a/plugins/meddpicc/package.json
+++ b/plugins/meddpicc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meddpicc",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "description": "MEDDPICC sales qualification and deal-execution framework",
   "license": "Apache-2.0",
   "workspaces": [

--- a/plugins/osint-framework/.xcsh-plugin/plugin.json
+++ b/plugins/osint-framework/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "osint-framework",
   "description": "OSINT Framework tool catalog and investigation skills — 1,064 free intelligence-gathering tools across 34 categories, mapped from osintframework.com. Category-based skills, executable investigation pipelines, CLI tool execution, and OPSEC-aware workflows.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/osint-framework/package.json
+++ b/plugins/osint-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osint-framework",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "OSINT Framework tool catalog and investigation skills — 1,064 intelligence-gathering tools across 34 categories",
   "license": "Apache-2.0"
 }

--- a/plugins/platform/.xcsh-plugin/plugin.json
+++ b/plugins/platform/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platform",
   "description": "F5 Distributed Cloud platform automation — web console via Chrome DevTools MCP and spec-aware REST API operations via cURL. Azure SSO authentication, deterministic navigation, API token management, and CRUD operations across 98 resource types with dependency-aware multi-step workflows.",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/platform",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/platform/package.json
+++ b/plugins/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "platform",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "description": "F5 Distributed Cloud platform automation — web console and spec-aware REST API operations",
   "license": "Apache-2.0"
 }

--- a/plugins/sales-engineer/.xcsh-plugin/plugin.json
+++ b/plugins/sales-engineer/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sales-engineer",
   "description": "Sales Engineer persona framework for F5 XC demo repositories — demo execution, environment operations, presentation, Q&A, post-session debrief",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/sales-engineer",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/sales-engineer/package.json
+++ b/plugins/sales-engineer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sales-engineer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Sales Engineer persona framework for demo execution and presentation",
   "license": "Apache-2.0"
 }

--- a/plugins/salesforce/.xcsh-plugin/plugin.json
+++ b/plugins/salesforce/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "salesforce",
   "description": "Salesforce pipeline intelligence — native xcsh tools (sf_setup, sf_query, sf_org_display, sf_pipeline_report), container-adapted authentication, context discovery, and pipeline reporting",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "author": {
     "name": "f5-sales-demo",
     "url": "https://github.com/f5-sales-demo"

--- a/plugins/salesforce/package.json
+++ b/plugins/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@f5-sales-demo/xcsh-salesforce",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Salesforce pipeline intelligence for xcsh — native tools, context discovery, pipeline reports",
   "main": "src/index.ts",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "xcsh": {
     "name": "Salesforce",
-    "version": "1.3.11",
+    "version": "1.3.12",
     "description": "Salesforce pipeline intelligence",
     "extensions": [
       "src/index.ts"


### PR DESCRIPTION
## Summary

Published the deterministic namespacing changes merged by #1111 under new installable plugin versions and restored Herdr's byte-identical upstream vendoring contract.

## Related Issue

Closes #1116

## Changes

- Patch-bumped all 17 marketplace plugins across catalog, plugin, and package manifests.
- Added one unambiguous release note for every new version.
- Restored the Herdr skill to the recorded upstream bytes and documented skill://herdr:herdr in UPSTREAM.md instead.

## Verification evidence

- scripts/validate-plugins.sh: all 17 manifests passed.
- scripts/check-version-bumps.sh origin/main: all 17 version bumps detected and accepted.
- scripts/run-plugin-tests.sh: every plugin suite passed.
- scripts/check-tests-are-hermetic.sh: no plugin test depends on a real cloud CLI.
- pre-commit run --all-files: all hooks passed.
- Herdr skill: 10,140 bytes; SHA-256 0786182f02ebf92708e09d82d79e4614d1a9c30bfc337643cc2af1d0fb9db29f; byte-identical to upstream.
- xcsh resolver regression: 51 passed, 0 failed across skill protocol, Bash URL expansion, and plugin display-name suites.
- scripts/agy-pre-push-review.sh: no critical or high finding remained.
- Required PR checks passed; the known advisory translation backlog remained outside #1116.

## Delivery evidence

- Squash-merged as 3c38268f91a9ef8f474cfe145840b31d739e9599.
- Release Plugins run 31497620941 published all 17 releases successfully.
- Main Validate Plugins run 31497620984 passed manifests, plugin suites, hermeticity, and published-tag auditing.
- Every new tag resolves to the merge commit and every release is non-draft and non-prerelease.
- An isolated xcsh profile discovered and installed all 17 exact versions from f5-sales-demo/marketplace; cached manifests, Herdr hash, and the installed GitHub canonical URI were verified.
- The 24 MB temporary xcsh UAT profile was deleted after verification.

## Checklist

- [x] Linked to a detailed issue with Closes #1116
- [x] Feature-complete and verified
- [x] Existing failing gates reproduce the defects and pass after the repair
- [x] Verified locally by running the actual validation and release paths
- [x] Pending, failed, behind, or conflicted states repaired through MERGED
- [x] Release artifacts installed and exercised through the consumer path
- [x] Follows project conventions
