### PR TITLE
feat(cloudstatus): add live request-scoped map evidence

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -210,7 +210,7 @@
     {
       "name": "cloudstatus",
       "description": "Live cloud status and Internet network intelligence for xcsh — current incidents, routing, registration, RPKI, peering, facilities, F5 Regional Edge evidence, and bounded path diagnostics",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`cloudstatus`** v1.5.0 — adds request-scoped `locations [query]` discovery, current
+  provenance-normalized `MapLocationV1` evidence, live representative metro research, and one-call
+  parent-session `render_map` visualization. It requires xcsh 20.19.0 or later and ships no
+  gazetteer, coordinate table, address inventory, topology snapshot, or durable location cache
+  ([#1166](https://github.com/f5-sales-demo/marketplace/issues/1166)).
+
 - **`cloudstatus`** v1.4.0 — adds xcsh-native live Internet and F5 network intelligence for
   hostnames, addresses, prefixes, ASNs, routes, peers, IXPs, facilities, and bounded path
   diagnostics. The release resolves current topology from Statuspage, PeeringDB, RIPEstat, and

--- a/plugins/cloudstatus/.xcsh-plugin/plugin.json
+++ b/plugins/cloudstatus/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudstatus",
   "description": "Live cloud status and Internet network intelligence for xcsh — current incidents, routing, registration, RPKI, peering, facilities, F5 Regional Edge evidence, and bounded path diagnostics",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/cloudstatus",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/cloudstatus/README.md
+++ b/plugins/cloudstatus/README.md
@@ -30,6 +30,7 @@ Investigate example.net: registration, DNS answers, route origins, and RPKI.
 Which prefixes does AS35280 currently announce, and which neighbours are observed?
 Show the direct facilities and IX participation for AS64496.
 Where is the Frankfurt F5 Regional Edge? Separate facts from facility candidates.
+Show a current map of Canadian F5 Regional Edges with coordinate provenance.
 Is this network potentially transit-free? Tell me when the evidence is indeterminate.
 Troubleshoot the path to 192.0.2.25 with bounded diagnostics.
 ```
@@ -47,7 +48,7 @@ The existing slash command remains status-only:
 ```
 
 Location and general Internet questions route through skills from ordinary
-language; version 1.4.0 adds no new slash command.
+language; version 1.5.0 adds no new slash command.
 
 ## Investigation model
 
@@ -80,6 +81,12 @@ It uses these source classes in order:
 API throttling and source outages are expected operating conditions. HTTP calls
 have bounded timeouts and retries, duplicate requests are memoized within one
 invocation, and usable partial evidence is retained.
+
+For current Regional Edge inventories, `locations [query]` matches live
+country, region, metro, site code, and component names. It emits normalized
+`MapLocationV1` evidence. Visual intent returns that evidence to the parent xcsh
+session for one `render_map` call; factual intent stays text-first. The operator
+never calls a second renderer or `display_media`.
 
 ## Evidence boundaries
 
@@ -130,11 +137,14 @@ export STATUSPAGE_URL=https://status.example.net
 ```
 
 F5 location investigation always uses current F5 Statuspage and AS35280 source
-records. There is no topology-matrix or address override.
+records. Representative metro points may use current cited Wikidata entity
+data. Public Nominatim is not used. There is no topology-matrix, gazetteer,
+address override, or durable location cache.
 
 ## Runtime requirements
 
-- xcsh with plugin skill, task-agent, `skill://`, Bash, and web-search support
+- xcsh 20.19.0 or later, which provides provenance-aware `render_map`
+- Plugin skill, task-agent, `skill://`, Bash, and web-search support
 - Python 3 standard library for network collection
 - `curl` and `jq` for status reports
 - Network access to the selected live sources

--- a/plugins/cloudstatus/agents/cloudstatus-network-operator.md
+++ b/plugins/cloudstatus/agents/cloudstatus-network-operator.md
@@ -26,7 +26,7 @@ python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py inspe
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py route "$CLOUDSTATUS_QUERY"
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py peering "$CLOUDSTATUS_QUERY"
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py location "$CLOUDSTATUS_QUERY"
-python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py edges "$CLOUDSTATUS_QUERY"
+python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations "$CLOUDSTATUS_QUERY"
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py path "$CLOUDSTATUS_QUERY"
 ```
 
@@ -56,6 +56,9 @@ relationship evidence; otherwise report `indeterminate`.
 
 For location results, even the strongest public correlation is not proof that
 a particular F5 service instance occupies a building. Preserve that caveat.
+Return the collector's `map_locations` unchanged to the parent for visual
+intent. Do not invoke `render_map` from the delegated operator and never supply
+a remembered coordinate.
 
 ## Output
 

--- a/plugins/cloudstatus/package.json
+++ b/plugins/cloudstatus/package.json
@@ -1,6 +1,9 @@
 {
   "name": "cloudstatus",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Live cloud status and Internet network intelligence for xcsh",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@f5-sales-demo/xcsh": ">=20.19.0"
+  }
 }

--- a/plugins/cloudstatus/scripts/tests/test_network_lookup.py
+++ b/plugins/cloudstatus/scripts/tests/test_network_lookup.py
@@ -326,6 +326,200 @@ class PeeringTests(EngineTestCase):
         self.assertEqual(report["inferences"][0]["assessment"], "unresolved")
         self.assertNotIn("exact_facility", report["facts"])
 
+
+class LocationInventoryTests(EngineTestCase):
+    def peering_fixtures(self):
+        return PeeringTests.peering_fixtures(self)
+
+    def base_fixtures(self):
+        return {
+            "components.json": {
+                "components": [
+                    {
+                        "id": "group-fixture",
+                        "name": "Example Region Regional Edges",
+                        "group": True,
+                    },
+                    {
+                        "id": "edge-fv1",
+                        "name": "Fixtureville (fv1), Exampleland",
+                        "group": False,
+                        "group_id": "group-fixture",
+                        "status": "operational",
+                        "longitude": 12.25,
+                        "latitude": 45.5,
+                        "address": "Synthetic address from current fixture",
+                    },
+                    {
+                        "id": "edge-sample",
+                        "name": "Sampletown, Testland",
+                        "group": False,
+                        "group_id": "group-fixture",
+                        "status": "operational",
+                    },
+                ]
+            },
+            "net?asn=35280": {
+                "data": [{"id": 900, "asn": 35280, "name": "F5 synthetic"}]
+            },
+            "netfac?net_id=900": {"data": []},
+            "netixlan?net_id=900": {"data": []},
+            "query.wikidata.org": {
+                "results": {
+                    "bindings": [
+                        {
+                            "place": {
+                                "value": "http://www.wikidata.org/entity/Q900001"
+                            },
+                            "metroLabel": {"value": "Sampletown"},
+                            "countryLabel": {"value": "Testland"},
+                            "coordinate": {"value": "Point(-73.5 40.25)"},
+                        }
+                    ]
+                }
+            },
+        }
+
+    def test_global_inventory_normalizes_published_and_live_metro_coordinates(self):
+        report = self.engine.Investigator(
+            http=FakeHttp(self.engine, self.base_fixtures())
+        ).run("locations", "")
+
+        locations = report["facts"]["map_locations"]
+        self.assertEqual(len(locations), 2)
+        self.assertEqual(locations[0]["precision"], "approximate")
+        self.assertEqual(locations[0]["longitude"], 12.25)
+        self.assertEqual(locations[1]["precision"], "metro")
+        self.assertEqual(locations[1]["resolution"], "approximate")
+        self.assertEqual(locations[1]["latitude"], 40.25)
+        self.assertEqual(
+            report["facts"]["location_records"][0]["component"]["published_location"][
+                "address"
+            ],
+            "Synthetic address from current fixture",
+        )
+        for location in locations:
+            for source in location["sources"]:
+                self.assertTrue(source["url"].startswith("https://"))
+                self.assertTrue(source["sourceName"])
+                self.assertEqual(source["observedAt"], report["observed_at"])
+                self.assertTrue(source["claim"])
+
+    def test_country_region_metro_site_code_and_component_queries(self):
+        fixtures = self.base_fixtures()
+        for query in (
+            "Exampleland",
+            "Fixtureville",
+            "fv1",
+            "Fixtureville (fv1)",
+        ):
+            with self.subTest(query=query):
+                report = self.engine.Investigator(
+                    http=FakeHttp(self.engine, fixtures)
+                ).run("locations", query)
+                self.assertEqual(len(report["facts"]["map_locations"]), 1)
+                self.assertEqual(report["facts"]["map_locations"][0]["id"], "edge-fv1")
+        region = self.engine.Investigator(http=FakeHttp(self.engine, fixtures)).run(
+            "locations", "Example Region"
+        )
+        self.assertEqual(len(region["facts"]["map_locations"]), 2)
+
+    def test_multiple_facilities_remain_ambiguous_at_a_metro_point(self):
+        fixtures = self.base_fixtures()
+        fixtures["components.json"]["components"] = [
+            fixtures["components.json"]["components"][0],
+            {
+                "id": "edge-dual",
+                "name": "Dualtown, Testland",
+                "group": False,
+                "group_id": "group-fixture",
+                "status": "operational",
+            },
+        ]
+        fixtures["netfac?net_id=900"] = {"data": [{"fac_id": 41}, {"fac_id": 42}]}
+        fixtures["fac?id__in=41%2C42"] = {
+            "data": [
+                {"id": 41, "name": "Synthetic One", "city": "Dualtown"},
+                {"id": 42, "name": "Synthetic Two", "city": "Dualtown"},
+            ]
+        }
+        fixtures["query.wikidata.org"] = {
+            "results": {
+                "bindings": [
+                    {
+                        "place": {"value": "http://www.wikidata.org/entity/Q900002"},
+                        "metroLabel": {"value": "Dualtown"},
+                        "countryLabel": {"value": "Testland"},
+                        "coordinate": {"value": "Point(5 6)"},
+                    }
+                ]
+            }
+        }
+
+        record = self.engine.Investigator(http=FakeHttp(self.engine, fixtures)).run(
+            "locations", "Dualtown"
+        )["facts"]["location_records"][0]
+        self.assertEqual(record["placement_assessment"], "ambiguous")
+        self.assertEqual(len(record["direct_metro_facilities"]), 2)
+        self.assertEqual(record["map_location"]["resolution"], "ambiguous")
+        self.assertEqual(record["map_location"]["precision"], "metro")
+
+    def test_single_direct_metro_facility_is_an_inferred_candidate(self):
+        fixtures = self.base_fixtures()
+        fixtures["components.json"]["components"] = [
+            fixtures["components.json"]["components"][0],
+            {
+                "id": "edge-candidate",
+                "name": "Candidatetown, Testland",
+                "group": False,
+                "group_id": "group-fixture",
+                "status": "operational",
+            },
+        ]
+        fixtures["netfac?net_id=900"] = {"data": [{"fac_id": 51}]}
+        fixtures["fac?id__in=51"] = {
+            "data": [
+                {
+                    "id": 51,
+                    "name": "Synthetic Facility",
+                    "city": "Candidatetown",
+                    "longitude": 8,
+                    "latitude": 9,
+                }
+            ]
+        }
+        fixtures["query.wikidata.org"] = {"results": {"bindings": []}}
+
+        record = self.engine.Investigator(http=FakeHttp(self.engine, fixtures)).run(
+            "locations", "Candidatetown"
+        )["facts"]["location_records"][0]
+        self.assertEqual(record["placement_assessment"], "candidate")
+        self.assertEqual(record["map_location"]["precision"], "inferred")
+        self.assertEqual(record["map_location"]["resolution"], "candidate")
+        self.assertEqual(record["map_location"]["confidence"], "low")
+
+    def test_unresolved_result_is_preserved_without_coordinates(self):
+        fixtures = self.base_fixtures()
+        fixtures["components.json"]["components"] = [
+            fixtures["components.json"]["components"][0],
+            {
+                "id": "edge-unresolved",
+                "name": "Unresolved Place, Testland",
+                "group": False,
+                "group_id": "group-fixture",
+                "status": "operational",
+            },
+        ]
+        fixtures["query.wikidata.org"] = {"results": {"bindings": []}}
+
+        location = self.engine.Investigator(http=FakeHttp(self.engine, fixtures)).run(
+            "locations", "Unresolved"
+        )["facts"]["map_locations"][0]
+        self.assertEqual(location["precision"], "unresolved")
+        self.assertEqual(location["resolution"], "unresolved")
+        self.assertNotIn("longitude", location)
+        self.assertNotIn("latitude", location)
+
     def test_site_codes_are_extracted_only_from_live_component_names(self):
         fixtures = self.peering_fixtures() | {
             "components.json": {

--- a/plugins/cloudstatus/scripts/tests/test_network_lookup.py
+++ b/plugins/cloudstatus/scripts/tests/test_network_lookup.py
@@ -1,3 +1,4 @@
+# ruff: noqa: ANN001, ANN003, ANN201, ANN202, D101, D102, D103, D107, INP001, PT009, PT027, S101, TC003
 """Hermetic unit tests for the cloudstatus network lookup engine."""
 
 from __future__ import annotations
@@ -252,40 +253,39 @@ class RoutingTests(EngineTestCase):
         )
 
 
-class PeeringTests(EngineTestCase):
-    def peering_fixtures(self):
-        return {
-            "net?asn=35280": {
-                "data": [{"id": 777, "asn": 35280, "name": "F5 fixture"}]
-            },
-            "netfac?net_id=777": {"data": [{"fac_id": 10}, {"fac_id": 11}]},
-            "fac?id__in=10%2C11": {
-                "data": [
-                    {
-                        "id": 10,
-                        "name": "Fixture FR4",
-                        "city": "Frankfurt",
-                        "country": "DE",
-                        "address1": "Live street 1",
-                    },
-                    {
-                        "id": 11,
-                        "name": "Fixture FRA campus",
-                        "city": "Frankfurt",
-                        "country": "DE",
-                        "address1": "Live street 2",
-                    },
-                ]
-            },
-            "netixlan?net_id=777": {
-                "data": [{"ix_id": 20, "name": "Fixture IX", "ipaddr4": "192.0.2.1"}]
-            },
-            "ix?id__in=20": {"data": [{"id": 20, "name": "Fixture IX"}]},
-            "ixfac?ix_id__in=20": {"data": [{"ix_id": 20, "fac_id": 11}]},
-        }
+def peering_fixtures() -> dict[str, Any]:
+    return {
+        "net?asn=35280": {"data": [{"id": 777, "asn": 35280, "name": "F5 fixture"}]},
+        "netfac?net_id=777": {"data": [{"fac_id": 10}, {"fac_id": 11}]},
+        "fac?id__in=10%2C11": {
+            "data": [
+                {
+                    "id": 10,
+                    "name": "Fixture FR4",
+                    "city": "Frankfurt",
+                    "country": "DE",
+                    "address1": "Live street 1",
+                },
+                {
+                    "id": 11,
+                    "name": "Fixture FRA campus",
+                    "city": "Frankfurt",
+                    "country": "DE",
+                    "address1": "Live street 2",
+                },
+            ]
+        },
+        "netixlan?net_id=777": {
+            "data": [{"ix_id": 20, "name": "Fixture IX", "ipaddr4": "192.0.2.1"}]
+        },
+        "ix?id__in=20": {"data": [{"id": 20, "name": "Fixture IX"}]},
+        "ixfac?ix_id__in=20": {"data": [{"ix_id": 20, "fac_id": 11}]},
+    }
 
+
+class PeeringTests(EngineTestCase):
     def test_resolves_net_id_and_batches_facility_addresses(self):
-        http = FakeHttp(self.engine, self.peering_fixtures())
+        http = FakeHttp(self.engine, peering_fixtures())
         report = self.engine.Investigator(http=http).run("peering", "AS35280")
         self.assertEqual(report["facts"]["network"]["id"], 777)
         self.assertEqual(
@@ -297,7 +297,7 @@ class PeeringTests(EngineTestCase):
         self.assertIn("ix_facility_candidates", report["facts"])
 
     def test_location_keeps_ambiguous_metro_candidates_unresolved(self):
-        fixtures = self.peering_fixtures() | {
+        fixtures = peering_fixtures() | {
             "components.json": {
                 "components": [
                     {"id": "g1", "name": "Europe PoPs", "group": True},
@@ -328,9 +328,6 @@ class PeeringTests(EngineTestCase):
 
 
 class LocationInventoryTests(EngineTestCase):
-    def peering_fixtures(self):
-        return PeeringTests.peering_fixtures(self)
-
     def base_fixtures(self):
         return {
             "components.json": {
@@ -521,7 +518,7 @@ class LocationInventoryTests(EngineTestCase):
         self.assertNotIn("latitude", location)
 
     def test_site_codes_are_extracted_only_from_live_component_names(self):
-        fixtures = self.peering_fixtures() | {
+        fixtures = peering_fixtures() | {
             "components.json": {
                 "components": [
                     {"id": "g1", "name": "Europe Regional Edges", "group": True},

--- a/plugins/cloudstatus/scripts/tests/test_structure.sh
+++ b/plugins/cloudstatus/scripts/tests/test_structure.sh
@@ -22,7 +22,7 @@ test_plugin_metadata_is_consistent() {
   package_version=$(jq -r '.version' "$package_json")
   marketplace_version=$(jq -r '.plugins[] | select(.name == "cloudstatus") | .version' "$marketplace_json")
 
-  [ "$plugin_version" = "1.4.0" ] || {
+  [ "$plugin_version" = "1.5.0" ] || {
     echo "plugin version is $plugin_version"
     return 1
   }
@@ -34,6 +34,7 @@ test_plugin_metadata_is_consistent() {
     echo "marketplace version is $marketplace_version"
     return 1
   }
+  jq -e '.peerDependencies["@f5-sales-demo/xcsh"] == ">=20.19.0"' "$package_json" >/dev/null
 }
 
 test_expected_runtime_files_exist() {
@@ -44,6 +45,7 @@ test_expected_runtime_files_exist() {
     "skills/monitor/references/commands.md"
     "skills/location/SKILL.md"
     "skills/location/references/correlation-rules.md"
+    "skills/location/references/source-hints.md"
     "skills/network-intelligence/SKILL.md"
     "skills/network-intelligence/references/source-ladder.md"
     "skills/network-intelligence/references/query-playbook.md"
@@ -107,8 +109,12 @@ PY
 }
 
 test_no_runtime_topology_or_address_dataset() {
-  if find "$PLUGIN_ROOT" -type f \( -iname '*matrix*.json' -o -iname '*topology*.json' -o -iname '*address*.json' \) | grep -q .; then
-    echo "runtime topology or address dataset exists"
+  if find "$PLUGIN_ROOT" -type f \( \
+    -iname '*matrix*.json' -o -iname '*topology*.json' -o \
+    -iname '*address*.json' -o -iname '*gazetteer*' -o \
+    -iname '*coordinate*.json' -o -iname '*location-cache*' -o \
+    -iname '*inventory-snapshot*' \) | grep -q .; then
+    echo "runtime topology, location, or address dataset exists"
     return 1
   fi
 
@@ -121,6 +127,21 @@ test_no_runtime_topology_or_address_dataset() {
     echo "$matches"
     return 1
   }
+}
+
+test_locations_use_parent_render_map_contract() {
+  local skill="$PLUGIN_ROOT/skills/location/SKILL.md"
+  local operator="$PLUGIN_ROOT/agents/cloudstatus-network-operator.md"
+  grep -q 'locations \[query\]' "$skill"
+  grep -q 'parent xcsh' "$skill"
+  grep -q '`render_map` exactly once' "$skill"
+  grep -q 'Do not call `display_media` afterward' "$skill"
+  grep -q 'network_lookup.py locations' "$operator"
+}
+
+test_public_nominatim_endpoint_is_not_shipped() {
+  ! grep -rIqi 'nominatim\.openstreetmap\.org' \
+    "$PLUGIN_ROOT/agents" "$PLUGIN_ROOT/skills"
 }
 
 test_no_runtime_path_depends_on_plugin_cwd() {

--- a/plugins/cloudstatus/skills/location/SKILL.md
+++ b/plugins/cloudstatus/skills/location/SKILL.md
@@ -5,8 +5,11 @@ description: Investigates live public evidence for F5 Distributed Cloud Regional
 
 # F5 Regional Edge location investigation
 
-Use `location` for one metro or site code. Use `edges` when the user asks for
-the current discovered Regional Edge inventory or an optional component filter.
+Use `location` for a narrow factual investigation of one metro or site code.
+Use `locations [query]` for current Regional Edge inventories and every visual
+location request. An empty query discovers every currently published Regional
+Edge component; a query matches the live country, region, metro, site code, or
+component name.
 
 Delegate with the xcsh `task` tool:
 
@@ -25,9 +28,11 @@ tasks:
       inventory requested by the user.
 
       ## Change
-      Read `skill://cloudstatus:location/references/correlation-rules.md` and
-      the network source ladder. Run the `location` or `edges` collector, then
-      research only unresolved evidence.
+      Read `skill://cloudstatus:location/references/correlation-rules.md`,
+      `skill://cloudstatus:location/references/source-hints.md`, and the network
+      source ladder. Run `locations` for visual or inventory intent and
+      `location` for narrow factual intent, then research only unresolved
+      evidence from current official sources.
 
       ## Edge Cases
       Multiple same-metro facilities remain competing candidates. IX presence
@@ -35,9 +40,19 @@ tasks:
       F5 component names.
 
       ## Acceptance
-      Return observed facts, labelled correlations, unresolved questions, and
-      direct source links.
+      Return observed facts, labelled correlations, unresolved questions,
+      direct source links, and the collector's validated `map_locations` array.
 ```
 
 Pass the exact user query and selected operation to the task. Do not substitute a
 stored address or a remembered facility list.
+
+For “show”, “where”, “map”, or country/region inventory intent, the parent xcsh
+session must invoke `render_map` exactly once with the returned `MapLocationV1`
+array. The delegated operator gathers evidence but does not display media.
+Preserve unresolved entries in the tool input so the textual evidence remains
+complete. Do not call `display_media` afterward.
+
+Keep ordinary narrow factual requests text-first unless the human asks for a
+visual. If `render_map` is unavailable, return the evidence list and state the
+xcsh version requirement instead of inventing another display path.

--- a/plugins/cloudstatus/skills/location/references/correlation-rules.md
+++ b/plugins/cloudstatus/skills/location/references/correlation-rules.md
@@ -32,3 +32,17 @@ Do not describe facilities as Tier-1. Report measurable current attributes:
 
 An address is a property of the facility record. It is not proof of F5 service
 placement.
+
+## Map normalization
+
+Every plotted point must have a source consulted during the current request.
+Use a source-published component coordinate when available. A sole current
+site-code/facility correlation is still `inferred/candidate`; multiple
+facilities remain `ambiguous`. A uniquely matched current Wikidata place entity
+may supply a representative `metro/approximate` coordinate, but it must never
+be described as a facility or exact edge location.
+
+Return unresolved components as `MapLocationV1` entries without coordinates so
+`render_map` includes them in its textual evidence without placing markers.
+Never use remembered coordinates or convert an address to coordinates without a
+current cited source.

--- a/plugins/cloudstatus/skills/location/references/source-hints.md
+++ b/plugins/cloudstatus/skills/location/references/source-hints.md
@@ -1,0 +1,61 @@
+# Request-scoped Regional Edge source hints
+
+These hints are starting points, not a location database. Consult sources during
+the current request and retain the observation time, URL, source name, and the
+claim that supports every coordinate.
+
+## Stable starting points
+
+| Source | Request template | Expected current fields |
+| --- | --- | --- |
+| F5 Statuspage | `https://www.f5cloudstatus.com/api/v2/components.json` | component/group IDs, names, status, update time, and any source-published location fields |
+| PeeringDB network | `https://www.peeringdb.com/api/net?asn=35280` | current network ID and identity |
+| Direct facilities | `https://www.peeringdb.com/api/netfac?net_id=<current-id>` | network-to-facility relationships |
+| Exchange LANs | `https://www.peeringdb.com/api/netixlan?net_id=<current-id>` | exchange participation; never facility residence by itself |
+| Facility records | `https://www.peeringdb.com/api/fac?id__in=<current-ids>` | operator, metro, address fields, coordinates when published, site URL, and update time |
+| Exchange records | `https://www.peeringdb.com/api/ix?id__in=<current-ids>` and `ixfac?ix_id__in=<current-ids>` | exchange identity and limited facility candidates |
+| Wikidata Query Service | `https://query.wikidata.org/sparql?query=<encoded-query>&format=json` | current entity IDs, English labels, country labels, and P625 coordinates |
+
+Open current official operator or facility pages after the deterministic
+collector when a facility candidate matters. Prefer a page URL returned in the
+current facility record. Do not manufacture an operator URL from memory.
+
+## Evidence ranking
+
+1. A coordinate or address directly published in the current F5 component
+   record is direct evidence for that record.
+2. A live F5 site code correlated with direct AS35280 facility presence is a
+   facility candidate. Even a sole candidate is `inferred/candidate`, never
+   exact service placement.
+3. Direct AS35280 metro presence establishes only network presence in a metro.
+4. An exchange-to-facility relationship is a research lead, not AS or service
+   residence.
+5. A current Wikidata P625 coordinate may represent a named metro. Mark it
+   `metro/approximate`, cite the entity, and state that it is not a facility.
+6. When candidates conflict or no trustworthy coordinate is available, return
+   `ambiguous` or `unresolved` and omit coordinates.
+
+Never use model memory as evidence. Public Nominatim is excluded from this
+workflow. Do not infer coordinates from postal text or similar-looking site
+codes.
+
+## Rate and cache discipline
+
+- Run only after a human request; there is no scheduled discovery.
+- Fetch the Statuspage inventory and AS35280 joins once per collector
+  invocation.
+- Batch PeeringDB IDs and exact Wikidata metro labels; do not crawl records or
+  prefetch adjacent entities.
+- Honor HTTP 429 and `Retry-After`, keep retries bounded, and preserve partial
+  evidence when a source is unavailable.
+- Memoization is invocation-scoped. Do not write location responses, topology,
+  facility mappings, or coordinates to a runtime cache.
+
+## Generic normalization examples
+
+A fictional component `Fixtureville (fv1), Exampleland` with one current
+Wikidata entity may be normalized to a representative metro point with
+`precision: metro`, `resolution: approximate`, and a claim that the coordinate
+represents the metro only. If two current direct facilities remain possible,
+use `resolution: ambiguous`. If the live sources supply no trustworthy point,
+return an unresolved `MapLocationV1` entry without longitude or latitude.

--- a/plugins/cloudstatus/skills/network-intelligence/SKILL.md
+++ b/plugins/cloudstatus/skills/network-intelligence/SKILL.md
@@ -13,7 +13,7 @@ Choose the narrowest deterministic operation:
 | Origin, announcement, neighbour, looking-glass, or RPKI question | `route` |
 | ASN facilities, exchanges, interconnection, or transit-free assessment | `peering` |
 | F5 Regional Edge metro or site-code question | `location` |
-| Current F5 Regional Edge components | `edges` |
+| Current or visual F5 Regional Edge inventory | `locations` |
 | Clear reachability, latency, hop, or path troubleshooting intent | `path` |
 
 Run `path` automatically for clear troubleshooting or path-analysis intent when

--- a/plugins/cloudstatus/skills/network-intelligence/references/query-playbook.md
+++ b/plugins/cloudstatus/skills/network-intelligence/references/query-playbook.md
@@ -10,7 +10,7 @@ network_lookup.py inspect <hostname|IP|prefix|ASN>
 network_lookup.py route <IP|prefix|ASN>
 network_lookup.py peering <ASN>
 network_lookup.py location <metro|site-code>
-network_lookup.py edges [query]
+network_lookup.py locations [query]
 network_lookup.py path <hostname|IP>
 ```
 
@@ -50,6 +50,8 @@ usable results from another source.
 3. Resolve the current PeeringDB record for AS35280 by ASN.
 4. Batch facility and exchange joins.
 5. Apply the location correlation rules and leave ambiguous metros unresolved.
+6. For a visual request, return normalized `MapLocationV1` records to the parent
+   session for one `render_map` call. Keep unresolved entries in that array.
 
 ### Troubleshooting path
 

--- a/plugins/cloudstatus/skills/network-intelligence/references/source-ladder.md
+++ b/plugins/cloudstatus/skills/network-intelligence/references/source-ladder.md
@@ -67,6 +67,11 @@ IXP participant directories, and operator looking glasses. Useful searches:
 
 Prefer a record page over a search snippet.
 
+For a representative metro point only, query current Wikidata entity data and
+cite the selected entity. Require a unique label/country match, mark the point
+`metro/approximate`, and leave ambiguous matches unresolved. Public Nominatim
+is excluded from the v1 location workflow.
+
 ## 6. Measurements and research
 
 - RIPE RIS and Route Views for independent route observations

--- a/plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py
+++ b/plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: EM101, EM102, PLR2004, TRY003
 # pylint: disable=too-many-lines
 """Live Internet and F5 network evidence collector for cloudstatus.
 
@@ -1180,7 +1181,9 @@ ORDER BY ?metroLabel ?place
                 )
         return result
 
-    def _collect_locations(self, query: str = "") -> dict[str, Any]:
+    def _collect_locations(  # pylint: disable=too-many-locals
+        self, query: str = ""
+    ) -> dict[str, Any]:
         """Return current Regional Edge evidence normalized for render_map."""
         edge_facts = self._collect_edges(query)
         edges = edge_facts["edge_components"]
@@ -1207,6 +1210,10 @@ ORDER BY ?metroLabel ?place
             }
             coordinate_source: dict[str, Any] | None = None
             published_point = _coordinate(published)
+            exact_point = _coordinate(exact[0]) if len(exact) == 1 else None
+            direct_point = (
+                _coordinate(direct_metro[0]) if len(direct_metro) == 1 else None
+            )
             if published_point:
                 location.update(
                     {
@@ -1222,13 +1229,12 @@ ORDER BY ?metroLabel ?place
                     "sourceName": "F5 Statuspage components",
                     "claim": "The current component record publishes this coordinate.",
                 }
-            elif len(exact) == 1 and _coordinate(exact[0]):
-                point = _coordinate(exact[0])
+            elif exact_point:
                 facility_id = exact[0].get("id")
                 location.update(
                     {
-                        "longitude": point[0],
-                        "latitude": point[1],
+                        "longitude": exact_point[0],
+                        "latitude": exact_point[1],
                         "precision": "inferred",
                         "resolution": "candidate",
                         "confidence": "medium",
@@ -1239,13 +1245,12 @@ ORDER BY ?metroLabel ?place
                     "sourceName": "PeeringDB facility",
                     "claim": "This coordinate belongs to the sole direct AS35280 facility whose current name matches the live site code; it remains a facility candidate, not proven service placement.",
                 }
-            elif len(direct_metro) == 1 and _coordinate(direct_metro[0]):
-                point = _coordinate(direct_metro[0])
+            elif direct_point:
                 facility_id = direct_metro[0].get("id")
                 location.update(
                     {
-                        "longitude": point[0],
-                        "latitude": point[1],
+                        "longitude": direct_point[0],
+                        "latitude": direct_point[1],
                         "precision": "inferred",
                         "resolution": "candidate",
                         "confidence": "low",

--- a/plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py
+++ b/plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py
@@ -39,6 +39,8 @@ STATUSPAGE_COMPONENTS = "https://www.f5cloudstatus.com/api/v2/components.json"
 PEERINGDB_API = "https://www.peeringdb.com/api"
 RIPESTAT_API = "https://stat.ripe.net/data"
 IANA_RDAP = "https://data.iana.org/rdap"
+WIKIDATA_QUERY_SERVICE = "https://query.wikidata.org"
+MAX_WIKIDATA_METROS = 100
 
 
 class InvalidInputError(ValueError):
@@ -185,7 +187,7 @@ class HttpClient:
             url,
             headers={
                 "Accept": "application/json",
-                "User-Agent": "cloudstatus-network-intelligence/1.4.0",
+                "User-Agent": "cloudstatus-network-intelligence/1.5.0 (+https://github.com/f5-sales-demo/marketplace)",
             },
         )
         last_error: SourceError | None = None
@@ -339,11 +341,72 @@ def _site_codes(name: str) -> list[str]:
     codes = []
     for candidate in re.findall(r"\(([^()]*)\)", name):
         value = candidate.strip().lower()
-        if re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", value) and any(
-            char.isdigit() for char in value
-        ):
+        if len(value) <= 32 and re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", value):
             codes.append(value)
     return list(dict.fromkeys(codes))
+
+
+def _component_place(name: str) -> tuple[str, str]:
+    """Extract only the metro and country text published in a component name."""
+    parts = [part.strip() for part in name.split(",")]
+    metro = re.sub(r"\s*\([^()]*\)\s*$", "", parts[0]).strip() if parts else ""
+    country = parts[-1] if len(parts) > 1 else ""
+    return metro, country
+
+
+def _component_region(group: str) -> str:
+    """Return the live group name without inventing a regional taxonomy."""
+    return re.sub(
+        r"\s*(?:regional\s+edges?|pops?)\s*$", "", group, flags=re.IGNORECASE
+    ).strip()
+
+
+def _coordinate(record: dict[str, Any]) -> tuple[float, float] | None:
+    """Read coordinates only from documented, source-supplied field pairs."""
+    pairs = (("longitude", "latitude"), ("lon", "lat"))
+    for longitude_key, latitude_key in pairs:
+        try:
+            longitude = float(record[longitude_key])
+            latitude = float(record[latitude_key])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if -180 <= longitude <= 180 and -90 <= latitude <= 90:
+            return longitude, latitude
+    return None
+
+
+def _published_location(record: dict[str, Any]) -> dict[str, Any]:
+    """Retain current source fields without creating an embedded location dataset."""
+    result: dict[str, Any] = {}
+    coordinates = _coordinate(record)
+    if coordinates:
+        result["longitude"], result["latitude"] = coordinates
+    for field in ("address", "address1", "address2", "city", "state", "country"):
+        if record.get(field):
+            result[field] = record[field]
+    return result
+
+
+def _location_id(value: Any, index: int) -> str:
+    """Build a stable render_map-compatible ID from the live component ID."""
+    candidate = re.sub(r"[^A-Za-z0-9_.:-]+", "-", str(value or "")).strip("-.")
+    if not candidate or not candidate[0].isalnum():
+        candidate = f"regional-edge-{index + 1}"
+    return candidate[:128]
+
+
+def _wikidata_point(value: Any) -> tuple[float, float] | None:
+    """Parse the WKT Point value returned by the current Wikidata query."""
+    match = re.fullmatch(
+        r"Point\((-?(?:\d+(?:\.\d+)?|\.\d+)) (-?(?:\d+(?:\.\d+)?|\.\d+))\)",
+        str(value),
+    )
+    if not match:
+        return None
+    longitude, latitude = float(match.group(1)), float(match.group(2))
+    if not (-180 <= longitude <= 180 and -90 <= latitude <= 90):
+        return None
+    return longitude, latitude
 
 
 def _plain_text(value: Any, maximum: int = 65_536) -> str:
@@ -362,6 +425,7 @@ class Investigator:
         self.inferences: list[dict[str, Any]] = []
         self._source_urls: set[str] = set()
         self._required_successes = 0
+        self.observed_at = _utc_now()
 
     def _reset(self) -> None:
         self.sources = []
@@ -369,10 +433,13 @@ class Investigator:
         self.inferences = []
         self._source_urls = set()
         self._required_successes = 0
+        self.observed_at = _utc_now()
 
     def _source(self, name: str, url: str, *, required: bool = True) -> None:
         if url not in self._source_urls:
-            self.sources.append({"name": name, "url": url})
+            self.sources.append(
+                {"name": name, "url": url, "observed_at": self.observed_at}
+            )
             self._source_urls.add(url)
         if required:
             self._required_successes += 1
@@ -396,9 +463,13 @@ class Investigator:
     def run(self, operation: str, raw_query: str = "") -> dict[str, Any]:
         """Run one supported evidence operation and return its JSON-ready report."""
         self._reset()
-        if operation == "edges":
+        if operation in {"edges", "locations"}:
             query_text = normalize_location_query(raw_query, optional=True)
-            facts = self._collect_edges(query_text)
+            facts = (
+                self._collect_locations(query_text)
+                if operation == "locations"
+                else self._collect_edges(query_text)
+            )
             normalized = query_text
         elif operation == "location":
             query_text = normalize_location_query(raw_query)
@@ -433,7 +504,7 @@ class Investigator:
         return {
             "operation": operation,
             "query": normalized,
-            "observed_at": _utc_now(),
+            "observed_at": self.observed_at,
             "status": status,
             "facts": facts,
             "inferences": self.inferences,
@@ -720,7 +791,11 @@ class Investigator:
         return _compact_rdap(payload) if isinstance(payload, dict) else None
 
     def _collect_peering(
-        self, asn: int, *, include_relationship_context: bool
+        self,
+        asn: int,
+        *,
+        include_relationship_context: bool,
+        include_ix_facilities: bool = True,
     ) -> dict[str, Any]:
         net_url = build_url(PEERINGDB_API, "net", {"asn": asn})
         net_payload = self._request(net_url, "PeeringDB net")
@@ -755,7 +830,13 @@ class Investigator:
             }
 
         netfac, netixlan = self._peering_memberships(int(net_id))
-        facts = self._join_peering_records(network, networks, netfac, netixlan)
+        facts = self._join_peering_records(
+            network,
+            networks,
+            netfac,
+            netixlan,
+            include_ix_facilities=include_ix_facilities,
+        )
         if include_relationship_context:
             neighbours = self._ripe("asn-neighbours", f"AS{asn}")
             if neighbours is not None:
@@ -789,10 +870,14 @@ class Investigator:
         candidates: list[dict[str, Any]],
         netfac: list[dict[str, Any]],
         netixlan: list[dict[str, Any]],
+        *,
+        include_ix_facilities: bool,
     ) -> dict[str, Any]:
         """Batch PeeringDB joins while retaining direct and IX evidence separately."""
         ix_ids = self._record_ids(netixlan, "ix_id")
-        exchanges, ixfac = self._exchange_records(ix_ids)
+        exchanges, ixfac = self._exchange_records(
+            ix_ids, include_facilities=include_ix_facilities
+        )
         direct_ids = self._record_ids(netfac, "fac_id")
         facilities = self._facility_records(
             direct_ids | self._record_ids(ixfac, "fac_id")
@@ -830,7 +915,7 @@ class Investigator:
         }
 
     def _exchange_records(
-        self, ix_ids: set[int]
+        self, ix_ids: set[int], *, include_facilities: bool
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         """Batch-fetch exchange and exchange-facility records."""
         if not ix_ids:
@@ -839,6 +924,8 @@ class Investigator:
         exchanges = self._request(
             build_url(PEERINGDB_API, "ix", {"id__in": joined}), "PeeringDB ix"
         )
+        if not include_facilities:
+            return self._records(exchanges), []
         ixfac = self._request(
             build_url(PEERINGDB_API, "ixfac", {"ix_id__in": joined}), "PeeringDB ixfac"
         )
@@ -925,16 +1012,30 @@ class Investigator:
         for item in components:
             if item.get("group") is True or item.get("group_id") not in groups:
                 continue
+            name = str(item.get("name", ""))
+            group = str(groups[item.get("group_id")] or "")
+            metro, country = _component_place(name)
             record = {
                 "id": item.get("id"),
                 "name": item.get("name"),
                 "status": item.get("status"),
                 "group": groups[item.get("group_id")],
-                "site_codes": _site_codes(str(item.get("name", ""))),
+                "region": _component_region(group),
+                "metro": metro,
+                "country": country,
+                "site_codes": _site_codes(name),
                 "updated_at": item.get("updated_at"),
+                "published_location": _published_location(item),
             }
             searchable = " ".join(
-                [str(record["name"]), str(record["group"]), *record["site_codes"]]
+                [
+                    str(record["name"]),
+                    str(record["group"]),
+                    str(record["region"]),
+                    str(record["metro"]),
+                    str(record["country"]),
+                    *record["site_codes"],
+                ]
             ).casefold()
             if not query_lower or query_lower in searchable:
                 edges.append(record)
@@ -943,6 +1044,278 @@ class Investigator:
                 {"id": key, "name": value} for key, value in groups.items()
             ],
             "edge_components": edges,
+        }
+
+    def _wikidata_metro_candidates(
+        self, edges: list[dict[str, Any]]
+    ) -> dict[tuple[str, str], list[dict[str, Any]]]:
+        """Resolve representative metro points in one request-scoped Wikidata query."""
+        metros = sorted(
+            {
+                str(edge.get("metro", "")).strip()
+                for edge in edges
+                if str(edge.get("metro", "")).strip()
+            },
+            key=str.casefold,
+        )
+        if len(metros) > MAX_WIKIDATA_METROS:
+            self._error(
+                "investigation bound",
+                f"Wikidata metro lookup is limited to {MAX_WIKIDATA_METROS} unique names per request",
+            )
+            metros = metros[:MAX_WIKIDATA_METROS]
+        if not metros:
+            return {}
+        values = " ".join(
+            f"{json.dumps(metro, ensure_ascii=False)}@en" for metro in metros
+        )
+        query = f"""
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?place ?metroLabel ?countryLabel ?coordinate WHERE {{
+  VALUES ?metroLabel {{ {values} }}
+  ?place rdfs:label ?metroLabel ; wdt:P625 ?coordinate .
+  OPTIONAL {{
+    ?place wdt:P17 ?country .
+    ?country rdfs:label ?countryLabel .
+    FILTER(LANG(?countryLabel) = "en")
+  }}
+}}
+ORDER BY ?metroLabel ?place
+""".strip()
+        url = build_url(
+            WIKIDATA_QUERY_SERVICE, "sparql", {"query": query, "format": "json"}
+        )
+        payload = self._request(url, "Wikidata SPARQL", required=False)
+        bindings = (
+            payload.get("results", {}).get("bindings", [])
+            if isinstance(payload, dict)
+            else []
+        )
+        result: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for binding in bindings if isinstance(bindings, list) else []:
+            if not isinstance(binding, dict):
+                continue
+            metro = str(binding.get("metroLabel", {}).get("value", "")).strip()
+            country = str(binding.get("countryLabel", {}).get("value", "")).strip()
+            point = _wikidata_point(
+                binding.get("coordinate", {}).get("value")
+                if isinstance(binding.get("coordinate"), dict)
+                else None
+            )
+            entity = str(binding.get("place", {}).get("value", ""))
+            entity_match = re.fullmatch(
+                r"https?://www\.wikidata\.org/entity/(Q[1-9][0-9]*)", entity
+            )
+            if not metro or not point or not entity_match:
+                continue
+            candidate = {
+                "id": entity_match.group(1),
+                "metro": metro,
+                "country": country,
+                "longitude": point[0],
+                "latitude": point[1],
+                "url": f"https://www.wikidata.org/wiki/{entity_match.group(1)}",
+            }
+            key = (metro.casefold(), country.casefold())
+            if candidate not in result.setdefault(key, []):
+                result[key].append(candidate)
+        return result
+
+    @staticmethod
+    def _matching_facilities(
+        edge: dict[str, Any], facilities: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Return direct metro and stronger live site-code facility correlations."""
+        metro = str(edge.get("metro", "")).casefold()
+        direct_metro = [
+            facility
+            for facility in facilities
+            if metro
+            and (
+                metro in str(facility.get("city", "")).casefold()
+                or metro in str(facility.get("name", "")).casefold()
+            )
+        ]
+        exact = [
+            facility
+            for facility in direct_metro
+            if any(
+                re.search(
+                    rf"(?<![a-z0-9]){re.escape(code)}(?![a-z0-9])",
+                    str(facility.get("name", "")),
+                    re.IGNORECASE,
+                )
+                for code in edge.get("site_codes", [])
+            )
+        ]
+        return direct_metro, exact
+
+    def _location_sources(
+        self,
+        edge: dict[str, Any],
+        coordinate_source: dict[str, Any] | None = None,
+    ) -> list[dict[str, str]]:
+        """Build render_map provenance from sources consulted in this invocation."""
+        result = [
+            {
+                "url": STATUSPAGE_COMPONENTS,
+                "sourceName": "F5 Statuspage components",
+                "observedAt": self.observed_at,
+                "claim": f"The current Regional Edge component is published as {edge.get('name')!r} in {edge.get('group')!r}.",
+            }
+        ]
+        if coordinate_source:
+            coordinate_claim = str(coordinate_source["claim"])
+            if coordinate_source["url"] == STATUSPAGE_COMPONENTS:
+                result[0]["claim"] += f" {coordinate_claim}"
+            else:
+                result.append(
+                    {
+                        "url": str(coordinate_source["url"]),
+                        "sourceName": str(coordinate_source["sourceName"]),
+                        "observedAt": self.observed_at,
+                        "claim": coordinate_claim,
+                    }
+                )
+        return result
+
+    def _collect_locations(self, query: str = "") -> dict[str, Any]:
+        """Return current Regional Edge evidence normalized for render_map."""
+        edge_facts = self._collect_edges(query)
+        edges = edge_facts["edge_components"]
+        peering = self._collect_peering(
+            35280,
+            include_relationship_context=False,
+            include_ix_facilities=False,
+        )
+        facilities = peering.get("direct_facilities", [])
+        wikidata = self._wikidata_metro_candidates(edges)
+        records: list[dict[str, Any]] = []
+        map_locations: list[dict[str, Any]] = []
+
+        for index, edge in enumerate(edges):
+            direct_metro, exact = self._matching_facilities(edge, facilities)
+            published = edge.get("published_location", {})
+            location: dict[str, Any] = {
+                "id": _location_id(edge.get("id"), index),
+                "label": str(edge.get("name") or f"Regional Edge {index + 1}"),
+                "precision": "unresolved",
+                "resolution": "unresolved",
+                "confidence": "unknown",
+                "sources": self._location_sources(edge),
+            }
+            coordinate_source: dict[str, Any] | None = None
+            published_point = _coordinate(published)
+            if published_point:
+                location.update(
+                    {
+                        "longitude": published_point[0],
+                        "latitude": published_point[1],
+                        "precision": "approximate",
+                        "resolution": "resolved",
+                        "confidence": "high",
+                    }
+                )
+                coordinate_source = {
+                    "url": STATUSPAGE_COMPONENTS,
+                    "sourceName": "F5 Statuspage components",
+                    "claim": "The current component record publishes this coordinate.",
+                }
+            elif len(exact) == 1 and _coordinate(exact[0]):
+                point = _coordinate(exact[0])
+                facility_id = exact[0].get("id")
+                location.update(
+                    {
+                        "longitude": point[0],
+                        "latitude": point[1],
+                        "precision": "inferred",
+                        "resolution": "candidate",
+                        "confidence": "medium",
+                    }
+                )
+                coordinate_source = {
+                    "url": f"https://www.peeringdb.com/fac/{facility_id}",
+                    "sourceName": "PeeringDB facility",
+                    "claim": "This coordinate belongs to the sole direct AS35280 facility whose current name matches the live site code; it remains a facility candidate, not proven service placement.",
+                }
+            elif len(direct_metro) == 1 and _coordinate(direct_metro[0]):
+                point = _coordinate(direct_metro[0])
+                facility_id = direct_metro[0].get("id")
+                location.update(
+                    {
+                        "longitude": point[0],
+                        "latitude": point[1],
+                        "precision": "inferred",
+                        "resolution": "candidate",
+                        "confidence": "low",
+                    }
+                )
+                coordinate_source = {
+                    "url": f"https://www.peeringdb.com/fac/{facility_id}",
+                    "sourceName": "PeeringDB facility",
+                    "claim": "This coordinate belongs to the sole current direct AS35280 facility found in the metro; it is an indirect candidate and does not prove Regional Edge placement.",
+                }
+            else:
+                key = (
+                    str(edge.get("metro", "")).casefold(),
+                    str(edge.get("country", "")).casefold(),
+                )
+                candidates = wikidata.get(key, [])
+                if not candidates and not key[1]:
+                    candidates = [
+                        candidate
+                        for (metro, _country), values in wikidata.items()
+                        if metro == key[0]
+                        for candidate in values
+                    ]
+                unique = {candidate["id"]: candidate for candidate in candidates}
+                if len(unique) == 1:
+                    candidate = next(iter(unique.values()))
+                    location.update(
+                        {
+                            "longitude": candidate["longitude"],
+                            "latitude": candidate["latitude"],
+                            "precision": "metro",
+                            "resolution": "ambiguous"
+                            if len(direct_metro) > 1
+                            else "approximate",
+                            "confidence": "medium",
+                        }
+                    )
+                    coordinate_source = {
+                        "url": candidate["url"],
+                        "sourceName": "Wikidata Query Service entity",
+                        "claim": "This is a current representative metro coordinate; it does not identify an F5 facility or service placement.",
+                    }
+            if coordinate_source:
+                location["sources"] = self._location_sources(edge, coordinate_source)
+            record = {
+                "component": edge,
+                "direct_metro_facilities": direct_metro,
+                "site_code_facility_candidates": exact,
+                "placement_assessment": (
+                    "candidate"
+                    if len(exact) == 1 or len(direct_metro) == 1
+                    else "ambiguous"
+                    if len(exact) > 1 or len(direct_metro) > 1
+                    else "unresolved"
+                ),
+                "map_location": location,
+            }
+            records.append(record)
+            map_locations.append(location)
+
+        return {
+            "regional_edge_groups": edge_facts["regional_edge_groups"],
+            "location_records": records,
+            "map_locations": map_locations,
+            "as35280_network": peering.get("network"),
+            "ix_participation": peering.get("ix_participation", []),
+            "source_hints": {
+                "instructions": "skill://cloudstatus:location/references/source-hints.md",
+                "durable_cache": False,
+            },
         }
 
     def _collect_location(self, query: str) -> dict[str, Any]:
@@ -1162,8 +1535,9 @@ def build_parser() -> argparse.ArgumentParser:
     for operation in ("inspect", "route", "peering", "location", "path"):
         command = subparsers.add_parser(operation)
         command.add_argument("query")
-    edges = subparsers.add_parser("edges")
-    edges.add_argument("query", nargs="?", default="")
+    for operation in ("edges", "locations"):
+        command = subparsers.add_parser(operation)
+        command.add_argument("query", nargs="?", default="")
     return parser
 
 


### PR DESCRIPTION
## Summary

Release Cloudstatus 1.5.0 with deterministic, request-scoped Regional Edge discovery normalized for the provenance-aware `render_map` tool now released in xcsh 20.19.0.

## Related Issue

Closes #1166

## Changes

- add `locations [query]` for live global inventory and country, region, metro, site-code, or component filtering
- normalize published, candidate, approximate, ambiguous, and unresolved evidence to `MapLocationV1`
- add current Statuspage, PeeringDB, official-source, and Wikidata research guidance without shipping a location database
- route visual intent to exactly one parent-session `render_map` call while keeping narrow factual requests text-first
- release Cloudstatus 1.5.0 with `@f5-sales-demo/xcsh >=20.19.0`

## Verification evidence

- `bash plugins/cloudstatus/scripts/tests/run-tests.sh` — 21 passed, 0 skipped, 0 failed
- `bash scripts/validate-plugins.sh` — all marketplace and plugin manifests passed
- `bash scripts/run-plugin-tests.sh` — every plugin suite and dependency postcondition passed
- `pre-commit run --files <all changed files>` — governance, hygiene, prose, shell, JSON, spelling, security, and locale hooks passed
- live read-only `locations Canada` — complete, no source errors, all plotted records current-request provenance-valid
- live read-only global `locations` — complete, no source errors, no invalid plotted provenance; counts were treated as transient observations
- xcsh v20.19.0 release chain passed immutable GitHub release, Homebrew installation, npm publication, and npm installation/native-addon verification

## Delivery evidence

- xcsh prerequisite: https://github.com/f5-sales-demo/xcsh/releases/tag/v20.19.0
- feature branch includes current `origin/main` (`7d98577`)
- squash auto-merge and post-merge cleanup will be recorded through the delivery loop

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above

- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions and style guides