### PR TITLE
fix: harden Regional Edge registry routing

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -210,7 +210,7 @@
     {
       "name": "cloudstatus",
       "description": "Live cloud status and Internet network intelligence for xcsh — current incidents, routing, registration, RPKI, peering, facilities, F5 Regional Edge evidence, and bounded path diagnostics",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`cloudstatus`** v1.5.1 — makes `cloudstatus:location` the sole registry-only
+  workflow for every F5 Distributed Cloud Regional Edge request. It adds compact
+  `cloudstatus.locations/v1` map output, direct parent-session collection, and
+  routing guards against delegated or ad hoc location research ([#1170](https://github.com/f5-sales-demo/marketplace/issues/1170)).
+
 - **`cloudstatus`** v1.5.0 — adds request-scoped `locations [query]` discovery, current
   provenance-normalized `MapLocationV1` evidence, live representative metro research, and one-call
   parent-session `render_map` visualization. It requires xcsh 20.19.0 or later and ships no

--- a/plugins/cloudstatus/.xcsh-plugin/plugin.json
+++ b/plugins/cloudstatus/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudstatus",
   "description": "Live cloud status and Internet network intelligence for xcsh — current incidents, routing, registration, RPKI, peering, facilities, F5 Regional Edge evidence, and bounded path diagnostics",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/cloudstatus",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/cloudstatus/README.md
+++ b/plugins/cloudstatus/README.md
@@ -13,12 +13,12 @@ network workflow accepts arbitrary hostnames, IP addresses, prefixes, and ASNs.
 | Skill | Use it for |
 | --- | --- |
 | `cloudstatus:monitor` | Service health, incidents, maintenance, components, and status briefings |
-| `cloudstatus:location` | F5 Regional Edge metros, site codes, AS35280 presence, and facility candidates |
+| `cloudstatus:location` | All F5 Regional Edge maps, inventories, metros, site codes, addresses, and facility candidates |
 | `cloudstatus:network-intelligence` | DNS, RDAP, BGP origins, RPKI, routes, neighbours, facilities, IXPs, peering, and bounded path diagnostics |
 
 The plugin installs two task agents. The status operator has only `read` and
-`bash`; the network operator adds `web_search` for the documented fallback
-research ladder.
+`bash`; the general network operator adds `web_search` for its documented
+fallback research ladder. Regional Edge work is never delegated to that agent.
 
 ## Ask in natural language
 
@@ -48,7 +48,7 @@ The existing slash command remains status-only:
 ```
 
 Location and general Internet questions route through skills from ordinary
-language; version 1.5.0 adds no new slash command.
+language; version 1.5.1 adds no new slash command.
 
 ## Investigation model
 
@@ -82,11 +82,15 @@ API throttling and source outages are expected operating conditions. HTTP calls
 have bounded timeouts and retries, duplicate requests are memoized within one
 invocation, and usable partial evidence is retained.
 
-For current Regional Edge inventories, `locations [query]` matches live
-country, region, metro, site code, and component names. It emits normalized
-`MapLocationV1` evidence. Visual intent returns that evidence to the parent xcsh
-session for one `render_map` call; factual intent stays text-first. The operator
-never calls a second renderer or `display_media`.
+For every Regional Edge request, `cloudstatus:location` is the sole
+registry-only workflow. Its direct `locations --format map-v1 [query]` collector
+matches live country, region, metro, site code, and component names and emits
+the compact `cloudstatus.locations/v1` envelope with normalized `MapLocationV1`
+evidence. It consults F5 Statuspage, PeeringDB, and Wikidata only; missing or
+conflicting evidence stays unresolved. Visual intent returns that evidence to
+the parent xcsh session for one `render_map` call; factual intent stays
+text-first. It never delegates, runs general search, or calls a second renderer
+or `display_media`.
 
 ## Evidence boundaries
 

--- a/plugins/cloudstatus/agents/cloudstatus-network-operator.md
+++ b/plugins/cloudstatus/agents/cloudstatus-network-operator.md
@@ -1,6 +1,6 @@
 ---
 name: cloudstatus-network-operator
-description: Investigates live Internet routing, registration, interconnection, F5 Regional Edge location evidence, and bounded path diagnostics with explicit fact and inference boundaries.
+description: Investigates live Internet routing, registration, interconnection, and bounded path diagnostics with explicit fact and inference boundaries.
 tools:
   - read
   - bash
@@ -9,15 +9,13 @@ tools:
 
 # Cloudstatus network operator
 
-Investigate the exact hostname, IP, prefix, ASN, route, peer, IXP, facility,
-metro, site code, or troubleshooting target assigned by the parent skill.
+Investigate the exact hostname, IP, prefix, ASN, route, peer, IXP, facility, or
+troubleshooting target assigned by the parent skill.
 
 Read these resources before working:
 
 - `skill://cloudstatus:network-intelligence/references/source-ladder.md`
 - `skill://cloudstatus:network-intelligence/references/query-playbook.md`
-- For F5 location questions,
-  `skill://cloudstatus:location/references/correlation-rules.md`
 
 Run the deterministic collector first. Use one of its public interfaces:
 
@@ -25,8 +23,6 @@ Run the deterministic collector first. Use one of its public interfaces:
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py inspect "$CLOUDSTATUS_QUERY"
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py route "$CLOUDSTATUS_QUERY"
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py peering "$CLOUDSTATUS_QUERY"
-python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py location "$CLOUDSTATUS_QUERY"
-python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations "$CLOUDSTATUS_QUERY"
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py path "$CLOUDSTATUS_QUERY"
 ```
 
@@ -53,12 +49,6 @@ peering, IXP participation with private interconnection, facility presence
 with service placement, or anycast indicators with proven architecture. Never
 call a facility Tier-1. A potentially transit-free assessment requires
 relationship evidence; otherwise report `indeterminate`.
-
-For location results, even the strongest public correlation is not proof that
-a particular F5 service instance occupies a building. Preserve that caveat.
-Return the collector's `map_locations` unchanged to the parent for visual
-intent. Do not invoke `render_map` from the delegated operator and never supply
-a remembered coordinate.
 
 ## Output
 

--- a/plugins/cloudstatus/package.json
+++ b/plugins/cloudstatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudstatus",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Live cloud status and Internet network intelligence for xcsh",
   "license": "Apache-2.0",
   "peerDependencies": {

--- a/plugins/cloudstatus/scripts/tests/test_agent.sh
+++ b/plugins/cloudstatus/scripts/tests/test_agent.sh
@@ -62,4 +62,8 @@ test_network_operator_documents_evidence_boundaries() {
   grep -qi 'inference' "$agent"
   grep -qi 'unresolved' "$agent"
   grep -q 'web_search' "$agent"
+  if grep -Eq 'network_lookup\.py (location|locations)|correlation-rules' "$agent"; then
+    echo "general network operator still handles Regional Edge locations"
+    return 1
+  fi
 }

--- a/plugins/cloudstatus/scripts/tests/test_network_lookup.py
+++ b/plugins/cloudstatus/scripts/tests/test_network_lookup.py
@@ -517,6 +517,45 @@ class LocationInventoryTests(EngineTestCase):
         self.assertNotIn("longitude", location)
         self.assertNotIn("latitude", location)
 
+    def test_map_v1_is_compact_versioned_and_keeps_provenance(self):
+        report = self.engine.Investigator(
+            http=FakeHttp(self.engine, self.base_fixtures())
+        ).run("locations", "Exampleland")
+        compact = self.engine.compact_locations_report(report)
+
+        self.assertEqual(compact["schema"], "cloudstatus.locations/v1")
+        self.assertEqual(compact["query"], "Exampleland")
+        self.assertEqual(compact["observed_at"], report["observed_at"])
+        self.assertEqual(len(compact["map_locations"]), 1)
+        self.assertEqual(compact["evidence"][0]["component"]["id"], "edge-fv1")
+        self.assertTrue(compact["evidence"][0]["coordinate_provenance"])
+        serialized = json.dumps(compact)
+        self.assertNotIn("Synthetic address from current fixture", serialized)
+        self.assertNotIn("regional_edge_groups", compact)
+        self.assertNotIn("ix_participation", compact)
+
+    def test_map_v1_preserves_ambiguous_and_unresolved_locations(self):
+        fixtures = self.base_fixtures()
+        fixtures["components.json"]["components"] = [
+            fixtures["components.json"]["components"][0],
+            {
+                "id": "edge-fictional",
+                "name": "Fictional Place, Testland",
+                "group": False,
+                "group_id": "group-fixture",
+                "status": "operational",
+            },
+        ]
+        fixtures["query.wikidata.org"] = {"results": {"bindings": []}}
+        report = self.engine.Investigator(http=FakeHttp(self.engine, fixtures)).run(
+            "locations", "Fictional"
+        )
+        compact = self.engine.compact_locations_report(report)
+        location = compact["map_locations"][0]
+        self.assertEqual(location["resolution"], "unresolved")
+        self.assertNotIn("longitude", location)
+        self.assertEqual(compact["evidence"][0]["placement_assessment"], "unresolved")
+
     def test_site_codes_are_extracted_only_from_live_component_names(self):
         fixtures = peering_fixtures() | {
             "components.json": {
@@ -565,6 +604,34 @@ class LocationInventoryTests(EngineTestCase):
 
 
 class FailureModeTests(EngineTestCase):
+    def test_locations_map_v1_cli_emits_compact_contract(self):
+        full_report = {
+            "operation": "locations",
+            "query": "Canada",
+            "observed_at": "2026-08-15T00:00:00Z",
+            "status": "complete",
+            "facts": {
+                "map_locations": [],
+                "location_records": [],
+                "regional_edge_groups": [{"id": "raw", "name": "omitted"}],
+            },
+            "inferences": [],
+            "sources": [{"name": "F5 Statuspage components", "url": "https://example.test"}],
+            "errors": [],
+        }
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(self.engine, "Investigator") as investigator,
+            mock.patch("sys.stdout", stdout),
+        ):
+            investigator.return_value.run.return_value = full_report
+            code = self.engine.main(["locations", "--format", "map-v1", "Canada"])
+        self.assertEqual(code, 0)
+        result = json.loads(stdout.getvalue())
+        self.assertEqual(result["schema"], "cloudstatus.locations/v1")
+        self.assertEqual(result["query"], "Canada")
+        self.assertNotIn("facts", result)
+
     def test_partial_source_failure_keeps_usable_results(self):
         http = FakeHttp(
             self.engine,

--- a/plugins/cloudstatus/scripts/tests/test_network_lookup.py
+++ b/plugins/cloudstatus/scripts/tests/test_network_lookup.py
@@ -616,7 +616,9 @@ class FailureModeTests(EngineTestCase):
                 "regional_edge_groups": [{"id": "raw", "name": "omitted"}],
             },
             "inferences": [],
-            "sources": [{"name": "F5 Statuspage components", "url": "https://example.test"}],
+            "sources": [
+                {"name": "F5 Statuspage components", "url": "https://example.test"}
+            ],
             "errors": [],
         }
         stdout = io.StringIO()

--- a/plugins/cloudstatus/scripts/tests/test_structure.sh
+++ b/plugins/cloudstatus/scripts/tests/test_structure.sh
@@ -22,7 +22,7 @@ test_plugin_metadata_is_consistent() {
   package_version=$(jq -r '.version' "$package_json")
   marketplace_version=$(jq -r '.plugins[] | select(.name == "cloudstatus") | .version' "$marketplace_json")
 
-  [ "$plugin_version" = "1.5.0" ] || {
+  [ "$plugin_version" = "1.5.1" ] || {
     echo "plugin version is $plugin_version"
     return 1
   }
@@ -131,12 +131,21 @@ test_no_runtime_topology_or_address_dataset() {
 
 test_locations_use_parent_render_map_contract() {
   local skill="$PLUGIN_ROOT/skills/location/SKILL.md"
-  local operator="$PLUGIN_ROOT/agents/cloudstatus-network-operator.md"
+  local network_skill="$PLUGIN_ROOT/skills/network-intelligence/SKILL.md"
   grep -q 'locations \[query\]' "$skill"
   grep -q 'parent xcsh' "$skill"
   grep -q '`render_map` exactly once' "$skill"
   grep -q 'Do not call `display_media` afterward' "$skill"
-  grep -q 'network_lookup.py locations' "$operator"
+  grep -q 'locations --format map-v1' "$skill"
+  grep -q 'CLOUDSTATUS_QUERY' "$skill"
+  if grep -Eqi '^[[:space:]]*agent:|cloudstatus-network-operator|^[[:space:]]*tasks:' "$skill"; then
+    echo "location workflow delegates or permits prohibited research"
+    return 1
+  fi
+  if grep -Eq '^[[:space:]]*\|.*Regional Edge.*\|' "$network_skill" || grep -Eq 'network_lookup\.py (location|locations)' "$network_skill"; then
+    echo "general network skill advertises Regional Edge handling"
+    return 1
+  fi
 }
 
 test_public_nominatim_endpoint_is_not_shipped() {

--- a/plugins/cloudstatus/skills/location/SKILL.md
+++ b/plugins/cloudstatus/skills/location/SKILL.md
@@ -1,58 +1,44 @@
 ---
 name: location
-description: Investigates live public evidence for F5 Distributed Cloud Regional Edge locations. Use for an F5 metro, Regional Edge, site code, AS35280 facility, colocation, physical-address, or “where is this F5 edge?” question. Correlates current F5 Statuspage component names with current PeeringDB records and explicitly leaves exact building placement unresolved when evidence does not converge.
+description: The mandatory registry-only workflow for every F5 Distributed Cloud Regional Edge request. Use for maps, inventories, country, region, metro, site code, address, “show”, “where”, and “which Regional Edges” prompts. Collects current F5 Statuspage, PeeringDB AS35280, and Wikidata evidence without web search or remembered locations.
 ---
 
 # F5 Regional Edge location investigation
 
-Use `location` for a narrow factual investigation of one metro or site code.
-Use `locations [query]` for current Regional Edge inventories and every visual
-location request. An empty query discovers every currently published Regional
-Edge component; a query matches the live country, region, metro, site code, or
-component name.
+Any prompt mentioning F5 Distributed Cloud Regional Edges must use this skill.
+Do not route it to `cloudstatus:network-intelligence`, a general operator, web
+search, OSINT geolocation, remembered information, source-code inspection, or
+an ad hoc HTTP/Python command.
 
-Delegate with the xcsh `task` tool:
+Run the collector directly in the parent session exactly once. Pass the exact
+geographic filter through the Bash environment as `CLOUDSTATUS_QUERY`; do not
+interpolate user text into the command.
 
-```yaml
-agent: cloudstatus-network-operator
-context: >-
-  Goal: investigate F5 Regional Edge location evidence live. Distinguish
-  direct AS facility presence from IX candidates, and do not claim exact
-  service placement without converging evidence.
-tasks:
-  - id: InvestigateF5Location
-    description: Correlate current F5 location evidence
-    assignment: |-
-      ## Target
-      Investigate the exact metro, site code, address, or Regional Edge
-      inventory requested by the user.
+For inventory, map, show, where, country, region, or “which Regional Edges”
+intent, use the compact map contract:
 
-      ## Change
-      Read `skill://cloudstatus:location/references/correlation-rules.md`,
-      `skill://cloudstatus:location/references/source-hints.md`, and the network
-      source ladder. Run `locations` for visual or inventory intent and
-      `location` for narrow factual intent, then research only unresolved
-      evidence from current official sources.
-
-      ## Edge Cases
-      Multiple same-metro facilities remain competing candidates. IX presence
-      never proves facility residence. Use only site codes visible in current
-      F5 component names.
-
-      ## Acceptance
-      Return observed facts, labelled correlations, unresolved questions,
-      direct source links, and the collector's validated `map_locations` array.
+```bash
+python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"
 ```
 
-Pass the exact user query and selected operation to the task. Do not substitute a
-stored address or a remembered facility list.
+For one narrow factual metro, site-code, or address investigation, use:
 
-For “show”, “where”, “map”, or country/region inventory intent, the parent xcsh
-session must invoke `render_map` exactly once with the returned `MapLocationV1`
-array. The delegated operator gathers evidence but does not display media.
-Preserve unresolved entries in the tool input so the textual evidence remains
-complete. Do not call `display_media` afterward.
+```bash
+python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py location "$CLOUDSTATUS_QUERY"
+```
 
-Keep ordinary narrow factual requests text-first unless the human asks for a
-visual. If `render_map` is unavailable, return the evidence list and state the
-xcsh version requirement instead of inventing another display path.
+Bounded retries built into the collector are allowed. Do not run a second
+collector command, follow up with general research, or inspect raw registry
+responses. Keep missing or conflicting evidence visibly unresolved.
+
+For inventory, map, show, where, country, or region intent, invoke `render_map`
+exactly once in the parent session with the returned `MapLocationV1` array.
+Preserve unresolved entries in that input. Do not call `display_media` afterward.
+Narrow factual requests remain text-first unless the person explicitly asks for
+a visual.
+
+The answer must include a short collection receipt: `Cloudstatus registry
+collector`, its observation time, and the consulted F5 Statuspage, PeeringDB,
+and Wikidata sources (including unavailable sources when applicable). Then
+separate observed facts, facility correlations, inferences, and unresolved
+limitations. A facility candidate never proves a Regional Edge building.

--- a/plugins/cloudstatus/skills/network-intelligence/SKILL.md
+++ b/plugins/cloudstatus/skills/network-intelligence/SKILL.md
@@ -12,8 +12,6 @@ Choose the narrowest deterministic operation:
 | General hostname, IP, prefix, or ASN investigation | `inspect` |
 | Origin, announcement, neighbour, looking-glass, or RPKI question | `route` |
 | ASN facilities, exchanges, interconnection, or transit-free assessment | `peering` |
-| F5 Regional Edge metro or site-code question | `location` |
-| Current or visual F5 Regional Edge inventory | `locations` |
 | Clear reachability, latency, hop, or path troubleshooting intent | `path` |
 
 Run `path` automatically for clear troubleshooting or path-analysis intent when

--- a/plugins/cloudstatus/skills/network-intelligence/references/query-playbook.md
+++ b/plugins/cloudstatus/skills/network-intelligence/references/query-playbook.md
@@ -9,8 +9,6 @@ The standard-library collector emits JSON with `operation`, normalized `query`,
 network_lookup.py inspect <hostname|IP|prefix|ASN>
 network_lookup.py route <IP|prefix|ASN>
 network_lookup.py peering <ASN>
-network_lookup.py location <metro|site-code>
-network_lookup.py locations [query]
 network_lookup.py path <hostname|IP>
 ```
 
@@ -42,16 +40,6 @@ usable results from another source.
 4. Join direct facilities separately from IX participation and IX facilities.
 5. For a potentially transit-free assessment, seek current relationship data
    and official policy. Return `indeterminate` without it.
-
-### F5 location
-
-1. Discover live Regional Edge groups and components from F5 Statuspage.
-2. Extract only parenthesized site codes present in those names.
-3. Resolve the current PeeringDB record for AS35280 by ASN.
-4. Batch facility and exchange joins.
-5. Apply the location correlation rules and leave ambiguous metros unresolved.
-6. For a visual request, return normalized `MapLocationV1` records to the parent
-   session for one `render_map` call. Keep unresolved entries in that array.
 
 ### Troubleshooting path
 

--- a/plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py
+++ b/plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py
@@ -1535,7 +1535,16 @@ def _compact_component(edge: dict[str, Any]) -> dict[str, Any]:
     """Return public component evidence without retaining source payload fields."""
     return {
         key: edge.get(key)
-        for key in ("id", "name", "status", "group", "region", "metro", "country", "site_codes")
+        for key in (
+            "id",
+            "name",
+            "status",
+            "group",
+            "region",
+            "metro",
+            "country",
+            "site_codes",
+        )
     }
 
 

--- a/plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py
+++ b/plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py
@@ -188,7 +188,7 @@ class HttpClient:
             url,
             headers={
                 "Accept": "application/json",
-                "User-Agent": "cloudstatus-network-intelligence/1.5.0 (+https://github.com/f5-sales-demo/marketplace)",
+                "User-Agent": "cloudstatus-network-intelligence/1.5.1 (+https://github.com/f5-sales-demo/marketplace)",
             },
         )
         last_error: SourceError | None = None
@@ -1531,6 +1531,72 @@ def exit_code(report: dict[str, Any]) -> int:
     return 0
 
 
+def _compact_component(edge: dict[str, Any]) -> dict[str, Any]:
+    """Return public component evidence without retaining source payload fields."""
+    return {
+        key: edge.get(key)
+        for key in ("id", "name", "status", "group", "region", "metro", "country", "site_codes")
+    }
+
+
+def _compact_facility(
+    facility: dict[str, Any], classification: str, coordinate_provenance: str
+) -> dict[str, Any]:
+    """Keep only a facility candidate's map-relevant, non-sensitive evidence."""
+    return {
+        "id": facility.get("id"),
+        "name": facility.get("name"),
+        "metro": facility.get("city"),
+        "country": facility.get("country"),
+        "classification": classification,
+        "coordinate_provenance": coordinate_provenance,
+    }
+
+
+def compact_locations_report(report: dict[str, Any]) -> dict[str, Any]:
+    """Create the stable, render-oriented locations map-v1 response."""
+    facts = report.get("facts", {})
+    evidence: list[dict[str, Any]] = []
+    for record in facts.get("location_records", []):
+        candidates = [
+            _compact_facility(item, "direct-metro", "PeeringDB facility")
+            for item in record.get("direct_metro_facilities", [])
+        ]
+        for item in record.get("site_code_facility_candidates", []):
+            compact = _compact_facility(item, "site-code", "PeeringDB facility")
+            if compact not in candidates:
+                candidates.append(compact)
+        evidence.append(
+            {
+                "component": _compact_component(record.get("component", {})),
+                "placement_assessment": record.get("placement_assessment"),
+                "facility_candidates": candidates,
+                "coordinate_provenance": [
+                    {
+                        "source_name": source.get("sourceName"),
+                        "url": source.get("url"),
+                        "claim": source.get("claim"),
+                    }
+                    for source in record.get("map_location", {}).get("sources", [])
+                ],
+                "limitations": [
+                    "Facility candidates and metro coordinates do not prove Regional Edge service placement."
+                ],
+            }
+        )
+    return {
+        "schema": "cloudstatus.locations/v1",
+        "observed_at": report.get("observed_at"),
+        "query": report.get("query"),
+        "status": report.get("status"),
+        "map_locations": facts.get("map_locations", []),
+        "evidence": evidence,
+        "sources": report.get("sources", []),
+        "inferences": report.get("inferences", []),
+        "errors": report.get("errors", []),
+    }
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the command-line parser for supported lookup operations."""
     parser = argparse.ArgumentParser(
@@ -1543,6 +1609,8 @@ def build_parser() -> argparse.ArgumentParser:
     for operation in ("edges", "locations"):
         command = subparsers.add_parser(operation)
         command.add_argument("query", nargs="?", default="")
+        if operation == "locations":
+            command.add_argument("--format", choices=("full", "map-v1"), default="full")
     return parser
 
 
@@ -1560,6 +1628,8 @@ def main(argv: list[str] | None = None) -> int:
         report = Investigator().run(operation, query)
     except InvalidInputError as error:
         report = invalid_report(operation, query, str(error))
+    if getattr(namespace, "format", "full") == "map-v1":
+        report = compact_locations_report(report)
     print(json.dumps(report, indent=2, sort_keys=False, ensure_ascii=False))  # noqa: T201
     return exit_code(report)
 


### PR DESCRIPTION
## Summary
- make `cloudstatus:location` the sole, direct registry-only workflow for F5 Distributed Cloud Regional Edge prompts
- add compact `cloudstatus.locations/v1` output through `locations --format map-v1`
- remove Regional Edge routing from the general network operator and add collector/routing contracts

## Verification
- `python3 plugins/cloudstatus/scripts/tests/test_network_lookup.py -v`
- `bash plugins/cloudstatus/scripts/tests/run-tests.sh`
- `ruff check plugins/cloudstatus/skills/network-intelligence/scripts/network_lookup.py plugins/cloudstatus/scripts/tests/test_network_lookup.py`
- live read-only `locations --format map-v1 "United States"`

Closes #1170