### PR TITLE
fix(ci): advance Antigravity review caller receipt

### DIFF
--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   review:
     if: vars.ANTIGRAVITY_REVIEW_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@2062cd557231a7827ad8e732a9c714987295efff
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@dbed9556992c2507a314db2981e991f310a30770
     with:
       pr_number: ${{ inputs.pr_number }}
       expected_base_sha: ${{ inputs.expected_base_sha }}


### PR DESCRIPTION
Closes #1180

## Summary

- advances only the immutable docs-control reusable-workflow SHA in the Antigravity review caller

## Validation

- `bash tests/test-github-api-resilience.sh`
- `bash scripts/validate-plugins.sh`
- `bash scripts/run-plugin-tests.sh`
- direct remote `bash scripts/agy-review.sh code --base origin/main` — reviewer and verifier approved with no findings