### PR TITLE
fix(azure): enforce live CE research routing

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -241,8 +241,8 @@
     },
     {
       "name": "azure",
-      "description": "Azure CLI integration with deterministic F5 Customer Edge discovery, immutable plans, approved apply/resume, lifecycle, status, and diagnostics",
-      "version": "2.0.0",
+      "description": "Azure CLI integration with official-source research, live F5 Customer Edge discovery, immutable plans, approved apply/resume, lifecycle, status, and diagnostics",
+      "version": "2.0.1",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`azure`** v2.0.1 — makes current official F5 and Microsoft research plus live Azure
+  Marketplace enumeration a mandatory Customer Edge gate. Natural-language CE paraphrases receive
+  deterministic runtime routing, discovery no longer requires guessed image or VM identifiers, and
+  synthesized prompt traces verify research and tool order through xcsh. Numeric tool schemas are
+  also compatible with Gemini providers ([#1176](https://github.com/f5-sales-demo/marketplace/issues/1176)).
+
 - **`azure`** v2.0.0 and **`platform`** v4.0.0 — add deterministic F5 Distributed Cloud
   Customer Edge administration for Azure Secure Mesh Site v2. The release adds live
   subscription-aware discovery, immutable plan/apply and resume, lifecycle and diagnostics,

--- a/docs/en/changelog.mdx
+++ b/docs/en/changelog.mdx
@@ -7,6 +7,15 @@ sidebar:
 
 Notable changes to the f5-sales-demo marketplace.
 
+## Azure 2.0.1
+
+- Require current official F5 and Microsoft research plus live Azure catalog and
+  subscription observations before CE recommendations or plans.
+- Route realistic Customer Edge paraphrases through a runtime research gate and
+  allow discovery to resolve exact image and VM identifiers without guesses.
+- Add synthesized prompt traces that verify the real xcsh tool sequence and fix
+  Gemini compatibility for numeric CE tool parameters.
+
 ## Azure 2.0.0 and Platform 4.0.0
 
 - Add deterministic F5 Customer Edge discovery, immutable planning, approved

--- a/docs/en/plugins/f5xc-azure.mdx
+++ b/docs/en/plugins/f5xc-azure.mdx
@@ -10,7 +10,7 @@ import { Aside, Badge } from '@astrojs/starlight/components';
 The **Azure** plugin keeps its generic Azure CLI tools and adds deterministic
 F5 Distributed Cloud Customer Edge (CE) administration for Secure Mesh Site v2.
 
-<Badge text="v2.0.0" variant="note" /> <Badge text="Development" variant="tip" />
+<Badge text="v2.0.1" variant="note" /> <Badge text="Development" variant="tip" />
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ F5 Distributed Cloud Customer Edge (CE) administration for Secure Mesh Site v2.
 
 | Tool | Purpose |
 | --- | --- |
-| `azure_compute_discover` | Rank regions using exact image, SKU, NIC, zone, quota, policy, Route Server, terms, and brownfield evidence |
+| `azure_compute_discover` | Enumerate the live Marketplace catalog and rank regions using exact image, SKU, NIC, zone, quota, policy, Route Server, terms, and brownfield evidence |
 | `azure_ce_plan` | Compile natural-language intent into a canonical secret-free plan and SHA-256 |
 | `azure_ce_apply` | Apply or resume only the exact persisted plan after stale-state and ownership checks |
 | `azure_ce_status` | Correlate Azure resources, checkpoints, Route Server peers, and F5 evidence |
@@ -32,6 +32,18 @@ F5 Distributed Cloud Customer Edge (CE) administration for Secure Mesh Site v2.
 The `azure-ce` skill coordinates authentication, discovery, recommendation,
 approval, Secure Mesh Site v2 creation, one-use bootstrap checkout, virtual
 machine launch, registration gates, routing activation, and verification.
+
+## Mandatory research gate
+
+Natural-language requests such as “F5 edge appliance,” “XC CE,” and “Secure Mesh
+node” route to the CE workflow. Before recommending an image, size, or region,
+the workflow retrieves the current official F5 Azure deployment guide and
+Microsoft Marketplace/SKU guidance. It then enumerates the live publisher,
+offer, image SKU, exact version, and compatible subscription-aware VM sizes.
+User-supplied catalog values are constraints to verify, never trusted defaults.
+
+The discovery result includes a secret-free research receipt and session
+artifact. Planning fails closed when that live discovery artifact is absent.
 
 <Aside type="caution">
   A plan never contains bootstrap material. Platform returns an opaque
@@ -64,6 +76,13 @@ Run `azure_ce_status`, `f5xc_ce_v2_status`, and passive
 `azure_ce_diagnose`. Confirm the expected node count, healthy registration,
 established BGP when applicable, correct effective routes, and a complete
 checkpoint.
+
+Maintainers can run a real synthesized-prompt trace without cloud mutation:
+
+```bash
+cd plugins/azure
+bun run eval:ce-prompt single-node-greenfield
+```
 
 ## Clean up
 

--- a/docs/en/plugins/index.mdx
+++ b/docs/en/plugins/index.mdx
@@ -22,7 +22,7 @@ branding, and development operations.
 | [f5xc-meddpicc](/marketplace/en/plugins/f5xc-meddpicc/) | 1.0.4 | Productivity | MEDDPICC sales qualification and deal-execution framework |
 | [f5xc-devcontainer](/marketplace/en/plugins/f5xc-devcontainer/) | 1.1.6 | Productivity | Container awareness — tool catalog, self-identity, self-diagnosis, and maintenance |
 | [f5xc-platform](/marketplace/en/plugins/f5xc-platform/) | 4.0.0 | Productivity | F5 XC platform automation with Secure Mesh Site v2 Customer Edge tools |
-| [Azure](/marketplace/en/plugins/f5xc-azure/) | 2.0.0 | Development | Azure CLI and deterministic F5 Customer Edge administration |
+| [Azure](/marketplace/en/plugins/f5xc-azure/) | 2.0.1 | Development | Azure CLI and research-backed deterministic F5 Customer Edge administration |
 | [osint-framework](/marketplace/en/plugins/osint-framework/) | 1.0.1 | Security | OSINT tool catalog and investigation skills — 1,064 free tools across 34 categories, investigation pipelines, correlation engine |
 | [f5xc-firecrawl](/marketplace/en/plugins/f5xc-firecrawl/) | 1.1.0 | Productivity | Local self-hosted web scraping — scrape, crawl, map, search, extract via firecrawl on localhost:3002 |
 

--- a/plugins/azure/.xcsh-plugin/plugin.json
+++ b/plugins/azure/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "azure",
   "description": "Azure CLI integration and deterministic F5 Customer Edge discovery, planning, lifecycle, and diagnostics",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/azure",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/azure/benchmarks/ce-prompt-scenarios.json
+++ b/plugins/azure/benchmarks/ce-prompt-scenarios.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "scenarios": [
+    {
+      "id": "single-node-greenfield",
+      "prompt": "I need an F5 Distributed Cloud Customer Edge in Azure named ce-research-eval with one node and two NICs in a new resource group named rg-ce-research-eval. Research the current official requirements and live options, then recommend the region, exact Marketplace image, and VM size. Do not create a plan or change anything.",
+      "requiredTools": ["web_search", "az_account_show", "azure_compute_discover"],
+      "forbiddenTools": ["az_exec", "azure_ce_plan", "azure_ce_apply"]
+    },
+    {
+      "id": "ha-brownfield",
+      "prompt": "Investigate a three-node highly available XC Customer Edge deployment named ce-ha-research in resource group rg-ce-ha-research into an existing Azure VNet. It needs four ordered interfaces and Route Server/BGP. Use current vendor documentation and my live subscription to identify viable regions, the real image plan and version, and compatible sizes. I will provide the brownfield resource IDs later, so use an empty brownfield list for this research pass. Research and report only; do not mutate or plan yet.",
+      "requiredTools": ["web_search", "az_account_show", "azure_compute_discover"],
+      "forbiddenTools": ["az_exec", "azure_ce_plan", "azure_ce_apply"]
+    },
+    {
+      "id": "marketplace-paraphrase",
+      "prompt": "Find the right Azure Marketplace F5 edge appliance for running Distributed Cloud close to my apps. Use the proposed name ce-edge-research and resource group rg-ce-edge-research. I want a single appliance with eight interfaces. Verify the current F5 and Microsoft guidance and check my subscription before recommending anything. Do not deploy resources or create a plan.",
+      "requiredTools": ["web_search", "az_account_show", "azure_compute_discover"],
+      "forbiddenTools": ["az_exec", "azure_ce_plan", "azure_ce_apply"]
+    },
+    {
+      "id": "lifecycle-research",
+      "prompt": "Before I resize our Azure Secure Mesh deployment ce-lifecycle-research in resource group rg-ce-lifecycle-research, research the current Customer Edge compute requirements and discover which subscription-aware VM sizes support all eight NICs. Give me evidence only and make no changes or plan.",
+      "requiredTools": ["web_search", "az_account_show", "azure_compute_discover"],
+      "forbiddenTools": ["az_exec", "azure_ce_plan", "azure_ce_apply"]
+    }
+  ]
+}

--- a/plugins/azure/benchmarks/verify-ce-prompt-trace.ts
+++ b/plugins/azure/benchmarks/verify-ce-prompt-trace.ts
@@ -1,0 +1,98 @@
+interface PromptScenario {
+  id: string;
+  prompt: string;
+  requiredTools: string[];
+  forbiddenTools: string[];
+}
+
+interface PromptScenarioFile {
+  version: number;
+  scenarios: PromptScenario[];
+}
+
+export interface TraceEvaluation {
+  pass: boolean;
+  tools: string[];
+  errors: string[];
+}
+
+interface TraceEvent {
+  type?: string;
+  toolName?: string;
+  result?: { isError?: boolean; content?: Array<{ type?: string; text?: string }> };
+}
+
+export function parseTrace(jsonl: string): TraceEvent[] {
+  return jsonl
+    .split(/\r?\n/)
+    .filter((line) => line.trim().startsWith('{'))
+    .map((line) => {
+      try {
+        return JSON.parse(line) as TraceEvent;
+      } catch {
+        return {};
+      }
+    });
+}
+
+export function evaluateTrace(scenario: PromptScenario, jsonl: string): TraceEvaluation {
+  const events = parseTrace(jsonl);
+  const starts = events.filter((event) => event.type === 'tool_execution_start' && event.toolName);
+  const tools = starts.map((event) => String(event.toolName));
+  const errors: string[] = [];
+
+  for (const required of scenario.requiredTools) {
+    if (!tools.includes(required)) errors.push(`missing required tool: ${required}`);
+  }
+  for (const forbidden of scenario.forbiddenTools) {
+    if (tools.includes(forbidden)) errors.push(`forbidden tool invoked: ${forbidden}`);
+  }
+
+  const discoverIndex = tools.indexOf('azure_compute_discover');
+  for (const prerequisite of ['web_search', 'az_account_show']) {
+    const index = tools.indexOf(prerequisite);
+    if (discoverIndex >= 0 && index >= discoverIndex)
+      errors.push(`${prerequisite} must complete before azure_compute_discover is invoked`);
+  }
+  const planIndex = tools.indexOf('azure_ce_plan');
+  if (planIndex >= 0 && (discoverIndex < 0 || planIndex < discoverIndex))
+    errors.push('azure_ce_plan was invoked before live discovery');
+
+  const discoveryResult = events.find(
+    (event) => event.type === 'tool_execution_end' && event.toolName === 'azure_compute_discover',
+  );
+  if (!discoveryResult) {
+    errors.push('missing azure_compute_discover result');
+  } else {
+    if (discoveryResult.result?.isError) errors.push('azure_compute_discover returned an error');
+    const evidence = (discoveryResult.result?.content ?? []).map((item) => item.text ?? '').join('\n');
+    if (!evidence.includes('Research: live Azure CLI catalog and subscription observations'))
+      errors.push('discovery result lacks the live-research receipt');
+    if (!evidence.includes('Official sources: retrieved live from F5 and Microsoft'))
+      errors.push('discovery result lacks live official-source evidence');
+    if (!evidence.includes('Pinned image: f5-networks:')) errors.push('discovery result lacks an observed F5 image');
+    if (!evidence.includes('Compatible VM sizes: Standard_'))
+      errors.push('discovery result lacks compatible VM-size evidence');
+    if (!evidence.includes('Discovery artifact: artifact://')) errors.push('discovery result lacks a session artifact');
+  }
+
+  return { pass: errors.length === 0, tools, errors };
+}
+
+async function main(): Promise<void> {
+  const scenarioPath = process.argv[2];
+  const scenarioId = process.argv[3];
+  const tracePath = process.argv[4];
+  if (!scenarioPath || !scenarioId || !tracePath) {
+    console.error('usage: bun benchmarks/verify-ce-prompt-trace.ts <scenarios.json> <scenario-id> <trace.jsonl>');
+    process.exit(2);
+  }
+  const data = (await Bun.file(scenarioPath).json()) as PromptScenarioFile;
+  const scenario = data.scenarios.find((item) => item.id === scenarioId);
+  if (!scenario) throw new Error(`Unknown prompt scenario: ${scenarioId}`);
+  const evaluation = evaluateTrace(scenario, await Bun.file(tracePath).text());
+  console.log(JSON.stringify({ scenario: scenario.id, ...evaluation }, null, 2));
+  if (!evaluation.pass) process.exit(1);
+}
+
+if (import.meta.main) await main();

--- a/plugins/azure/package.json
+++ b/plugins/azure/package.json
@@ -1,15 +1,16 @@
 {
   "name": "@f5-sales-demo/xcsh-azure",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Azure CLI tools and deterministic F5 Customer Edge administration for xcsh",
   "main": "src/index.ts",
   "scripts": {
     "test": "bun test",
-    "test:watch": "bun test --watch"
+    "test:watch": "bun test --watch",
+    "eval:ce-prompt": "bash scripts/evals/run-ce-prompt-eval.sh"
   },
   "xcsh": {
     "name": "Azure",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "extensions": [
       "src/index.ts"
     ]

--- a/plugins/azure/scripts/evals/run-ce-prompt-eval.sh
+++ b/plugins/azure/scripts/evals/run-ce-prompt-eval.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+scenario_file="$plugin_dir/benchmarks/ce-prompt-scenarios.json"
+scenario_id=${1:-single-node-greenfield}
+model=${2:-google-antigravity/gemini-3-flash}
+trace_file=$(mktemp "${TMPDIR:-/tmp}/azure-ce-prompt-trace.XXXXXX.jsonl")
+trap 'rm -f "$trace_file"' EXIT
+
+prompt=$(jq -er --arg id "$scenario_id" '.scenarios[] | select(.id == $id) | .prompt' "$scenario_file")
+
+xcsh \
+  --model "$model" \
+  --thinking minimal \
+  --mode json \
+  --plugin-dir "$plugin_dir" \
+  --no-session \
+  -p "$prompt" >"$trace_file"
+
+bun "$plugin_dir/benchmarks/verify-ce-prompt-trace.ts" "$scenario_file" "$scenario_id" "$trace_file"

--- a/plugins/azure/skills/azure-ce/SKILL.md
+++ b/plugins/azure/skills/azure-ce/SKILL.md
@@ -2,10 +2,12 @@
 name: azure-ce
 description: >-
   Discover, plan, deploy, reconcile, operate, diagnose, repair, and tear down F5
-  Distributed Cloud Customer Edge on Azure with Secure Mesh Site v2. Use for any
-  Azure CE request involving one-node or three-node HA topology, ordered NICs,
-  Marketplace images, Route Server/BGP, UDRs, brownfield networks, lifecycle
-  changes, cloud-init, or cross-plane Azure and F5 health evidence.
+  Distributed Cloud Customer Edge on Azure with Secure Mesh Site v2. Use whenever
+  the user says Customer Edge, F5 CE, XC CE, Distributed Cloud node, Secure Mesh,
+  cloud CE appliance, three-node F5 cluster, CE image, CE Marketplace appliance,
+  or asks to deploy or operate F5 Distributed Cloud in Azure. Covers one-node or
+  three-node HA topology, ordered NICs, Marketplace images, Route Server/BGP,
+  UDRs, brownfield networks, lifecycle changes, cloud-init, and cross-plane health.
 ---
 
 # Azure Customer Edge
@@ -16,25 +18,54 @@ Read [contracts.md](references/contracts.md) before planning or mutating a CE si
 
 ## Orchestration
 
-1. Check Azure authentication with `az_account_show`. Check Platform authentication
+1. Research the current vendor procedure before making any recommendation. Use
+   `web_search` to retrieve the official F5 **Deploy Secure Mesh Site v2 in Azure**
+   guide from `docs.cloud.f5.com` and Microsoft image/SKU guidance from
+   `learn.microsoft.com`. Read the relevant results and cite their titles and URLs.
+   Do not substitute memory, cached identifiers, third-party pages, or generic CLI
+   help. If current official sources cannot be retrieved, stop before recommending
+   a catalog tuple, region, VM size, or plan.
+2. Check Azure authentication with `az_account_show`. Check Platform authentication
    without displaying credentials.
-2. Call `azure_compute_discover` before recommending a region. Rank every returned
-   AzureCloud region and explain the leading eligible choice and rejected choices.
-3. Translate the user's natural-language request into the typed `AzureCeIntent`.
+3. Call `azure_compute_discover` without publisher, offer, plan, version, or VM-size
+   hints unless the user explicitly pins one. The tool must enumerate live Azure
+   publishers, offers, image SKUs, exact versions, and subscription-aware VM SKUs;
+   validate terms, quota, policy, zones, NIC limits, Route Server support, and
+   brownfield proximity; and persist a discovery artifact. Require
+   `research.method=azure-cli-live`, the enumerated command receipt, and official
+   source URLs in its result. Never guess or copy catalog identifiers from a prior
+   session. Rank every returned AzureCloud region and explain the leading eligible
+   choice and rejected choices.
+4. Translate the user's natural-language request into the typed `AzureCeIntent`.
+   Copy the exact image tuple and a compatible VM size from the discovery result.
    Call `azure_ce_plan` with the discovery artifact. Do not ask the user to author
-   YAML or add bootstrap material.
-4. Display the exact plan ID, SHA-256, pinned image, topology, ordered NICs, zones,
+   YAML or add bootstrap material. Never call `azure_ce_plan` before successful
+   official-source research and live discovery.
+5. Display the exact plan ID, SHA-256, pinned image, topology, ordered NICs, zones,
    routing, security warnings, brownfield changes, rollback state, billable resources,
    and ordered actions. Obtain explicit approval.
-5. Call `f5xc_ce_v2_site` without a hash to plan the Secure Mesh Site v2 change.
+6. Call `f5xc_ce_v2_site` without a hash to plan the Secure Mesh Site v2 change.
    Display its hash, then call it again with the exact hash after approval.
-6. For each node immediately before launch, call `f5xc_ce_v2_bootstrap`. Pass only
+7. For each node immediately before launch, call `f5xc_ce_v2_bootstrap`. Pass only
    the returned `f5xc-ce://` reference to `azure_ce_apply`. Never read, expand,
    copy, quote, log, or persist token bytes.
-7. Call `f5xc_ce_v2_status` at every registration, health, and BGP gate. Pass only
+8. Call `f5xc_ce_v2_status` at every registration, health, and BGP gate. Pass only
    its non-secret evidence to `azure_ce_apply` or `azure_ce_status`.
-8. Activate UDR or Route Server routing only after every required node is registered
+9. Activate UDR or Route Server routing only after every required node is registered
    and healthy. Finish with `azure_ce_status` and passive `azure_ce_diagnose` evidence.
+
+## Research Receipt
+
+Before showing a recommendation or plan, summarize the evidence in this order:
+
+1. official F5 guidance consulted;
+2. official Microsoft image and subscription-aware SKU guidance consulted;
+3. authenticated subscription and AzureCloud environment;
+4. live publisher, offer, image SKU, exact version, and terms status;
+5. compatible VM sizes and ranked regions with rejected-region reasons;
+6. discovery artifact ID.
+
+Absence of any item is a failed research gate, not permission to infer a value.
 
 ## Lifecycle and Recovery
 

--- a/plugins/azure/skills/azure-ce/agents/openai.yaml
+++ b/plugins/azure/skills/azure-ce/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Azure Customer Edge"
-  short_description: "Plan and operate deterministic F5 CE sites"
-  default_prompt: "Use $azure-ce to discover, plan, and safely deploy an F5 Customer Edge site in Azure."
+  short_description: "Research, plan, and operate deterministic F5 CE sites"
+  default_prompt: "Use $azure-ce to research current official F5 and Microsoft guidance, run live subscription-aware Azure discovery, and safely plan an F5 Customer Edge site in Azure without guessing image or VM identifiers."

--- a/plugins/azure/skills/azure-ce/references/contracts.md
+++ b/plugins/azure/skills/azure-ce/references/contracts.md
@@ -2,6 +2,13 @@
 
 ## Determinism
 
+- Research current official guidance from F5 and Microsoft before live discovery.
+  A recommendation requires both retrieved official sources and an
+  `azure-cli-live` discovery receipt; neither model memory nor a prior session is an
+  observation.
+- Enumerate the Marketplace publisher, offer, image SKU, and versions using
+  `az vm image list-publishers`, `list-offers`, `list-skus`, and `list`. Treat
+  user-supplied values only as constraints that must be observed live.
 - Treat identical normalized intent and observations as byte-identical input to the
   canonical plan, SHA-256, and ordered argv actions.
 - Pin the exact Marketplace publisher, offer, plan, and image version. Reject
@@ -61,6 +68,8 @@
 ## Authoritative references
 
 - [Azure VM SKU discovery](https://learn.microsoft.com/en-us/cli/azure/vm#az-vm-list-skus)
+- [Azure Marketplace image discovery](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage)
 - [Azure Route Server FAQ](https://learn.microsoft.com/en-us/azure/route-server/route-server-faq)
+- [F5 Secure Mesh Site v2 on Azure](https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/how-to/site-management/deploy-sms-az-clickops)
 - [F5 Secure Mesh Site v2 deployment](https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/how-to/site-management/create-secure-mesh-site-v2)
 - [F5 CE registration and upgrade](https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/reference/ce-reg-upg-ref)

--- a/plugins/azure/skills/azure-index/SKILL.md
+++ b/plugins/azure/skills/azure-index/SKILL.md
@@ -19,11 +19,18 @@ Route the user's request to the correct skill or agent.
 
 ### F5 Customer Edge
 
-Keywords: "Customer Edge", "CE site", "Secure Mesh Site", "F5 XC on
-Azure", "Route Server", "CE BGP", "CE bootstrap", "CE lifecycle"
+Keywords and paraphrases: "Customer Edge", "F5 CE", "XC CE", "CE site",
+"Secure Mesh Site", "secure mesh node", "F5 XC on Azure", "Distributed Cloud
+node", "Distributed Cloud appliance", "F5 cloud edge", "F5 appliance from the
+Azure Marketplace", "one-node CE", "three-node F5 cluster", "CE HA", "Route
+Server", "CE BGP", "CE bootstrap", "CE lifecycle", "CE image", and requests to
+deploy, resize, replace, repair, inspect, or tear down F5 Distributed Cloud in Azure.
 
 - Invoke `azure:azure-ce` for discovery, planning, mutation, lifecycle,
   status, diagnostics, cloud-init, or teardown.
+- Route ambiguous phrases combining F5 or Distributed Cloud with Azure deployment,
+  VM, appliance, node, edge, routing, or HA to `azure:azure-ce`; do not treat them
+  as generic VM requests.
 - Never route CE mutation through the generic CLI operator or legacy
   Azure VNet Site, Fleet, or shared-token procedures.
 

--- a/plugins/azure/src/ce/canonical.ts
+++ b/plugins/azure/src/ce/canonical.ts
@@ -37,6 +37,7 @@ export function fingerprintObservation(observation: AzureCeObservation, brownfie
     schemaVersion: observation.schemaVersion,
     subscription: observation.subscription,
     image: observation.image,
+    research: observation.research,
     regions: observation.regions,
     resources: observation.resources.filter((resource) => allowlist.has(resource.id.toLowerCase())),
   });

--- a/plugins/azure/src/ce/discovery.ts
+++ b/plugins/azure/src/ce/discovery.ts
@@ -9,11 +9,11 @@ import type {
 
 export interface AzureComputeDiscoveryInput {
   subscriptionId: string;
-  publisher: string;
-  offer: string;
-  plan: string;
+  publisher?: string;
+  offer?: string;
+  plan?: string;
   version?: string;
-  vmSize: string;
+  vmSize?: string;
   requiredNics: number;
   nodeCount: 1 | 3;
   requireRouteServer?: boolean;
@@ -25,6 +25,48 @@ export interface AzureComputeDiscoveryInput {
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_IMAGE_PART = /^[a-zA-Z0-9._-]+$/;
 const RESOURCE_ID = /^\/subscriptions\/([^/]+)\//i;
+const F5_CE_PUBLISHER = 'f5-networks';
+const F5_CE_OFFER = 'f5xc_customer_edge';
+const OFFICIAL_SOURCES = [
+  'https://docs.cloud.f5.com/docs-v2/multi-cloud-network-connect/how-to/site-management/deploy-sms-az-clickops',
+  'https://learn.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage',
+  'https://learn.microsoft.com/en-us/cli/azure/vm#az-vm-list-skus',
+] as const;
+
+async function verifyOfficialSources(fetcher: typeof fetch): Promise<void> {
+  await Promise.all(
+    OFFICIAL_SOURCES.map(async (url) => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 15_000);
+      try {
+        const response = await fetcher(url, {
+          redirect: 'follow',
+          signal: controller.signal,
+          headers: { 'user-agent': 'xcsh-azure-ce-research/2' },
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const body = await response.text();
+        if (body.trim().length < 100) throw new Error('response was empty');
+      } catch (error) {
+        throw new Error(
+          `Official CE research failed for ${url}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+    }),
+  );
+}
+
+interface CatalogSelection {
+  catalogRegion: string;
+  publisher: string;
+  offer: string;
+  plan: string;
+  version: string;
+  urn: string;
+  locations: unknown[];
+}
 
 function normalizeLocation(value: unknown): string {
   return String(value ?? '')
@@ -121,6 +163,115 @@ function compareVersionDescending(left: string, right: string): number {
   return 0;
 }
 
+function exactName(items: Array<Record<string, unknown>>, expected: string): string | undefined {
+  return items
+    .map((item) => String(item.name ?? ''))
+    .filter((name) => name.toLowerCase() === expected.toLowerCase())
+    .sort((left, right) => left.localeCompare(right))[0];
+}
+
+async function resolveMarketplaceImage(
+  api: AzExecApi,
+  regions: string[],
+  subscriptionId: string,
+  input: AzureComputeDiscoveryInput,
+): Promise<CatalogSelection> {
+  const requestedPublisher = input.publisher ?? F5_CE_PUBLISHER;
+  const requestedOffer = input.offer ?? F5_CE_OFFER;
+
+  for (const region of regions) {
+    let publishers: Array<Record<string, unknown>>;
+    try {
+      publishers = await json(api, [
+        'vm',
+        'image',
+        'list-publishers',
+        '--location',
+        region,
+        '--subscription',
+        subscriptionId,
+      ]);
+    } catch {
+      continue;
+    }
+    const publisher = exactName(publishers, requestedPublisher);
+    if (!publisher) continue;
+
+    const offers = await json<Array<Record<string, unknown>>>(api, [
+      'vm',
+      'image',
+      'list-offers',
+      '--location',
+      region,
+      '--publisher',
+      publisher,
+      '--subscription',
+      subscriptionId,
+    ]);
+    const offer = exactName(offers, requestedOffer);
+    if (!offer) continue;
+
+    const rawPlans = await json<Array<Record<string, unknown>>>(api, [
+      'vm',
+      'image',
+      'list-skus',
+      '--location',
+      region,
+      '--publisher',
+      publisher,
+      '--offer',
+      offer,
+      '--subscription',
+      subscriptionId,
+    ]);
+    const plans = rawPlans
+      .map((item) => String(item.name ?? ''))
+      .filter(Boolean)
+      .filter((name) => (input.plan ? name.toLowerCase() === input.plan.toLowerCase() : /crt-/i.test(name)))
+      .sort(compareVersionDescending);
+
+    for (const plan of plans) {
+      const images = await json<Array<Record<string, unknown>>>(api, [
+        'vm',
+        'image',
+        'list',
+        '--location',
+        region,
+        '--publisher',
+        publisher,
+        '--offer',
+        offer,
+        '--sku',
+        plan,
+        '--all',
+        '--subscription',
+        subscriptionId,
+      ]);
+      const selected = images
+        .filter((image) => String(image.version).toLowerCase() !== 'latest')
+        .filter((image) => !input.version || String(image.version) === input.version)
+        .sort(
+          (left, right) =>
+            compareVersionDescending(String(left.version), String(right.version)) ||
+            canonicalStringify(left).localeCompare(canonicalStringify(right)),
+        )[0];
+      if (!selected) continue;
+      const version = String(selected.version);
+      return {
+        catalogRegion: region,
+        publisher: String(selected.publisher ?? publisher),
+        offer: String(selected.offer ?? offer),
+        plan: String(selected.sku ?? plan),
+        version,
+        urn: String(selected.urn ?? `${publisher}:${offer}:${plan}:${version}`),
+        locations: Array.isArray(selected.locations) ? selected.locations : [],
+      };
+    }
+  }
+
+  throw new Error('No live F5 CE Marketplace image matched the requested hints in any permitted AzureCloud region');
+}
+
 function capability(raw: Record<string, unknown>, name: string): string | undefined {
   const capabilities = Array.isArray(raw.capabilities) ? (raw.capabilities as Array<Record<string, unknown>>) : [];
   return capabilities.find((item) => String(item.name).toLowerCase() === name.toLowerCase())?.value as
@@ -128,47 +279,53 @@ function capability(raw: Record<string, unknown>, name: string): string | undefi
     | undefined;
 }
 
-function skuForRegion(
+function compareVmSize(left: AzureCeVmSizeObservation, right: AzureCeVmSizeObservation): number {
+  return (
+    Number(left.restricted) - Number(right.restricted) ||
+    left.vCpus - right.vCpus ||
+    left.memoryGb - right.memoryGb ||
+    left.maxNics - right.maxNics ||
+    left.name.localeCompare(right.name)
+  );
+}
+
+function skusForRegion(
   rawSkus: Array<Record<string, unknown>>,
-  vmSize: string,
+  requestedSize: string | undefined,
   region: string,
-): AzureCeVmSizeObservation | undefined {
-  let sku: Record<string, unknown> | undefined;
-  let info: Record<string, unknown> | undefined;
-  for (const candidate of rawSkus) {
-    if (
-      String(candidate.name).toLowerCase() !== vmSize.toLowerCase() ||
-      String(candidate.resourceType).toLowerCase() !== 'virtualmachines'
-    )
-      continue;
-    const candidateInfo = (
-      Array.isArray(candidate.locationInfo) ? (candidate.locationInfo as Array<Record<string, unknown>>) : []
-    ).find((item) => normalizeLocation(item.location) === region);
-    if (candidateInfo) {
-      sku = candidate;
-      info = candidateInfo;
-      break;
-    }
-  }
-  if (!sku || !info) return undefined;
-  const restrictions = Array.isArray(sku.restrictions) ? (sku.restrictions as Array<Record<string, unknown>>) : [];
-  const restricted = restrictions.some((restriction) => {
-    const locations = ((restriction.restrictionInfo as Record<string, unknown> | undefined)?.locations ??
-      restriction.locations) as unknown;
-    return (
-      !Array.isArray(locations) ||
-      locations.length === 0 ||
-      locations.some((location) => normalizeLocation(location) === region)
+): AzureCeVmSizeObservation[] {
+  const byName = new Map<string, AzureCeVmSizeObservation>();
+  for (const sku of rawSkus) {
+    const name = String(sku.name ?? '');
+    if (!name || String(sku.resourceType).toLowerCase() !== 'virtualmachines') continue;
+    if (requestedSize && name.toLowerCase() !== requestedSize.toLowerCase()) continue;
+    const info = (Array.isArray(sku.locationInfo) ? (sku.locationInfo as Array<Record<string, unknown>>) : []).find(
+      (item) => normalizeLocation(item.location) === region,
     );
-  });
-  return {
-    name: String(sku.name),
-    maxNics: Number(capability(sku, 'MaxNetworkInterfaces') ?? 0),
-    vCpus: Number(capability(sku, 'vCPUs') ?? capability(sku, 'vCPUsAvailable') ?? 0),
-    memoryGb: Number(capability(sku, 'MemoryGB') ?? 0),
-    zones: (Array.isArray(info.zones) ? info.zones : []).map(String).sort(),
-    restricted,
-  };
+    if (!info) continue;
+    const restrictions = Array.isArray(sku.restrictions) ? (sku.restrictions as Array<Record<string, unknown>>) : [];
+    const restricted = restrictions.some((restriction) => {
+      const locations = ((restriction.restrictionInfo as Record<string, unknown> | undefined)?.locations ??
+        restriction.locations) as unknown;
+      return (
+        !Array.isArray(locations) ||
+        locations.length === 0 ||
+        locations.some((location) => normalizeLocation(location) === region)
+      );
+    });
+    const observation: AzureCeVmSizeObservation = {
+      name,
+      maxNics: Number(capability(sku, 'MaxNetworkInterfaces') ?? 0),
+      vCpus: Number(capability(sku, 'vCPUs') ?? capability(sku, 'vCPUsAvailable') ?? 0),
+      memoryGb: Number(capability(sku, 'MemoryGB') ?? 0),
+      zones: (Array.isArray(info.zones) ? info.zones : []).map(String).sort(),
+      restricted,
+    };
+    const existing = byName.get(name.toLowerCase());
+    if (!existing || canonicalStringify(observation).localeCompare(canonicalStringify(existing)) < 0)
+      byName.set(name.toLowerCase(), observation);
+  }
+  return [...byName.values()].sort(compareVmSize);
 }
 
 function safeResourceState(raw: Record<string, unknown>): Record<string, unknown> {
@@ -221,7 +378,8 @@ function validateInput(input: AzureComputeDiscoveryInput): void {
     ['plan', input.plan],
     ['vmSize', input.vmSize],
   ] as const) {
-    if (!SAFE_IMAGE_PART.test(value)) throw new Error(`${label} contains unsupported characters`);
+    if (value !== undefined && !SAFE_IMAGE_PART.test(value))
+      throw new Error(`${label} contains unsupported characters`);
   }
   if (input.version?.toLowerCase() === 'latest') throw new Error('The image version latest is forbidden');
   if (input.requiredNics < 1 || input.requiredNics > 8) throw new Error('requiredNics must be between 1 and 8');
@@ -241,10 +399,12 @@ function validateInput(input: AzureComputeDiscoveryInput): void {
 export async function discoverAzureCompute(
   input: AzureComputeDiscoveryInput,
   api: AzExecApi,
+  fetcher: typeof fetch = fetch,
 ): Promise<AzureCeObservation> {
   validateInput(input);
   const subscriptionId = input.subscriptionId.toLowerCase();
-  const [account, locations, rawImages, rawSkus, provider, policies] = await Promise.all([
+  await verifyOfficialSources(fetcher);
+  const [account, locations, rawSkus, provider, policies] = await Promise.all([
     json<Record<string, unknown>>(api, ['account', 'show', '--subscription', subscriptionId]),
     json<{ value?: Array<Record<string, unknown>> }>(api, [
       'rest',
@@ -252,20 +412,6 @@ export async function discoverAzureCompute(
       'get',
       '--url',
       `https://management.azure.com/subscriptions/${subscriptionId}/locations?api-version=2022-12-01`,
-    ]),
-    json<Array<Record<string, unknown>>>(api, [
-      'vm',
-      'image',
-      'list',
-      '--publisher',
-      input.publisher,
-      '--offer',
-      input.offer,
-      '--sku',
-      input.plan,
-      '--all',
-      '--subscription',
-      subscriptionId,
     ]),
     json<Array<Record<string, unknown>>>(api, ['vm', 'list-skus', '--all', '--subscription', subscriptionId]),
     json<Record<string, unknown>>(api, [
@@ -282,17 +428,16 @@ export async function discoverAzureCompute(
     throw new Error('Azure CLI returned a different subscription');
   if (String(account.environmentName) !== 'AzureCloud') throw new Error('Only AzureCloud subscriptions are supported');
 
-  const images = rawImages
-    .filter((image) => String(image.version).toLowerCase() !== 'latest')
-    .filter((image) => !input.version || String(image.version) === input.version)
-    .sort(
-      (a, b) =>
-        compareVersionDescending(String(a.version), String(b.version)) ||
-        canonicalStringify(a).localeCompare(canonicalStringify(b)),
-    );
-  const selected = images[0];
-  if (!selected) throw new Error('No exact F5 CE image version is available for the requested publisher/offer/plan');
-  const urn = String(selected.urn ?? `${input.publisher}:${input.offer}:${input.plan}:${String(selected.version)}`);
+  const physicalRegions = (locations.value ?? [])
+    .filter(
+      (location) =>
+        String((location.metadata as Record<string, unknown> | undefined)?.regionType ?? 'Physical') === 'Physical',
+    )
+    .map((location) => normalizeLocation(location.name))
+    .filter(Boolean)
+    .sort();
+  const selected = await resolveMarketplaceImage(api, physicalRegions, subscriptionId, input);
+  const urn = selected.urn;
   const terms = await json<Record<string, unknown>>(api, [
     'vm',
     'image',
@@ -313,16 +458,7 @@ export async function discoverAzureCompute(
     for (const location of Array.isArray(type.locations) ? type.locations : [])
       routeServerLocations.add(normalizeLocation(location));
   }
-  const physicalRegions = (locations.value ?? [])
-    .filter(
-      (location) =>
-        String((location.metadata as Record<string, unknown> | undefined)?.regionType ?? 'Physical') === 'Physical',
-    )
-    .map((location) => normalizeLocation(location.name))
-    .filter(Boolean);
-  const imageLocations = new Set<string>(
-    (Array.isArray(selected.locations) ? selected.locations : []).map(normalizeLocation),
-  );
+  const imageLocations = new Set<string>(selected.locations.map(normalizeLocation));
   const imageAvailability = new Map<string, boolean | undefined>();
   if (imageLocations.size === 0) {
     const availabilityPairs = await mapLimit(
@@ -371,7 +507,11 @@ export async function discoverAzureCompute(
   }
 
   const preliminary: AzureCeRegionObservation[] = physicalRegions.map((region) => {
-    const vmSize = skuForRegion(rawSkus, input.vmSize, region);
+    const availableVmSizes = skusForRegion(rawSkus, input.vmSize, region);
+    const eligibleVmSizes = availableVmSizes.filter(
+      (size) => !size.restricted && size.maxNics >= input.requiredNics && size.vCpus >= 8 && size.memoryGb >= 32,
+    );
+    const vmSize = eligibleVmSizes[0] ?? availableVmSizes[0];
     const policyDenied = policies.some(
       (policy) =>
         String(policy.complianceState).toLowerCase() === 'noncompliant' &&
@@ -385,11 +525,13 @@ export async function discoverAzureCompute(
     else if (imageLocations.size === 0 && imageAvailability.get(region) === undefined)
       blockers.push('image-observation-failed');
     if (!vmSize) blockers.push('vm-size-unavailable');
-    else {
-      if (vmSize.restricted) blockers.push('sku-restricted');
-      if (vmSize.maxNics < input.requiredNics) blockers.push('nic-limit');
-      if (vmSize.vCpus < 8 || vmSize.memoryGb < 32) blockers.push('ce-minimum-size');
-      if (input.nodeCount === 3 && vmSize.zones.length < 3) reasons.push('fewer-than-three-zones');
+    else if (eligibleVmSizes.length === 0) {
+      if (availableVmSizes.every((size) => size.restricted)) blockers.push('sku-restricted');
+      if (availableVmSizes.every((size) => size.maxNics < input.requiredNics)) blockers.push('nic-limit');
+      if (availableVmSizes.every((size) => size.vCpus < 8 || size.memoryGb < 32)) blockers.push('ce-minimum-size');
+      if (blockers.length === 0) blockers.push('no-compatible-vm-size');
+    } else if (input.nodeCount === 3 && vmSize.zones.length < 3) {
+      reasons.push('fewer-than-three-zones');
     }
     const quota = quotas.get(region);
     if (quota === undefined) blockers.push('quota-observation-failed');
@@ -406,7 +548,7 @@ export async function discoverAzureCompute(
       routeServerSupported: routeServerLocations.has(region),
       quotaAvailable: quota ?? 0,
       policyAllowed: !policyDenied,
-      vmSizes: vmSize ? [vmSize] : [],
+      vmSizes: (eligibleVmSizes.length > 0 ? eligibleVmSizes : availableVmSizes).slice(0, 24),
       proximity: proximity.get(region) ?? 0,
     };
   });
@@ -424,14 +566,28 @@ export async function discoverAzureCompute(
     schemaVersion: 1,
     subscription: { id: subscriptionId, tenantId: String(account.tenantId ?? ''), cloud: 'AzureCloud' },
     image: {
-      publisher: input.publisher,
-      offer: input.offer,
-      plan: String(terms.plan ?? input.plan),
-      version: String(selected.version),
+      publisher: selected.publisher,
+      offer: selected.offer,
+      plan: String(terms.plan ?? selected.plan),
+      version: selected.version,
       urn,
       termsAccepted: Boolean(terms.accepted),
     },
     regions: preliminary,
     resources: resourceObservations,
+    research: {
+      method: 'azure-cli-live',
+      officialSourceRetrieval: 'live',
+      catalogRegion: selected.catalogRegion,
+      commands: [
+        'az vm image list-publishers',
+        'az vm image list-offers',
+        'az vm image list-skus',
+        'az vm image list',
+        'az vm image terms show',
+        'az vm list-skus --all',
+      ],
+      officialSources: [...OFFICIAL_SOURCES],
+    },
   };
 }

--- a/plugins/azure/src/ce/planner.ts
+++ b/plugins/azure/src/ce/planner.ts
@@ -1257,6 +1257,24 @@ function buildLifecycleActions(
 export function compileAzureCePlan(input: AzureCeIntent, observation: AzureCeObservation): AzureCePlan {
   const intent = normalizeIntent(input);
   if (observation.schemaVersion !== 1) fail('unsupported observation schema');
+  const requiredResearchCommands = [
+    'az vm image list-publishers',
+    'az vm image list-offers',
+    'az vm image list-skus',
+    'az vm image list',
+    'az vm image terms show',
+    'az vm list-skus --all',
+  ];
+  if (observation.research?.method !== 'azure-cli-live') fail('live Azure research receipt is required');
+  if (observation.research.officialSourceRetrieval !== 'live')
+    fail('live official-source research receipt is required');
+  for (const command of requiredResearchCommands) {
+    if (!observation.research.commands.includes(command)) fail(`live Azure research receipt is missing ${command}`);
+  }
+  if (!observation.research.officialSources.some((source) => source.startsWith('https://docs.cloud.f5.com/')))
+    fail('official F5 research source is required');
+  if (!observation.research.officialSources.some((source) => source.startsWith('https://learn.microsoft.com/')))
+    fail('official Microsoft research source is required');
   if (observation.subscription.cloud !== 'AzureCloud') fail('only AzureCloud is supported');
   if (observation.subscription.id.toLowerCase() !== intent.subscriptionId)
     fail('observation subscription does not match intent');

--- a/plugins/azure/src/ce/types.ts
+++ b/plugins/azure/src/ce/types.ts
@@ -111,6 +111,13 @@ export interface AzureCeObservation {
   };
   regions: AzureCeRegionObservation[];
   resources: AzureCeResourceObservation[];
+  research: {
+    method: 'azure-cli-live';
+    officialSourceRetrieval: 'live';
+    catalogRegion: string;
+    commands: string[];
+    officialSources: string[];
+  };
 }
 
 export type AzureCeActionKind =

--- a/plugins/azure/src/index.ts
+++ b/plugins/azure/src/index.ts
@@ -24,6 +24,23 @@ function sanitizeHintField(value: unknown, maxLen = 200): string {
   return value.replace(/[^\x20-\x7E]/g, '').slice(0, maxLen);
 }
 
+export function isAzureCePrompt(prompt: string): boolean {
+  const normalized = prompt.toLowerCase().replace(/[^a-z0-9]+/g, ' ');
+  const azureContext = /\bazure\b|\bmarketplace\b/.test(normalized);
+  const ceContext =
+    /\bcustomer edge\b|\bf5 ce\b|\bxc ce\b|\bsecure mesh\b|\bce site\b|\bce node\b|\bce image\b/.test(normalized) ||
+    /\bf5\b.*\b(distributed cloud|xc|edge|appliance|route server|bgp)\b/.test(normalized) ||
+    /\bdistributed cloud\b.*\b(node|edge|appliance|azure|marketplace)\b/.test(normalized);
+  return azureContext && ceContext;
+}
+
+export const AZURE_CE_RESEARCH_GATE = [
+  'AZURE CUSTOMER EDGE ROUTE: Use the azure:azure-ce workflow for this request.',
+  'Before any recommendation or azure_ce_plan call, use web_search to retrieve and read the current official F5 Secure Mesh Site v2 Azure deployment guide from docs.cloud.f5.com and Microsoft Marketplace image and subscription-aware VM SKU guidance from learn.microsoft.com.',
+  'Then call az_account_show and azure_compute_discover. Omit publisher, offer, plan, version, and vmSize unless the user explicitly pinned them; live discovery must enumerate those values.',
+  'Require the azure-cli-live research receipt and discovery artifact. Never guess identifiers, use generic az_exec for CE research, plan before discovery, or mutate without approval.',
+].join('\n');
+
 const factory: ExtensionFactory = async (pi) => {
   pi.setLabel('Azure');
 
@@ -97,30 +114,39 @@ const factory: ExtensionFactory = async (pi) => {
     });
   }
 
-  if (azAvailable && typeof pi.on === 'function') {
-    pi.on('before_agent_start', async (_event: unknown, ctx: { cwd: string }) => {
+  if (typeof pi.on === 'function') {
+    pi.on('before_agent_start', async (event: { prompt?: string }, ctx: { cwd: string }) => {
+      const ceRequest = isAzureCePrompt(String(event?.prompt ?? ''));
+      const accountLines: string[] = [];
       try {
+        if (!azAvailable) throw new Error('az CLI unavailable');
         const cwd = ctx?.cwd || process.cwd();
         const result = Bun.spawnSync(['az', 'account', 'show', '--output', 'json'], { cwd });
-        if (result.exitCode !== 0) return;
-        const account = JSON.parse(new TextDecoder().decode(result.stdout));
-        const lines = [
-          account.name ? `Subscription: ${sanitizeHintField(account.name)} (${sanitizeHintField(account.id)})` : '',
-          account.tenantId ? `Tenant: ${sanitizeHintField(account.tenantId)}` : '',
-          account.user?.name
-            ? `User: ${sanitizeHintField(account.user.name)} (${sanitizeHintField(account.user.type)})`
-            : '',
-          account.environmentName ? `Cloud: ${sanitizeHintField(account.environmentName)}` : '',
-        ]
-          .filter(Boolean)
-          .join('\n');
-        if (!lines) return;
-        return {
-          message: { customType: 'azure_hint', content: lines, display: false },
-        };
+        if (result.exitCode === 0) {
+          const account = JSON.parse(new TextDecoder().decode(result.stdout));
+          accountLines.push(
+            ...[
+              account.name ? `Subscription: ${sanitizeHintField(account.name)} (${sanitizeHintField(account.id)})` : '',
+              account.tenantId ? `Tenant: ${sanitizeHintField(account.tenantId)}` : '',
+              account.user?.name
+                ? `User: ${sanitizeHintField(account.user.name)} (${sanitizeHintField(account.user.type)})`
+                : '',
+              account.environmentName ? `Cloud: ${sanitizeHintField(account.environmentName)}` : '',
+            ].filter(Boolean),
+          );
+        }
       } catch {
-        return;
+        // The research gate must still be injected when account observation fails.
       }
+      const content = [...(ceRequest ? [AZURE_CE_RESEARCH_GATE] : []), ...accountLines].join('\n');
+      if (!content) return;
+      return {
+        message: {
+          customType: ceRequest ? 'azure_ce_research_gate' : 'azure_hint',
+          content,
+          display: false,
+        },
+      };
     });
   }
 

--- a/plugins/azure/src/tools/azure-ce-plan.ts
+++ b/plugins/azure/src/tools/azure-ce-plan.ts
@@ -26,7 +26,7 @@ export function createAzureCePlanTool(pi: PluginInterface) {
     parameters: Type.Object({
       discoveryArtifactId: Type.String(),
       intent: Type.Object({
-        schemaVersion: Type.Literal(1),
+        schemaVersion: Type.Number({ minimum: 1, maximum: 1 }),
         operation: Type.Union(
           [
             'deploy',

--- a/plugins/azure/src/tools/azure-compute-discover.ts
+++ b/plugins/azure/src/tools/azure-compute-discover.ts
@@ -10,16 +10,16 @@ export function createAzureComputeDiscoverTool(pi: PluginInterface, makeApi: (cw
     name: 'azure_compute_discover',
     label: 'Discover Azure CE Compute',
     description:
-      'Discover and rank subscription-aware AzureCloud regions for F5 Customer Edge using exact Marketplace image versions, VM SKU/NIC/zones, quota, policy, Route Server support, brownfield proximity, and terms status.',
+      'Mandatory live research gate for F5 Customer Edge. Enumerates the Azure Marketplace publisher, offer, plan, and exact image version plus subscription-aware VM SKU/NIC/zones, quota, policy, Route Server support, brownfield proximity, and terms status. Call this before any recommendation or plan; do not guess catalog identifiers or VM sizes.',
     parameters: Type.Object({
       subscriptionId: Type.String(),
-      publisher: Type.String(),
-      offer: Type.String(),
-      plan: Type.String(),
+      publisher: Type.Optional(Type.String()),
+      offer: Type.Optional(Type.String()),
+      plan: Type.Optional(Type.String()),
       version: Type.Optional(Type.String()),
-      vmSize: Type.String(),
+      vmSize: Type.Optional(Type.String()),
       requiredNics: Type.Number({ minimum: 1, maximum: 8 }),
-      nodeCount: Type.Union([Type.Literal(1), Type.Literal(3)]),
+      nodeCount: Type.Number({ minimum: 1, maximum: 3, description: 'Node count; only 1 or 3 is valid.' }),
       requireRouteServer: Type.Optional(Type.Boolean()),
       deploymentName: Type.String(),
       resourceGroup: Type.String(),
@@ -41,11 +41,19 @@ export function createAzureComputeDiscoverTool(pi: PluginInterface, makeApi: (cw
               `${region.rank}. ${region.name}: ${region.eligible ? 'eligible' : 'ineligible'}${region.reasons.length ? ` (${region.reasons.join(', ')})` : ''}`,
           )
           .join('\n');
+        const leadingRegion = observation.regions.find((region) => region.eligible);
+        const compatibleSizes = (leadingRegion?.vmSizes ?? [])
+          .slice(0, 12)
+          .map(
+            (size) =>
+              `${size.name} (${size.vCpus} vCPU, ${size.memoryGb} GB, ${size.maxNics} NICs, zones ${size.zones.join('/') || 'regional'})`,
+          )
+          .join('; ');
         return {
           content: [
             {
               type: 'text' as const,
-              text: `Pinned image: ${observation.image.urn}\nMarketplace terms: ${observation.image.termsAccepted ? 'accepted' : 'not accepted'}\n${ranked}\nDiscovery artifact: ${artifactId ? `artifact://${artifactId}` : 'session memory only'}`,
+              text: `Research: live Azure CLI catalog and subscription observations (${observation.research.catalogRegion})\nOfficial sources: retrieved live from F5 and Microsoft\nPinned image: ${observation.image.urn}\nMarketplace terms: ${observation.image.termsAccepted ? 'accepted' : 'not accepted'}\nLeading eligible region: ${leadingRegion?.name ?? 'none'}\nCompatible VM sizes: ${compatibleSizes || 'none'}\n${ranked}\nDiscovery artifact: ${artifactId ? `artifact://${artifactId}` : 'session memory only'}`,
             },
           ],
           details: { tool: 'azure_compute_discover', artifactId, observation },

--- a/plugins/azure/test/ce/apply.test.ts
+++ b/plugins/azure/test/ce/apply.test.ts
@@ -48,6 +48,20 @@ const observation: AzureCeObservation = {
     },
   ],
   resources: [],
+  research: {
+    method: 'azure-cli-live',
+    officialSourceRetrieval: 'live',
+    catalogRegion: 'canadacentral',
+    commands: [
+      'az vm image list-publishers',
+      'az vm image list-offers',
+      'az vm image list-skus',
+      'az vm image list',
+      'az vm image terms show',
+      'az vm list-skus --all',
+    ],
+    officialSources: ['https://docs.cloud.f5.com/example', 'https://learn.microsoft.com/example'],
+  },
 };
 
 describe('Azure CE apply protections', () => {

--- a/plugins/azure/test/ce/discovery.test.ts
+++ b/plugins/azure/test/ce/discovery.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from 'bun:test';
 import type { AzExecApi } from '../../src/az/exec';
-import { discoverAzureCompute } from '../../src/ce/discovery';
+import {
+  type AzureComputeDiscoveryInput,
+  discoverAzureCompute as discoverAzureComputeWithOfficialResearch,
+} from '../../src/ce/discovery';
 
-function api(fixtures: Record<string, unknown>): AzExecApi {
+const officialFetch = (async () => new Response('official guidance '.repeat(20), { status: 200 })) as typeof fetch;
+
+function discoverAzureCompute(input: AzureComputeDiscoveryInput, azureApi: AzExecApi) {
+  return discoverAzureComputeWithOfficialResearch(input, azureApi, officialFetch);
+}
+
+function api(fixtures: Record<string, unknown>, calls: string[] = []): AzExecApi {
   return {
     async exec(_command, args) {
       const key = args.filter((arg) => arg !== '--output' && arg !== 'json').join(' ');
+      calls.push(key);
       const value = fixtures[key];
       if (value === undefined && key.startsWith('group show '))
         return { stdout: '', stderr: 'ResourceGroupNotFound', exitCode: 1 };
@@ -30,6 +40,37 @@ const baseFixtures: Record<string, unknown> = {
         { name: 'canadacentral', metadata: { regionType: 'Physical' } },
       ],
     },
+  'vm image list-publishers --location canadacentral --subscription 11111111-1111-4111-8111-111111111111': [
+    { name: 'Canonical' },
+    { name: 'f5-networks' },
+  ],
+  'vm image list-offers --location canadacentral --publisher f5-networks --subscription 11111111-1111-4111-8111-111111111111':
+    [{ name: 'f5-big-ip-best' }, { name: 'f5xc_customer_edge' }],
+  'vm image list-skus --location canadacentral --publisher f5-networks --offer f5xc_customer_edge --subscription 11111111-1111-4111-8111-111111111111':
+    [
+      { name: 'f5-distributed-cloud-customer-edge-internal' },
+      { name: 'f5xc-ce-crt-20250701' },
+      { name: 'f5xc-ce-crt-20260201' },
+    ],
+  'vm image list --location canadacentral --publisher f5-networks --offer f5xc_customer_edge --sku f5xc-ce-crt-20260201 --all --subscription 11111111-1111-4111-8111-111111111111':
+    [
+      {
+        publisher: 'f5-networks',
+        offer: 'f5xc_customer_edge',
+        sku: 'f5xc-ce-crt-20260201',
+        version: '20260201.0177.1',
+        urn: 'f5-networks:f5xc_customer_edge:f5xc-ce-crt-20260201:20260201.0177.1',
+      },
+      {
+        publisher: 'f5-networks',
+        offer: 'f5xc_customer_edge',
+        sku: 'f5xc-ce-crt-20260201',
+        version: '20260201.0178.1',
+        urn: 'f5-networks:f5xc_customer_edge:f5xc-ce-crt-20260201:20260201.0178.1',
+      },
+    ],
+  'vm image terms show --urn f5-networks:f5xc_customer_edge:f5xc-ce-crt-20260201:20260201.0178.1 --subscription 11111111-1111-4111-8111-111111111111':
+    { accepted: true, plan: 'f5xc-ce-crt-20260201' },
   'vm image list --publisher f5-networks --offer f5xc-customer-edge --sku f5xc-ce --all --subscription 11111111-1111-4111-8111-111111111111':
     [
       {
@@ -79,13 +120,67 @@ const baseFixtures: Record<string, unknown> = {
 };
 
 describe('discoverAzureCompute', () => {
+  it('fails closed when current official guidance cannot be retrieved', async () => {
+    const unavailable = (async () => new Response('unavailable', { status: 503 })) as typeof fetch;
+    const calls: string[] = [];
+    await expect(
+      discoverAzureComputeWithOfficialResearch(
+        {
+          subscriptionId,
+          deploymentName: 'ce-demo',
+          resourceGroup: 'rg-ce-demo',
+          requiredNics: 2,
+          nodeCount: 1,
+          brownfieldResourceIds: [],
+        },
+        api(baseFixtures, calls),
+        unavailable,
+      ),
+    ).rejects.toThrow(/Official CE research failed/);
+    expect(calls).toEqual([]);
+  });
+
+  it('researches the live catalog and compatible VM sizes without guessed identifiers', async () => {
+    const calls: string[] = [];
+    const result = await discoverAzureCompute(
+      {
+        subscriptionId,
+        deploymentName: 'ce-demo',
+        resourceGroup: 'rg-ce-demo',
+        requiredNics: 8,
+        nodeCount: 3,
+        brownfieldResourceIds: [],
+      },
+      api(baseFixtures, calls),
+    );
+
+    expect(result.image).toEqual({
+      publisher: 'f5-networks',
+      offer: 'f5xc_customer_edge',
+      plan: 'f5xc-ce-crt-20260201',
+      version: '20260201.0178.1',
+      urn: 'f5-networks:f5xc_customer_edge:f5xc-ce-crt-20260201:20260201.0178.1',
+      termsAccepted: true,
+    });
+    expect(result.regions[0].vmSizes[0].name).toBe('Standard_D8s_v5');
+    expect(result.research.method).toBe('azure-cli-live');
+    expect(result.research.officialSourceRetrieval).toBe('live');
+    expect(result.research.catalogRegion).toBe('canadacentral');
+    expect(calls).toContain(
+      'vm image list-publishers --location canadacentral --subscription 11111111-1111-4111-8111-111111111111',
+    );
+    expect(calls).toContain(
+      'vm image list-offers --location canadacentral --publisher f5-networks --subscription 11111111-1111-4111-8111-111111111111',
+    );
+    expect(calls).toContain(
+      'vm image list-skus --location canadacentral --publisher f5-networks --offer f5xc_customer_edge --subscription 11111111-1111-4111-8111-111111111111',
+    );
+  });
+
   it('pins the newest exact non-latest image and ranks every physical region', async () => {
     const result = await discoverAzureCompute(
       {
         subscriptionId,
-        publisher: 'f5-networks',
-        offer: 'f5xc-customer-edge',
-        plan: 'f5xc-ce',
         deploymentName: 'ce-demo',
         resourceGroup: 'rg-ce-demo',
         vmSize: 'Standard_D8s_v5',
@@ -95,7 +190,7 @@ describe('discoverAzureCompute', () => {
       },
       api(baseFixtures),
     );
-    expect(result.image.version).toBe('2026.08.15');
+    expect(result.image.version).toBe('20260201.0178.1');
     expect(result.regions.map((region) => region.name).sort()).toEqual(['canadacentral', 'eastus']);
     expect(result.regions.find((region) => region.name === 'canadacentral')?.eligible).toBe(true);
     expect(result.regions.find((region) => region.name === 'eastus')?.eligible).toBe(false);
@@ -110,9 +205,6 @@ describe('discoverAzureCompute', () => {
     const result = await discoverAzureCompute(
       {
         subscriptionId,
-        publisher: 'f5-networks',
-        offer: 'f5xc-customer-edge',
-        plan: 'f5xc-ce',
         deploymentName: 'ce-demo',
         resourceGroup: 'rg-ce-demo',
         vmSize: 'Standard_D8s_v5',
@@ -126,6 +218,38 @@ describe('discoverAzureCompute', () => {
     expect(result.regions.find((region) => region.name === 'canadacentral')?.reasons).toContain('policy-deny');
   });
 
+  it('selects a live compatible VM candidate instead of a restricted lower-cost size', async () => {
+    const fixtures = structuredClone(baseFixtures);
+    const skus = fixtures['vm list-skus --all --subscription 11111111-1111-4111-8111-111111111111'] as Array<
+      Record<string, unknown>
+    >;
+    skus[0].restrictions = [{ restrictionInfo: { locations: ['canadacentral'] } }];
+    skus.push({
+      name: 'Standard_E8s_v5',
+      resourceType: 'virtualMachines',
+      restrictions: [],
+      capabilities: [
+        { name: 'MaxNetworkInterfaces', value: '8' },
+        { name: 'vCPUs', value: '8' },
+        { name: 'MemoryGB', value: '64' },
+      ],
+      locationInfo: [{ location: 'canadacentral', zones: ['1', '2', '3'] }],
+    });
+    const result = await discoverAzureCompute(
+      {
+        subscriptionId,
+        deploymentName: 'ce-demo',
+        resourceGroup: 'rg-ce-demo',
+        requiredNics: 8,
+        nodeCount: 1,
+        brownfieldResourceIds: [],
+      },
+      api(fixtures),
+    );
+    expect(result.regions[0].name).toBe('canadacentral');
+    expect(result.regions[0].vmSizes[0].name).toBe('Standard_E8s_v5');
+  });
+
   it('keeps an otherwise valid HA region eligible when zones require a declared fallback', async () => {
     const fixtures = structuredClone(baseFixtures);
     const skus = fixtures['vm list-skus --all --subscription 11111111-1111-4111-8111-111111111111'] as Array<{
@@ -135,9 +259,6 @@ describe('discoverAzureCompute', () => {
     const result = await discoverAzureCompute(
       {
         subscriptionId,
-        publisher: 'f5-networks',
-        offer: 'f5xc-customer-edge',
-        plan: 'f5xc-ce',
         deploymentName: 'ce-demo',
         resourceGroup: 'rg-ce-demo',
         vmSize: 'Standard_D8s_v5',
@@ -181,9 +302,6 @@ describe('discoverAzureCompute', () => {
     const result = await discoverAzureCompute(
       {
         subscriptionId,
-        publisher: 'f5-networks',
-        offer: 'f5xc-customer-edge',
-        plan: 'f5xc-ce',
         deploymentName: 'ce-demo',
         resourceGroup: 'rg-ce-demo',
         vmSize: 'Standard_D8s_v5',
@@ -201,9 +319,6 @@ describe('discoverAzureCompute', () => {
       discoverAzureCompute(
         {
           subscriptionId,
-          publisher: 'f5-networks',
-          offer: 'f5xc-customer-edge',
-          plan: 'f5xc-ce',
           version: 'latest',
           deploymentName: 'ce-demo',
           resourceGroup: 'rg-ce-demo',
@@ -220,9 +335,6 @@ describe('discoverAzureCompute', () => {
       discoverAzureCompute(
         {
           subscriptionId,
-          publisher: 'f5-networks',
-          offer: 'f5xc-customer-edge',
-          plan: 'f5xc-ce',
           deploymentName: 'ce-demo',
           resourceGroup: 'rg-ce-demo',
           vmSize: 'Standard_D8s_v5',

--- a/plugins/azure/test/ce/planner.test.ts
+++ b/plugins/azure/test/ce/planner.test.ts
@@ -32,6 +32,20 @@ function observation(overrides: Partial<AzureCeObservation> = {}): AzureCeObserv
       },
     ],
     resources: [],
+    research: {
+      method: 'azure-cli-live',
+      officialSourceRetrieval: 'live',
+      catalogRegion: 'canadacentral',
+      commands: [
+        'az vm image list-publishers',
+        'az vm image list-offers',
+        'az vm image list-skus',
+        'az vm image list',
+        'az vm image terms show',
+        'az vm list-skus --all',
+      ],
+      officialSources: ['https://docs.cloud.f5.com/example', 'https://learn.microsoft.com/example'],
+    },
     ...overrides,
   };
 }
@@ -93,6 +107,12 @@ describe('compileAzureCePlan', () => {
     expect(plan.image.version).toBe('2026.08.15');
     expect(plan.image.version).not.toBe('latest');
     expect(JSON.stringify(plan)).not.toContain('bootstrapToken');
+  });
+
+  it('rejects planning from an artifact without the complete live research receipt', () => {
+    const missing = observation();
+    missing.research.commands = missing.research.commands.filter((command) => command !== 'az vm image list-offers');
+    expect(() => compileAzureCePlan(intent(), missing)).toThrow(/research receipt/i);
   });
 
   it('uses one node and UDR routing for non-HA', () => {

--- a/plugins/azure/test/ce/prompt-trace.test.ts
+++ b/plugins/azure/test/ce/prompt-trace.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test';
+import { evaluateTrace } from '../../benchmarks/verify-ce-prompt-trace';
+
+const scenario = {
+  id: 'test',
+  prompt: 'research CE',
+  requiredTools: ['web_search', 'az_account_show', 'azure_compute_discover'],
+  forbiddenTools: ['az_exec', 'azure_ce_apply'],
+};
+
+function event(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+const successfulDiscovery = {
+  type: 'tool_execution_end',
+  toolName: 'azure_compute_discover',
+  result: {
+    isError: false,
+    content: [
+      {
+        type: 'text',
+        text: 'Research: live Azure CLI catalog and subscription observations (canadacentral)\nOfficial sources: retrieved live from F5 and Microsoft\nPinned image: f5-networks:f5xc_customer_edge:f5xc-ce-crt:1.2.3\nCompatible VM sizes: Standard_D8s_v5 (8 vCPU, 32 GB, 8 NICs, zones 1/2/3)\nDiscovery artifact: artifact://azure-ce-discovery-abc',
+      },
+    ],
+  },
+};
+
+describe('CE synthesized prompt trace evaluation', () => {
+  it('accepts a captured official research, auth, and live discovery sequence', () => {
+    const trace = [
+      event({ type: 'tool_execution_start', toolName: 'web_search' }),
+      event({ type: 'tool_execution_start', toolName: 'az_account_show' }),
+      event({ type: 'tool_execution_start', toolName: 'azure_compute_discover' }),
+      event(successfulDiscovery),
+    ].join('\n');
+    expect(evaluateTrace(scenario, trace)).toEqual({
+      pass: true,
+      tools: ['web_search', 'az_account_show', 'azure_compute_discover'],
+      errors: [],
+    });
+  });
+
+  it('rejects a trace that guesses a plan before research', () => {
+    const trace = [
+      event({ type: 'tool_execution_start', toolName: 'azure_ce_plan' }),
+      event({ type: 'tool_execution_start', toolName: 'azure_compute_discover' }),
+      event(successfulDiscovery),
+    ].join('\n');
+    const result = evaluateTrace(scenario, trace);
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('missing required tool: web_search');
+    expect(result.errors).toContain('azure_ce_plan was invoked before live discovery');
+  });
+
+  it('rejects failed discovery or a missing live-research receipt', () => {
+    const trace = [
+      event({ type: 'tool_execution_start', toolName: 'web_search' }),
+      event({ type: 'tool_execution_start', toolName: 'az_account_show' }),
+      event({ type: 'tool_execution_start', toolName: 'azure_compute_discover' }),
+      event({ type: 'tool_execution_end', toolName: 'azure_compute_discover', result: { isError: true } }),
+    ].join('\n');
+    const result = evaluateTrace(scenario, trace);
+    expect(result.pass).toBe(false);
+    expect(result.errors).toContain('azure_compute_discover returned an error');
+    expect(result.errors).toContain('discovery result lacks the live-research receipt');
+  });
+});

--- a/plugins/azure/test/extension.test.ts
+++ b/plugins/azure/test/extension.test.ts
@@ -69,7 +69,7 @@ describe('Azure Status extension', () => {
     expect(statuses[0].name).toBe('Azure');
   });
 
-  it('registers session_start event handler', async () => {
+  it('registers session and research-routing event handlers', async () => {
     const events: string[] = [];
     const mockPi = baseMockPi({
       on(event: string) {
@@ -78,6 +78,20 @@ describe('Azure Status extension', () => {
     });
     await factory(mockPi);
     expect(events).toContain('session_start');
+    expect(events).toContain('before_agent_start');
+  });
+
+  it('defines the mandatory research route for synthesized Azure CE paraphrases', async () => {
+    const { AZURE_CE_RESEARCH_GATE, isAzureCePrompt } = await import('../src/index');
+    expect(
+      isAzureCePrompt(
+        'Find the right Azure Marketplace F5 edge appliance for running Distributed Cloud close to my apps.',
+      ),
+    ).toBe(true);
+    expect(isAzureCePrompt('List the virtual machines in Azure.')).toBe(false);
+    expect(AZURE_CE_RESEARCH_GATE).toContain('use web_search');
+    expect(AZURE_CE_RESEARCH_GATE).toContain('azure_compute_discover');
+    expect(AZURE_CE_RESEARCH_GATE).toContain('Never guess identifiers');
   });
 
   it.skipIf(!AZ_INSTALLED)(


### PR DESCRIPTION
## Summary

- route natural-language Azure Customer Edge requests through current official F5 and Microsoft research before planning
- enumerate the live F5 Marketplace catalog and subscription-aware VM SKU constraints without guessed publisher, offer, plan, version, or size values
- persist and validate a live-research receipt so stale or incomplete observations fail closed
- add synthesized prompt scenarios and trace verification for greenfield, HA/brownfield, Marketplace, and lifecycle requests
- release Azure plugin 2.0.1

## Verification

- `bun test` in `plugins/azure`: 194 passed
- `bunx tsc --noEmit`
- `bunx biome check src test`
- `scripts/run-plugin-tests.sh`
- `scripts/check-tests-are-hermetic.sh`
- `scripts/validate-plugins.sh`
- `scripts/check-repo-hygiene.sh`
- `scripts/check-version-bumps.sh origin/main`
- `gitleaks detect --redact`
- `scripts/agy-pre-push-review.sh`
- four real xcsh synthesized prompt traces passed with live web research and authenticated Azure discovery; no cloud mutation performed
- direct live discovery ranked 63 physical Azure regions, found 50 eligible, and pinned an exact non-`latest` F5 CE image

Closes #1176