### PR TITLE
fix(ci): isolate Bun installation on persistent runners

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -70,12 +70,11 @@ jobs:
             sudo apt-get update -qq && sudo apt-get install -y -qq jq
           fi
 
-      # Pinned, not a range: a floating runtime turns an unrelated bun release into a
-      # mystery CI failure.
+      # The repository-owned installer verifies the pinned release digest and extracts
+      # under runner.temp. Persistent runners may have a live Bun process in ~/.bun,
+      # which makes setup-bun's shared-home overwrite fail with ETXTBSY.
       - name: Install bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.14
+        run: ./scripts/install-ci-bun.sh
 
       - name: Run plugin test suites
         run: ./scripts/run-plugin-tests.sh

--- a/scripts/install-ci-bun.sh
+++ b/scripts/install-ci-bun.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Install the pinned CI Bun release without mutating a persistent runner user's home.
+set -euo pipefail
+
+bun_version=1.3.14
+
+if [[ -z "${RUNNER_TEMP:-}" || "$RUNNER_TEMP" != /* || "$RUNNER_TEMP" == *$'\n'* ]]; then
+  echo "RUNNER_TEMP must be an absolute path without newlines" >&2
+  exit 1
+fi
+if [[ -z "${GITHUB_PATH:-}" || "$GITHUB_PATH" != /* || "$GITHUB_PATH" == *$'\n'* ]]; then
+  echo "GITHUB_PATH must be an absolute path without newlines" >&2
+  exit 1
+fi
+
+for command_name in curl sha256sum uname unzip; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Required command is unavailable: ${command_name}" >&2
+    exit 1
+  fi
+done
+
+case "$(uname -m)" in
+x86_64)
+  bun_asset=bun-linux-x64.zip
+  expected_sha256=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f
+  ;;
+aarch64 | arm64)
+  bun_asset=bun-linux-aarch64.zip
+  expected_sha256=a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b
+  ;;
+*)
+  echo "Unsupported Linux architecture: $(uname -m)" >&2
+  exit 1
+  ;;
+esac
+
+install_root=$(mktemp -d "${RUNNER_TEMP%/}/bun-${bun_version}.XXXXXX")
+archive_path="${install_root}/${bun_asset}"
+download_url="https://github.com/oven-sh/bun/releases/download/bun-v${bun_version}/${bun_asset}"
+
+curl --fail --location --proto '=https' --show-error --silent --tlsv1.2 \
+  --output "$archive_path" "$download_url"
+printf '%s  %s\n' "$expected_sha256" "$archive_path" | sha256sum --check --status
+unzip -q "$archive_path" -d "$install_root"
+
+bun_bin_dir="${install_root}/${bun_asset%.zip}"
+actual_version=$("${bun_bin_dir}/bun" --version)
+if [[ "$actual_version" != "$bun_version" ]]; then
+  echo "Expected Bun ${bun_version}, got ${actual_version}" >&2
+  exit 1
+fi
+
+printf '%s\n' "$bun_bin_dir" >>"$GITHUB_PATH"
+printf 'Installed Bun %s in the runner temporary directory\n' "$actual_version"

--- a/tests/test-run-plugin-tests.sh
+++ b/tests/test-run-plugin-tests.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SOURCE_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 WORKFLOW="$SOURCE_ROOT/.github/workflows/validate-plugins.yml"
+INSTALLER="$SOURCE_ROOT/scripts/install-ci-bun.sh"
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
@@ -15,10 +16,26 @@ fail() {
   exit 1
 }
 
-if grep -Fq 'bun-version: 1.3.14' "$WORKFLOW"; then
+if grep -Fq 'bun_version=1.3.14' "$INSTALLER"; then
   pass "plugin CI uses current Bun 1.3.14"
 else
   fail "plugin CI must use current Bun 1.3.14"
+fi
+
+if grep -Fq 'run: ./scripts/install-ci-bun.sh' "$WORKFLOW" &&
+  ! grep -Fq 'oven-sh/setup-bun' "$WORKFLOW"; then
+  pass "plugin CI uses the repository-owned Bun installer"
+else
+  fail "plugin CI must avoid setup-bun's shared runner-home installation"
+fi
+
+if [ -x "$INSTALLER" ] &&
+  grep -Fq 'RUNNER_TEMP' "$INSTALLER" &&
+  grep -Fq '951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f' \
+    "$INSTALLER"; then
+  pass "Bun installer binds the verified artifact to runner temp"
+else
+  fail "Bun installer must be executable and verify the pinned artifact in runner temp"
 fi
 
 missing_locks=()


### PR DESCRIPTION
## Summary

Install the pinned Bun runtime under the per-job runner temporary directory so persistent runner processes cannot make CI fail with `ETXTBSY`. The installer verifies the official Bun 1.3.14 release SHA-256 before execution.

## Related Issue

Closes #1132

## Changes

- replace the shared-home setup-bun step with a repository-owned isolated installer
- verify the pinned x64 or ARM64 Linux release digest before adding Bun to `GITHUB_PATH`
- add regression coverage for the workflow route, pinned version, runner-temp isolation, and digest

## Verification evidence

- red test: `bash tests/test-run-plugin-tests.sh` failed until the isolated installer was wired in
- `bash tests/test-run-plugin-tests.sh` — 7 assertions passed
- actual installer execution — downloaded, verified, and executed Bun `1.3.14` from a fresh temp directory
- isolated `./scripts/run-plugin-tests.sh` — all plugin shell and Bun suites passed
- `./scripts/check-tests-are-hermetic.sh` — exited 0
- `./scripts/validate-plugins.sh` — all validation checks passed
- `bash scripts/check-pii.sh --scope head --mode enforce` — clean
- ShellCheck, shfmt, actionlint, bash syntax, and `git diff --check` — passed
- CI run [31543234570](https://github.com/f5-sales-demo/marketplace/actions/runs/31543234570) — required plugin suite passed

## Delivery evidence

- Squash-merged as `99cb6c45854ffe6ce6455760f3dae739889a57bc`.
- Task worktree and confirmed-merged local branch removed; main is clean and synchronized.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [x] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions