### PR TITLE
fix(ci): repair missing TypeBox test dependency

### DIFF
--- a/scripts/check-plugin-runtime-dependencies.sh
+++ b/scripts/check-plugin-runtime-dependencies.sh
@@ -18,6 +18,8 @@ EXPECTED_ACP="1.3.0"
 EXPECTED_GOOGLE_GENAI="2.15.0"
 EXPECTED_TYPEBOX_RANGE="^0.34.52"
 EXPECTED_BUN_TYPES_RANGE="^1.3.14"
+EXPECTED_TYPEBOX="0.34.52"
+EXPECTED_BUN_TYPES="1.3.14"
 RUNTIME_PLUGINS=(aws azure gcloud github gitlab salesforce)
 STATIC_FAILURES=0
 INSTALLED_FAILURES=0
@@ -121,6 +123,14 @@ for plugin in "${RUNTIME_PLUGINS[@]}"; do
       "$EXPECTED_ACP" "$plugin installed ACP SDK version"
     require_installed_json_value "$node_modules/@google/genai/package.json" '.version' \
       "$EXPECTED_GOOGLE_GENAI" "$plugin installed Google GenAI version"
+    require_installed_json_value "$node_modules/@sinclair/typebox/package.json" '.version' \
+      "$EXPECTED_TYPEBOX" "$plugin installed TypeBox version"
+    require_installed_json_value "$node_modules/bun-types/package.json" '.version' \
+      "$EXPECTED_BUN_TYPES" "$plugin installed Bun types version"
+  elif $REPAIR; then
+    # A fresh checkout has no physical graph yet. The test runner calls this checker with
+    # --repair as its precondition, so that mode must materialize every runtime plugin graph.
+    fail_installed "$plugin node_modules is missing"
   fi
 done
 
@@ -136,12 +146,10 @@ if [ "$INSTALLED_FAILURES" -ne 0 ] && $REPAIR; then
   }
   echo "Repairing installed plugin dependencies from frozen lockfiles..." >&2
   for plugin in "${RUNTIME_PLUGINS[@]}"; do
-    if [ -d "$REPO_ROOT/plugins/$plugin/node_modules" ]; then
-      (
-        cd "$REPO_ROOT/plugins/$plugin"
-        PUPPETEER_SKIP_DOWNLOAD=1 bun install --force --frozen-lockfile
-      ) || exit 1
-    fi
+    (
+      cd "$REPO_ROOT/plugins/$plugin"
+      PUPPETEER_SKIP_DOWNLOAD=1 bun install --force --frozen-lockfile
+    ) || exit 1
   done
   exec bash "$0"
 fi

--- a/tests/test-plugin-runtime-dependencies.sh
+++ b/tests/test-plugin-runtime-dependencies.sh
@@ -78,6 +78,28 @@ else
   pass "a stale physical dependency installation fails"
 fi
 
+MISSING_TYPEBOX="$WORK/missing-typebox"
+copy_runtime_state "$MISSING_TYPEBOX"
+AWS_NODE_MODULES="$MISSING_TYPEBOX/plugins/aws/node_modules"
+mkdir -p \
+  "$AWS_NODE_MODULES/@f5-sales-demo/xcsh" \
+  "$AWS_NODE_MODULES/@f5-sales-demo/pi-utils" \
+  "$AWS_NODE_MODULES/@anthropic-ai/sdk" \
+  "$AWS_NODE_MODULES/@agentclientprotocol/sdk" \
+  "$AWS_NODE_MODULES/@google/genai" \
+  "$AWS_NODE_MODULES/bun-types"
+printf '{"version":"20.2.7"}\n' >"$AWS_NODE_MODULES/@f5-sales-demo/xcsh/package.json"
+printf '{"version":"20.2.7"}\n' >"$AWS_NODE_MODULES/@f5-sales-demo/pi-utils/package.json"
+printf '{"version":"0.115.0"}\n' >"$AWS_NODE_MODULES/@anthropic-ai/sdk/package.json"
+printf '{"version":"1.3.0"}\n' >"$AWS_NODE_MODULES/@agentclientprotocol/sdk/package.json"
+printf '{"version":"2.15.0"}\n' >"$AWS_NODE_MODULES/@google/genai/package.json"
+printf '{"version":"1.3.14"}\n' >"$AWS_NODE_MODULES/bun-types/package.json"
+if REPO_ROOT="$MISSING_TYPEBOX" bash "$CHECK" >/dev/null 2>&1; then
+  fail "a physical installation missing TypeBox must fail"
+else
+  pass "a physical installation missing TypeBox fails"
+fi
+
 mkdir -p "$BAD_INSTALL/scripts" "$BAD_INSTALL/plugins/aws/scripts/tests"
 cp "$CHECK" "$BAD_INSTALL/scripts/check-plugin-runtime-dependencies.sh"
 cp "$RUNNER" "$BAD_INSTALL/scripts/run-plugin-tests.sh"
@@ -105,12 +127,16 @@ mkdir -p \
   node_modules/@f5-sales-demo/pi-utils \
   node_modules/@anthropic-ai/sdk \
   node_modules/@agentclientprotocol/sdk \
-  node_modules/@google/genai
+  node_modules/@google/genai \
+  node_modules/@sinclair/typebox \
+  node_modules/bun-types
 printf '{"version":"20.2.7"}\n' >node_modules/@f5-sales-demo/xcsh/package.json
 printf '{"version":"20.2.7"}\n' >node_modules/@f5-sales-demo/pi-utils/package.json
 printf '{"version":"0.115.0"}\n' >node_modules/@anthropic-ai/sdk/package.json
 printf '{"version":"1.3.0"}\n' >node_modules/@agentclientprotocol/sdk/package.json
 printf '{"version":"2.15.0"}\n' >node_modules/@google/genai/package.json
+printf '{"version":"0.34.52"}\n' >node_modules/@sinclair/typebox/package.json
+printf '{"version":"1.3.14"}\n' >node_modules/bun-types/package.json
 EOF
 chmod +x "$BAD_INSTALL/test-bin/bun"
 if ! PATH="$BAD_INSTALL/test-bin:$PATH" RUNNER_TEST_MARKER="$BAD_INSTALL/suite-ran" \

--- a/tests/test-run-plugin-tests.sh
+++ b/tests/test-run-plugin-tests.sh
@@ -91,7 +91,7 @@ if [ -e "$INSTALL_FAILURE/state/test-ran" ]; then
 else
   pass "an install failure stops before bun tests"
 fi
-if grep -Fq 'install --frozen-lockfile|true' "$INSTALL_FAILURE/state/calls"; then
+if grep -Eq 'install( --force)? --frozen-lockfile\|(true|1)' "$INSTALL_FAILURE/state/calls"; then
   pass "dependency installs disable browser downloads"
 else
   fail "dependency installs must set PUPPETEER_SKIP_DOWNLOAD=true"


### PR DESCRIPTION
## Summary
- make the runtime dependency preflight materialize every runtime plugin graph on repair
- validate installed TypeBox and Bun types versions before tests run
- cover missing-TypeBox and clean-install regressions

## Verification
- bash tests/test-plugin-runtime-dependencies.sh
- bash tests/test-run-plugin-tests.sh
- bash scripts/validate-plugins.sh
- bash scripts/check-tests-are-hermetic.sh
- bash scripts/run-plugin-tests.sh
- bash scripts/agy-review.sh code --base origin/main

Closes #1184