### PR TITLE
chore(herdr): refresh vendored skill provenance

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -371,7 +371,7 @@
     {
       "name": "herdr",
       "description": "Control Herdr, a terminal multiplexer for coding agents — inspect workspaces, tabs and panes, split panes, run commands without stealing focus, read pane output, and coordinate sibling agents. Requires HERDR_ENV=1.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`herdr`** bumped to v1.0.3
+
 - **`azure`** v2.0.1 — makes current official F5 and Microsoft research plus live Azure
   Marketplace enumeration a mandatory Customer Edge gate. Natural-language CE paraphrases receive
   deterministic runtime routing, discovery no longer requires guessed image or VM identifiers, and

--- a/plugins/herdr/.xcsh-plugin/plugin.json
+++ b/plugins/herdr/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr",
   "description": "Control Herdr, a terminal multiplexer for coding agents — inspect workspaces, tabs and panes, split panes, run commands without stealing focus, read pane output, and coordinate sibling agents. Requires HERDR_ENV=1.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/herdr",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/herdr/UPSTREAM.md
+++ b/plugins/herdr/UPSTREAM.md
@@ -11,11 +11,11 @@ The marketplace registers this vendored skill under the canonical URI
 | Upstream repository | <https://github.com/herdrdev/herdr> |
 | Upstream path | `skills/herdr/SKILL.md` |
 | Pinned ref | `master` |
-| Vendored commit | `eacea2daf0b72973173b728936b27478374f2cd2` |
-| Last upstream change to `SKILL.md` | `f6060cf682f69ef8302c25e8924c0b27aef7ae16` (2026-07-29) |
+| Vendored commit | `51b7064ef0a02642393bab1d2eea0f4dbd8414d2` |
+| Last upstream change to `SKILL.md` | `51b7064ef0a02642393bab1d2eea0f4dbd8414d2` (2026-08-15) |
 | SHA-256 of vendored file | `0786182f02ebf92708e09d82d79e4614d1a9c30bfc337643cc2af1d0fb9db29f` |
 | Size | 10140 bytes |
-| Retrieved | 2026-08-03 |
+| Retrieved | 2026-08-16 |
 | Upstream license | Apache-2.0 |
 
 ## Attribution


### PR DESCRIPTION
Closes #1182

## Summary

- re-vendors the current `herdrdev/herdr@master` skill receipt (byte-identical content)
- updates provenance to commit `51b7064ef0a02642393bab1d2eea0f4dbd8414d2` and bumps Herdr to 1.0.3

## Validation

- direct upstream fetch plus `cmp -s`
- `bash scripts/validate-plugins.sh`
- `bash scripts/run-plugin-tests.sh herdr`
- direct remote `bash scripts/agy-review.sh code --base origin/main` — reviewer and verifier approved with no findings