### PR TITLE
fix(ci): remove apt fallback from plugin validation

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -40,12 +40,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install jq
-        run: |
-          if ! command -v jq &> /dev/null; then
-            sudo apt-get update -qq && sudo apt-get install -y -qq jq
-          fi
-
       - name: Run plugin validation
         run: ./scripts/validate-plugins.sh
 
@@ -63,12 +57,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - name: Install jq
-        run: |
-          if ! command -v jq &> /dev/null; then
-            sudo apt-get update -qq && sudo apt-get install -y -qq jq
-          fi
 
       # The repository-owned installer verifies the pinned release digest and extracts
       # under runner.temp. Persistent runners may have a live Bun process in ~/.bun,


### PR DESCRIPTION
## Summary

Restore marketplace pull-request CI under the newly synced self-hosted-runner policy by removing redundant package-install fallbacks from the plugin validation workflow.

## Related Issue

Closes #1168

## Changes

- remove both conditional `sudo apt-get` jq installation steps
- retain runner selection, plugin validation, version checks, test execution, and hermeticity checks unchanged
- rely on the governed marketplace runner image, which already supplied jq to the passing #1167 plugin-suite job

## Verification evidence

- pre-change `audit-runner-workflows.py` failed for `validate` and `test` with the exact self-hosted sudo/apt finding
- post-change `audit-runner-workflows.py` passed: validated workflow routing and immutable pins
- `pre-commit run --files .github/workflows/validate-plugins.yml` passed every applicable hook, including Actions security
- `git diff --check` passed

## Delivery evidence

- Cloudstatus PR #1167 will update from corrected `main` after this isolated repair merges

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions and style guides