### PR TITLE
test: add Regional Edge prompt trace acceptance

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -210,7 +210,7 @@
     {
       "name": "cloudstatus",
       "description": "Live cloud status and Internet network intelligence for xcsh — current incidents, routing, registration, RPKI, peering, facilities, F5 Regional Edge evidence, and bounded path diagnostics",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+- **`cloudstatus`** v1.5.2 — adds an xcsh JSONL prompt-trace acceptance matrix
+  for Regional Edge routing. It verifies one registry collector, visual-only
+  single-map rendering, factual non-rendering, ordering, and prohibited-tool
+  behavior against both hermetic and authenticated local runs ([#1192](https://github.com/f5-sales-demo/marketplace/issues/1192)).
+
 - **`herdr`** bumped to v1.0.3
 
 - **`azure`** v2.0.1 — makes current official F5 and Microsoft research plus live Azure

--- a/plugins/cloudstatus/.xcsh-plugin/plugin.json
+++ b/plugins/cloudstatus/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudstatus",
   "description": "Live cloud status and Internet network intelligence for xcsh — current incidents, routing, registration, RPKI, peering, facilities, F5 Regional Edge evidence, and bounded path diagnostics",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/cloudstatus",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/cloudstatus/README.md
+++ b/plugins/cloudstatus/README.md
@@ -48,7 +48,7 @@ The existing slash command remains status-only:
 ```
 
 Location and general Internet questions route through skills from ordinary
-language; version 1.5.1 adds no new slash command.
+language; version 1.5.2 adds no new slash command.
 
 ## Investigation model
 
@@ -91,6 +91,22 @@ conflicting evidence stays unresolved. Visual intent returns that evidence to
 the parent xcsh session for one `render_map` call; factual intent stays
 text-first. It never delegates, runs general search, or calls a second renderer
 or `display_media`.
+
+## Prompt-trace acceptance
+
+`benchmarks/location-prompt-scenarios.json` defines visual and factual
+Regional Edge prompts. The verifier checks xcsh JSONL tool traces: every
+scenario reads `cloudstatus:location`, invokes one registry collector, forbids
+delegation and search, and renders exactly once only for visual intent.
+
+Run the hermetic contract suite with the plugin tests. To run an authenticated
+local acceptance scenario, provide an xcsh 20.19.0+ executable (or use the
+installed `xcsh`):
+
+```bash
+XCSH_BIN=xcsh bash plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh visual-us gpt-5.6-luna
+XCSH_BIN=xcsh bash plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh factual-site-code gpt-5.6-luna
+```
 
 ## Evidence boundaries
 

--- a/plugins/cloudstatus/benchmarks/location-prompt-scenarios.json
+++ b/plugins/cloudstatus/benchmarks/location-prompt-scenarios.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "scenarios": [
+    {
+      "id": "visual-us",
+      "intent": "visual",
+      "prompt": "Show a current map of F5 Distributed Cloud Regional Edges in the United States, with coordinate provenance.",
+      "collector": "locations --format map-v1"
+    },
+    {
+      "id": "visual-canada",
+      "intent": "visual",
+      "prompt": "Show Canadian F5 Distributed Cloud Regional Edges on a map with coordinate provenance.",
+      "collector": "locations --format map-v1"
+    },
+    {
+      "id": "visual-global",
+      "intent": "visual",
+      "prompt": "Which F5 Distributed Cloud Regional Edges are currently published? Show the global inventory on a map.",
+      "collector": "locations --format map-v1"
+    },
+    {
+      "id": "factual-metro",
+      "intent": "factual",
+      "prompt": "Investigate the Frankfurt F5 Distributed Cloud Regional Edge. Give the evidence and limitations only; do not make a map.",
+      "collector": "location"
+    },
+    {
+      "id": "factual-site-code",
+      "intent": "factual",
+      "prompt": "Investigate F5 Distributed Cloud Regional Edge site code fr4. Give the evidence and limitations only; do not make a map.",
+      "collector": "location"
+    },
+    {
+      "id": "factual-unresolved",
+      "intent": "factual",
+      "prompt": "Investigate the fictional F5 Distributed Cloud Regional Edge in Exampleville. Preserve unresolved evidence and do not make a map.",
+      "collector": "location"
+    }
+  ]
+}

--- a/plugins/cloudstatus/benchmarks/verify-location-prompt-trace.py
+++ b/plugins/cloudstatus/benchmarks/verify-location-prompt-trace.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=invalid-name
 # ruff: noqa: D103, EM102, PLR2004, T201, TRY003
 """Verify deterministic Cloudstatus Regional Edge tool traces from xcsh JSONL."""
 

--- a/plugins/cloudstatus/benchmarks/verify-location-prompt-trace.py
+++ b/plugins/cloudstatus/benchmarks/verify-location-prompt-trace.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# ruff: noqa: D103, EM102, PLR2004, T201, TRY003
+"""Verify deterministic Cloudstatus Regional Edge tool traces from xcsh JSONL."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def parse_trace(trace_path: Path) -> list[dict[str, Any]]:
+    """Read only well-formed JSONL events, ignoring streaming noise safely."""
+    events: list[dict[str, Any]] = []
+    for line in trace_path.read_text(encoding="utf-8").splitlines():
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            events.append(item)
+    return events
+
+
+def tool_starts(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return completed tool starts in the order xcsh executed them."""
+    return [
+        event
+        for event in events
+        if event.get("type") == "tool_execution_start" and event.get("toolName")
+    ]
+
+
+def tool_input(event: dict[str, Any]) -> dict[str, Any]:
+    """Accommodate the stable xcsh input field and earlier trace aliases."""
+    for key in ("input", "args", "arguments"):
+        value = event.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def evaluate_trace(scenario: dict[str, Any], jsonl: str) -> dict[str, Any]:
+    """Evaluate one scenario without interpreting model prose or live results."""
+    events: list[dict[str, Any]] = []
+    for line in jsonl.splitlines():
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            events.append(item)
+    starts = tool_starts(events)
+    tools = [str(event["toolName"]) for event in starts]
+    errors: list[str] = []
+
+    skill_reads = [
+        index
+        for index, event in enumerate(starts)
+        if event["toolName"] == "read"
+        and "cloudstatus/location" in str(tool_input(event).get("path", ""))
+    ]
+    if len(skill_reads) != 1:
+        errors.append(
+            f"expected one cloudstatus location skill read, found {len(skill_reads)}"
+        )
+
+    collector = str(scenario["collector"])
+    collector_starts = [
+        index
+        for index, event in enumerate(starts)
+        if event["toolName"] == "bash"
+        and "network_lookup.py" in str(tool_input(event).get("command", ""))
+    ]
+    if len(collector_starts) != 1:
+        errors.append(
+            f"expected one registry collector Bash call, found {len(collector_starts)}"
+        )
+    elif collector not in str(
+        tool_input(starts[collector_starts[0]]).get("command", "")
+    ):
+        errors.append(f"collector must use {collector!r}")
+
+    render_starts = [
+        index for index, event in enumerate(starts) if event["toolName"] == "render_map"
+    ]
+    expected_renders = 1 if scenario["intent"] == "visual" else 0
+    if len(render_starts) != expected_renders:
+        errors.append(
+            f"expected {expected_renders} render_map calls, found {len(render_starts)}"
+        )
+
+    errors.extend(
+        f"forbidden tool invoked: {forbidden}"
+        for forbidden in ("task", "web_search", "display_media")
+        if forbidden in tools
+    )
+
+    if skill_reads and collector_starts and skill_reads[0] > collector_starts[0]:
+        errors.append("cloudstatus:location must be read before the collector")
+    if render_starts and collector_starts and collector_starts[0] > render_starts[0]:
+        errors.append("collector must run before render_map")
+
+    return {"pass": not errors, "tools": tools, "errors": errors}
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            "usage: verify-location-prompt-trace.py <scenarios.json> <scenario-id> <trace.jsonl>",
+            file=sys.stderr,
+        )
+        return 2
+    scenarios = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["scenarios"]
+    scenario = next((item for item in scenarios if item["id"] == sys.argv[2]), None)
+    if scenario is None:
+        raise ValueError(f"unknown scenario: {sys.argv[2]}")
+    result = evaluate_trace(scenario, Path(sys.argv[3]).read_text(encoding="utf-8"))
+    print(json.dumps({"scenario": scenario["id"], **result}, indent=2))
+    return 0 if result["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/cloudstatus/package.json
+++ b/plugins/cloudstatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudstatus",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Live cloud status and Internet network intelligence for xcsh",
   "license": "Apache-2.0",
   "peerDependencies": {

--- a/plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh
+++ b/plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+scenario_file="$plugin_dir/benchmarks/location-prompt-scenarios.json"
+scenario_id=${1:-visual-us}
+model=${2:-gpt-5.6-luna}
+xcsh_bin=${XCSH_BIN:-xcsh}
+trace_file=$(mktemp "${TMPDIR:-/tmp}/cloudstatus-location-prompt-trace.XXXXXX.jsonl")
+trap 'rm -f "$trace_file"' EXIT
+
+prompt=$(jq -er --arg id "$scenario_id" '.scenarios[] | select(.id == $id) | .prompt' "$scenario_file")
+
+"$xcsh_bin" \
+  --model "$model" \
+  --thinking low \
+  --mode json \
+  --plugin-dir "$plugin_dir" \
+  --no-session \
+  -p "$prompt" >"$trace_file"
+
+python3 "$plugin_dir/benchmarks/verify-location-prompt-trace.py" "$scenario_file" "$scenario_id" "$trace_file"

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
@@ -1,0 +1,124 @@
+# ruff: noqa: D101, D102, D103, EM102, INP001, PT009, TC003, TRY003
+"""Hermetic trace-contract tests for Cloudstatus Regional Edge prompt routing."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import unittest
+from types import ModuleType
+
+PLUGIN_ROOT = pathlib.Path(__file__).resolve().parents[2]
+VERIFIER_PATH = PLUGIN_ROOT / "benchmarks/verify-location-prompt-trace.py"
+
+
+def load_verifier() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "cloudstatus_location_trace", VERIFIER_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {VERIFIER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def trace(*events: dict[str, object]) -> str:
+    return "\n".join(json.dumps(event) for event in events)
+
+
+def start(name: str, input_value: dict[str, object]) -> dict[str, object]:
+    return {"type": "tool_execution_start", "toolName": name, "input": input_value}
+
+
+class LocationPromptTraceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.verifier = load_verifier()
+
+    def test_visual_trace_requires_location_collector_then_one_renderer(self) -> None:
+        result = self.verifier.evaluate_trace(
+            {"intent": "visual", "collector": "locations --format map-v1"},
+            trace(
+                start("read", {"path": "skill://cloudstatus/location"}),
+                start(
+                    "bash",
+                    {
+                        "command": 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
+                    },
+                ),
+                start("render_map", {"locations": []}),
+            ),
+        )
+        self.assertTrue(result["pass"], result["errors"])
+
+    def test_factual_trace_rejects_a_renderer(self) -> None:
+        result = self.verifier.evaluate_trace(
+            {"intent": "factual", "collector": "location"},
+            trace(
+                start("read", {"path": "skill://cloudstatus/location"}),
+                start(
+                    "bash",
+                    {"command": 'network_lookup.py location "$CLOUDSTATUS_QUERY"'},
+                ),
+                start("render_map", {"locations": []}),
+            ),
+        )
+        self.assertFalse(result["pass"])
+        self.assertIn("expected 0 render_map calls, found 1", result["errors"])
+
+    def test_rejects_duplicate_collector_and_forbidden_tools(self) -> None:
+        result = self.verifier.evaluate_trace(
+            {"intent": "visual", "collector": "locations --format map-v1"},
+            trace(
+                start("read", {"path": "skill://cloudstatus/location"}),
+                start(
+                    "bash",
+                    {
+                        "command": 'network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
+                    },
+                ),
+                start("web_search", {"query": "F5 Regional Edge"}),
+                start(
+                    "bash",
+                    {
+                        "command": 'network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
+                    },
+                ),
+                start("task", {}),
+                start("display_media", {}),
+                start("render_map", {"locations": []}),
+            ),
+        )
+        self.assertFalse(result["pass"])
+        self.assertIn(
+            "expected one registry collector Bash call, found 2", result["errors"]
+        )
+        self.assertIn("forbidden tool invoked: task", result["errors"])
+        self.assertIn("forbidden tool invoked: web_search", result["errors"])
+        self.assertIn("forbidden tool invoked: display_media", result["errors"])
+
+    def test_rejects_wrong_order_and_missing_skill_read(self) -> None:
+        result = self.verifier.evaluate_trace(
+            {"intent": "visual", "collector": "locations --format map-v1"},
+            trace(
+                start(
+                    "bash",
+                    {
+                        "command": 'network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
+                    },
+                ),
+                start("render_map", {"locations": []}),
+            ),
+        )
+        self.assertFalse(result["pass"])
+        self.assertIn(
+            "expected one cloudstatus location skill read, found 0", result["errors"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
@@ -35,6 +35,8 @@ def start(name: str, input_value: dict[str, object]) -> dict[str, object]:
 
 
 class LocationPromptTraceTests(unittest.TestCase):
+    verifier: ModuleType
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.verifier = load_verifier()

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.sh
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Hermetic xcsh JSONL acceptance-contract suite.
+
+set -euo pipefail
+
+test_location_prompt_trace_suite() {
+  python3 "$PLUGIN_ROOT/scripts/tests/test_location_prompt_trace.py" -v
+}

--- a/plugins/cloudstatus/scripts/tests/test_structure.sh
+++ b/plugins/cloudstatus/scripts/tests/test_structure.sh
@@ -22,7 +22,7 @@ test_plugin_metadata_is_consistent() {
   package_version=$(jq -r '.version' "$package_json")
   marketplace_version=$(jq -r '.plugins[] | select(.name == "cloudstatus") | .version' "$marketplace_json")
 
-  [ "$plugin_version" = "1.5.1" ] || {
+  [ "$plugin_version" = "1.5.2" ] || {
     echo "plugin version is $plugin_version"
     return 1
   }
@@ -50,6 +50,9 @@ test_expected_runtime_files_exist() {
     "skills/network-intelligence/references/source-ladder.md"
     "skills/network-intelligence/references/query-playbook.md"
     "skills/network-intelligence/scripts/network_lookup.py"
+    "benchmarks/location-prompt-scenarios.json"
+    "benchmarks/verify-location-prompt-trace.py"
+    "scripts/evals/run-location-prompt-eval.sh"
     "agents/cloudstatus-status-operator.md"
     "agents/cloudstatus-network-operator.md"
     "commands/cloud-status.md"
@@ -62,6 +65,16 @@ test_expected_runtime_files_exist() {
       return 1
     }
   done
+}
+
+test_location_prompt_scenarios_cover_required_intents() {
+  local scenarios="$PLUGIN_ROOT/benchmarks/location-prompt-scenarios.json"
+  jq -e '
+    .version == 1 and
+    ([.scenarios[].id] | sort) == ["factual-metro", "factual-site-code", "factual-unresolved", "visual-canada", "visual-global", "visual-us"] and
+    ([.scenarios[] | select(.intent == "visual")] | length) == 3 and
+    ([.scenarios[] | select(.intent == "factual")] | length) == 3
+  ' "$scenarios" >/dev/null
 }
 
 test_skill_frontmatter_has_only_name_and_description() {


### PR DESCRIPTION
## Summary
- add six natural-language Regional Edge visual/factual acceptance scenarios
- verify xcsh JSONL traces for skill read, one collector, render counts, order, and forbidden tools
- provide a documented authenticated local runner

## Validation
- `bash plugins/cloudstatus/scripts/tests/run-tests.sh`
- `bash scripts/validate-plugins.sh`
- `ruff check` and `ruff format --check` for new Python files
- built xcsh 20.20.0 with `bun run build`
- authenticated xcsh visual-US and factual-site-code trace runs passed

Closes #1192