### PR TITLE
fix: enforce Regional Edge collector routing

### DIFF
--- a/.xcsh-plugin/marketplace.json
+++ b/.xcsh-plugin/marketplace.json
@@ -210,7 +210,7 @@
     {
       "name": "cloudstatus",
       "description": "Live cloud status and Internet network intelligence for xcsh — current incidents, routing, registration, RPKI, peering, facilities, F5 Regional Edge evidence, and bounded path diagnostics",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "author": {
         "name": "f5-sales-demo"
       },

--- a/plugins/cloudstatus/.xcsh-plugin/plugin.json
+++ b/plugins/cloudstatus/.xcsh-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudstatus",
   "description": "Live cloud status and Internet network intelligence for xcsh — current incidents, routing, registration, RPKI, peering, facilities, F5 Regional Edge evidence, and bounded path diagnostics",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "homepage": "https://github.com/f5-sales-demo/marketplace/tree/main/plugins/cloudstatus",
   "license": "Apache-2.0",
   "author": {

--- a/plugins/cloudstatus/README.md
+++ b/plugins/cloudstatus/README.md
@@ -97,7 +97,9 @@ or `display_media`.
 `benchmarks/location-prompt-scenarios.json` defines visual and factual
 Regional Edge prompts. The verifier checks xcsh JSONL tool traces: every
 scenario reads `cloudstatus:location`, invokes one registry collector, forbids
-delegation and search, and renders exactly once only for visual intent.
+delegation and search, and proves exactly one successful `render_map`
+start/completion pair with a canonical, byte-verified PNG only for visual
+intent. Factual scenarios prove that no render or image result occurred.
 
 Run the hermetic contract suite with the plugin tests. To run an authenticated
 local acceptance scenario, provide an xcsh 20.19.0+ executable (or use the
@@ -119,9 +121,12 @@ XCSH_DEV_DIR=/path/to/xcsh LOCATION_UAT_REPEAT=4 LOCATION_UAT_SYNTHESIZE=1 \
   bash plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh visual-address-us gpt-5.6-luna
 ```
 
-Failed runs retain their JSONL trace under `/tmp` (or
-`LOCATION_UAT_ARTIFACT_DIR`) for diagnosis; successful runs leave no temporary
-artifacts. A caller-supplied artifact directory is always retained.
+Each attempt emits a compact JSON receipt with named claims, tool ordering,
+dimensions, decoded byte count, SHA-256, and basemap. Failed runs retain their
+JSONL trace, receipt, and any verified PNG under `/tmp` for diagnosis;
+successful runs leave no temporary artifacts. A caller-supplied
+`LOCATION_UAT_ARTIFACT_DIR` is always retained and stores the PNG beside its
+trace and receipt. Receipts and summaries never contain image base64.
 
 ## Evidence boundaries
 

--- a/plugins/cloudstatus/README.md
+++ b/plugins/cloudstatus/README.md
@@ -48,7 +48,7 @@ The existing slash command remains status-only:
 ```
 
 Location and general Internet questions route through skills from ordinary
-language; version 1.5.2 adds no new slash command.
+language; version 1.5.3 adds no new slash command.
 
 ## Investigation model
 
@@ -107,6 +107,21 @@ installed `xcsh`):
 XCSH_BIN=xcsh bash plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh visual-us gpt-5.6-luna
 XCSH_BIN=xcsh bash plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh factual-site-code gpt-5.6-luna
 ```
+
+For local xcsh development, set `XCSH_DEV_DIR` to the xcsh checkout; the
+runner then starts a fresh `bun run dev -- --plugin-dir … --no-session` process
+for every attempt. Run the whole matrix, or repeat and synthesize controlled
+variants of the exact address-map regression:
+
+```bash
+XCSH_DEV_DIR=/path/to/xcsh bash plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh --all gpt-5.6-luna
+XCSH_DEV_DIR=/path/to/xcsh LOCATION_UAT_REPEAT=4 LOCATION_UAT_SYNTHESIZE=1 \
+  bash plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh visual-address-us gpt-5.6-luna
+```
+
+Failed runs retain their JSONL trace under `/tmp` (or
+`LOCATION_UAT_ARTIFACT_DIR`) for diagnosis; successful runs leave no temporary
+artifacts. A caller-supplied artifact directory is always retained.
 
 ## Evidence boundaries
 

--- a/plugins/cloudstatus/benchmarks/location-prompt-scenarios.json
+++ b/plugins/cloudstatus/benchmarks/location-prompt-scenarios.json
@@ -8,6 +8,12 @@
       "collector": "locations --format map-v1"
     },
     {
+      "id": "visual-address-us",
+      "intent": "visual",
+      "prompt": "show me a map of all the address locations of the F5 regional edges that are located in the united states",
+      "collector": "locations --format map-v1"
+    },
+    {
       "id": "visual-canada",
       "intent": "visual",
       "prompt": "Show Canadian F5 Distributed Cloud Regional Edges on a map with coordinate provenance.",

--- a/plugins/cloudstatus/benchmarks/verify-location-prompt-trace.py
+++ b/plugins/cloudstatus/benchmarks/verify-location-prompt-trace.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-function-docstring,too-many-branches,too-many-locals,too-many-statements
 # ruff: noqa: D103, EM101, EM102, PLR2004, T201, TRY003, TRY004
 """Verify deterministic Cloudstatus Regional Edge tool traces from xcsh JSONL."""
 

--- a/plugins/cloudstatus/benchmarks/verify-location-prompt-trace.py
+++ b/plugins/cloudstatus/benchmarks/verify-location-prompt-trace.py
@@ -1,20 +1,28 @@
 #!/usr/bin/env python3
 # pylint: disable=invalid-name
-# ruff: noqa: D103, EM102, PLR2004, T201, TRY003
+# ruff: noqa: D103, EM101, EM102, PLR2004, T201, TRY003, TRY004
 """Verify deterministic Cloudstatus Regional Edge tool traces from xcsh JSONL."""
 
 from __future__ import annotations
 
+import argparse
+import base64
+import binascii
+import hashlib
 import json
-import sys
+import re
+import struct
 from pathlib import Path
 from typing import Any
 
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+SHA256_REF = re.compile(r"^blob:sha256:([a-f0-9]{64})$")
 
-def parse_trace(trace_path: Path) -> list[dict[str, Any]]:
+
+def parse_jsonl(jsonl: str) -> list[dict[str, Any]]:
     """Read only well-formed JSONL events, ignoring streaming noise safely."""
     events: list[dict[str, Any]] = []
-    for line in trace_path.read_text(encoding="utf-8").splitlines():
+    for line in jsonl.splitlines():
         try:
             item = json.loads(line)
         except json.JSONDecodeError:
@@ -24,8 +32,13 @@ def parse_trace(trace_path: Path) -> list[dict[str, Any]]:
     return events
 
 
+def parse_trace(trace_path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL trace from disk."""
+    return parse_jsonl(trace_path.read_text(encoding="utf-8"))
+
+
 def tool_starts(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Return completed tool starts in the order xcsh executed them."""
+    """Return tool starts in execution order."""
     return [
         event
         for event in events
@@ -34,27 +47,152 @@ def tool_starts(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def tool_input(event: dict[str, Any]) -> dict[str, Any]:
-    """Accommodate the stable xcsh input field and earlier trace aliases."""
-    for key in ("input", "args", "arguments"):
+    """Accommodate the stable xcsh args field and earlier trace aliases."""
+    for key in ("args", "input", "arguments"):
         value = event.get(key)
         if isinstance(value, dict):
             return value
     return {}
 
 
-def evaluate_trace(scenario: dict[str, Any], jsonl: str) -> dict[str, Any]:
-    """Evaluate one scenario without interpreting model prose or live results."""
-    events: list[dict[str, Any]] = []
-    for line in jsonl.splitlines():
-        try:
-            item = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(item, dict):
-            events.append(item)
+def parse_png(png: bytes) -> tuple[int, int]:
+    """Validate the structural PNG contract and return IHDR dimensions."""
+    if not png.startswith(PNG_SIGNATURE):
+        raise ValueError("invalid PNG signature")
+    offset = len(PNG_SIGNATURE)
+    chunks: list[bytes] = []
+    dimensions: tuple[int, int] | None = None
+    saw_idat = False
+    saw_iend = False
+    while offset < len(png):
+        if len(png) - offset < 12:
+            raise ValueError("invalid PNG chunk bounds")
+        length = struct.unpack(">I", png[offset : offset + 4])[0]
+        chunk_type = png[offset + 4 : offset + 8]
+        data_start = offset + 8
+        data_end = data_start + length
+        crc_end = data_end + 4
+        if crc_end > len(png):
+            raise ValueError("invalid PNG chunk bounds")
+        recorded_crc = struct.unpack(">I", png[data_end:crc_end])[0]
+        actual_crc = binascii.crc32(chunk_type + png[data_start:data_end]) & 0xFFFFFFFF
+        if recorded_crc != actual_crc:
+            raise ValueError(
+                f"invalid PNG CRC for {chunk_type.decode('ascii', 'replace')}"
+            )
+        if not chunks and chunk_type != b"IHDR":
+            raise ValueError("PNG IHDR must be the first chunk")
+        if chunk_type == b"IHDR":
+            if chunks or length != 13:
+                raise ValueError("invalid PNG IHDR")
+            width, height = struct.unpack(">II", png[data_start : data_start + 8])
+            if width <= 0 or height <= 0:
+                raise ValueError("PNG dimensions must be positive")
+            dimensions = (width, height)
+        elif chunk_type == b"IDAT":
+            if dimensions is None or saw_iend:
+                raise ValueError("invalid PNG IDAT ordering")
+            saw_idat = True
+        elif chunk_type == b"IEND":
+            if length != 0 or not saw_idat:
+                raise ValueError("invalid PNG IEND")
+            saw_iend = True
+            if crc_end != len(png):
+                raise ValueError("PNG contains data after IEND")
+        chunks.append(chunk_type)
+        offset = crc_end
+    if dimensions is None:
+        raise ValueError("PNG is missing IHDR")
+    if not saw_idat:
+        raise ValueError("PNG is missing IDAT")
+    if not saw_iend or chunks[-1] != b"IEND":
+        raise ValueError("PNG is missing IEND")
+    return dimensions
+
+
+def verify_media_result(completion: dict[str, Any]) -> tuple[dict[str, Any], bytes]:
+    """Validate a successful canonical render_map result and return its receipt."""
+    if completion.get("isError") is not False:
+        raise ValueError("render_map completion reported an error")
+    result = completion.get("result")
+    if not isinstance(result, dict):
+        raise ValueError("render_map completion is missing a result object")
+    content = result.get("content")
+    if not isinstance(content, list):
+        raise ValueError("render_map result content must be an array")
+    image_blocks = [
+        block
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "image"
+    ]
+    if len(image_blocks) != 1 or image_blocks[0].get("mimeType") != "image/png":
+        raise ValueError("render_map must return exactly one image/png content block")
+    encoded = image_blocks[0].get("data")
+    if not isinstance(encoded, str):
+        raise ValueError("image/png content is missing strict base64 data")
+    try:
+        png = base64.b64decode(encoded.encode("ascii"), validate=True)
+    except (UnicodeEncodeError, ValueError, binascii.Error) as error:
+        raise ValueError("image/png content is not strict base64") from error
+    width, height = parse_png(png)
+
+    details = result.get("details")
+    if not isinstance(details, dict) or details.get("mediaResult") != "xcsh.media/v1":
+        raise ValueError("render_map result is missing xcsh.media/v1 details")
+    descriptor = details.get("descriptor")
+    if not isinstance(descriptor, dict) or descriptor.get("version") != 1:
+        raise ValueError("render_map result is missing a canonical media descriptor")
+    if descriptor.get("kind") != "image":
+        raise ValueError("canonical media descriptor kind must be image")
+    if descriptor.get("width") != width or descriptor.get("height") != height:
+        raise ValueError("descriptor dimensions do not match the PNG IHDR")
+    original = descriptor.get("original")
+    if not isinstance(original, dict) or original.get("mimeType") != "image/png":
+        raise ValueError("descriptor.original must describe image/png")
+    if original.get("bytes") != len(png):
+        raise ValueError(
+            "descriptor.original decoded byte count does not match the PNG"
+        )
+    digest = hashlib.sha256(png).hexdigest()
+    ref_match = SHA256_REF.fullmatch(str(original.get("ref", "")))
+    if ref_match is None or ref_match.group(1) != digest:
+        raise ValueError("descriptor.original SHA-256 does not match the PNG")
+    provenance = descriptor.get("provenance")
+    metadata = descriptor.get("metadata")
+    if (
+        not isinstance(provenance, dict)
+        or provenance.get("sourceType") != "tool"
+        or provenance.get("source") != "render_map"
+    ):
+        raise ValueError("descriptor provenance must identify the render_map tool")
+    if not isinstance(metadata, dict) or metadata.get("producer") != "render_map":
+        raise ValueError("descriptor metadata producer must be render_map")
+    if details.get("displayMethod") != "inline":
+        raise ValueError("canonical media displayMethod must be inline")
+    basemap = metadata.get("basemap")
+    if not isinstance(basemap, str) or not basemap:
+        raise ValueError("descriptor metadata must include a basemap")
+    return (
+        {
+            "dimensions": [width, height],
+            "bytes": len(png),
+            "sha256": digest,
+            "basemap": basemap,
+        },
+        png,
+    )
+
+
+def analyze_trace(
+    scenario: dict[str, Any], jsonl: str
+) -> tuple[dict[str, Any], bytes | None]:
+    """Evaluate one scenario and retain verified PNG bytes only for extraction."""
+    events = parse_jsonl(jsonl)
     starts = tool_starts(events)
     tools = [str(event["toolName"]) for event in starts]
     errors: list[str] = []
+    image_receipt: dict[str, Any] | None = None
+    png: bytes | None = None
 
     skill_reads = [
         index
@@ -83,42 +221,138 @@ def evaluate_trace(scenario: dict[str, Any], jsonl: str) -> dict[str, Any]:
     ):
         errors.append(f"collector must use {collector!r}")
 
-    render_starts = [
-        index for index, event in enumerate(starts) if event["toolName"] == "render_map"
+    render_starts = [event for event in starts if event["toolName"] == "render_map"]
+    render_completions = [
+        event
+        for event in events
+        if event.get("type") == "tool_execution_end"
+        and event.get("toolName") == "render_map"
     ]
-    expected_renders = 1 if scenario["intent"] == "visual" else 0
+    completion_ids = [str(event.get("toolCallId", "")) for event in render_completions]
+    duplicate_completion_ids = sorted(
+        {value for value in completion_ids if completion_ids.count(value) > 1}
+    )
+    if duplicate_completion_ids:
+        errors.append(
+            f"duplicate render_map completion IDs: {', '.join(duplicate_completion_ids)}"
+        )
+
+    visual = scenario["intent"] == "visual"
+    expected_renders = 1 if visual else 0
     if len(render_starts) != expected_renders:
         errors.append(
-            f"expected {expected_renders} render_map calls, found {len(render_starts)}"
+            f"expected {expected_renders} render_map starts, found {len(render_starts)}"
         )
+    if len(render_completions) != expected_renders:
+        errors.append(
+            f"expected {expected_renders} render_map completions, found {len(render_completions)}"
+        )
+
+    paired = False
+    if visual and len(render_starts) == 1 and len(render_completions) == 1:
+        start_id = render_starts[0].get("toolCallId")
+        completion_id = render_completions[0].get("toolCallId")
+        paired = (
+            isinstance(start_id, str) and start_id != "" and start_id == completion_id
+        )
+        if paired:
+            try:
+                image_receipt, png = verify_media_result(render_completions[0])
+            except ValueError as error:
+                errors.append(str(error))
+        else:
+            errors.append(
+                "expected one successful render_map start/completion pair with the same toolCallId"
+            )
+    elif visual:
+        errors.append("expected one successful render_map start/completion pair")
+
+    image_events = [
+        event
+        for event in events
+        if event.get("type") == "tool_execution_end"
+        and isinstance(event.get("result"), dict)
+        and isinstance(event["result"].get("content"), list)
+        and any(
+            isinstance(block, dict) and block.get("type") == "image"
+            for block in event["result"]["content"]
+        )
+    ]
+    if not visual and image_events:
+        errors.append("factual scenario returned image content")
 
     errors.extend(
         f"forbidden tool invoked: {forbidden}"
         for forbidden in ("task", "web_search", "display_media")
         if forbidden in tools
     )
-
+    ordering_valid = True
     if skill_reads and collector_starts and skill_reads[0] > collector_starts[0]:
         errors.append("cloudstatus:location must be read before the collector")
-    if render_starts and collector_starts and collector_starts[0] > render_starts[0]:
+        ordering_valid = False
+    render_indices = [
+        index for index, event in enumerate(starts) if event["toolName"] == "render_map"
+    ]
+    if render_indices and collector_starts and collector_starts[0] > render_indices[0]:
         errors.append("collector must run before render_map")
+        ordering_valid = False
 
-    return {"pass": not errors, "tools": tools, "errors": errors}
+    claims = {
+        "location_skill_read_once": len(skill_reads) == 1,
+        "registry_collector_once": len(collector_starts) == 1,
+        "forbidden_tools_absent": not any(
+            name in tools for name in ("task", "web_search", "display_media")
+        ),
+        "tool_ordering_valid": ordering_valid,
+        "successful_render_pair": visual and paired and image_receipt is not None,
+        "valid_png": visual and image_receipt is not None,
+        "zero_image_generation": not visual
+        and not render_starts
+        and not render_completions
+        and not image_events,
+    }
+    receipt = {"claims": claims, "image": image_receipt, "toolOrdering": tools}
+    return {
+        "pass": not errors,
+        "tools": tools,
+        "errors": errors,
+        "receipt": receipt,
+    }, png
+
+
+def evaluate_trace(scenario: dict[str, Any], jsonl: str) -> dict[str, Any]:
+    """Evaluate one scenario without returning or printing encoded image bytes."""
+    result, _png = analyze_trace(scenario, jsonl)
+    return result
 
 
 def main() -> int:
-    if len(sys.argv) != 4:
-        print(
-            "usage: verify-location-prompt-trace.py <scenarios.json> <scenario-id> <trace.jsonl>",
-            file=sys.stderr,
-        )
-        return 2
-    scenarios = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))["scenarios"]
-    scenario = next((item for item in scenarios if item["id"] == sys.argv[2]), None)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scenarios", type=Path)
+    parser.add_argument("scenario_id")
+    parser.add_argument("trace", type=Path)
+    parser.add_argument("--receipt", type=Path)
+    parser.add_argument("--extract-png", type=Path)
+    args = parser.parse_args()
+    scenarios = json.loads(args.scenarios.read_text(encoding="utf-8"))["scenarios"]
+    scenario = next(
+        (item for item in scenarios if item["id"] == args.scenario_id), None
+    )
     if scenario is None:
-        raise ValueError(f"unknown scenario: {sys.argv[2]}")
-    result = evaluate_trace(scenario, Path(sys.argv[3]).read_text(encoding="utf-8"))
-    print(json.dumps({"scenario": scenario["id"], **result}, indent=2))
+        raise ValueError(f"unknown scenario: {args.scenario_id}")
+    result, png = analyze_trace(scenario, args.trace.read_text(encoding="utf-8"))
+    output = {
+        "scenario": scenario["id"],
+        "pass": result["pass"],
+        **result["receipt"],
+        "errors": result["errors"],
+    }
+    compact = json.dumps(output, separators=(",", ":"), sort_keys=True)
+    print(compact)
+    if args.receipt:
+        args.receipt.write_text(compact + "\n", encoding="utf-8")
+    if args.extract_png and png is not None:
+        args.extract_png.write_bytes(png)
     return 0 if result["pass"] else 1
 
 

--- a/plugins/cloudstatus/extensions/regional-edge-guard.ts
+++ b/plugins/cloudstatus/extensions/regional-edge-guard.ts
@@ -1,30 +1,93 @@
-import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
+import { createHash } from 'node:crypto';
+import type { ExtensionAPI } from '@f5-sales-demo/xcsh';
 
 const LOCATION_SKILL = /cloudstatus(?:[:/])location\b/i;
 const REGIONAL_EDGE = /\bregional\s+edges?\b/i;
-const COLLECTOR = /^\s*python3\s+skill:\/\/cloudstatus:network-intelligence\/scripts\/network_lookup\.py\s+(locations\s+--format\s+map-v1|location)\s+"\$CLOUDSTATUS_QUERY"\s*$/;
+const COLLECTOR =
+  /^\s*python3\s+skill:\/\/cloudstatus:network-intelligence\/scripts\/network_lookup\.py\s+(locations\s+--format\s+map-v1|location)\s+"\$CLOUDSTATUS_QUERY"\s*$/;
 
 type WorkflowState = {
-	active: boolean;
-	skillRead: boolean;
-	collector: "map" | "factual" | undefined;
-	rendered: boolean;
+  active: boolean;
+  skillRead: boolean;
+  collector: 'map' | 'factual' | undefined;
+  rendered: boolean;
 };
 
 function freshState(): WorkflowState {
-	return { active: false, skillRead: false, collector: undefined, rendered: false };
+  return { active: false, skillRead: false, collector: undefined, rendered: false };
 }
 
 function inputText(input: Record<string, unknown>): string {
-	try {
-		return JSON.stringify(input);
-	} catch {
-		return "";
-	}
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return '';
+  }
 }
 
 function blocked(reason: string) {
-	return { block: true, reason: `Cloudstatus Regional Edge guard: ${reason}` };
+  return { block: true, reason: `Cloudstatus Regional Edge guard: ${reason}` };
+}
+
+function decodeStrictBase64(value: unknown): Buffer | undefined {
+  if (typeof value !== 'string' || value.length === 0 || value.length % 4 !== 0) return undefined;
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) return undefined;
+  const decoded = Buffer.from(value, 'base64');
+  return decoded.toString('base64') === value ? decoded : undefined;
+}
+
+function invalidMapResult(event: {
+  content: Array<{ type: string; mimeType?: string; data?: string }>;
+  details: unknown;
+  isError: boolean;
+}): string | undefined {
+  if (event.isError) return 'render_map returned an error';
+  const images = event.content.filter((block) => block.type === 'image');
+  if (images.length !== 1 || images[0].mimeType !== 'image/png')
+    return 'render_map did not return exactly one PNG image';
+  const png = decodeStrictBase64(images[0].data);
+  if (!png || png.length < 24 || !png.subarray(0, 8).equals(Buffer.from('89504e470d0a1a0a', 'hex'))) {
+    return 'render_map returned malformed PNG media';
+  }
+  const width = png.readUInt32BE(16);
+  const height = png.readUInt32BE(20);
+  if (width <= 0 || height <= 0) return 'render_map returned invalid PNG dimensions';
+  if (!event.details || typeof event.details !== 'object') return 'render_map omitted canonical media details';
+  const details = event.details as Record<string, unknown>;
+  const descriptor = details.descriptor;
+  if (details.mediaResult !== 'xcsh.media/v1' || !descriptor || typeof descriptor !== 'object') {
+    return 'render_map omitted the canonical xcsh.media/v1 descriptor';
+  }
+  const media = descriptor as Record<string, unknown>;
+  const original = media.original as Record<string, unknown> | undefined;
+  const provenance = media.provenance as Record<string, unknown> | undefined;
+  const metadata = media.metadata as Record<string, unknown> | undefined;
+  const digest = createHash('sha256').update(png).digest('hex');
+  if (
+    media.version !== 1 ||
+    media.kind !== 'image' ||
+    media.width !== width ||
+    media.height !== height ||
+    original?.mimeType !== 'image/png' ||
+    original?.bytes !== png.length ||
+    original?.ref !== `blob:sha256:${digest}` ||
+    provenance?.sourceType !== 'tool' ||
+    provenance?.source !== 'render_map' ||
+    metadata?.producer !== 'render_map' ||
+    details.displayMethod !== 'inline'
+  ) {
+    return 'render_map returned malformed canonical media metadata';
+  }
+  return undefined;
+}
+
+function failedResult(reason: string) {
+  return {
+    isError: true,
+    content: [
+      { type: 'text' as const, text: `Cloudstatus Regional Edge guard: ${reason}; a second render is not permitted.` },
+    ],
+  };
 }
 
 /**
@@ -34,47 +97,55 @@ function blocked(reason: string) {
  * containing Regional Edge language, so ordinary network-intelligence work is unaffected.
  */
 export default function regionalEdgeGuard(pi: ExtensionAPI): void {
-	let state = freshState();
+  let state = freshState();
 
-	pi.on("session_start", () => {
-		state = freshState();
-	});
+  pi.on('session_start', () => {
+    state = freshState();
+  });
 
-	pi.on("tool_call", event => {
-		const text = inputText(event.input);
-		if (event.toolName === "read" && LOCATION_SKILL.test(text)) {
-			state.active = true;
-			state.skillRead = true;
-			return undefined;
-		}
+  pi.on('tool_call', (event) => {
+    const text = inputText(event.input);
+    if (event.toolName === 'read' && LOCATION_SKILL.test(text)) {
+      state.active = true;
+      state.skillRead = true;
+      return undefined;
+    }
 
-		if ((event.toolName === "task" || event.toolName === "web_search") && REGIONAL_EDGE.test(text)) {
-			state.active = true;
-			return blocked("use cloudstatus:location and its direct registry collector; do not delegate or search");
-		}
+    if ((event.toolName === 'task' || event.toolName === 'web_search') && REGIONAL_EDGE.test(text)) {
+      state.active = true;
+      return blocked('use cloudstatus:location and its direct registry collector; do not delegate or search');
+    }
 
-		if (!state.active) return undefined;
+    if (!state.active) return undefined;
 
-		if (event.toolName === "task" || event.toolName === "web_search" || event.toolName === "display_media") {
-			return blocked("this workflow does not permit delegation, web search, or display media");
-		}
+    if (event.toolName === 'task' || event.toolName === 'web_search' || event.toolName === 'display_media') {
+      return blocked('this workflow does not permit delegation, web search, or display media');
+    }
 
-		if (event.toolName === "bash") {
-			const command = String(event.input.command ?? "");
-			const match = command.match(COLLECTOR);
-			if (!state.skillRead) return blocked("read cloudstatus:location before invoking the registry collector");
-			if (!match) return blocked("only the direct network_lookup.py registry collector is allowed");
-			if (state.collector) return blocked("the registry collector may run exactly once per request");
-			state.collector = match[1].startsWith("locations") ? "map" : "factual";
-			return undefined;
-		}
+    if (event.toolName === 'bash') {
+      const command = String(event.input.command ?? '');
+      const match = command.match(COLLECTOR);
+      if (!state.skillRead) return blocked('read cloudstatus:location before invoking the registry collector');
+      if (!match) return blocked('only the direct network_lookup.py registry collector is allowed');
+      if (state.collector) return blocked('the registry collector may run exactly once per request');
+      state.collector = match[1].startsWith('locations') ? 'map' : 'factual';
+      return undefined;
+    }
 
-		if (event.toolName === "render_map") {
-			if (state.collector !== "map") return blocked("render_map requires locations --format map-v1, not a factual location call");
-			if (state.rendered) return blocked("render_map may run exactly once per request");
-			state.rendered = true;
-		}
+    if (event.toolName === 'render_map') {
+      if (state.collector !== 'map')
+        return blocked('render_map requires locations --format map-v1, not a factual location call');
+      if (state.rendered) return blocked('render_map may run exactly once per request');
+      state.rendered = true;
+    }
 
-		return undefined;
-	});
+    return undefined;
+  });
+
+  pi.on('tool_result', (event) => {
+    if (!state.active || event.toolName !== 'render_map') return undefined;
+    if (state.collector !== 'map' || !state.rendered) return failedResult('unexpected render_map result');
+    const reason = invalidMapResult(event);
+    return reason ? failedResult(reason) : undefined;
+  });
 }

--- a/plugins/cloudstatus/extensions/regional-edge-guard.ts
+++ b/plugins/cloudstatus/extensions/regional-edge-guard.ts
@@ -1,0 +1,80 @@
+import type { ExtensionAPI } from "@f5-sales-demo/xcsh";
+
+const LOCATION_SKILL = /cloudstatus(?:[:/])location\b/i;
+const REGIONAL_EDGE = /\bregional\s+edges?\b/i;
+const COLLECTOR = /^\s*python3\s+skill:\/\/cloudstatus:network-intelligence\/scripts\/network_lookup\.py\s+(locations\s+--format\s+map-v1|location)\s+"\$CLOUDSTATUS_QUERY"\s*$/;
+
+type WorkflowState = {
+	active: boolean;
+	skillRead: boolean;
+	collector: "map" | "factual" | undefined;
+	rendered: boolean;
+};
+
+function freshState(): WorkflowState {
+	return { active: false, skillRead: false, collector: undefined, rendered: false };
+}
+
+function inputText(input: Record<string, unknown>): string {
+	try {
+		return JSON.stringify(input);
+	} catch {
+		return "";
+	}
+}
+
+function blocked(reason: string) {
+	return { block: true, reason: `Cloudstatus Regional Edge guard: ${reason}` };
+}
+
+/**
+ * Enforce the Regional Edge registry-only workflow at the tool boundary.
+ *
+ * This deliberately activates only for the location skill or an attempted task/search
+ * containing Regional Edge language, so ordinary network-intelligence work is unaffected.
+ */
+export default function regionalEdgeGuard(pi: ExtensionAPI): void {
+	let state = freshState();
+
+	pi.on("session_start", () => {
+		state = freshState();
+	});
+
+	pi.on("tool_call", event => {
+		const text = inputText(event.input);
+		if (event.toolName === "read" && LOCATION_SKILL.test(text)) {
+			state.active = true;
+			state.skillRead = true;
+			return undefined;
+		}
+
+		if ((event.toolName === "task" || event.toolName === "web_search") && REGIONAL_EDGE.test(text)) {
+			state.active = true;
+			return blocked("use cloudstatus:location and its direct registry collector; do not delegate or search");
+		}
+
+		if (!state.active) return undefined;
+
+		if (event.toolName === "task" || event.toolName === "web_search" || event.toolName === "display_media") {
+			return blocked("this workflow does not permit delegation, web search, or display media");
+		}
+
+		if (event.toolName === "bash") {
+			const command = String(event.input.command ?? "");
+			const match = command.match(COLLECTOR);
+			if (!state.skillRead) return blocked("read cloudstatus:location before invoking the registry collector");
+			if (!match) return blocked("only the direct network_lookup.py registry collector is allowed");
+			if (state.collector) return blocked("the registry collector may run exactly once per request");
+			state.collector = match[1].startsWith("locations") ? "map" : "factual";
+			return undefined;
+		}
+
+		if (event.toolName === "render_map") {
+			if (state.collector !== "map") return blocked("render_map requires locations --format map-v1, not a factual location call");
+			if (state.rendered) return blocked("render_map may run exactly once per request");
+			state.rendered = true;
+		}
+
+		return undefined;
+	});
+}

--- a/plugins/cloudstatus/extensions/regional-edge-guard.ts
+++ b/plugins/cloudstatus/extensions/regional-edge-guard.ts
@@ -36,6 +36,50 @@ function decodeStrictBase64(value: unknown): Buffer | undefined {
   return decoded.toString('base64') === value ? decoded : undefined;
 }
 
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of data) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngDimensions(png: Buffer): [number, number] | undefined {
+  if (png.length < 33 || !png.subarray(0, 8).equals(Buffer.from('89504e470d0a1a0a', 'hex'))) return undefined;
+  let offset = 8;
+  let dimensions: [number, number] | undefined;
+  let sawIdat = false;
+  let sawIend = false;
+  while (offset < png.length) {
+    if (png.length - offset < 12) return undefined;
+    const length = png.readUInt32BE(offset);
+    const type = png.subarray(offset + 4, offset + 8);
+    const dataEnd = offset + 8 + length;
+    const crcEnd = dataEnd + 4;
+    if (crcEnd > png.length || png.readUInt32BE(dataEnd) !== crc32(png.subarray(offset + 4, dataEnd))) {
+      return undefined;
+    }
+    if (!dimensions) {
+      if (!type.equals(Buffer.from('IHDR')) || length !== 13) return undefined;
+      const width = png.readUInt32BE(offset + 8);
+      const height = png.readUInt32BE(offset + 12);
+      if (width <= 0 || height <= 0) return undefined;
+      dimensions = [width, height];
+    } else if (type.equals(Buffer.from('IHDR'))) {
+      return undefined;
+    } else if (type.equals(Buffer.from('IDAT'))) {
+      if (sawIend) return undefined;
+      sawIdat = true;
+    } else if (type.equals(Buffer.from('IEND'))) {
+      if (length !== 0 || !sawIdat || crcEnd !== png.length) return undefined;
+      sawIend = true;
+    }
+    offset = crcEnd;
+  }
+  return dimensions && sawIdat && sawIend ? dimensions : undefined;
+}
+
 function invalidMapResult(event: {
   content: Array<{ type: string; mimeType?: string; data?: string }>;
   details: unknown;
@@ -46,12 +90,9 @@ function invalidMapResult(event: {
   if (images.length !== 1 || images[0].mimeType !== 'image/png')
     return 'render_map did not return exactly one PNG image';
   const png = decodeStrictBase64(images[0].data);
-  if (!png || png.length < 24 || !png.subarray(0, 8).equals(Buffer.from('89504e470d0a1a0a', 'hex'))) {
-    return 'render_map returned malformed PNG media';
-  }
-  const width = png.readUInt32BE(16);
-  const height = png.readUInt32BE(20);
-  if (width <= 0 || height <= 0) return 'render_map returned invalid PNG dimensions';
+  const dimensions = png ? pngDimensions(png) : undefined;
+  if (!png || !dimensions) return 'render_map returned malformed PNG media';
+  const [width, height] = dimensions;
   if (!event.details || typeof event.details !== 'object') return 'render_map omitted canonical media details';
   const details = event.details as Record<string, unknown>;
   const descriptor = details.descriptor;

--- a/plugins/cloudstatus/package.json
+++ b/plugins/cloudstatus/package.json
@@ -1,8 +1,15 @@
 {
   "name": "cloudstatus",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Live cloud status and Internet network intelligence for xcsh",
   "license": "Apache-2.0",
+  "xcsh": {
+    "name": "Cloudstatus",
+    "version": "1.5.3",
+    "extensions": [
+      "extensions/regional-edge-guard.ts"
+    ]
+  },
   "peerDependencies": {
     "@f5-sales-demo/xcsh": ">=20.19.0"
   }

--- a/plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh
+++ b/plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh
@@ -6,17 +6,70 @@ scenario_file="$plugin_dir/benchmarks/location-prompt-scenarios.json"
 scenario_id=${1:-visual-us}
 model=${2:-gpt-5.6-luna}
 xcsh_bin=${XCSH_BIN:-xcsh}
-trace_file=$(mktemp "${TMPDIR:-/tmp}/cloudstatus-location-prompt-trace.XXXXXX.jsonl")
-trap 'rm -f "$trace_file"' EXIT
+xcsh_dev_dir=${XCSH_DEV_DIR:-}
+repeat=${LOCATION_UAT_REPEAT:-1}
+synthesize=${LOCATION_UAT_SYNTHESIZE:-0}
+if [ -n "${LOCATION_UAT_ARTIFACT_DIR:-}" ]; then
+  artifact_dir=$LOCATION_UAT_ARTIFACT_DIR
+  artifact_dir_owned=0
+else
+  artifact_dir=$(mktemp -d "${TMPDIR:-/tmp}/cloudstatus-location-prompt-traces.XXXXXX")
+  artifact_dir_owned=1
+fi
+keep_artifacts=0
+mkdir -p "$artifact_dir"
+trap '[ "$keep_artifacts" -eq 1 ] || [ "$artifact_dir_owned" -eq 0 ] || rm -rf "$artifact_dir"' EXIT
 
-prompt=$(jq -er --arg id "$scenario_id" '.scenarios[] | select(.id == $id) | .prompt' "$scenario_file")
+if [ "$scenario_id" = "--all" ]; then
+  while IFS= read -r id; do
+    "$0" "$id" "$model"
+  done < <(jq -r '.scenarios[].id' "$scenario_file")
+  exit 0
+fi
 
-"$xcsh_bin" \
-  --model "$model" \
-  --thinking low \
-  --mode json \
-  --plugin-dir "$plugin_dir" \
-  --no-session \
-  -p "$prompt" >"$trace_file"
+run_xcsh() {
+  if [ -n "$xcsh_dev_dir" ]; then
+    (
+      cd "$xcsh_dev_dir"
+      bun run dev -- "$@"
+    )
+  else
+    "$xcsh_bin" "$@"
+  fi
+}
 
-python3 "$plugin_dir/benchmarks/verify-location-prompt-trace.py" "$scenario_file" "$scenario_id" "$trace_file"
+run_one() {
+  local run_id=$1
+  local prompt=$2
+  local trace_file="$artifact_dir/${scenario_id}-${run_id}.jsonl"
+  run_xcsh \
+    --model "$model" \
+    --thinking low \
+    --mode json \
+    --plugin-dir "$plugin_dir" \
+    --no-session \
+    -p "$prompt" >"$trace_file"
+  if ! python3 "$plugin_dir/benchmarks/verify-location-prompt-trace.py" "$scenario_file" "$scenario_id" "$trace_file"; then
+    keep_artifacts=1
+    echo "trace retained for diagnosis: $trace_file" >&2
+    return 1
+  fi
+}
+
+if [ "$synthesize" = 1 ]; then
+  [ "$scenario_id" = "visual-address-us" ] || {
+    echo "LOCATION_UAT_SYNTHESIZE=1 requires visual-address-us" >&2
+    exit 2
+  }
+  run=0
+  while IFS= read -r item; do
+    prompt=$(jq -er '.prompt' <<<"$item")
+    run=$((run + 1))
+    run_one "$run" "$prompt"
+  done < <(python3 "$plugin_dir/scripts/evals/synthesize-location-prompt-uats.py" --scenario "$scenario_id" --count "$repeat")
+else
+  prompt=$(jq -er --arg id "$scenario_id" '.scenarios[] | select(.id == $id) | .prompt' "$scenario_file")
+  for run in $(seq 1 "$repeat"); do
+    run_one "$run" "$prompt"
+  done
+fi

--- a/plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh
+++ b/plugins/cloudstatus/scripts/evals/run-location-prompt-eval.sh
@@ -42,14 +42,24 @@ run_one() {
   local run_id=$1
   local prompt=$2
   local trace_file="$artifact_dir/${scenario_id}-${run_id}.jsonl"
+  local receipt_file="${trace_file%.jsonl}.receipt.json"
+  local png_file="${trace_file%.jsonl}.png"
+  local xcsh_status=0
+  local verification_status=0
   run_xcsh \
     --model "$model" \
     --thinking low \
     --mode json \
     --plugin-dir "$plugin_dir" \
     --no-session \
-    -p "$prompt" >"$trace_file"
-  if ! python3 "$plugin_dir/benchmarks/verify-location-prompt-trace.py" "$scenario_file" "$scenario_id" "$trace_file"; then
+    -p "$prompt" >"$trace_file" || xcsh_status=$?
+  python3 "$plugin_dir/benchmarks/verify-location-prompt-trace.py" \
+    "$scenario_file" \
+    "$scenario_id" \
+    "$trace_file" \
+    --receipt "$receipt_file" \
+    --extract-png "$png_file" || verification_status=$?
+  if [ "$xcsh_status" -ne 0 ] || [ "$verification_status" -ne 0 ]; then
     keep_artifacts=1
     echo "trace retained for diagnosis: $trace_file" >&2
     return 1

--- a/plugins/cloudstatus/scripts/evals/synthesize-location-prompt-uats.py
+++ b/plugins/cloudstatus/scripts/evals/synthesize-location-prompt-uats.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# pylint: disable=invalid-name,line-too-long,missing-function-docstring
+# ruff: noqa: D103, EM101, EM102, T201, TRY003
 """Generate controlled live-UAT variants for the Regional Edge address-map regression."""
 
 from __future__ import annotations

--- a/plugins/cloudstatus/scripts/evals/synthesize-location-prompt-uats.py
+++ b/plugins/cloudstatus/scripts/evals/synthesize-location-prompt-uats.py
@@ -12,18 +12,23 @@ ADDRESS_MAP_VARIANTS = (
     EXACT_ADDRESS_MAP_PROMPT,
     "Show a map of every address location for F5 Regional Edges located in the United States.",
     "Map all United States address locations of the F5 Distributed Cloud Regional Edges.",
-    "I need a US map of all address locations for F5 Regional Edges; do not research the addresses one by one.",
+    "I need a map of all United States address locations for F5 Regional Edges; use United States as the registry filter and do not research addresses one by one.",
 )
 
 
 def synthesize(scenario_id: str, count: int) -> list[dict[str, str]]:
     """Return deterministic, semantically equivalent prompts for one live scenario."""
     if scenario_id != "visual-address-us":
-        raise ValueError(f"prompt synthesis is only defined for visual-address-us, not {scenario_id}")
+        raise ValueError(
+            f"prompt synthesis is only defined for visual-address-us, not {scenario_id}"
+        )
     if count < 1:
         raise ValueError("count must be positive")
     return [
-        {"id": scenario_id, "prompt": ADDRESS_MAP_VARIANTS[index % len(ADDRESS_MAP_VARIANTS)]}
+        {
+            "id": scenario_id,
+            "prompt": ADDRESS_MAP_VARIANTS[index % len(ADDRESS_MAP_VARIANTS)],
+        }
         for index in range(count)
     ]
 

--- a/plugins/cloudstatus/scripts/evals/synthesize-location-prompt-uats.py
+++ b/plugins/cloudstatus/scripts/evals/synthesize-location-prompt-uats.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Generate controlled live-UAT variants for the Regional Edge address-map regression."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+EXACT_ADDRESS_MAP_PROMPT = "show me a map of all the address locations of the F5 regional edges that are located in the united states"
+
+ADDRESS_MAP_VARIANTS = (
+    EXACT_ADDRESS_MAP_PROMPT,
+    "Show a map of every address location for F5 Regional Edges located in the United States.",
+    "Map all United States address locations of the F5 Distributed Cloud Regional Edges.",
+    "I need a US map of all address locations for F5 Regional Edges; do not research the addresses one by one.",
+)
+
+
+def synthesize(scenario_id: str, count: int) -> list[dict[str, str]]:
+    """Return deterministic, semantically equivalent prompts for one live scenario."""
+    if scenario_id != "visual-address-us":
+        raise ValueError(f"prompt synthesis is only defined for visual-address-us, not {scenario_id}")
+    if count < 1:
+        raise ValueError("count must be positive")
+    return [
+        {"id": scenario_id, "prompt": ADDRESS_MAP_VARIANTS[index % len(ADDRESS_MAP_VARIANTS)]}
+        for index in range(count)
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", default="visual-address-us")
+    parser.add_argument("--count", type=int, default=4)
+    args = parser.parse_args()
+    for item in synthesize(args.scenario, args.count):
+        print(json.dumps(item))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_synthesis.py
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_synthesis.py
@@ -1,0 +1,47 @@
+"""Hermetic tests for live Regional Edge UAT prompt synthesis."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+PLUGIN_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SYNTHESIS_PATH = PLUGIN_ROOT / "scripts/evals/synthesize-location-prompt-uats.py"
+
+
+def load_synthesis():
+    spec = importlib.util.spec_from_file_location("location_prompt_synthesis", SYNTHESIS_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SYNTHESIS_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class LocationPromptSynthesisTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.synthesis = load_synthesis()
+
+    def test_synthesizes_address_map_variants_from_the_exact_regression(self) -> None:
+        variants = self.synthesis.synthesize("visual-address-us", 3)
+        self.assertEqual(len(variants), 3)
+        self.assertEqual(variants[0]["id"], "visual-address-us")
+        self.assertEqual(
+            variants[0]["prompt"],
+            "show me a map of all the address locations of the F5 regional edges that are located in the united states",
+        )
+        self.assertIn("Regional Edge", variants[1]["prompt"])
+
+    def test_rejects_unknown_scenarios_and_non_positive_counts(self) -> None:
+        with self.assertRaises(ValueError):
+            self.synthesis.synthesize("unknown", 1)
+        with self.assertRaises(ValueError):
+            self.synthesis.synthesize("visual-address-us", 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_synthesis.py
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_synthesis.py
@@ -1,3 +1,5 @@
+# ruff: noqa: D101, D102, D103, EM102, INP001, PT009, PT027, TC003, TRY003
+# pylint: disable=line-too-long,missing-class-docstring,missing-function-docstring
 """Hermetic tests for live Regional Edge UAT prompt synthesis."""
 
 from __future__ import annotations
@@ -6,12 +8,13 @@ import importlib.util
 import pathlib
 import sys
 import unittest
+from types import ModuleType
 
 PLUGIN_ROOT = pathlib.Path(__file__).resolve().parents[2]
 SYNTHESIS_PATH = PLUGIN_ROOT / "scripts/evals/synthesize-location-prompt-uats.py"
 
 
-def load_synthesis():
+def load_synthesis() -> ModuleType:
     spec = importlib.util.spec_from_file_location(
         "location_prompt_synthesis", SYNTHESIS_PATH
     )
@@ -24,6 +27,8 @@ def load_synthesis():
 
 
 class LocationPromptSynthesisTests(unittest.TestCase):
+    synthesis: ModuleType
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.synthesis = load_synthesis()

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_synthesis.py
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_synthesis.py
@@ -12,7 +12,9 @@ SYNTHESIS_PATH = PLUGIN_ROOT / "scripts/evals/synthesize-location-prompt-uats.py
 
 
 def load_synthesis():
-    spec = importlib.util.spec_from_file_location("location_prompt_synthesis", SYNTHESIS_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "location_prompt_synthesis", SYNTHESIS_PATH
+    )
     if spec is None or spec.loader is None:
         raise RuntimeError(f"cannot load {SYNTHESIS_PATH}")
     module = importlib.util.module_from_spec(spec)
@@ -27,14 +29,15 @@ class LocationPromptSynthesisTests(unittest.TestCase):
         cls.synthesis = load_synthesis()
 
     def test_synthesizes_address_map_variants_from_the_exact_regression(self) -> None:
-        variants = self.synthesis.synthesize("visual-address-us", 3)
-        self.assertEqual(len(variants), 3)
+        variants = self.synthesis.synthesize("visual-address-us", 4)
+        self.assertEqual(len(variants), 4)
         self.assertEqual(variants[0]["id"], "visual-address-us")
         self.assertEqual(
             variants[0]["prompt"],
             "show me a map of all the address locations of the F5 regional edges that are located in the united states",
         )
         self.assertIn("Regional Edge", variants[1]["prompt"])
+        self.assertIn("United States as the registry filter", variants[3]["prompt"])
 
     def test_rejects_unknown_scenarios_and_non_positive_counts(self) -> None:
         with self.assertRaises(ValueError):

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
@@ -57,6 +57,20 @@ class LocationPromptTraceTests(unittest.TestCase):
         )
         self.assertTrue(result["pass"], result["errors"])
 
+    def test_exact_address_map_regression_is_a_visual_collector_scenario(self) -> None:
+        scenarios = json.loads(
+            (PLUGIN_ROOT / "benchmarks/location-prompt-scenarios.json").read_text(
+                encoding="utf-8"
+            )
+        )["scenarios"]
+        scenario = next(item for item in scenarios if item["id"] == "visual-address-us")
+        self.assertEqual(scenario["intent"], "visual")
+        self.assertEqual(scenario["collector"], "locations --format map-v1")
+        self.assertEqual(
+            scenario["prompt"],
+            "show me a map of all the address locations of the F5 regional edges that are located in the united states",
+        )
+
     def test_factual_trace_rejects_a_renderer(self) -> None:
         result = self.verifier.evaluate_trace(
             {"intent": "factual", "collector": "location"},

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
@@ -1,4 +1,5 @@
 # ruff: noqa: D101, D102, D103, EM102, INP001, PT009, S603, TC003, TRY003
+# pylint: disable=line-too-long,missing-class-docstring,missing-function-docstring,too-many-arguments
 """Hermetic trace-contract tests for Cloudstatus Regional Edge prompt routing."""
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ import tempfile
 import unittest
 import zlib
 from types import ModuleType
+from typing import Any
 
 PLUGIN_ROOT = pathlib.Path(__file__).resolve().parents[2]
 VERIFIER_PATH = PLUGIN_ROOT / "benchmarks/verify-location-prompt-trace.py"
@@ -34,13 +36,13 @@ def load_verifier() -> ModuleType:
     return module
 
 
-def trace(*events: dict[str, object]) -> str:
+def trace(*events: dict[str, Any]) -> str:
     return "\n".join(json.dumps(event) for event in events)
 
 
 def start(
-    name: str, input_value: dict[str, object], call_id: str | None = None
-) -> dict[str, object]:
+    name: str, input_value: dict[str, Any], call_id: str | None = None
+) -> dict[str, Any]:
     return {
         "type": "tool_execution_start",
         "toolCallId": call_id or f"{name}-call",
@@ -72,10 +74,10 @@ def render_result(
     image: bytes | None = None,
     image_data: str | None = None,
     is_error: bool = False,
-    details: object | None = None,
+    details: Any | None = None,
     width: int = 2,
     height: int = 3,
-) -> dict[str, object]:
+) -> dict[str, Any]:
     payload = valid_png(width, height) if image is None else image
     digest = hashlib.sha256(payload).hexdigest()
     if details is None:
@@ -97,7 +99,7 @@ def render_result(
             },
             "displayMethod": "inline",
         }
-    content: list[dict[str, object]] = [
+    content: list[dict[str, Any]] = [
         {
             "type": "image",
             "mimeType": "image/png",
@@ -116,7 +118,7 @@ def render_result(
     }
 
 
-def workflow(*render_events: dict[str, object]) -> str:
+def workflow(*render_events: dict[str, Any]) -> str:
     return trace(
         start("read", {"path": "skill://cloudstatus/location"}),
         start(
@@ -141,7 +143,7 @@ class LocationPromptTraceTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.verifier = load_verifier()
 
-    def assert_error(self, result: dict[str, object], fragment: str) -> None:
+    def assert_error(self, result: dict[str, Any], fragment: str) -> None:
         self.assertFalse(result["pass"])
         self.assertTrue(
             any(fragment in error for error in result["errors"]), result["errors"]

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py
@@ -1,13 +1,21 @@
-# ruff: noqa: D101, D102, D103, EM102, INP001, PT009, TC003, TRY003
+# ruff: noqa: D101, D102, D103, EM102, INP001, PT009, S603, TC003, TRY003
 """Hermetic trace-contract tests for Cloudstatus Regional Edge prompt routing."""
 
 from __future__ import annotations
 
+import base64
+import binascii
+import hashlib
 import importlib.util
 import json
+import os
 import pathlib
+import struct
+import subprocess
 import sys
+import tempfile
 import unittest
+import zlib
 from types import ModuleType
 
 PLUGIN_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -30,8 +38,100 @@ def trace(*events: dict[str, object]) -> str:
     return "\n".join(json.dumps(event) for event in events)
 
 
-def start(name: str, input_value: dict[str, object]) -> dict[str, object]:
-    return {"type": "tool_execution_start", "toolName": name, "input": input_value}
+def start(
+    name: str, input_value: dict[str, object], call_id: str | None = None
+) -> dict[str, object]:
+    return {
+        "type": "tool_execution_start",
+        "toolCallId": call_id or f"{name}-call",
+        "toolName": name,
+        "args": input_value,
+    }
+
+
+def png_chunk(chunk_type: bytes, data: bytes) -> bytes:
+    crc = binascii.crc32(chunk_type + data) & 0xFFFFFFFF
+    return struct.pack(">I", len(data)) + chunk_type + data + struct.pack(">I", crc)
+
+
+def valid_png(width: int = 2, height: int = 3) -> bytes:
+    rows = b"".join(b"\x00" + (b"\x00\x00\x00\xff" * width) for _ in range(height))
+    return b"".join(
+        (
+            b"\x89PNG\r\n\x1a\n",
+            png_chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)),
+            png_chunk(b"IDAT", zlib.compress(rows)),
+            png_chunk(b"IEND", b""),
+        )
+    )
+
+
+def render_result(
+    *,
+    call_id: str = "render-call",
+    image: bytes | None = None,
+    image_data: str | None = None,
+    is_error: bool = False,
+    details: object | None = None,
+    width: int = 2,
+    height: int = 3,
+) -> dict[str, object]:
+    payload = valid_png(width, height) if image is None else image
+    digest = hashlib.sha256(payload).hexdigest()
+    if details is None:
+        details = {
+            "mediaResult": "xcsh.media/v1",
+            "descriptor": {
+                "version": 1,
+                "id": f"media_{digest[:24]}",
+                "kind": "image",
+                "width": width,
+                "height": height,
+                "original": {
+                    "ref": f"blob:sha256:{digest}",
+                    "mimeType": "image/png",
+                    "bytes": len(payload),
+                },
+                "provenance": {"sourceType": "tool", "source": "render_map"},
+                "metadata": {"producer": "render_map", "basemap": "schematic"},
+            },
+            "displayMethod": "inline",
+        }
+    content: list[dict[str, object]] = [
+        {
+            "type": "image",
+            "mimeType": "image/png",
+            "data": image_data
+            if image_data is not None
+            else base64.b64encode(payload).decode("ascii"),
+        },
+        {"type": "text", "text": "evidence"},
+    ]
+    return {
+        "type": "tool_execution_end",
+        "toolCallId": call_id,
+        "toolName": "render_map",
+        "isError": is_error,
+        "result": {"content": content, "details": details},
+    }
+
+
+def workflow(*render_events: dict[str, object]) -> str:
+    return trace(
+        start("read", {"path": "skill://cloudstatus/location"}),
+        start(
+            "bash",
+            {
+                "command": 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
+            },
+        ),
+        start("render_map", {"locations": []}, "render-call"),
+        *render_events,
+    )
+
+
+VISUAL = {"intent": "visual", "collector": "locations --format map-v1"}
+FACTUAL = {"intent": "factual", "collector": "location"}
 
 
 class LocationPromptTraceTests(unittest.TestCase):
@@ -41,21 +141,239 @@ class LocationPromptTraceTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.verifier = load_verifier()
 
-    def test_visual_trace_requires_location_collector_then_one_renderer(self) -> None:
+    def assert_error(self, result: dict[str, object], fragment: str) -> None:
+        self.assertFalse(result["pass"])
+        self.assertTrue(
+            any(fragment in error for error in result["errors"]), result["errors"]
+        )
+
+    def test_visual_trace_requires_one_successful_render_pair(self) -> None:
+        result = self.verifier.evaluate_trace(VISUAL, workflow(render_result()))
+        self.assertTrue(result["pass"], result["errors"])
+        self.assertEqual(result["receipt"]["claims"]["valid_png"], True)
+        self.assertEqual(result["receipt"]["image"]["dimensions"], [2, 3])
+
+    def test_rejects_render_start_without_completion(self) -> None:
+        self.assert_error(
+            self.verifier.evaluate_trace(VISUAL, workflow()),
+            "successful render_map start/completion pair",
+        )
+
+    def test_rejects_mismatched_and_duplicate_completion_ids(self) -> None:
+        mismatched = self.verifier.evaluate_trace(
+            VISUAL, workflow(render_result(call_id="other-call"))
+        )
+        self.assert_error(mismatched, "successful render_map start/completion pair")
+        duplicate = self.verifier.evaluate_trace(
+            VISUAL, workflow(render_result(), render_result())
+        )
+        self.assert_error(duplicate, "duplicate render_map completion")
+
+    def test_rejects_errored_text_only_and_missing_descriptor_results(self) -> None:
+        errored = self.verifier.evaluate_trace(
+            VISUAL, workflow(render_result(is_error=True))
+        )
+        self.assert_error(errored, "render_map completion reported an error")
+
+        text_only = render_result()
+        text_only["result"]["content"] = [{"type": "text", "text": "fallback"}]
+        self.assert_error(
+            self.verifier.evaluate_trace(VISUAL, workflow(text_only)),
+            "exactly one image/png content block",
+        )
+
+        missing_descriptor = render_result(details={"mediaResult": "xcsh.media/v1"})
+        self.assert_error(
+            self.verifier.evaluate_trace(VISUAL, workflow(missing_descriptor)),
+            "canonical media descriptor",
+        )
+
+        wrong_source_type = render_result()
+        wrong_source_type["result"]["details"]["descriptor"]["provenance"][
+            "sourceType"
+        ] = "model"
+        self.assert_error(
+            self.verifier.evaluate_trace(VISUAL, workflow(wrong_source_type)),
+            "provenance",
+        )
+
+    def test_rejects_invalid_base64_png_structure_and_crc(self) -> None:
+        invalid_base64 = self.verifier.evaluate_trace(
+            VISUAL, workflow(render_result(image_data="%%%"))
+        )
+        self.assert_error(invalid_base64, "strict base64")
+
+        invalid_structure = self.verifier.evaluate_trace(
+            VISUAL, workflow(render_result(image=b"not a png"))
+        )
+        self.assert_error(invalid_structure, "PNG signature")
+
+        bad_crc = bytearray(valid_png())
+        bad_crc[-1] ^= 0x01
+        invalid_crc = self.verifier.evaluate_trace(
+            VISUAL, workflow(render_result(image=bytes(bad_crc)))
+        )
+        self.assert_error(invalid_crc, "PNG CRC")
+
+    def test_rejects_dimensions_byte_count_and_sha_mismatches(self) -> None:
+        dimensions = render_result()
+        dimensions["result"]["details"]["descriptor"]["width"] = 99
+        self.assert_error(
+            self.verifier.evaluate_trace(VISUAL, workflow(dimensions)),
+            "descriptor dimensions",
+        )
+
+        byte_count = render_result()
+        byte_count["result"]["details"]["descriptor"]["original"]["bytes"] += 1
+        self.assert_error(
+            self.verifier.evaluate_trace(VISUAL, workflow(byte_count)),
+            "decoded byte count",
+        )
+
+        digest = render_result()
+        digest["result"]["details"]["descriptor"]["original"]["ref"] = (
+            "blob:sha256:" + ("0" * 64)
+        )
+        self.assert_error(
+            self.verifier.evaluate_trace(VISUAL, workflow(digest)), "SHA-256"
+        )
+
+    def test_factual_trace_succeeds_without_render_or_image(self) -> None:
         result = self.verifier.evaluate_trace(
-            {"intent": "visual", "collector": "locations --format map-v1"},
+            FACTUAL,
             trace(
                 start("read", {"path": "skill://cloudstatus/location"}),
                 start(
                     "bash",
-                    {
-                        "command": 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
-                    },
+                    {"command": 'network_lookup.py location "$CLOUDSTATUS_QUERY"'},
                 ),
-                start("render_map", {"locations": []}),
             ),
         )
         self.assertTrue(result["pass"], result["errors"])
+        self.assertEqual(result["receipt"]["claims"]["zero_image_generation"], True)
+
+    def test_factual_trace_rejects_any_render_or_image(self) -> None:
+        result = self.verifier.evaluate_trace(
+            FACTUAL,
+            trace(
+                start("read", {"path": "skill://cloudstatus/location"}),
+                start(
+                    "bash",
+                    {"command": 'network_lookup.py location "$CLOUDSTATUS_QUERY"'},
+                ),
+                render_result(),
+            ),
+        )
+        self.assert_error(result, "expected 0 render_map")
+        self.assert_error(result, "factual scenario returned image content")
+
+    def test_rejects_duplicate_collector_forbidden_tools_and_wrong_order(self) -> None:
+        result = self.verifier.evaluate_trace(
+            VISUAL,
+            trace(
+                start(
+                    "bash",
+                    {
+                        "command": 'network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
+                    },
+                    "collector-1",
+                ),
+                start("web_search", {"query": "F5 Regional Edge"}),
+                start(
+                    "bash",
+                    {
+                        "command": 'network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
+                    },
+                    "collector-2",
+                ),
+                start("task", {}),
+                start("display_media", {}),
+                start("render_map", {"locations": []}, "render-call"),
+                render_result(),
+            ),
+        )
+        self.assert_error(result, "expected one registry collector Bash call, found 2")
+        self.assert_error(result, "forbidden tool invoked: task")
+        self.assert_error(
+            result, "expected one cloudstatus location skill read, found 0"
+        )
+
+    def test_cli_writes_compact_receipt_and_png_without_base64(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            scenarios = root / "scenarios.json"
+            trace_path = root / "trace.jsonl"
+            receipt = root / "trace.receipt.json"
+            png_path = root / "trace.png"
+            scenarios.write_text(
+                json.dumps({"scenarios": [{"id": "visual", **VISUAL}]}),
+                encoding="utf-8",
+            )
+            trace_path.write_text(workflow(render_result()), encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(VERIFIER_PATH),
+                    str(scenarios),
+                    "visual",
+                    str(trace_path),
+                    "--receipt",
+                    str(receipt),
+                    "--extract-png",
+                    str(png_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertEqual(png_path.read_bytes(), valid_png())
+            receipt_text = receipt.read_text(encoding="utf-8")
+            self.assertNotIn(
+                base64.b64encode(valid_png()).decode("ascii"), receipt_text
+            )
+            parsed = json.loads(receipt_text)
+            self.assertEqual(
+                parsed["image"]["sha256"], hashlib.sha256(valid_png()).hexdigest()
+            )
+            self.assertNotIn("data", parsed)
+
+    def test_uat_runner_retains_receipt_and_png_in_requested_artifact_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            artifact_dir = root / "artifacts"
+            fake_xcsh = root / "xcsh"
+            fake_xcsh.write_text(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$FAKE_XCSH_TRACE\"\n",
+                encoding="utf-8",
+            )
+            fake_xcsh.chmod(0o755)
+            environment = {
+                **os.environ,
+                "XCSH_BIN": str(fake_xcsh),
+                "FAKE_XCSH_TRACE": workflow(render_result()),
+                "LOCATION_UAT_ARTIFACT_DIR": str(artifact_dir),
+            }
+            completed = subprocess.run(
+                [
+                    "/bin/bash",
+                    str(PLUGIN_ROOT / "scripts/evals/run-location-prompt-eval.sh"),
+                    "visual-address-us",
+                    "test-model",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            receipt = artifact_dir / "visual-address-us-1.receipt.json"
+            png_path = artifact_dir / "visual-address-us-1.png"
+            self.assertTrue(receipt.is_file())
+            self.assertEqual(png_path.read_bytes(), valid_png())
+            encoded = base64.b64encode(valid_png()).decode("ascii")
+            self.assertNotIn(encoded, completed.stdout)
+            self.assertNotIn(encoded, receipt.read_text(encoding="utf-8"))
 
     def test_exact_address_map_regression_is_a_visual_collector_scenario(self) -> None:
         scenarios = json.loads(
@@ -66,74 +384,6 @@ class LocationPromptTraceTests(unittest.TestCase):
         scenario = next(item for item in scenarios if item["id"] == "visual-address-us")
         self.assertEqual(scenario["intent"], "visual")
         self.assertEqual(scenario["collector"], "locations --format map-v1")
-        self.assertEqual(
-            scenario["prompt"],
-            "show me a map of all the address locations of the F5 regional edges that are located in the united states",
-        )
-
-    def test_factual_trace_rejects_a_renderer(self) -> None:
-        result = self.verifier.evaluate_trace(
-            {"intent": "factual", "collector": "location"},
-            trace(
-                start("read", {"path": "skill://cloudstatus/location"}),
-                start(
-                    "bash",
-                    {"command": 'network_lookup.py location "$CLOUDSTATUS_QUERY"'},
-                ),
-                start("render_map", {"locations": []}),
-            ),
-        )
-        self.assertFalse(result["pass"])
-        self.assertIn("expected 0 render_map calls, found 1", result["errors"])
-
-    def test_rejects_duplicate_collector_and_forbidden_tools(self) -> None:
-        result = self.verifier.evaluate_trace(
-            {"intent": "visual", "collector": "locations --format map-v1"},
-            trace(
-                start("read", {"path": "skill://cloudstatus/location"}),
-                start(
-                    "bash",
-                    {
-                        "command": 'network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
-                    },
-                ),
-                start("web_search", {"query": "F5 Regional Edge"}),
-                start(
-                    "bash",
-                    {
-                        "command": 'network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
-                    },
-                ),
-                start("task", {}),
-                start("display_media", {}),
-                start("render_map", {"locations": []}),
-            ),
-        )
-        self.assertFalse(result["pass"])
-        self.assertIn(
-            "expected one registry collector Bash call, found 2", result["errors"]
-        )
-        self.assertIn("forbidden tool invoked: task", result["errors"])
-        self.assertIn("forbidden tool invoked: web_search", result["errors"])
-        self.assertIn("forbidden tool invoked: display_media", result["errors"])
-
-    def test_rejects_wrong_order_and_missing_skill_read(self) -> None:
-        result = self.verifier.evaluate_trace(
-            {"intent": "visual", "collector": "locations --format map-v1"},
-            trace(
-                start(
-                    "bash",
-                    {
-                        "command": 'network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"'
-                    },
-                ),
-                start("render_map", {"locations": []}),
-            ),
-        )
-        self.assertFalse(result["pass"])
-        self.assertIn(
-            "expected one cloudstatus location skill read, found 0", result["errors"]
-        )
 
 
 if __name__ == "__main__":

--- a/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.sh
+++ b/plugins/cloudstatus/scripts/tests/test_location_prompt_trace.sh
@@ -6,3 +6,7 @@ set -euo pipefail
 test_location_prompt_trace_suite() {
   python3 "$PLUGIN_ROOT/scripts/tests/test_location_prompt_trace.py" -v
 }
+
+test_location_prompt_synthesis_suite() {
+  python3 "$PLUGIN_ROOT/scripts/tests/test_location_prompt_synthesis.py" -v
+}

--- a/plugins/cloudstatus/scripts/tests/test_regional_edge_guard.sh
+++ b/plugins/cloudstatus/scripts/tests/test_regional_edge_guard.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Hermetic runtime-policy tests for the plugin extension.
+
+set -euo pipefail
+
+test_regional_edge_guard_suite() {
+  (
+    cd "$MARKETPLACE_ROOT"
+    bun test "./plugins/cloudstatus/scripts/tests/test_regional_edge_guard.ts" --max-concurrency 2
+  )
+}

--- a/plugins/cloudstatus/scripts/tests/test_regional_edge_guard.ts
+++ b/plugins/cloudstatus/scripts/tests/test_regional_edge_guard.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import regionalEdgeGuard from "../../extensions/regional-edge-guard";
+
+type ToolCallHandler = (event: { toolName: string; input: Record<string, unknown> }) => unknown;
+type SessionStartHandler = () => unknown;
+
+function guard() {
+	let toolCall: ToolCallHandler | undefined;
+	let sessionStart: SessionStartHandler | undefined;
+	regionalEdgeGuard({
+		on(event: string, handler: ToolCallHandler | SessionStartHandler) {
+			if (event === "tool_call") toolCall = handler as ToolCallHandler;
+			if (event === "session_start") sessionStart = handler as SessionStartHandler;
+		},
+	} as Parameters<typeof regionalEdgeGuard>[0]);
+	return { call: (toolName: string, input: Record<string, unknown> = {}) => toolCall?.({ toolName, input }), reset: () => sessionStart?.() };
+}
+
+const locationSkill = { path: "skill://cloudstatus/location/SKILL.md" };
+const mapCollector = { command: 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"' };
+const factualCollector = { command: 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py location "$CLOUDSTATUS_QUERY"' };
+
+describe("Cloudstatus Regional Edge guard", () => {
+	it("allows the one direct visual collector followed by one map", () => {
+		const runtime = guard();
+		expect(runtime.call("read", locationSkill)).toBeUndefined();
+		expect(runtime.call("bash", mapCollector)).toBeUndefined();
+		expect(runtime.call("render_map", { locations: [] })).toBeUndefined();
+	});
+
+	it("allows a factual collector but never a map", () => {
+		const runtime = guard();
+		runtime.call("read", locationSkill);
+		expect(runtime.call("bash", factualCollector)).toBeUndefined();
+		expect(runtime.call("render_map", { locations: [] })).toMatchObject({ block: true });
+	});
+
+	it("blocks delegation and search when Regional Edge text appears before the skill", () => {
+		const runtime = guard();
+		expect(runtime.call("task", { prompt: "research F5 Regional Edge addresses" })).toMatchObject({ block: true });
+		expect(runtime.call("web_search", { query: "F5 Regional Edge locations" })).toMatchObject({ block: true });
+	});
+
+	it("blocks forbidden tools and arbitrary Bash after the location skill", () => {
+		const runtime = guard();
+		runtime.call("read", locationSkill);
+		for (const [toolName, input] of [
+			["task", { prompt: "delegate" }],
+			["web_search", { query: "edge" }],
+			["display_media", {}],
+			["bash", { command: "curl https://example.test" }],
+		] as const) {
+			expect(runtime.call(toolName, input)).toMatchObject({ block: true });
+		}
+	});
+
+	it("blocks duplicate collection plus premature and duplicate rendering", () => {
+		const runtime = guard();
+		runtime.call("read", locationSkill);
+		expect(runtime.call("render_map", { locations: [] })).toMatchObject({ block: true });
+		expect(runtime.call("bash", mapCollector)).toBeUndefined();
+		expect(runtime.call("bash", mapCollector)).toMatchObject({ block: true });
+		expect(runtime.call("render_map", { locations: [] })).toBeUndefined();
+		expect(runtime.call("render_map", { locations: [] })).toMatchObject({ block: true });
+	});
+
+	it("resets for each top-level session and preserves ordinary network-intelligence delegation", () => {
+		const runtime = guard();
+		runtime.call("read", locationSkill);
+		runtime.call("bash", factualCollector);
+		expect(runtime.call("bash", factualCollector)).toMatchObject({ block: true });
+		runtime.reset();
+		expect(runtime.call("task", { prompt: "Investigate BGP paths for AS35280" })).toBeUndefined();
+		expect(runtime.call("bash", factualCollector)).toBeUndefined();
+	});
+});

--- a/plugins/cloudstatus/scripts/tests/test_regional_edge_guard.ts
+++ b/plugins/cloudstatus/scripts/tests/test_regional_edge_guard.ts
@@ -1,76 +1,150 @@
-import { describe, expect, it } from "bun:test";
-import regionalEdgeGuard from "../../extensions/regional-edge-guard";
+import { describe, expect, it } from 'bun:test';
+import { createHash } from 'node:crypto';
+import regionalEdgeGuard from '../../extensions/regional-edge-guard';
 
 type ToolCallHandler = (event: { toolName: string; input: Record<string, unknown> }) => unknown;
+type ToolResultHandler = (event: {
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  content: Array<Record<string, unknown>>;
+  details?: unknown;
+  isError: boolean;
+}) => unknown;
 type SessionStartHandler = () => unknown;
 
 function guard() {
-	let toolCall: ToolCallHandler | undefined;
-	let sessionStart: SessionStartHandler | undefined;
-	regionalEdgeGuard({
-		on(event: string, handler: ToolCallHandler | SessionStartHandler) {
-			if (event === "tool_call") toolCall = handler as ToolCallHandler;
-			if (event === "session_start") sessionStart = handler as SessionStartHandler;
-		},
-	} as Parameters<typeof regionalEdgeGuard>[0]);
-	return { call: (toolName: string, input: Record<string, unknown> = {}) => toolCall?.({ toolName, input }), reset: () => sessionStart?.() };
+  let toolCall: ToolCallHandler | undefined;
+  let toolResult: ToolResultHandler | undefined;
+  let sessionStart: SessionStartHandler | undefined;
+  regionalEdgeGuard({
+    on(event: string, handler: ToolCallHandler | ToolResultHandler | SessionStartHandler) {
+      if (event === 'tool_call') toolCall = handler as ToolCallHandler;
+      if (event === 'tool_result') toolResult = handler as ToolResultHandler;
+      if (event === 'session_start') sessionStart = handler as SessionStartHandler;
+    },
+  } as Parameters<typeof regionalEdgeGuard>[0]);
+  return {
+    call: (toolName: string, input: Record<string, unknown> = {}) => toolCall?.({ toolName, input }),
+    result: (event: Parameters<ToolResultHandler>[0]) => toolResult?.(event),
+    reset: () => sessionStart?.(),
+  };
 }
 
-const locationSkill = { path: "skill://cloudstatus/location/SKILL.md" };
-const mapCollector = { command: 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"' };
-const factualCollector = { command: 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py location "$CLOUDSTATUS_QUERY"' };
+const locationSkill = { path: 'skill://cloudstatus/location/SKILL.md' };
+const mapCollector = {
+  command:
+    'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py locations --format map-v1 "$CLOUDSTATUS_QUERY"',
+};
+const factualCollector = {
+  command: 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py location "$CLOUDSTATUS_QUERY"',
+};
+const png = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/P9mW6QAAAABJRU5ErkJggg==',
+  'base64',
+);
 
-describe("Cloudstatus Regional Edge guard", () => {
-	it("allows the one direct visual collector followed by one map", () => {
-		const runtime = guard();
-		expect(runtime.call("read", locationSkill)).toBeUndefined();
-		expect(runtime.call("bash", mapCollector)).toBeUndefined();
-		expect(runtime.call("render_map", { locations: [] })).toBeUndefined();
-	});
+function mapResult(overrides: Record<string, unknown> = {}) {
+  const sha256 = createHash('sha256').update(png).digest('hex');
+  return {
+    toolCallId: 'render-call',
+    toolName: 'render_map',
+    input: { locations: [] },
+    content: [{ type: 'image', mimeType: 'image/png', data: png.toString('base64') }],
+    details: {
+      mediaResult: 'xcsh.media/v1',
+      descriptor: {
+        version: 1,
+        kind: 'image',
+        width: 1,
+        height: 1,
+        original: { ref: `blob:sha256:${sha256}`, mimeType: 'image/png', bytes: png.length },
+        provenance: { sourceType: 'tool', source: 'render_map' },
+        metadata: { producer: 'render_map', basemap: 'schematic' },
+      },
+      displayMethod: 'inline',
+    },
+    isError: false,
+    ...overrides,
+  };
+}
 
-	it("allows a factual collector but never a map", () => {
-		const runtime = guard();
-		runtime.call("read", locationSkill);
-		expect(runtime.call("bash", factualCollector)).toBeUndefined();
-		expect(runtime.call("render_map", { locations: [] })).toMatchObject({ block: true });
-	});
+describe('Cloudstatus Regional Edge guard', () => {
+  it('allows the one direct visual collector followed by one map', () => {
+    const runtime = guard();
+    expect(runtime.call('read', locationSkill)).toBeUndefined();
+    expect(runtime.call('bash', mapCollector)).toBeUndefined();
+    expect(runtime.call('render_map', { locations: [] })).toBeUndefined();
+    expect(runtime.result(mapResult())).toBeUndefined();
+  });
 
-	it("blocks delegation and search when Regional Edge text appears before the skill", () => {
-		const runtime = guard();
-		expect(runtime.call("task", { prompt: "research F5 Regional Edge addresses" })).toMatchObject({ block: true });
-		expect(runtime.call("web_search", { query: "F5 Regional Edge locations" })).toMatchObject({ block: true });
-	});
+  it('marks errored, image-less, and non-canonical map results as failed without allowing a retry', () => {
+    for (const invalid of [
+      mapResult({ isError: true }),
+      mapResult({ content: [{ type: 'text', text: 'fallback' }] }),
+      mapResult({ details: undefined }),
+      mapResult({
+        details: {
+          ...mapResult().details,
+          descriptor: {
+            ...(mapResult().details as ReturnType<typeof mapResult>['details']).descriptor,
+            provenance: { sourceType: 'model', source: 'render_map' },
+          },
+        },
+      }),
+    ]) {
+      const runtime = guard();
+      runtime.call('read', locationSkill);
+      runtime.call('bash', mapCollector);
+      runtime.call('render_map', { locations: [] });
+      expect(runtime.result(invalid)).toMatchObject({ isError: true });
+      expect(runtime.call('render_map', { locations: [] })).toMatchObject({ block: true });
+    }
+  });
 
-	it("blocks forbidden tools and arbitrary Bash after the location skill", () => {
-		const runtime = guard();
-		runtime.call("read", locationSkill);
-		for (const [toolName, input] of [
-			["task", { prompt: "delegate" }],
-			["web_search", { query: "edge" }],
-			["display_media", {}],
-			["bash", { command: "curl https://example.test" }],
-		] as const) {
-			expect(runtime.call(toolName, input)).toMatchObject({ block: true });
-		}
-	});
+  it('allows a factual collector but never a map', () => {
+    const runtime = guard();
+    runtime.call('read', locationSkill);
+    expect(runtime.call('bash', factualCollector)).toBeUndefined();
+    expect(runtime.call('render_map', { locations: [] })).toMatchObject({ block: true });
+  });
 
-	it("blocks duplicate collection plus premature and duplicate rendering", () => {
-		const runtime = guard();
-		runtime.call("read", locationSkill);
-		expect(runtime.call("render_map", { locations: [] })).toMatchObject({ block: true });
-		expect(runtime.call("bash", mapCollector)).toBeUndefined();
-		expect(runtime.call("bash", mapCollector)).toMatchObject({ block: true });
-		expect(runtime.call("render_map", { locations: [] })).toBeUndefined();
-		expect(runtime.call("render_map", { locations: [] })).toMatchObject({ block: true });
-	});
+  it('blocks delegation and search when Regional Edge text appears before the skill', () => {
+    const runtime = guard();
+    expect(runtime.call('task', { prompt: 'research F5 Regional Edge addresses' })).toMatchObject({ block: true });
+    expect(runtime.call('web_search', { query: 'F5 Regional Edge locations' })).toMatchObject({ block: true });
+  });
 
-	it("resets for each top-level session and preserves ordinary network-intelligence delegation", () => {
-		const runtime = guard();
-		runtime.call("read", locationSkill);
-		runtime.call("bash", factualCollector);
-		expect(runtime.call("bash", factualCollector)).toMatchObject({ block: true });
-		runtime.reset();
-		expect(runtime.call("task", { prompt: "Investigate BGP paths for AS35280" })).toBeUndefined();
-		expect(runtime.call("bash", factualCollector)).toBeUndefined();
-	});
+  it('blocks forbidden tools and arbitrary Bash after the location skill', () => {
+    const runtime = guard();
+    runtime.call('read', locationSkill);
+    for (const [toolName, input] of [
+      ['task', { prompt: 'delegate' }],
+      ['web_search', { query: 'edge' }],
+      ['display_media', {}],
+      ['bash', { command: 'curl https://example.test' }],
+    ] as const) {
+      expect(runtime.call(toolName, input)).toMatchObject({ block: true });
+    }
+  });
+
+  it('blocks duplicate collection plus premature and duplicate rendering', () => {
+    const runtime = guard();
+    runtime.call('read', locationSkill);
+    expect(runtime.call('render_map', { locations: [] })).toMatchObject({ block: true });
+    expect(runtime.call('bash', mapCollector)).toBeUndefined();
+    expect(runtime.call('bash', mapCollector)).toMatchObject({ block: true });
+    expect(runtime.call('render_map', { locations: [] })).toBeUndefined();
+    expect(runtime.call('render_map', { locations: [] })).toMatchObject({ block: true });
+  });
+
+  it('resets for each top-level session and preserves ordinary network-intelligence delegation', () => {
+    const runtime = guard();
+    runtime.call('read', locationSkill);
+    runtime.call('bash', factualCollector);
+    expect(runtime.call('bash', factualCollector)).toMatchObject({ block: true });
+    runtime.reset();
+    expect(runtime.call('task', { prompt: 'Investigate BGP paths for AS35280' })).toBeUndefined();
+    expect(runtime.call('bash', factualCollector)).toBeUndefined();
+  });
 });

--- a/plugins/cloudstatus/scripts/tests/test_regional_edge_guard.ts
+++ b/plugins/cloudstatus/scripts/tests/test_regional_edge_guard.ts
@@ -40,17 +40,17 @@ const factualCollector = {
   command: 'python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py location "$CLOUDSTATUS_QUERY"',
 };
 const png = Buffer.from(
-  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/P9mW6QAAAABJRU5ErkJggg==',
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABBAEAX+XDSwAAAABJRU5ErkJggg==',
   'base64',
 );
 
-function mapResult(overrides: Record<string, unknown> = {}) {
-  const sha256 = createHash('sha256').update(png).digest('hex');
+function mapResult(overrides: Record<string, unknown> = {}, image = png) {
+  const sha256 = createHash('sha256').update(image).digest('hex');
   return {
     toolCallId: 'render-call',
     toolName: 'render_map',
     input: { locations: [] },
-    content: [{ type: 'image', mimeType: 'image/png', data: png.toString('base64') }],
+    content: [{ type: 'image', mimeType: 'image/png', data: image.toString('base64') }],
     details: {
       mediaResult: 'xcsh.media/v1',
       descriptor: {
@@ -58,7 +58,7 @@ function mapResult(overrides: Record<string, unknown> = {}) {
         kind: 'image',
         width: 1,
         height: 1,
-        original: { ref: `blob:sha256:${sha256}`, mimeType: 'image/png', bytes: png.length },
+        original: { ref: `blob:sha256:${sha256}`, mimeType: 'image/png', bytes: image.length },
         provenance: { sourceType: 'tool', source: 'render_map' },
         metadata: { producer: 'render_map', basemap: 'schematic' },
       },
@@ -79,10 +79,13 @@ describe('Cloudstatus Regional Edge guard', () => {
   });
 
   it('marks errored, image-less, and non-canonical map results as failed without allowing a retry', () => {
+    const corruptCrc = Buffer.from(png);
+    corruptCrc[corruptCrc.length - 1] ^= 1;
     for (const invalid of [
       mapResult({ isError: true }),
       mapResult({ content: [{ type: 'text', text: 'fallback' }] }),
       mapResult({ details: undefined }),
+      mapResult({}, corruptCrc),
       mapResult({
         details: {
           ...mapResult().details,

--- a/plugins/cloudstatus/scripts/tests/test_structure.sh
+++ b/plugins/cloudstatus/scripts/tests/test_structure.sh
@@ -22,7 +22,7 @@ test_plugin_metadata_is_consistent() {
   package_version=$(jq -r '.version' "$package_json")
   marketplace_version=$(jq -r '.plugins[] | select(.name == "cloudstatus") | .version' "$marketplace_json")
 
-  [ "$plugin_version" = "1.5.2" ] || {
+  [ "$plugin_version" = "1.5.3" ] || {
     echo "plugin version is $plugin_version"
     return 1
   }
@@ -50,6 +50,7 @@ test_expected_runtime_files_exist() {
     "skills/network-intelligence/references/source-ladder.md"
     "skills/network-intelligence/references/query-playbook.md"
     "skills/network-intelligence/scripts/network_lookup.py"
+    "extensions/regional-edge-guard.ts"
     "benchmarks/location-prompt-scenarios.json"
     "benchmarks/verify-location-prompt-trace.py"
     "scripts/evals/run-location-prompt-eval.sh"
@@ -71,10 +72,14 @@ test_location_prompt_scenarios_cover_required_intents() {
   local scenarios="$PLUGIN_ROOT/benchmarks/location-prompt-scenarios.json"
   jq -e '
     .version == 1 and
-    ([.scenarios[].id] | sort) == ["factual-metro", "factual-site-code", "factual-unresolved", "visual-canada", "visual-global", "visual-us"] and
-    ([.scenarios[] | select(.intent == "visual")] | length) == 3 and
+    ([.scenarios[].id] | sort) == ["factual-metro", "factual-site-code", "factual-unresolved", "visual-address-us", "visual-canada", "visual-global", "visual-us"] and
+    ([.scenarios[] | select(.intent == "visual")] | length) == 4 and
     ([.scenarios[] | select(.intent == "factual")] | length) == 3
   ' "$scenarios" >/dev/null
+}
+
+test_cloudstatus_declares_the_regional_edge_guard_extension() {
+  jq -e '.xcsh.extensions == ["extensions/regional-edge-guard.ts"]' "$PLUGIN_ROOT/package.json" >/dev/null
 }
 
 test_skill_frontmatter_has_only_name_and_description() {

--- a/plugins/cloudstatus/skills/location/SKILL.md
+++ b/plugins/cloudstatus/skills/location/SKILL.md
@@ -27,6 +27,11 @@ For one narrow factual metro, site-code, or address investigation, use:
 python3 skill://cloudstatus:network-intelligence/scripts/network_lookup.py location "$CLOUDSTATUS_QUERY"
 ```
 
+For example, “show me a map of all the address locations of the F5 Regional
+Edges that are located in the United States” is an inventory/map request. “All
+address locations” remains collector-only: use `locations --format map-v1` and
+do not research individual addresses or facilities.
+
 Bounded retries built into the collector are allowed. Do not run a second
 collector command, follow up with general research, or inspect raw registry
 responses. Keep missing or conflicting evidence visibly unresolved.

--- a/plugins/cloudstatus/skills/location/SKILL.md
+++ b/plugins/cloudstatus/skills/location/SKILL.md
@@ -10,9 +10,10 @@ Do not route it to `cloudstatus:network-intelligence`, a general operator, web
 search, OSINT geolocation, remembered information, source-code inspection, or
 an ad hoc HTTP/Python command.
 
-Run the collector directly in the parent session exactly once. Pass the exact
-geographic filter through the Bash environment as `CLOUDSTATUS_QUERY`; do not
-interpolate user text into the command.
+Run the collector directly in the parent session exactly once. Pass only the
+normalized geographic filter through the Bash environment as
+`CLOUDSTATUS_QUERY` (for example, `United States`, not the full user request);
+do not interpolate user text into the command.
 
 For inventory, map, show, where, country, region, or “which Regional Edges”
 intent, use the compact map contract:


### PR DESCRIPTION
## Summary

- enforce the Cloudstatus Regional Edge registry-only workflow at runtime
- pair `render_map` starts and completions by `toolCallId` and reject incomplete, errored, duplicate, or mismatched rendering
- validate strict base64, complete PNG structure/CRCs, dimensions, bytes, SHA-256, and canonical `xcsh.media/v1` metadata
- emit compact JSON receipts and retain extracted PNGs without logging base64
- add the exact address-map regression, synthesized fresh-session UAT automation, and normalized geographic-filter guidance
- apply the Marketplace-required Biome formatting and release Cloudstatus 1.5.3

## Test evidence

- red verifier suite against the old implementation: 11 tests, 7 failures and 2 errors
- red runtime-guard suite against the old implementation: image-less completion test failed because no `tool_result` handler existed
- `bash plugins/cloudstatus/scripts/tests/run-tests.sh`: 26 pass, 0 fail
- `bun test ./plugins/cloudstatus/scripts/tests/test_regional_edge_guard.ts`: 7 pass, 0 fail
- `python3 -m unittest plugins/cloudstatus/scripts/tests/test_location_prompt_trace.py`: 12 pass
- `./scripts/run-plugin-tests.sh`: all plugin suites pass; Cloudstatus 26 pass and fleet total shown in the workflow log
- `./scripts/check-tests-are-hermetic.sh`: no plugin test depends on a real cloud CLI
- `./scripts/validate-plugins.sh`: passed
- `bash scripts/check-pii.sh --scope head --mode enforce`: clean
- exact Biome gate on the extension and test: passed with no fixes
- linked xcsh semantic renderer test-only PR: f5-sales-demo/xcsh#3240

## Live acceptance

- three independent exact-prompt `bun run dev --plugin-dir` sessions: all receipts passed and extracted 1200x760 PNGs
- four controlled synthesized address-map variants: all receipts passed after normalizing the registry filter
- full US / address-US / Canada / global / metro / site-code / unresolved matrix: all four visual receipts prove one valid PNG; all three factual receipts prove zero image generation
- locally compiled xcsh binary: exact-prompt receipt passed with a 266,190-byte PNG, SHA-256 `1b911c2370c12e545316d44e4fdb18a61d2d6153b3afb387d3038884d1d48a8e`
- retained local evidence root: `/tmp/cloudstatus-uat-1195-final`

Closes #1195
